### PR TITLE
Add missing @class attribute to <navref> in chunking phase

### DIFF
--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -443,6 +443,7 @@ public final class ChunkMapReader implements AbstractReader {
             final Element navref = node.getOwnerDocument().createElement(MAP_NAVREF.localName);
             final String newMapFile = generateFilename("MAPCHUNK", ".ditamap");
             navref.setAttribute(MAPGROUP_D_MAPREF.localName,newMapFile);
+            navref.setAttribute(ATTRIBUTE_NAME_CLASS, MAP_NAVREF.toString());
             //replace node with navref
             node.getParentNode().replaceChild(navref,node);
             root.appendChild(node);


### PR DESCRIPTION
A `<topicset>` element inherits a `@chunk` attribute value of `to-navigation` from
the DTD. In the chunking phase, elements with `@chunk="to-navigation"` are
converted into a `<navref>` element. Currently, this `<navref>` element gets no
`@class` attribute value.

With the Eclipse Help transtype, this `<navref>` element should be converted into
a `<link>` element in the Eclipse Help TOC file, but since `map2eclipseImpl.xsl`
(correctly) matches against the `@class` attribute instead of the element name, it
ignores the `<navref>` element and the `<link>` element is never created. Adding the
missing `@class` attribute to the `<navref>` element solves the problem.
