### PR TITLE
Proposal for better Glossary processing

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -410,8 +410,16 @@ See the accompanying license.txt file for applicable licenses.
     <variable id="Glossary even header"><param ref-name="pagenum"/>&#xA0;|&#xA0;<param ref-name="heading"/>&#xA0;|&#xA0;<param ref-name="prodname"/></variable>
      
      <!-- The heading string to put at the top of the Glossary -->
+
      <variable id="Glossary">Glossary</variable>
-     
+     <!-- The string to put before the acronym list -->
+     <variable id="Acronyms">Acronyms: </variable>
+
+     <!-- The string to put before the Abbreviation list -->
+     <variable id="Abbrevs">Abbreviations: </variable>
+
+     <!-- The string to put before the Abbreviation list -->
+     <variable id="Synonyms">Synonyms: </variable>     
      <!-- The heading string to put at the top of the List of Tables -->
      <variable id="List of Tables">List of Tables</variable>
      

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -126,4 +126,29 @@
   <variable id="#menucascade-separator">&#xA0;&#x3E; </variable>
   <variable id="#quote-start">“</variable>
   <variable id="#quote-end">”</variable>
+    <!--Glossary Variables-->
+    <!-- The footer that appears on the odd-numbered glossary pages. -->
+    <variable id="Glossary odd footer"/>
+
+    <!-- The footer that appears on the even-numbered glossary pages. -->
+    <variable id="Glossary even footer"/>
+
+    <!-- The header that appears on the odd-numbered glossary pages. -->
+    <variable id="Glossary odd header"><param ref-name="prodname"/>&#xA0;|&#xA0;<variable id="Glossary"/>&#xA0;|&#xA0;<param ref-name="pagenum"/></variable>
+
+    <!-- The header that appears on the even-numbered glossary pages. -->
+    <variable id="Glossary even header"><param ref-name="pagenum"/>&#xA0;|&#xA0;<variable id="Glossary"/>&#xA0;|&#xA0;<param ref-name="prodname"/></variable>
+
+     <!-- The heading string to put at the top of the Glossary -->
+     <variable id="Glossary">Termenlijst</variable>
+
+     <!-- The string to put before the acronym list -->
+     <variable id="Acronyms">Acroniemen: </variable>
+
+     <!-- The string to put before the Abbreviation list -->
+     <variable id="Abbrevs">Afkortingen: </variable>
+
+     <!-- The string to put before the Abbreviation list -->
+     <variable id="Synonyms">Synoniemen: </variable>
+
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/glossary-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/glossary-attr.xsl
@@ -39,11 +39,42 @@ See the accompanying license.txt file for applicable licenses.
         <xsl:attribute name="font-weight">bold</xsl:attribute>
     </xsl:attribute-set>
 
+    <xsl:attribute-set name="__glossary__group-head">
+       <!-- <xsl:attribute name="font-weight">bold</xsl:attribute>
+            <xsl:attribute name="border-bottom">solid 0.5pt black</xsl:attribute>
+            <xsl:attribute name="end-indent">4cm</xsl:attribute>
+            <xsl:attribute name="space-before">10pt</xsl:attribute>-->
+        <xsl:attribute name="span">all</xsl:attribute>
+    </xsl:attribute-set>
+
     <xsl:attribute-set name="__glossary__term">
         <xsl:attribute name="font-weight">bold</xsl:attribute>
+        <xsl:attribute name="space-before">3pt</xsl:attribute>
+        <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__glossary__def">
-        <xsl:attribute name="margin-left"><xsl:value-of select="$side-col-width"/></xsl:attribute>
     </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__abbrevs">
+        </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__abbrevs-label">
+        <xsl:attribute name="font-weight">bold</xsl:attribute>
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__acronyms">
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__acronyms-label">
+         <xsl:attribute name="font-weight">bold</xsl:attribute>
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__synonyms">
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__glossary__synonyms-label">
+        <xsl:attribute name="font-weight">bold</xsl:attribute>
+    </xsl:attribute-set>
+                
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
@@ -79,4 +79,13 @@
     <xsl:attribute name="display-align">after</xsl:attribute>
   </xsl:attribute-set>
     
