### PR TITLE
Convert File based processing to URI based to support external URIs

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -100,6 +100,22 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         }
     }
 
+    private static class FileOrUriArgument extends Argument {
+        FileOrUriArgument(final String property) {
+            super(property);
+        }
+
+        @Override
+        String getValue(final String value) {
+            final File f = new File(value);
+            if (f.exists()) {
+                return f.getAbsolutePath();
+            } else {
+                return value;
+            }
+        }
+    }
+
     /**
      * A Set of args are are handled by the launcher and should not be seen by
      * Main.
@@ -119,8 +135,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         ARGUMENTS.put("-f", new StringArgument("transtype"));
         ARGUMENTS.put("-format", new StringArgument("transtype"));
         ARGUMENTS.put("-transtype", new StringArgument("transtype"));
-        ARGUMENTS.put("-i", new FileArgument("args.input"));
-        ARGUMENTS.put("-input", new FileArgument("args.input"));
+        ARGUMENTS.put("-i", new FileOrUriArgument("args.input"));
+        ARGUMENTS.put("-input", new FileOrUriArgument("args.input"));
         ARGUMENTS.put("-o", new FileArgument("output.dir"));
         ARGUMENTS.put("-output", new FileArgument("output.dir"));
         ARGUMENTS.put("-filter", new FileArgument("args.filter"));

--- a/src/main/java/org/dita/dost/log/MessageBean.java
+++ b/src/main/java/org/dita/dost/log/MessageBean.java
@@ -9,8 +9,8 @@
 package org.dita.dost.log;
 
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
 
-import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -39,7 +39,7 @@ public final class MessageBean {
     private final String reason;
 
     private final String response;
-    private String srcFile;
+    private URI srcFile;
     private int srcLine = -1;
     private int srcColumn = -1;
 
@@ -109,13 +109,11 @@ public final class MessageBean {
         }
         final MessageBean ret = new MessageBean(this);
         if (locator.getSystemId() != null) {
-            URI s;
             try {
-                s = new URI(locator.getSystemId());
+                ret.srcFile = new URI(locator.getSystemId());
             } catch (final URISyntaxException e) {
                 throw new RuntimeException("Failed to parse URI '" + locator.getSystemId() + "': " + e.getMessage(), e);
             }
-            ret.srcFile = new File(s).getAbsolutePath();
         }
         ret.srcLine = locator.getLineNumber(); 
         ret.srcColumn = locator.getColumnNumber();
@@ -129,7 +127,7 @@ public final class MessageBean {
      */
     public MessageBean setLocation(final Attributes atts) {
         final MessageBean ret = new MessageBean(this);
-        final String xtrf = atts.getValue(ATTRIBUTE_NAME_XTRF);
+        final URI xtrf = toURI(atts.getValue(ATTRIBUTE_NAME_XTRF));
         if (xtrf != null) {
             ret.srcFile = xtrf;
         }
@@ -156,7 +154,7 @@ public final class MessageBean {
         final MessageBean ret = new MessageBean(this);
         final String xtrf = elem.getAttribute(ATTRIBUTE_NAME_XTRF);
         if (!xtrf.isEmpty()) {
-            ret.srcFile = xtrf;
+            ret.srcFile = toURI(xtrf);
         }
         final String xtrc = elem.getAttribute(ATTRIBUTE_NAME_XTRC);
         if (!xtrc.isEmpty()) {

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -58,7 +58,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         //        fis.add(f);
         //    }
         //}
-        fis.add(job.getFileInfo(toURI(job.getInputMap())));
+        fis.add(job.getFileInfo(job.getInputMap()));
         if (!fis.isEmpty()) {
             final MapMetaReader metaReader = new MapMetaReader();
             metaReader.setLogger(logger);

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -571,6 +571,10 @@ public final class ChunkMapReader extends AbstractDomFilter {
      * @return map of changed files
      */
     public Map<String, String> getChangeTable() {
+        for (final Map.Entry<String, String> e: changeTable.entrySet()) {
+            assert new File(e.getKey()).isAbsolute();
+            assert new File(e.getValue()).isAbsolute();
+        }
         return Collections.unmodifiableMap(changeTable);
     }
 
@@ -580,6 +584,10 @@ public final class ChunkMapReader extends AbstractDomFilter {
      * @return conflict table
      */
     public Map<String, String> getConflicTable() {
+        for (final Map.Entry<String, String> e: conflictTable.entrySet()) {
+            assert new File(e.getKey()).isAbsolute();
+            assert new File(e.getValue()).isAbsolute();
+        }
         return conflictTable;
     }
 

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -724,12 +724,16 @@ public final class Constants {
     /** Constant for generated property file name(subrelation.xml).*/
     public static final String FILE_NAME_SUBJECT_RELATION = "subrelation.xml";
 
-    /** Property name for input file system path */
+    /** Property name for input file system path. Deprecated since 2.2 */
+    @Deprecated
     public static final String INPUT_DITAMAP = "user.input.file";
+    public static final String INPUT_DITAMAP_URI = "user.input.file.uri";
     /** Property name for input file list file list file, i.e. file which points to a file which points to the input file */
     public static final String INPUT_DITAMAP_LIST_FILE_LIST = "user.input.file.listfile";
-    /** Property name for input directory system path */
+    /** Property name for input directory system path. Deprecated since 2.2 */
+    @Deprecated
     public static final String INPUT_DIR = "user.input.dir";
+    public static final String INPUT_DIR_URI = "user.input.dir.uri";
     /** Property name for copy-to target2sourcemap list file */
     public static final String COPYTO_TARGET_TO_SOURCE_MAP_LIST = "copytotarget2sourcemaplist";
     /** Property name for relflag image list file */

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -207,7 +207,7 @@ public final class FileUtils {
      * @param sep path separator
      * @return relative path using {@link Constants#UNIX_SEPARATOR} path separator
      */
-    public static String getRelativePath(final String basePath, final String refPath, final String sep) {
+    private static String getRelativePath(final String basePath, final String refPath, final String sep) {
         final StringBuilder upPathBuffer = new StringBuilder(128);
         final StringBuilder downPathBuffer = new StringBuilder(128);
         final StringTokenizer mapTokenizer = new StringTokenizer(normalizePath(basePath, File.separator), File.separator);
@@ -292,7 +292,7 @@ public final class FileUtils {
      * @return relative path to base path, {@code null} if reference path was a single file
      */
     private static String getRelativePathForPath(final String relativePath, final String sep) {
-        final StringTokenizer tokenizer = new StringTokenizer(separatorsToUnix(relativePath), UNIX_SEPARATOR);
+        final StringTokenizer tokenizer = new StringTokenizer(relativePath.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR), UNIX_SEPARATOR);
         final StringBuilder buffer = new StringBuilder();
         if (tokenizer.countTokens() == 1){
             return null;
@@ -425,16 +425,6 @@ public final class FileUtils {
         }
 
         return buff.toString();
-    }
-
-    /**
-     * Translate path separators from Windows to Unix.
-     * @param path path to translate
-     * @return UNIX path
-     */
-    @Deprecated
-    public static String separatorsToUnix(final String path) {
-        return path.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR);
     }
 
 

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -84,8 +84,11 @@ public final class Job {
     private static final String PROPERTY_ONLY_TOPIC_IN_MAP = ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP;
     private static final String PROPERTY_GENERATE_COPY_OUTER = ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER;
     private static final String PROPERTY_OUTPUT_DIR = ANT_INVOKER_EXT_PARAM_OUTPUTDIR;
+    /** Deprecated since 2.2 */
+    @Deprecated
     private static final String PROPERTY_INPUT_MAP = "InputMapDir";
-    
+    private static final String PROPERTY_INPUT_MAP_URI = "InputMapDir.uri";
+
     /** File name for key definition file */
     public static final String KEYDEF_LIST_FILE = "keydef.xml";
     /** File name for key definition file */
@@ -422,7 +425,7 @@ public final class Job {
     }
     
     /**
-     * Return the copy-to map.
+     * Return the copy-to map from target to source.
      *
      * @return copy-to map, empty map if no mapping is defined
      */
@@ -440,7 +443,7 @@ public final class Job {
     }
     
     /**
-     * Set copy-to map.
+     * Set copy-to map from target to source.
      */
     public void setCopytoMap(final Map<URI, URI> value) {
         final Map<String, String> res = new HashMap<String, String>();
@@ -455,8 +458,8 @@ public final class Job {
      *
      * @return input file path relative to input directory
      */
-    public File getInputMap() {
-       return new File(getProperty(INPUT_DITAMAP));
+    public URI getInputMap() {
+       return toURI(getProperty(INPUT_DITAMAP_URI));
     }
 
     /**
@@ -464,8 +467,8 @@ public final class Job {
      * 
      * @return absolute input directory path 
      */
-    public File getInputDir() {
-        return new File(getProperty(INPUT_DIR));
+    public URI getInputDir() {
+        return toURI(getProperty(INPUT_DIR_URI));
     }
 
     /**
@@ -845,7 +848,15 @@ public final class Job {
      * @param flag generatecopyouter flag
      */
     public void setGeneratecopyouter(final String flag){
-        prop.put(PROPERTY_GENERATE_COPY_OUTER, Generate.get(Integer.parseInt(flag)).toString());
+        setGeneratecopyouter(Generate.get(Integer.parseInt(flag)));
+    }
+
+    /**
+     * Set the generatecopyouter.
+     * @param flag generatecopyouter flag
+     */
+    public void setGeneratecopyouter(final Generate flag){
+        prop.put(PROPERTY_GENERATE_COPY_OUTER, flag.toString());
     }
  
     /**
@@ -868,16 +879,21 @@ public final class Job {
      * Get input file path.
      * @return absolute input file path
      */
-    public File getInputFile(){
-        return new File(prop.get(PROPERTY_INPUT_MAP).toString());
+    public URI getInputFile() {
+        return toURI(prop.get(PROPERTY_INPUT_MAP_URI).toString());
     }
 
     /**
      * Set input map path.
      * @param inputFile absolute input map path
      */
-    public void setInputFile(final File inputFile){
-        prop.put(PROPERTY_INPUT_MAP, inputFile.getAbsolutePath());
+    public void setInputFile(final URI inputFile) {
+        assert inputFile.isAbsolute();
+        prop.put(PROPERTY_INPUT_MAP_URI, inputFile.toString());
+        // Deprecated since 2.1
+        if (inputFile.getScheme().equals("file")) {
+            prop.put(PROPERTY_INPUT_MAP, new File(inputFile).getAbsolutePath());
+        }
     }
 
     

--- a/src/main/java/org/dita/dost/util/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/util/JobSourceSet.java
@@ -1,0 +1,84 @@
+package org.dita.dost.util;
+
+import org.apache.tools.ant.types.AbstractFileSet;
+import org.apache.tools.ant.types.Resource;
+import org.apache.tools.ant.types.ResourceCollection;
+import org.apache.tools.ant.types.resources.FileResource;
+import org.apache.tools.ant.types.resources.URLResource;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.dita.dost.util.Constants.ANT_REFERENCE_JOB;
+
+public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
+
+    private String format;
+    private Collection<Resource> res;
+    private boolean isFilesystemOnly = true;
+
+    public JobSourceSet() {
+        super();
+    }
+
+    private Collection<Resource> getResults() {
+        if (res == null) {
+            if (format == null) {
+                throw new IllegalStateException();
+            }
+            final Job job = getProject().getReference(ANT_REFERENCE_JOB);
+            if (job == null) {
+                throw new IllegalStateException();
+            }
+            res = new ArrayList<>();
+            for (final Job.FileInfo f : job.getFileInfo(new Job.FileInfo.Filter() {
+                @Override
+                public boolean accept(final Job.FileInfo f) {
+                    return f.format != null && f.format.equals(format);
+                }
+            })) {
+                final File tempFile = new File(job.tempDir, f.file.getPath());
+                if (tempFile.exists()) {
+                    res.add(new FileResource(tempFile));
+                } else if (f.src.getScheme().equals("file")) {
+                    final File srcFile = new File(f.src);
+                    if (srcFile.exists()) {
+                        res.add(new FileResource(srcFile));
+                    }
+                } else {
+                    try {
+                        res.add(new URLResource(f.src.toURL()));
+                    } catch (final MalformedURLException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                    isFilesystemOnly = false;
+                }
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public Iterator<Resource> iterator() {
+        return getResults().iterator();
+    }
+
+    @Override
+    public int size() {
+        return getResults().size();
+    }
+
+    @Override
+    public boolean isFilesystemOnly() {
+        getResults();
+        return isFilesystemOnly;
+    }
+
+    public void setFormat(final String format) {
+        this.format = format;
+    }
+
+}

--- a/src/main/java/org/dita/dost/util/URLUtils.java
+++ b/src/main/java/org/dita/dost/util/URLUtils.java
@@ -332,7 +332,7 @@ public final class URLUtils {
      * @return cleaned URI
      */
     public static String clean(final String path) {
-        return clean(path, true);
+        return clean(path.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR), true);
     }
     
     /**
@@ -486,6 +486,9 @@ public final class URLUtils {
         if (file == null) {
             return null;
         }
+        if (File.separatorChar == '\\' && file.indexOf('\\') != -1) {
+            return toURI(new File(file));
+        }
         try {
             return new URI(file);
         } catch (final URISyntaxException e) {
@@ -548,12 +551,27 @@ public final class URLUtils {
      * Create new URI with a given path.
      * 
      * @param orig URI to set path on
-     * @param path new paht, {@code null} for no path
+     * @param path new path, {@code null} for no path
      * @return new URI instance with given path
      */
     public static URI setPath(final URI orig, final String path) {
         try {
             return new URI(orig.getScheme(), orig.getUserInfo(), orig.getHost(), orig.getPort(), path, orig.getQuery(), orig.getFragment());
+        } catch (final URISyntaxException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Create new URI with a given scheme.
+     *
+     * @param orig URI to set scheme on
+     * @param scheme new scheme, {@code null} for no scheme
+     * @return new URI instance with given path
+     */
+    public static URI setScheme(final URI orig, final String scheme) {
+        try {
+            return new URI(scheme, orig.getUserInfo(), orig.getHost(), orig.getPort(), orig.getPath(), orig.getQuery(), orig.getFragment());
         } catch (final URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -662,8 +680,9 @@ public final class URLUtils {
             return new File(file.getPath()).exists();
         } else if ("file".equals(file.getScheme())) {
             return new File(file).exists();
-        } else  {
-            return false;
+        } else {
+            // Assume non-file URIs always exists and force fetching them
+            return true;
         }
     }
     

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -411,8 +411,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
 
     void updateList() {
         try {
-            // XXX: This may have to use new
-            // File(resolve(filePath,FILE_NAME_DITA_LIST_XML)).getParent()
+            // XXX: Why do we need to update copy-to map because all copy-to have been processed already
             final Map<URI, URI> copytotarget2sourcemaplist = job.getCopytoMap();
             copytotarget2source.putAll(copytotarget2sourcemaplist);
             for (final String file : copytoSource) {
@@ -513,6 +512,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
      *         {@code null} string is returned.
      */
     String getFirstTopicId(final String absolutePathToFile) {
+        assert new File(absolutePathToFile).isAbsolute();
         if (absolutePathToFile == null || !isAbsolutePath(absolutePathToFile)) {
             return null;
         }

--- a/src/main/java/org/dita/dost/writer/DebugFilter.java
+++ b/src/main/java/org/dita/dost/writer/DebugFilter.java
@@ -41,7 +41,7 @@ public final class DebugFilter extends AbstractXMLFilter {
 	 * @param inputFile absolute path to input file
 	 */
 	public void setInputFile(final File inputFile) {
-	    this.inputFile = inputFile.getAbsolutePath();
+	    this.inputFile = inputFile.getAbsoluteFile().toURI().toString();
 	}
 
 	/**

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -102,9 +102,9 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
 
     @Override
     public void startDocument() throws SAXException {
-        final File path2Project = DebugAndFilterModule.getPathtoProject(getRelativePath(new File(job.getInputDir(), "dummy"), toFile(currentFile)),
+        final File path2Project = DebugAndFilterModule.getPathtoProject(getRelativePath(toFile(job.getInputDir().resolve("dummy")), toFile(currentFile)),
                 toFile(currentFile),
-                job.getInputFile(),
+                toFile(job.getInputFile()),
                 job);
         getContentHandler().startDocument();
         if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {

--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -69,8 +69,8 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
 
                         final URI source = currentFile.resolve(file);
                         final URI target = currentFile.resolve(stripFragment(generatedCopyTo));
-                        final URI relSource = getRelativePath(job.getInputDir().toURI(), source);
-                        final URI relTarget = getRelativePath(job.getInputDir().toURI(), target);
+                        final URI relSource = getRelativePath(job.getInputDir(), source);
+                        final URI relTarget = getRelativePath(job.getInputDir(), target);
                         copyToMap.put(relTarget, relSource);
 
                         final AttributesImpl buf = new AttributesImpl(atts);
@@ -98,7 +98,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
             ext.append('.');
             ext.append(getExtension(path.toString()));
             final URI dst = toURI(replaceExtension(path.toString(), ext.toString()));
-            final URI target = URLUtils.getRelativePath(new File(job.getInputDir(), "dummy").toURI(), currentFile.resolve(dst));
+            final URI target = URLUtils.getRelativePath(job.getInputDir().resolve("dummy"), currentFile.resolve(dst));
             if (job.getFileInfo(target) == null) {
                 return setFragment(dst, fragment);
             }

--- a/src/main/java/org/dita/dost/writer/TopicRefWriter.java
+++ b/src/main/java/org/dita/dost/writer/TopicRefWriter.java
@@ -46,14 +46,23 @@ public final class TopicRefWriter extends AbstractXMLFilter {
      * @param conflictTable conflictTable
      */
     public void setup(final Map<String, String> conflictTable) {
+        for (final Map.Entry<String, String> e: changeTable.entrySet()) {
+            assert new File(e.getKey()).isAbsolute();
+            assert new File(e.getValue()).isAbsolute();
+        }
         this.conflictTable = conflictTable;
     }
 
     public void setChangeTable(final Map<String, String> changeTable) {
+        for (final Map.Entry<String, String> e: changeTable.entrySet()) {
+            assert new File(e.getKey()).isAbsolute();
+            assert new File(e.getValue()).isAbsolute();
+        }
         this.changeTable = changeTable;
     }
 
     public void setFixpath(final String fixpath) {
+        assert fixpath != null ? new File(fixpath).isAbsolute() : true;
         this.fixpath = fixpath;
     }
 

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -222,7 +222,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
                     break;
                 case LAX:
                     try {
-                        final String u = new URI(URLUtils.clean(FileUtils.separatorsToUnix(href))).toASCIIString();
+                        final String u = new URI(URLUtils.clean(href)).toASCIIString();
                         if (res == null) {
 							res = new AttributesImpl(atts);
 						}

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -124,6 +124,10 @@
     <classpath refid="dost.class.path" />
   </typedef>
   
+  <typedef name="dita-fileset" classname="org.dita.dost.util.JobSourceSet">
+    <classpath refid="dost.class.path" />
+  </typedef>
+
   <macrodef name="job-helper" >
     <attribute name="file"/>
     <attribute name="property"/>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -38,45 +38,9 @@
     description="Preprocessing ended" />
   
   <target name="preprocess.init">
-    <dita-ot-fail id="DOTA069F">
-      <condition>
-        <and>
-          <isset property="args.input"/>
-          <not>
-            <isset property="args.input.dir"/>
-          </not>
-          <not>
-            <available file="${args.input}" type="file"/>
-          </not>
-        </and>
-      </condition>
-      <param name="1" location="${args.input}"/>
-    </dita-ot-fail>
-    <dita-ot-fail id="DOTA069F">
-      <condition>
-        <and>
-          <isset property="args.input"/>
-          <isset property="args.input.dir"/>
-          <not>
-            <or>
-              <available file="${args.input}" type="file"/>
-              <available file="${args.input.dir}/${args.input}" type="file"/>
-            </or>
-          </not>
-        </and>
-      </condition>
-      <param name="1" location="${args.input}"/>
-    </dita-ot-fail>
     <dita-ot-fail id="DOTA002F">
       <condition>
-        <and>
-          <not>
-            <isset property="args.input"/>
-          </not>
-          <not>
-            <isset property="args.input.uri"/>
-          </not>
-        </and>
+        <not><isset property="args.input"/></not>
       </condition>
     </dita-ot-fail>
     
@@ -563,43 +527,25 @@
      
   <target name="copy-image"
     unless="preprocess.copy-image.skip"
-    dita:depends="{depend.preprocess.copy-image.pre},copy-image-check"
+    dita:depends="{depend.preprocess.copy-image.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction" 
     description="Copy image files">
     <condition property="copy-image.todir" value="${output.dir}/${uplevels}" else="${output.dir}">
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
-    <copy todir="${copy-image.todir}">
-      <fileset dir="${user.input.dir}" includesfile="${dita.temp.dir}/${imagefile}" />
+    <copy todir="${copy-image.todir}" failonerror="false">
+      <dita-fileset format="image" />
     </copy>
   </target>
   
-  <target name="copy-image-check">
-    <condition property="preprocess.copy-image.skip">
-      <or>
-        <isset property="preprocess.copy-files.skip"/>
-        <isset property="noImagelist"/>
-      </or>
-    </condition>
-  </target>
-
   <target name="copy-html"
-    dita:depends="{depend.preprocess.copy-html.pre},copy-html-check"
+    dita:depends="{depend.preprocess.copy-html.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.copy-html.skip"
     description="Copy html files">
-    <copy todir="${output.dir}">
-      <fileset dir="${user.input.dir}" includesfile="${dita.temp.dir}/${htmlfile}"/>
+    <copy todir="${output.dir}" failonerror="false">
+      <dita-fileset format="html" />
     </copy>
-  </target>
-
-  <target name="copy-html-check">
-    <condition property="preprocess.copy-html.skip">
-      <or>
-        <isset property="preprocess.copy-files.skip"/>
-        <length file="${dita.temp.dir}/${htmlfile}" length="0"/>
-      </or>
-    </condition>
   </target>
   
   <target name="copy-flag"

--- a/src/main/xsl/job-helper.xsl
+++ b/src/main/xsl/job-helper.xsl
@@ -48,9 +48,11 @@
       <xsl:when test="$property = 'hreftargetslist'">
         <xsl:apply-templates select="job/files/file[@target = 'true']"/>
       </xsl:when>
+      <!-- Deprecated since 2.2 -->
       <xsl:when test="$property = 'htmllist'">
         <xsl:apply-templates select="job/files/file[@format = 'html']"/>
       </xsl:when>
+      <!-- Deprecated since 2.2 -->
       <xsl:when test="$property = 'imagelist'">
         <xsl:apply-templates select="job/files/file[@format = 'image']"/>
       </xsl:when>

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -4,12 +4,11 @@
  */
 package org.dita.dost.module;
 
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR;
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
+import static org.dita.dost.util.Constants.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.dita.dost.util.URLUtils.toURI;
+import static org.dita.dost.util.Job.Generate.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,15 +61,16 @@ public class DebugAndFilterModuleTest {
         final File outDir = new File(tempDir, "out");
         tmpDir = new File(tempDir, "temp");
         TestUtils.copy(new File(resourceDir, "temp"), tmpDir);
-        final Job props = new Job(tmpDir);
-        for (final Job.FileInfo fi: props.getFileInfo()) {
-            props.add(new Job.FileInfo.Builder(fi).src(inputDir.toURI().resolve(fi.uri)).build());
+        final Job job = new Job(tmpDir);
+        for (final Job.FileInfo fi: job.getFileInfo()) {
+            job.add(new Job.FileInfo.Builder(fi).src(inputDir.toURI().resolve(fi.uri)).build());
         }
-        props.setInputFile(inputMap.getAbsoluteFile());
-        props.setGeneratecopyouter("1");
-        props.setOutputDir(outDir);
-        props.setProperty("user.input.dir", inputDir.getAbsolutePath());
-        props.write();
+        job.setInputFile(inputMap.getAbsoluteFile().toURI());
+        job.setGeneratecopyouter(NOT_GENERATEOUTTER);
+        job.setOutputDir(outDir);
+        job.setProperty(INPUT_DIR, inputDir.getAbsolutePath());
+        job.setProperty(INPUT_DIR_URI, inputDir.getAbsoluteFile().toURI().toString());
+        job.write();
 
         final PipelineHashIO pipelineInput = new PipelineHashIO();
         pipelineInput.setAttribute("inputmap", inputMap.getPath());
@@ -82,10 +82,10 @@ public class DebugAndFilterModuleTest {
         pipelineInput.setAttribute("indextype", "xhtml");
         pipelineInput.setAttribute("encoding", "en-US");
         pipelineInput.setAttribute("targetext", ".html");
-        pipelineInput.setAttribute("validate", "false");
-        pipelineInput.setAttribute("generatecopyouter", "1");
+        pipelineInput.setAttribute("validate", Boolean.FALSE.toString());
+        pipelineInput.setAttribute("generatecopyouter", Integer.toString(NOT_GENERATEOUTTER.type));
         pipelineInput.setAttribute("outercontrol", "warn");
-        pipelineInput.setAttribute("onlytopicinmap", "false");
+        pipelineInput.setAttribute("onlytopicinmap", Boolean.FALSE.toString());
         pipelineInput.setAttribute("ditalist", new File(tmpDir, "dita.list").getPath());
         pipelineInput.setAttribute("maplinks", new File(tmpDir, "maplinks.unordered").getPath());
         pipelineInput.setAttribute(Constants.ANT_INVOKER_EXT_PARAN_SETSYSTEMID, "yes");
@@ -94,7 +94,7 @@ public class DebugAndFilterModuleTest {
 
         final AbstractFacade facade = new PipelineFacade();
         facade.setLogger(new TestUtils.TestLogger());
-        facade.setJob(new Job(tmpDir));
+        facade.setJob(job);
         facade.execute("DebugAndFilter", pipelineInput);
     }
 

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Job.Generate.NOT_GENERATEOUTTER;
 import static org.junit.Assert.*;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.Job.*;
@@ -90,9 +91,9 @@ public class TestGenMapAndTopicListModule {
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_ENCODING, "en-US");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_TARGETEXT, ".html");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE, Boolean.TRUE.toString());
-        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER, "1");
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER, Integer.toString(NOT_GENERATEOUTTER.type));
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL, "warn");
-        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP, "false");
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP, Boolean.FALSE.toString());
         //pipelineInput.setAttribute("ditalist", new File(tempDir, FILE_NAME_DITA_LIST).getPath());
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_MAPLINKS, new File(tempDir, "maplinks.unordered").getPath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID, "no");

--- a/src/test/java/org/dita/dost/util/JobTest.java
+++ b/src/test/java/org/dita/dost/util/JobTest.java
@@ -5,6 +5,8 @@
 package org.dita.dost.util;
 
 import static org.junit.Assert.*;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +37,8 @@ public final class JobTest {
 
     @Test
     public void testGetProperty() {
-        assertEquals("/foo/bar", job.getProperty("user.input.dir"));
+        assertEquals("/foo/bar", job.getProperty(INPUT_DIR));
+        assertEquals("file:/foo/bar", job.getProperty(INPUT_DIR_URI));
     }
 
     @Test
@@ -65,12 +68,12 @@ public final class JobTest {
 
     @Test
     public void testGetInputMap() {
-        assertEquals(new File("foo"), job.getInputMap());
+        assertEquals(toURI("foo"), job.getInputMap());
     }
 
     @Test
     public void testGetValue() {
-        assertEquals(new File("/foo/bar"), job.getInputDir());
+        assertEquals(new File("/foo/bar").toURI(), job.getInputDir());
     }
 
     @AfterClass

--- a/src/test/java/org/dita/dost/util/JobTest.java
+++ b/src/test/java/org/dita/dost/util/JobTest.java
@@ -72,8 +72,8 @@ public final class JobTest {
     }
 
     @Test
-    public void testGetValue() {
-        assertEquals(new File("/foo/bar").toURI(), job.getInputDir());
+    public void testGetValue() throws URISyntaxException {
+        assertEquals(new URI("file:/foo/bar"), job.getInputDir());
     }
 
     @AfterClass

--- a/src/test/java/org/dita/dost/util/URLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/URLUtilsTest.java
@@ -63,7 +63,7 @@ public class URLUtilsTest {
         assertEquals("f%C3%B6%C3%A5.dita", URLUtils.clean("f\u00f6\u00e5.dita"));
         
         assertEquals("foo/bar.dita", URLUtils.clean("foo/bar.dita"));
-        assertEquals("foo%5Cbar.dita", URLUtils.clean("foo\\bar.dita"));
+        assertEquals("foo/bar.dita", URLUtils.clean("foo\\bar.dita"));
         
         assertEquals("foo?bar=baz&qux=quxx", URLUtils.clean("foo?bar=baz&qux=quxx"));
     }

--- a/src/test/resources/DebugAndFilterModuleTest/temp/.job.xml
+++ b/src/test/resources/DebugAndFilterModuleTest/temp/.job.xml
@@ -6,6 +6,9 @@
   <property name="user.input.file">
     <string>maps/root-map-01.ditamap</string>
   </property>
+  <property name="user.input.file.uri">
+    <string>maps/root-map-01.ditamap</string>
+  </property>
   <property name="codereffile">
     <string>coderef.list</string>
   </property>
@@ -29,9 +32,6 @@
   </property>
   <property name="conreftargetsfile">
     <string>conreftargets.list</string>
-  </property>
-  <property name="imagefile">
-    <string>image.list</string>
   </property>
   <property name="hreftargetsfile">
     <string>hreftargets.list</string>
@@ -63,14 +63,8 @@
   <property name="outditafilesfile">
     <string>outditafiles.list</string>
   </property>
-  <property name="htmlfile">
-    <string>html.list</string>
-  </property>
   <property name="canditopicsfile">
     <string>canditopics.list</string>
-  </property>
-  <property name="user.input.dir">
-    <string>/Users/jelovirt/Work/github/dita-ot/src/test/resources/DebugAndFilterModuleTest/input</string>
   </property>
   <property name="relflagimagefile">
     <string>relflagimage.list</string>

--- a/src/test/resources/JobTest/src/.job.xml
+++ b/src/test/resources/JobTest/src/.job.xml
@@ -3,6 +3,9 @@
   <property name="user.input.file">
     <string>foo</string>
   </property>
+  <property name="user.input.file.uri">
+    <string>foo</string>
+  </property>
   <property name="copytotarget2sourcemaplist">
     <map>
       <entry key="baz">
@@ -15,6 +18,9 @@
   </property>
   <property name="user.input.dir">
     <string>/foo/bar</string>
+  </property>
+  <property name="user.input.dir.uri">
+    <string>file:/foo/bar</string>
   </property>
   <files>
     <file uri="foo2" path="foo2" conref-target="true"/>


### PR DESCRIPTION
Convert code to use URIs where system paths are used. This will allow eventually accessing resources with non-file URIs.

Support is extended to `dita` command to enable:

```
dita -i http://example.com/test.ditamap -f html5
```