### PR TITLE
Adding CSS file for the XHTML-based formats of the DITA-OT documentation

### DIFF
--- a/src/main/doc/resource/dita-ot-doc.css
+++ b/src/main/doc/resource/dita-ot-doc.css
@@ -1,7 +1,4 @@
-/* SDL-ID CSS file, created 26 February 2011 by Kristen James Eberlein. 
-   Based on a combination of commonltr.css, shipped with the DITA OT, and the CSS file used by IBM SSG
-   1 March 2012: Revised to include article
-* */
+/* Version 1, 22 March 2013 */
 
 /****************************************
 Basic fonts and typography


### PR DESCRIPTION
Adding initial draft of CSS file. This should be used for the both forms of the DITA-OT documentation -- in the downloadable ZIP and on the Web site at SourceForge
