### PR TITLE
Fix text overflow issue in PDF ToC entries with long titles.

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
@@ -112,7 +112,6 @@ See the accompanying license.txt file for applicable licenses.
 
     <xsl:attribute-set name="__toc__title">
       <xsl:attribute name="end-indent"><xsl:value-of select="$toc.text-indent"/></xsl:attribute>
-      <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__toc__page-number">


### PR DESCRIPTION
If a topic had a really long title (say 110+ characters), the text in the table of contents entry for that topic would overflow the end of the page because `keep-together.within-line` was set to `always` for the `__toc__title` attribute set.

Screenshots: [before](https://www.dropbox.com/s/q0an44a89r8asg3/before.png) and [after](https://www.dropbox.com/s/rnls1ek8y21g6f7/after.png).
