### PR TITLE
Update 2.0 branch with fix for FILTERFILEURL

### DIFF
--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -165,7 +165,10 @@
     </xsl:choose>
   </xsl:variable>
   
-<xsl:variable name="FILTERDOC" select="document($FILTERFILEURL,/)"/>
+<xsl:variable name="FILTERDOC"
+              select="if (string-length($FILTERFILEURL) > 0)
+                      then document($FILTERFILEURL, /)
+                      else ()"/>
 
 <!-- Define a newline character -->
 <xsl:variable name="newline"><xsl:text>


### PR DESCRIPTION
Comment in the commit is wrong due to copy/paste error, this is a fix for the 2.0 code rather than the 1.8 code. Same issue though, #1565.
