### PR TITLE
Remove unused templates

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
@@ -73,18 +73,6 @@ See the accompanying license.txt file for applicable licenses.
         </fo:inline>
     </xsl:template>
 
-    <xsl:template name="processCopyrigth">
-        <xsl:apply-templates select="/bookmap/*[contains(@class,' topic/topic ')]" mode="process-preface"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="process-preface">
-        <xsl:param name="include" select="'true'"/>
-        <xsl:variable name="topicType">
-            <xsl:call-template name="determineTopicType"/>
-        </xsl:variable>
-
-    </xsl:template>
-
     <xsl:variable name="map" select="//opentopic:map"/>
 
     <xsl:template name="createFrontMatter">


### PR DESCRIPTION
The latter template throws a non-fatal error because it has an `<xsl:variable>` element with no following sibling instructions. I couldn't find any templates that use the `processCopyrigth` template, either.
