### PR TITLE
Wrap itemgroup task elements into <div> elements #1331

### DIFF
--- a/src/main/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/xsl/xslhtml/taskdisplay.xsl
@@ -929,7 +929,7 @@
   <div>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
-    <xsl:text> </xsl:text><xsl:call-template name="flagcheck"/>
+    <xsl:call-template name="flagcheck"/>
     <xsl:call-template name="revblock">
       <xsl:with-param name="flagrules" select="$flagrules"></xsl:with-param>
     </xsl:call-template>


### PR DESCRIPTION
This change ensures that `<stepxmp>`, `<stepresult>`, `<info>`, and `<tutorialinfo>` are wrapped in a `<div>` element in the HTML output.

I felt that `<div>` made more sense than `<span>` in this case since `<span>` is conventionally used for inline elements rather than block elements.

I also removed the `<xsl:text> </xsl:text>` element (bb787cdef0cc82538434cdea2a036380fa0a3e07) because I don't think it's needed any more after this change.
