### PR TITLE
Fix of the next problem:

### DIFF
--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -636,9 +636,18 @@ public final class Job {
                 ff.isActive = true;
             }
         } else if (key.equals(HTML_LIST)) {
+        	
             for (final String f: value) {
-            	getOrAdd(f).format = "html";
+            	
+            	FileInfo info = getOrAdd(f);
+            	
+            	if("dita".equals(info.format)){
+            		continue;
+            	}
+            	
+            	info.format = "html";
             }
+            
         } else if (key.equals(IMAGE_LIST)) {
             for (final String f: value) {
             	getOrAdd(f).format = "image";


### PR DESCRIPTION
If the same dita topic is placed into ditalist and htmllist, topic will
not put to the temp folder and as a result will not published. 
The problem occures when `<xref>` link has "format" attribute with non
"dita" value, and not "html" value. 
In our case  we have next self-referenced link:

``` xml
<xref format="Figure and Page"
href="#Assembling_the_Antenna_1/WRM_CHDGFBHA">Installing Limit Switch
Counterpart</xref>
```

Due non standard format value this topic was placed to the htmllist, and
as a result was not publish, despite it was also placed to the ditalist.
From our point of view the logic has to be next: if topic was marked as
"dita" it has to be moved to the temp folder for further publication,
regardless it was also marked as "html".
