### PR TITLE
Updates for Batik plugin integration with SVGImage in Plus plugins.

### DIFF
--- a/src/main/plus-plugins/com.moldflow.dita.plus-allhtml-svgimage/plugin.xml
+++ b/src/main/plus-plugins/com.moldflow.dita.plus-allhtml-svgimage/plugin.xml
@@ -1,6 +1,7 @@
 <plugin id="com.moldflow.dita.plus-allhtml-svgimage">
 
   <require plugin="com.moldflow.dita.plus-transtype-anyhtml"/>
+  <require plugin="org.apache.xmlgraphics.batik" />
 
   <feature extension="dita.conductor.xhtml.param" value="insert-ant-topic-html-xslt.xml" type="file"/>
 

--- a/src/main/plus-plugins/org.apache.xmlgraphics.batik/plugin.xml
+++ b/src/main/plus-plugins/org.apache.xmlgraphics.batik/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="batik-1.7">
+<plugin id="org.apache.xmlgraphics.batik">
     <feature extension="dita.conductor.lib.import" file="batik.jar"/>
     <feature extension="dita.conductor.lib.import" file="batik-svgpp.jar"/>
     <feature extension="dita.conductor.lib.import" file="batik-ttfsvg.jar"/>


### PR DESCRIPTION
A quick fix for the base plugin name for the batik plugin in its plugin.xml file.  The other update is to link the svgimage plugin with the batik plugin.
