### PR TITLE
XSLT optimizations for PDF stylesheets

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -47,6 +47,13 @@ See the accompanying license.txt file for applicable licenses.
 
     <xsl:key name="id" match="*[@id]" use="@id"/>
     <xsl:key name="map-id" match="opentopic:map//*[@id]" use="@id"/>
+    <xsl:key name="topic-id"
+                 match="*[@id][contains(@class, ' topic/topic ')] |
+                        ot-placeholder:*[@id]"
+                 use="@id"/>
+
+    <xsl:key name="fnById" match="*[contains(@class, ' topic/fn ')]" use="@id"/>
+    <xsl:key name="class" match="*[@class]" use="tokenize(@class, ' ')"/>
 
     <xsl:variable name="msgprefix" select="'PDFX'"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -276,7 +276,9 @@ See the accompanying license.txt file for applicable licenses.
     <!-- xref to footnote makes a callout. -->
     <xsl:template match="*[contains(@class,' topic/xref ')][@type='fn']" priority="2">
         <xsl:variable name="href-fragment" select="substring-after(@href, '#')"/>
-        <xsl:variable name="footnote-target" select="//*[contains(@class, ' topic/fn ')][@id = substring-after($href-fragment, '/')][ancestor::*[contains(@class, ' topic/topic ')][1]/@id = substring-before($href-fragment, '/')]"/>
+        <xsl:variable name="elemId" select="substring-after($href-fragment, '/')"/>
+        <xsl:variable name="topicId" select="substring-before($href-fragment, '/')"/>
+        <xsl:variable name="footnote-target" select="key('fnById', $elemId)[ancestor::*[contains(@class, ' topic/topic ')][1]/@id = $topicId]"/>
         <xsl:apply-templates select="$footnote-target" mode="footnote-callout"/>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -108,8 +108,7 @@ See the accompanying license.txt file for applicable licenses.
           </xsl:call-template>
         </xsl:if>
         <xsl:if test="@href and @id">
-            <xsl:variable name="searchId" select="@id"/>
-            <xsl:if test="not(//*[contains(@class, ' topic/topic ')][@id = $searchId]) and not($searchId = '')">
+            <xsl:if test="not(@id = '') and empty(key('topic-id', @id))">
               <xsl:call-template name="output-message">
                 <xsl:with-param name="msgnum">005</xsl:with-param>
                 <xsl:with-param name="msgsev">F</xsl:with-param>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -515,13 +515,15 @@
         <xsl:variable name="entryNumber">
             <xsl:call-template name="countEntryNumber"/>
         </xsl:variable>
+        <xsl:variable name="colspec"
+            select="ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/colspec ')][position() = number($entryNumber)]"/>
         <xsl:variable name="char">
             <xsl:choose>
                 <xsl:when test="@char">
                     <xsl:value-of select="@char"/>
                 </xsl:when>
-                <xsl:when test="ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/colspec ')][position() = number($entryNumber)]/@char">
-                    <xsl:value-of select="ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/colspec ')][position() = $entryNumber]/@char"/>
+                <xsl:when test="$colspec/@char">
+                    <xsl:value-of select="$colspec/@char"/>
                 </xsl:when>
             </xsl:choose>
         </xsl:variable>
@@ -530,8 +532,8 @@
                 <xsl:when test="@charoff">
                     <xsl:value-of select="@charoff"/>
                 </xsl:when>
-                <xsl:when test="ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/colspec ')][position() = number($entryNumber)]/@charoff">
-                    <xsl:value-of select="ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/colspec ')][position() = $entryNumber]/@charoff"/>
+                <xsl:when test="$colspec/@charoff">
+                    <xsl:value-of select="$colspec/@charoff"/>
                 </xsl:when>
                 <xsl:otherwise>50</xsl:otherwise>
             </xsl:choose>


### PR DESCRIPTION
Backported from version 2.0 (#1672). This commit only includes the XSLT1-compatible changes in that PR.

The table/fig/fn numbering optimizations in #1672 use node comparison operators, which are only available in XPath 2, so we can't use them directly in 1.8 (which is XSLT1-only). It might be possible to backport the changes to XSLT1 somehow, but I'm not sure how much of an effect that'd have, and I can't get exact profiling data because the XSLT stylesheets in 1.8 use EXSLT extensions, which means I can't easily use Saxon HE to profile the stylesheets. Saxon B doesn't have the profiling feature as far as I can tell.

These changes were tested using [these fixtures](https://github.com/eerohele/dita-ot-issues/tree/master/fixtures/1672) and the DITA 1.2 Specification, just as #1672. DITA-OT produces the same `topic.fo` file in both cases both before and after applying these changes, so this shouldn't break anything.

No profiling data since I can't profile the stylesheets, but a quick test suggests that these changes shave about 1.5 minutes off the entire processing time for the DITA 1.2 Specification.