### PR TITLE
Prevent PDF table rows from inheriting @rowsep from previous row #1486

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -898,7 +898,7 @@
                         <xsl:when test="../parent::node()[contains(@class, ' topic/tbody ')]">
                             <xsl:variable name="entryNum" select="count(preceding-sibling::*[contains(@class, ' topic/entry ')]) + 1"/>
                             <xsl:variable name="prevEntryRowsep">
-                                <xsl:for-each select="../preceding-sibling::*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')][$entryNum]">
+                                <xsl:for-each select="../preceding-sibling::*[contains(@class, ' topic/row ')][1]/*[contains(@class, ' topic/entry ')][$entryNum]">
                                     <xsl:call-template name="getTableRowsep"/>
                                 </xsl:for-each>
                             </xsl:variable>


### PR DESCRIPTION
Please try this out before merging it if you have the chance. You can use [this Gist](https://gist.github.com/emth/6368345) if you want. `tables.xsl` is pretty mystifying in places (and certainly could use an XSLT2.0 rewrite), but I _think_ I got it right.
