### PR TITLE
	modified:   src/main/java/org/dita/dost/writer/KeyrefPaser.java

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -403,7 +403,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                             // it exists.
                             if (TOPIC_IMAGE.matches(currentElement.type)) {
                                 valid = true;
-                                target_output = normalizeHrefValue(URLUtils.getRelativePath(job.tempDir.toURI().resolve(inputFile.getPath()), job.tempDir.toURI().resolve(target)), elementId);
+                                target_output = normalizeHrefValue(URLUtils.getRelativePath(job.tempDir.toURI().resolve(toURI(inputFile)), job.tempDir.toURI().resolve(target)), elementId);
                                 XMLUtils.addOrSetAttribute(resAtts, currentElement.refAttr, target_output.toString());
                             } else if (isLocalDita(elem)) {
                                 final File topicFile = toFile(job.tempDir.toURI().resolve(stripFragment(target)));


### PR DESCRIPTION
The fix for issue #1662 only worked for keyrefs that contained slashes (/), but not conrefs.

We noticed that conrefs with slashes failed right in the same neighborhood as the fix for #1662.  Inspecting the code shows that the replacement of inputFile.getPath() with toURI(inputFile) had not been done on line 406 (where our Java log reported a failure). 

After making the fix, conrefs with slashes work correctly. 