### PR TITLE
Download and initialize Ivy in initialization phase

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
     <delete dir="${package.output.dir}"/>
   </target>
 
-  <target name="init-java" depends="clean-java">
+  <target name="init-java" depends="clean-java, init-ivy">
     <mkdir dir="${lib.dir}"/>
     <mkdir dir="${bin.dir}"/>
     <ivy:retrieve pattern="${lib.dir}/[artifact](-[classifier]).[ext]" conf="compile"/>    


### PR DESCRIPTION
If the `init-ivy` target isn't called, the user will have to install Ivy manually before compilation.
