### PR TITLE
Fix text overflow issue in lot/lof entries with long titles

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lot-lof-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lot-lof-attr.xsl
@@ -22,7 +22,6 @@
   </xsl:attribute-set>
 
   <xsl:attribute-set name="__lotf__title" use-attribute-sets="__lotf__content">
-    <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
   </xsl:attribute-set>
   
   <xsl:attribute-set name="__lotf__page-number">


### PR DESCRIPTION
Same issue as #1359 but for lot/lof titles.

Duplicate of #1427 but for the `hotfix/1.7.1` branch.
