### PR TITLE
Move mapref processing to beginning of preprocess

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -18,6 +18,7 @@
                   preprocess.init,
                   gen-list,
                   debug-filter,
+                  mapref,
                   copy-files,
                   keyref,
                   conrefpush,
@@ -25,7 +26,6 @@
                   profile,
                   topic-fragment,
                   coderef,
-                  mapref,
                   move-meta-entries,
                   mappull,
                   chunk,
@@ -331,6 +331,19 @@
       <module class="org.dita.dost.module.KeyrefModule">
         <param name="transtype" value="${transtype}"/>
       </module>
+    </pipeline>
+    <pipeline message="Resolve mapref in ditamap" taskname="mapref">
+      <xslt basedir="${dita.temp.dir}"
+            reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
+            style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"
+            filenameparameter="file-being-processed">
+        <includesfile name="${dita.temp.dir}/${fullditamapfile}"/>
+        <param name="TRANSTYPE" expression="${transtype}" />
+        <param name="child-topicref-warning" expression="false"/>
+        <param name="keep-submap-href" expression="false"/>
+        <dita:extension id="dita.preprocess.mapref.param" behavior="org.dita.dost.platform.InsertAction"/>
+        <xmlcatalog refid="dita.catalog"/>
+      </xslt>
     </pipeline>
   </target>
   

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -39,19 +39,18 @@ public class TestKeyrefReader {
 
     @Test
     public void testKeyrefReader() throws Exception {
-        final String path = System.getProperty("user.dir");
         final File filename = new File(srcDir, "keyrefreader.xml");
 
-        final Set <String> set = new HashSet<String> ();
-        set.add("blatview");
-        set.add("blatfeference");
-        set.add("blatintro");
-        set.add("keyword");
-        set.add("escape");
-        set.add("top");
-        set.add("nested");
+//        final Set <String> set = new HashSet<String> ();
+//        set.add("blatview");
+//        set.add("blatfeference");
+//        set.add("blatintro");
+//        set.add("keyword");
+//        set.add("escape");
+//        set.add("top");
+//        set.add("nested");
         final KeyrefReader keyrefreader = new KeyrefReader();
-        keyrefreader.setKeys(set);
+//        keyrefreader.setKeys(set);
         keyrefreader.read(toURI(filename.getAbsolutePath()));
         final Map<String, Element> act= keyrefreader.getKeyDefinition();
 
@@ -64,6 +63,29 @@ public class TestKeyrefReader {
         exp.put("top", "<topicref keys='top' class='- map/topicref ' navtitle='top'><topicmeta class='- map/topicmeta '><keywords class='- topic/keywords '><keyword class='- topic/keyword '>top keyword</keyword></keywords></topicmeta><topicref keys='nested' class='- map/topicref ' navtitle='nested'><topicmeta class='- map/topicmeta '><keywords class='- topic/keywords '><keyword class='- topic/keyword '>nested keyword</keyword></keywords></topicmeta></topicref></topicref>");
         exp.put("nested", "<topicref keys='nested' class='- map/topicref ' navtitle='nested'><topicmeta class='- map/topicmeta '><keywords class='- topic/keywords '><keyword class='- topic/keyword '>nested keyword</keyword></keywords></topicmeta></topicref>");
         
+        TestUtils.resetXMLUnit();
+        XMLUnit.setIgnoreWhitespace(true);
+        assertEquals(exp.keySet(), act.keySet());
+        for (Map.Entry<String, String> e: exp.entrySet()) {
+            final Document ev = keyDefToDoc(e.getValue());
+            final Document av = act.get(e.getKey()).getOwnerDocument();
+            assertXMLEqual(ev, av);
+        }
+    }
+
+    @Test
+    public void testMergeMap() throws Exception {
+        final File filename = new File(srcDir, "merged.xml");
+
+        final KeyrefReader keyrefreader = new KeyrefReader();
+        keyrefreader.read(toURI(filename.getAbsolutePath()));
+        final Map<String, Element> act= keyrefreader.getKeyDefinition();
+
+        final Map<String, String> exp = new HashMap<String, String>();
+        exp.put("toner-specs", "<keydef class=\"+ map/topicref mapgropup-d/keydef \" keys=\"toner-specs\" href=\"toner-type-a-specs.dita\"/>");
+        exp.put("toner-handling", "<keydef class=\"+ map/topicref mapgropup-d/keydef \" keys=\"toner-handling\" href=\"toner-type-b-handling.dita\"/>");
+        exp.put("toner-disposal", "<keydef class=\"+ map/topicref mapgropup-d/keydef \" keys=\"toner-disposal\" href=\"toner-type-c-disposal.dita\"/>");
+
         TestUtils.resetXMLUnit();
         XMLUnit.setIgnoreWhitespace(true);
         assertEquals(exp.keySet(), act.keySet());

--- a/src/test/resources/TestKeyrefReader/src/keyrefreader.xml
+++ b/src/test/resources/TestKeyrefReader/src/keyrefreader.xml
@@ -7,7 +7,7 @@
     <topicref class="- map/topicref " href="blatviewduplicate.dita" keys="blatview" locktitle="yes" navtitle="blatview duplicate"></topicref>
     
     <!-- skipped key -->
-    <topicref class="- map/topicref " href="blatexample.dita" keys="blatexample" locktitle="yes" navtitle="blatexample"></topicref>
+    <!--topicref class="- map/topicref " href="blatexample.dita" keys="blatexample" locktitle="yes" navtitle="blatexample"></topicref-->
     
     <!-- skipped topicref -->
     <topicref class="- map/topicref " href="keyRef_blatexample.dita" locktitle="yes" navtitle="keyRef_blatexample"></topicref>

--- a/src/test/resources/TestKeyrefReader/src/merged.xml
+++ b/src/test/resources/TestKeyrefReader/src/merged.xml
@@ -1,0 +1,12 @@
+<map class="- map/map ">
+  <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-specs" href="toner-type-a-specs.dita"/>
+  <submap class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap ">
+    <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-specs" href="toner-type-b-specs.dita"/>
+    <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-handling" href="toner-type-b-handling.dita"/>
+  </submap>
+  <submap class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap ">
+    <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-specs" href="toner-type-c-specs.dita"/>
+    <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-handling" href="toner-type-c-handling.dita"/>
+    <keydef class="+ map/topicref mapgropup-d/keydef " keys="toner-disposal" href="toner-type-c-disposal.dita"/>
+  </submap>
+</map>


### PR DESCRIPTION
This will simply keyref processing and also enable easier implementation of DITA 1.3 branch filtering because all processing can be done on a single map.