### PR TITLE
Fix unitless length-to-pixels

### DIFF
--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -180,7 +180,7 @@
       <xsl:when test="string(number($units))!='NaN' and string(number($numeric-value))!='NaN'">
         <!-- Since $units is a number, the input was unitless, so we default
           the unit to pixels and just return the input value -->
-        <xsl:value-of select="round(number(concat($numeric-value,$units)))"/>
+        <xsl:value-of select="$dimen"/>
       </xsl:when>
       <xsl:when test="string(number($numeric-value))='NaN'">
         <!-- If the input isn't valid, just return 100% -->


### PR DESCRIPTION
Do not remove decimal point when unitless length has two decimal digits (e.g. "88.21" was replaced with "8821").

I have the following example:
```xml
<image href="images/sot669_sv.svg" width="432.27" height="88.21" placement="break" class="- topic/image "/>
```
There `width` and `height` values are replaced by `43227` and `8821`. This happens because `$numeric-value` already does not include the decimal point after the `number` conversion:

https://github.com/dita-ot/dita-ot/blob/develop/src/main/xsl/common/dita-utilities.xsl#L178