### PR TITLE
Fixes #1922 by setting distinct marker names for 1st and 2nd level in…

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -326,17 +326,24 @@ See the accompanying license.txt file for applicable licenses.
 
   <xsl:template match="opentopic-index:index.entry" mode="index-postprocess">
     <xsl:variable name="value" select="@value"/>
+    
+    <xsl:variable name="markerName" as="xs:string"
+       select="concat('index-continued-', count(ancestor-or-self::opentopic-index:index.entry))"
+    />
+
     <xsl:choose>
       <xsl:when test="opentopic-index:index.entry">
         <fo:table>
           <xsl:if test="$index.continued-enabled">
             <fo:table-header>
-              <fo:retrieve-table-marker retrieve-class-name="index-continued" retrieve-position-within-table="last-starting"/>
+              <fo:retrieve-table-marker retrieve-class-name="{$markerName}"
+                  retrieve-position-within-table="last-starting"
+              />
             </fo:table-header>
           </xsl:if>
           <fo:table-body>
             <xsl:if test="$index.continued-enabled">
-              <fo:marker marker-class-name="index-continued"/>
+              <fo:marker marker-class-name="{$markerName}"/>
             </xsl:if>
             <fo:table-row>
               <fo:table-cell>
@@ -382,7 +389,7 @@ See the accompanying license.txt file for applicable licenses.
           </fo:table-body>
           <fo:table-body>
             <xsl:if test="$index.continued-enabled">
-              <fo:marker marker-class-name="index-continued">
+              <fo:marker marker-class-name="{$markerName}">
                 <fo:table-row>
                   <fo:table-cell>
                     <fo:block xsl:use-attribute-sets="index-indents" keep-together="always">


### PR DESCRIPTION
Use distinct marker names for 1st and 2nd level index entry table makers.

See the attached images for the index before the fix and the same index after the fix. Note the continued headers at the top of the 2nd column.

Before:
![issue1922-before-fix 295](https://cloud.githubusercontent.com/assets/1004229/7869838/e38ce140-054a-11e5-97cf-c2f888b91aa9.png)

After:
![issue1922-after-fix 295](https://cloud.githubusercontent.com/assets/1004229/7869837/e37ae62a-054a-11e5-9320-5ec181e6f18b.png)