+  <!-- Glossary -->
+  <xsl:attribute-set name="region-glossary.odd" use-attribute-sets="region-body.odd">
+      <xsl:attribute name="column-count">2</xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="region-glossary.even" use-attribute-sets="region-body.even">
+      <xsl:attribute name="column-count">2</xsl:attribute>
+  </xsl:attribute-set>
+
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
@@ -2,111 +2,136 @@
 <!-- This file is part of the DITA Open Toolkit project.
      See the accompanying license.txt file for applicable licenses. -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:opentopic="http://www.idiominc.com/opentopic"
-                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
-                exclude-result-prefixes="xs opentopic dita-ot ditamsg">
-  
-  <xsl:param name="first-use-scope" select="'document'"/>
-  
-  <xsl:key name="abbreviated-form-keyref"
-           match="*[contains(@class, ' abbrev-d/abbreviated-form ')]
-                   [empty(ancestor::opentopic:map) and empty(ancestor::*[contains(@class, ' topic/title ')])]
-                   [@keyref]"
-           use="@keyref"/>
-  
-  <xsl:template match="*[contains(@class,' abbrev-d/abbreviated-form ')]" name="topic.abbreviated-form">
-    <xsl:variable name="keys" select="@keyref"/>
-    <xsl:variable name="target" select="key('id', substring(@href, 2))"/>
-    <xsl:choose>
-      <xsl:when test="$keys and $target/self::*[contains(@class,' glossentry/glossentry ')]">
-        <xsl:call-template name="topic.term">
-          <xsl:with-param name="contents">
-            <xsl:variable name="use-abbreviated-form" as="xs:boolean">
-              <xsl:apply-templates select="." mode="use-abbreviated-form"/>
-            </xsl:variable>
-            <xsl:choose>
-              <xsl:when test="$use-abbreviated-form">
-                <xsl:apply-templates select="$target" mode="getMatchingAcronym"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:apply-templates select="$target" mode="getMatchingSurfaceForm"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:with-param>
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:opentopic="http://www.idiominc.com/opentopic"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="2.0"
+    exclude-result-prefixes="xs opentopic dita-ot ditamsg">
+
+    <!-- The scope of when the 'first occurence' of a term happens
+         values: document, chapter, topic    -->
+    <xsl:param name="abbreviated-form.first-use-scope" select="'document'"/>
+    <!-- Do you want the first acronym appended?
+         Values: flase()  gives glossSurfaceForm
+                 true()   gives glossSurfaceForm (glossAcronym[1])  -->
+    <xsl:param name="abbreviated-form.add-acronym" select="true()" />
+
+    <xsl:key name="abbreviated-form-keyref"
+        match="*[contains(@class, ' abbrev-d/abbreviated-form ')]
+        [empty(ancestor::opentopic:map) and empty(ancestor::*[contains(@class, ' topic/title ')])]
+        [@keyref]"
+        use="@keyref"/>
+
+    <xsl:key name="oid" match="*[@oid]" use="@oid"/>
+
+    <xsl:template match="*[contains(@class,' abbrev-d/abbreviated-form ')]"
+        name="topic.abbreviated-form">
+        <xsl:variable name="keys" select="@keyref"/>
+        <xsl:variable name="target" select="key('oid', @keyref)"/>
+        <xsl:choose>
+            <xsl:when test="$keys and $target/self::*[contains(@class,' glossentry/glossentry ')]">
+                <!-- A glossentry was found in the document -->
+                <xsl:call-template name="topic.term">
+                    <xsl:with-param name="contents">
+                        <xsl:variable name="use-abbreviated-form" as="xs:boolean">
+                            <xsl:apply-templates select="." mode="use-abbreviated-form"/>
+                        </xsl:variable>
+                        <xsl:choose>
+                            <xsl:when test="$use-abbreviated-form">
+                                <xsl:apply-templates select="$target" mode="getMatchingAcronym"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:apply-templates select="$target" mode="getMatchingSurfaceForm"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:with-param>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="." mode="ditamsg:no-glossentry-for-abbreviated-form">
+                    <xsl:with-param name="keys" select="$keys"/>
+                </xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Should abbreviated form of glossary entry be used -->
+    <xsl:template match="*" mode="use-abbreviated-form" as="xs:boolean">
+        <xsl:variable name="first-use-scope-root" as="element()">
+            <xsl:call-template name="get-first-use-scope-root"/>
+        </xsl:variable>
+        <xsl:sequence
+            select="not(generate-id(.) = generate-id(key('abbreviated-form-keyref', @keyref, $first-use-scope-root)[1]))"
+        />
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class,' topic/copyright ')]//*" mode="use-abbreviated-form"
+        as="xs:boolean">
+        <xsl:sequence select="false()"/>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class,' topic/title ')]//*" mode="use-abbreviated-form"
+        as="xs:boolean">
+        <xsl:sequence select="true()"/>
+    </xsl:template>
+
+    <!-- Get element to use as root when  -->
+    <xsl:template name="get-first-use-scope-root" as="element()">
+        <xsl:choose>
+            <xsl:when test="$abbreviated-form.first-use-scope = 'topic'">
+                <xsl:sequence select="ancestor::*[contains(@class, ' topic/topic ')][1]"/>
+            </xsl:when>
+            <xsl:when test="$abbreviated-form.first-use-scope = 'chapter'">
+                <xsl:sequence
+                    select="ancestor::*[contains(@class, ' topic/topic ')][position() = last()]"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="/*"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="*" mode="getMatchingSurfaceForm">
+        <xsl:variable name="glossSurfaceForm"
+            select="*[contains(@class, ' glossentry/glossBody ')]/*[contains(@class, ' glossentry/glossSurfaceForm ')]"/>
+        <xsl:choose>
+            <xsl:when test="$glossSurfaceForm">
+                <xsl:apply-templates select="$glossSurfaceForm/node()"/>
+                <xsl:if
+                    test="$abbreviated-form.add-acronym and count(descendant-or-self::*[contains(@class, ' glossentry/glossAcronym ')]) gt 0">
+                    <xsl:text> (</xsl:text>
+                    <xsl:apply-templates
+                        select="descendant-or-self::*[contains(@class, ' glossentry/glossAcronym ')][1]"/>
+                    <xsl:text>)</xsl:text>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="*" mode="getMatchingAcronym">
+        <xsl:variable name="glossAcronym"
+            select="*[contains(@class, ' glossentry/glossBody ')]/*[contains(@class, ' glossentry/glossAlt ')]/*[contains(@class, ' glossentry/glossAcronym ')]"/>
+        <xsl:choose>
+            <xsl:when test="$glossAcronym">
+                <xsl:apply-templates select="$glossAcronym[1]/node()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="*" mode="ditamsg:no-glossentry-for-abbreviated-form">
+        <xsl:param name="keys"/>
+        <xsl:call-template name="output-message">
+            <xsl:with-param name="msgcat">DOTX</xsl:with-param>
+            <xsl:with-param name="msgnum">060</xsl:with-param>
+            <xsl:with-param name="msgsev">W</xsl:with-param>
+            <xsl:with-param name="msgparams">%1=<xsl:value-of select="$keys"/></xsl:with-param>
         </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:apply-templates select="." mode="ditamsg:no-glossentry-for-abbreviated-form">
