### PR TITLE
Add author info onto PDF cover for normal maps #1677

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
@@ -37,12 +37,6 @@ See the accompanying license.txt file for applicable licenses.
     exclude-result-prefixes="opentopic"
     version="2.0">
 
-    <xsl:template match="*[contains(@class, ' map/topicmeta ')]">
-        <fo:block-container xsl:use-attribute-sets="__frontmatter__owner__container">
-            <xsl:apply-templates/>
-        </fo:block-container>
-    </xsl:template>
-
     <xsl:template match="*[contains(@class, ' topic/author ')]">
         <fo:block xsl:use-attribute-sets="author" >
             <xsl:apply-templates/>
@@ -108,8 +102,9 @@ See the accompanying license.txt file for applicable licenses.
     </fo:block>
     <!-- set the subtitle -->
     <xsl:apply-templates select="$map//*[contains(@class,' bookmap/booktitlealt ')]"/>
+
     <fo:block xsl:use-attribute-sets="__frontmatter__owner">
-      <xsl:apply-templates select="$map//*[contains(@class,' bookmap/bookmeta ')]"/>
+      <xsl:apply-templates select="$map/*[contains(@class,' map/topicmeta ')]"/>
     </fo:block>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
@@ -5,16 +5,24 @@ See the accompanying license.txt file for applicable licenses.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:opentopic="http://www.idiominc.com/opentopic"
+  exclude-result-prefixes="opentopic"
   version="2.0">
 
   <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[contains(@class,' map/searchtitle ')]"/>
 
-  <xsl:template match="*[contains(@class, ' map/topicmeta ')]">
-    <!--
-    <fo:block xsl:use-attribute-sets="topicmeta">
+  <xsl:template match="opentopic:map/*[contains(@class, ' map/topicmeta ')]">
+    <fo:block-container xsl:use-attribute-sets="__frontmatter__owner__container">
+      <fo:block>
+        <xsl:apply-templates/>
+      </fo:block>
+    </fo:block-container>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' map/topicmeta ')][not(parent::opentopic:map)]">
+    <fo:block-container xsl:use-attribute-sets="topicmeta">
       <xsl:apply-templates/>
-    </fo:block>
-    -->
+    </fo:block-container>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' map/map ')]/*[contains(@class, ' map/reltable ')]">


### PR DESCRIPTION
[Fixtures](https://github.com/eerohele/dita-ot-issues/tree/master/fixtures/1677).

I'm not sure the `<xsl:template match="*[contains(@class, ' map/topicmeta ')][not(parent::opentopic:map)]">` template is actually 100% necessary, but I suppose it's a bit easier to add processing for `<topicmeta>` elements that aren't children of `<map>` if it's there since you can theoretically just do something like `<xsl:apply-templates select="$whatever/*[contains(@class, ' map/topicmeta ')]"/>` and have some kind of default processing.
