### PR TITLE
Fix support for topics inside glossarylist #1189

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -38,7 +38,8 @@ See the accompanying license.txt file for applicable licenses.
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
     xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
-    exclude-result-prefixes="opentopic opentopic-index opentopic-func dita2xslfo xs"
+    xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
+    exclude-result-prefixes="ot-placeholder opentopic opentopic-index opentopic-func dita2xslfo xs"
     version="2.0">
 
     <xsl:key name="id" match="*[@id]" use="@id"/>
@@ -156,7 +157,7 @@ See the accompanying license.txt file for applicable licenses.
                     </xsl:choose>
                 </xsl:variable>
                 <xsl:choose>
-                    <xsl:when test="not(ancestor::*[contains(@class,' topic/topic ')])">
+                    <xsl:when test="not(ancestor::*[contains(@class,' topic/topic ')]) and not(ancestor::ot-placeholder:glossarylist)">
                         <fo:page-sequence master-reference="{$page-sequence-reference}" xsl:use-attribute-sets="__force__page__count">
                             <xsl:call-template name="startPageNumbering"/>
                             <xsl:call-template name="insertBodyStaticContents"/>


### PR DESCRIPTION
Gist [here](https://github.com/dita-ot/dita-ot/issues/1189#issuecomment-15171589).

In the Gist that was attached to the issue, the problem is not in fact the `<glossentry>` element; it's the `<topichead>` elements that are nested inside `<glossarylist>`.

The cause of the issue is that `commons.xsl` creates a new `fo:page-sequence` for each _top-level_ topic, and `glossary.xsl` creates a new `fo:page-sequence` for the `<glossarylist>` element. However, the code in `commons.xsl` doesn't check whether the current topic is inside a `<glossarylist>` element. Since the `<topicref>` elements inside `<glossarylist>` do not have ancestor topics (only topicheads), the generated XSL-FO code will have nested `<fo:page-sequence>` elements.

Adding a check for a `<glossarylist>` ancestor into `commons.xsl` fixes the problem, because then the topicrefs inside `<glossarylist>` are handled like regular nested topics.

By the way, on a semi-related note: `commons.xsl` seems to have a mix of Windows and Unix line endings, which tends to make diffing somewhat inconvenient. Can we fix that?