-          <xsl:with-param name="keys" select="$keys"/>
-        </xsl:apply-templates>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-  <!-- Should abbreviated form of glossary entry be used -->
-  <xsl:template match="*" mode="use-abbreviated-form" as="xs:boolean">
-    <xsl:variable name="first-use-scope-root" as="element()">
-      <xsl:call-template name="get-first-use-scope-root"/>
-    </xsl:variable>
-    <xsl:sequence select="not(generate-id(.) = generate-id(key('abbreviated-form-keyref', @keyref, $first-use-scope-root)[1]))"/>
-  </xsl:template>
-  <xsl:template match="*[contains(@class,' topic/copyright ')]//*" mode="use-abbreviated-form" as="xs:boolean">
-    <xsl:sequence select="false()"/>
-  </xsl:template>
-  <xsl:template match="*[contains(@class,' topic/title ')]//*" mode="use-abbreviated-form" as="xs:boolean">
-    <xsl:sequence select="true()"/>
-  </xsl:template>  
-
-  <!-- Get element to use as root when  -->
-  <xsl:template name="get-first-use-scope-root" as="element()">
-    <xsl:choose>
-      <xsl:when test="$first-use-scope = 'topic'">
-        <xsl:sequence select="ancestor::*[contains(@class, ' topic/topic ')][1]"/>
-      </xsl:when>
-      <xsl:when test="$first-use-scope = 'chapter'">
-        <xsl:sequence select="ancestor::*[contains(@class, ' topic/topic ')][position() = last()]"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="/*"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-  
-  <xsl:template match="*" mode="getMatchingSurfaceForm">
-    <xsl:variable name="glossSurfaceForm" select="*[contains(@class, ' glossentry/glossBody ')]/*[contains(@class, ' glossentry/glossSurfaceForm ')]"/>
-    <xsl:choose>
-      <xsl:when test="$glossSurfaceForm">
-        <xsl:apply-templates select="$glossSurfaceForm/node()"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:apply-templates select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-  
-  <xsl:template match="*" mode="getMatchingAcronym">
-    <xsl:variable name="glossAcronym" select="*[contains(@class, ' glossentry/glossBody ')]/*[contains(@class, ' glossentry/glossAlt ')]/*[contains(@class, ' glossentry/glossAcronym ')]"/>
-    <xsl:choose>
-      <xsl:when test="$glossAcronym">
-        <xsl:apply-templates select="$glossAcronym[1]/node()"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:apply-templates select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-  
-  <xsl:template match="*" mode="ditamsg:no-glossentry-for-abbreviated-form">
-    <xsl:param name="keys"/>
-    <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">060</xsl:with-param>
-      <xsl:with-param name="msgsev">W</xsl:with-param>
-      <xsl:with-param name="msgparams">%1=<xsl:value-of select="$keys"/></xsl:with-param>
-    </xsl:call-template>
-  </xsl:template>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -1,39 +1,47 @@
 ﻿<?xml version='1.0'?>
 
