### PR TITLE
Fix xrefs to preface topics #1732

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -42,6 +42,7 @@ See the accompanying license.txt file for applicable licenses.
              <xsl:call-template name="insertPrefaceStaticContents"/>
              <fo:flow flow-name="xsl-region-body">
                  <fo:block xsl:use-attribute-sets="topic">
+                     <xsl:call-template name="commonattributes"/>
                      <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
                          <fo:marker marker-class-name="current-topic-number">
                              <xsl:number format="1"/>


### PR DESCRIPTION
[Fixtures](https://github.com/eerohele/dita-ot-issues/tree/master/fixtures/1732).

The "commonattributes" template wasn't called for preface topics, which
meant that no @id attribute was added for them when generating the
output XSL-FO markup.

This should also probably be merged into the 1.8.5 branch if possible?