-<xsl:stylesheet 
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-xmlns:fo="http://www.w3.org/1999/XSL/Format" 
-xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
-exclude-result-prefixes="ot-placeholder"
-version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
+    exclude-result-prefixes="ot-placeholder" version="2.0">
 
     <xsl:template match="ot-placeholder:glossarylist">
-    
-            <fo:page-sequence master-reference="glossary-sequence" xsl:use-attribute-sets="__force__page__count">
-                <xsl:call-template name="insertGlossaryStaticContents"/>
-                <fo:flow flow-name="xsl-region-body">
-                    <fo:marker marker-class-name="current-header">
-                      <xsl:call-template name="insertVariable">
+
+        <fo:page-sequence master-reference="glossary-sequence"
+            xsl:use-attribute-sets="__force__page__count">
+            <xsl:call-template name="insertGlossaryStaticContents"/>
+            <fo:flow flow-name="xsl-region-body">
+                <fo:marker marker-class-name="current-header">
+                    <xsl:call-template name="insertVariable">
                         <xsl:with-param name="theVariableID" select="'Glossary'"/>
-                      </xsl:call-template>
-                    </fo:marker>
+                    </xsl:call-template>
+                </fo:marker>
 
-                    <fo:block xsl:use-attribute-sets="__glossary__label" id="{$id.glossary}">
-                        <xsl:call-template name="insertVariable">
-                            <xsl:with-param name="theVariableID" select="'Glossary'"/>
-                        </xsl:call-template>
-                    </fo:block>
+                <fo:block xsl:use-attribute-sets="__glossary__label" id="{$id.glossary}">
+                    <xsl:call-template name="insertVariable">
+                        <xsl:with-param name="theVariableID" select="'Glossary'"/>
+                    </xsl:call-template>
+                </fo:block>
 
-                    <xsl:apply-templates/>
+                <xsl:apply-templates/>
 
-                    <!--xsl:apply-templates select="/descendant-or-self::*[contains(@class, ' glossentry/glossentry ')]" mode="glossary"/-->
-               
-                </fo:flow>
-            </fo:page-sequence>
-       
+            </fo:flow>
+        </fo:page-sequence>
+
     </xsl:template>
 
-    <xsl:template match="ot-placeholder:glossarylist//*[contains(@class, ' glossentry/glossentry ')]">
+    <!-- Glossary Group Headings -->
+    <xsl:template
+        match="ot-placeholder:glossarylist//*[contains(@class, ' glossgroup/glossgroup ')]">
+        <fo:block xsl:use-attribute-sets="__glossary__group-head">
+            <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
+        </fo:block>
+    </xsl:template>
+    
+    <!-- Glossary entry -->
+    <xsl:template
+        match="ot-placeholder:glossarylist//*[contains(@class, ' glossentry/glossentry ')]">
         <fo:block>
             <xsl:call-template name="commonattributes"/>
             <fo:block>
@@ -41,13 +49,89 @@ version="2.0">
                     <xsl:call-template name="generate-toc-id"/>
                 </xsl:attribute>
                 <fo:block xsl:use-attribute-sets="__glossary__term">
-                    <xsl:apply-templates select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
+                    <xsl:apply-templates
+                        select="*[contains(@class, ' glossentry/glossterm ')]/node()"/>
+                    <xsl:if
+                        test="count(descendant-or-self::*[contains(@class, ' glossentry/glossAcronym ')]) gt 0">
+                        <xsl:text> (</xsl:text>
+                        <xsl:apply-templates 
+                            select="descendant-or-self::*[contains(@class, ' glossentry/glossAcronym ')][1]"/>
+                        <xsl:text>)</xsl:text>
+                    </xsl:if>
                 </fo:block>
                 <fo:block xsl:use-attribute-sets="__glossary__def">
-                    <xsl:apply-templates select="*[contains(@class, ' glossentry/glossdef ')]/node()"/>
+                    <xsl:apply-templates
+                        select="*[contains(@class, ' glossentry/glossdef ')]/node()"/>
+                    <xsl:apply-templates select="*[contains(@class, ' glossentry/glossBody ')]"/>
+                    <xsl:apply-templates select="*[contains(@class, ' topic/related-links ')]"/>
                 </fo:block>
             </fo:block>
         </fo:block>
     </xsl:template>
 
+    <xsl:template match="*[contains(@class, ' glossentry/glossBody ')]">
+        <xsl:variable name="synonyms"
+            select="descendant-or-self::*[contains(@class, ' glossentry/glossSynonym ')]/node()"/>
+        <xsl:variable name="acronyms"
+            select="descendant-or-self::*[contains(@class, ' glossentry/glossAcronym ')]/node()"/>
+        <xsl:variable name="abbrevs"
+            select="descendant-or-self::*[contains(@class, ' glossentry/glossAbbreviation ')]/node()"/>
+        <!-- Synonyms -->
+        <xsl:if test="count($synonyms) gt 0">
+            <fo:block xsl:use-attribute-sets="__glossary__synonyms">
+                <fo:inline xsl:use-attribute-sets="__glossary__synonyms-label">
+                    <xsl:call-template name="insertVariable">
+                        <xsl:with-param name="theVariableID" select="'Synonyms'"/>
+                    </xsl:call-template>
+                </fo:inline>
+                <xsl:for-each
+                    select="descendant-or-self::*[contains(@class, ' glossentry/glossSynonym ')]">
+                    <xsl:apply-templates select="."/>
+                    <xsl:if test="position() lt last()">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                </xsl:for-each>
+            </fo:block>
+        </xsl:if>
+        <!-- Acronyms -->
+        <xsl:if test="count($acronyms) gt 0">
+            <fo:block xsl:use-attribute-sets="__glossary__acronyms">
+                <fo:inline xsl:use-attribute-sets="__glossary__acronyms-label">
+                    <xsl:call-template name="insertVariable">
+                        <xsl:with-param name="theVariableID" select="'Acronyms'"/>
+                    </xsl:call-template>
+                </fo:inline>
+                <xsl:value-of select="string-join($acronyms, ', ')"/>
+            </fo:block>
+        </xsl:if>
+        <!-- Abbrevs -->
+        <xsl:if test="count($abbrevs) gt 0">
+            <fo:block xsl:use-attribute-sets="__glossary__abbrevs">
+                <fo:inline xsl:use-attribute-sets="__glossary__abbrevs-label">
+                    <xsl:call-template name="insertVariable">
+                        <xsl:with-param name="theVariableID" select="'Abbrevs'"/>
+                    </xsl:call-template>
+                </fo:inline>
+                <xsl:for-each
+                    select="descendant-or-self::*[contains(@class, ' glossentry/glossAbbreviation ')]">
+                    <xsl:apply-templates select="."/>
+                    <xsl:if test="position() lt last()">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                </xsl:for-each>
+            </fo:block>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class, ' glossentry/glossSynonym ')]">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class, ' glossentry/glossAbbreviation ')]">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class, ' glossentry/glossAcronym ')]">
+        <xsl:apply-templates/>
+    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Changed stylesheets to get Glossary items similar to this:
>**x86-64 (x86-64)**
  A 64-bit extension of IA-32, the 32-bit generation
  of the x86 instruction set. It supports vastly
  larger amounts of virtual memory and physical
  ...
  compatible with 16-bit and 32-bit x86 code. The
  x86-64 specification is not compatible with the
  Intel Itanium (IA-64) architecture.
  **Synonyms:** Intel 64
  **Acronyms:** x86-64, x64, EM64T
  **Related Links**
  Intel Itanium architecture on page 234