### PR TITLE
Lazy key definition reading

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -255,7 +255,7 @@
     <mkdir dir="${test.bin.dir}"/>
     <javac destdir="${test.bin.dir}"
            debug="on"
-           source="1.6" target="1.6">
+           source="1.7" target="1.7">
       <src>
         <pathelement location="${test.java.dir}"/>
       </src>

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -558,11 +558,11 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
             final String key = e.getKey();
             final KeyDef value = e.getValue();
             if (!keysDefMap.containsKey(key)) {
-                keysDefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile));
+                keysDefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile, null));
             }
             // if the current file is also a schema file
             if (schemeSet.contains(currentFile)) {
-                schemekeydefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile));
+                schemekeydefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile, null));
             }
         }
 
@@ -1168,7 +1168,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         final Collection<KeyDef> res = new ArrayList<KeyDef>(keydefs.size());
         for (final KeyDef k: keydefs) {
             final URI source = tempFileNameScheme.generateTempFileName(k.source);
-            res.add(new KeyDef(k.keys, k.href, k.scope, source));
+            res.add(new KeyDef(k.keys, k.href, k.scope, source, null));
         }
         return res;
     }
@@ -1187,7 +1187,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
                              ? tempFileNameScheme.generateTempFileName(file.href)
                              : file.href;
             final URI source = tempFileNameScheme.generateTempFileName(file.source);
-            final KeyDef keyDef = new KeyDef(keys, href, file.scope, source);
+            final KeyDef keyDef = new KeyDef(keys, href, file.scope, source, null);
             updated.add(keyDef);
         }
         // write key definition

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -142,9 +142,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
     /** Set of files with "@processing-role=resource-only" */
     private final Set<URI> resourceOnlySet;
 
-    /** Map of all key definitions */
-    private final Map<String, KeyDef> keysDefMap;
-
     /** Absolute basedir for processing */
     private URI baseInputDir;
 
@@ -214,7 +211,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         outDitaFilesSet = new HashSet<URI>(128);
         relFlagImagesSet = new LinkedHashSet<URI>(128);
         conrefpushSet = new HashSet<URI>(128);
-        keysDefMap = new HashMap<String, KeyDef>();
         keyrefSet = new HashSet<URI>(128);
         coderefSet = new HashSet<URI>(128);
 
@@ -557,10 +553,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
             // key and value.keys will differ when keydef is a redirect to another keydef
             final String key = e.getKey();
             final KeyDef value = e.getValue();
-            if (!keysDefMap.containsKey(key)) {
-                keysDefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile, null));
-            }
-            // if the current file is also a schema file
             if (schemeSet.contains(currentFile)) {
                 schemekeydefMap.put(key, new KeyDef(key, value.href, value.scope, currentFile, null));
             }
@@ -985,7 +977,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
 
         // Convert copyto map into set and output
         job.setCopytoMap(addFilePrefix(copytoMap));
-        writeKeyDefinition(keysDefMap);
 
         try {
             logger.info("Serializing job specification");
@@ -1171,31 +1162,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
             res.add(new KeyDef(k.keys, k.href, k.scope, source, null));
         }
         return res;
-    }
-    
-    /**
-     * Add key definition to job configuration
-     *
-     * @param keydefs key defintions to add
-     */
-    private void writeKeyDefinition(final Map<String, KeyDef> keydefs) {
-        // update value
-        final Collection<KeyDef> updated = new ArrayList<KeyDef>(keydefs.size());
-        for (final KeyDef file: keydefs.values()) {
-            final String keys = file.keys;
-            final URI href = (file.href != null && ATTR_SCOPE_VALUE_LOCAL.equals(file.scope))
-                             ? tempFileNameScheme.generateTempFileName(file.href)
-                             : file.href;
-            final URI source = tempFileNameScheme.generateTempFileName(file.source);
-            final KeyDef keyDef = new KeyDef(keys, href, file.scope, source, null);
-            updated.add(keyDef);
-        }
-        // write key definition
-        try {
-            KeyDef.writeKeydef(new File(job.tempDir, KEYDEF_LIST_FILE), updated);
-        } catch (final DITAOTException e) {
-            logger.error("Failed to write key definition file: " + e.getMessage(), e);
-        }
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -123,4 +123,17 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
         return null;
     }
 
+    /**
+     * Add key definition to job configuration
+     *
+     * @param keydefs key defintions to add
+     */
+    private void writeKeyDefinition(final Map<String, KeyDef> keydefs) {
+        try {
+            KeyDef.writeKeydef(new File(job.tempDir, KEYDEF_LIST_FILE), keydefs.values());
+        } catch (final DITAOTException e) {
+            logger.error("Failed to write key definition file: " + e.getMessage(), e);
+        }
+    }
+
 }

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -66,12 +66,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             }
         });
         if (!fis.isEmpty()) {
-            final Map<String, KeyDef> keymap = new HashMap<String, KeyDef>();
-            final Collection<KeyDef> keydefs = KeyDef.readKeydef(new File(job.tempDir, KEYDEF_LIST_FILE));
-            for (final KeyDef keyDef: keydefs) {
-                keymap.put(keyDef.keys, keyDef);
-            }
-            
             final KeyrefReader reader = new KeyrefReader();
             reader.setLogger(logger);
             final URI mapFile = job.getInputMap();
@@ -92,7 +86,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                 final ConkeyrefFilter conkeyrefFilter = new ConkeyrefFilter();
                 conkeyrefFilter.setLogger(logger);
                 conkeyrefFilter.setJob(job);
-                conkeyrefFilter.setKeyDefinitions(keymap);
+                conkeyrefFilter.setKeyDefinitions(keyDefinition);
                 conkeyrefFilter.setCurrentFile(file);
                 conkeyrefFilter.setDelayConrefUtils(delayConrefUtils);
                 filters.add(conkeyrefFilter);
@@ -102,7 +96,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                 parser.setJob(job);
                 parser.setKeyDefinition(keyDefinition);
                 parser.setCurrentFile(file);
-                parser.setKeyMap(keymap);
                 filters.add(parser);
 
                 try {

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -78,7 +78,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             logger.info("Reading " + job.tempDir.toURI().resolve(mapFile).toString());
             reader.read(job.tempDir.toURI().resolve(mapFile));
 
-            final Map<String, Element> keyDefinition = reader.getKeyDefinition();
+            final Map<String, KeyDef> keyDefinition = reader.getKeyDefinition();
             transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
             delayConrefUtils = transtype.equals(INDEX_TYPE_ECLIPSEHELP) ? new DelayConrefUtils() : null;
             

--- a/src/main/java/org/dita/dost/reader/KeydefFilter.java
+++ b/src/main/java/org/dita/dost/reader/KeydefFilter.java
@@ -145,7 +145,7 @@ public final class KeydefFilter extends AbstractXMLFilter {
                     if (target != null && !target.toString().isEmpty()) {
                         final String attrScope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
                         if (attrScope != null && (attrScope.equals(ATTR_SCOPE_VALUE_EXTERNAL) || attrScope.equals(ATTR_SCOPE_VALUE_PEER))) {
-                            keysDefMap.put(key, new KeyDef(key, target, attrScope, null));
+                            keysDefMap.put(key, new KeyDef(key, target, attrScope, null, null));
                         } else {
                             String tail = null;
                             if (target.getFragment() != null) {
@@ -155,7 +155,7 @@ public final class KeydefFilter extends AbstractXMLFilter {
                             if (!target.isAbsolute()) {
                                 target = currentDir.resolve(target);
                             }
-                            keysDefMap.put(key, new KeyDef(key, setFragment(target, tail), ATTR_SCOPE_VALUE_LOCAL, null));
+                            keysDefMap.put(key, new KeyDef(key, setFragment(target, tail), ATTR_SCOPE_VALUE_LOCAL, null, null));
                         }
                     } else if (!StringUtils.isEmptyString(keyRef)) {
                         // store multi-level keys.
@@ -163,7 +163,7 @@ public final class KeydefFilter extends AbstractXMLFilter {
                     } else {
                         // target is null or empty, it is useful in the future
                         // when consider the content of key definition
-                        keysDefMap.put(key, new KeyDef(key, null, null, null));
+                        keysDefMap.put(key, new KeyDef(key, null, null, null, null));
                     }
                 } else {
                     logger.info(MessageUtils.getInstance().getMessage("DOTJ045I", key, target != null ? target.toString() : null).toString());

--- a/src/main/java/org/dita/dost/util/KeyDef.java
+++ b/src/main/java/org/dita/dost/util/KeyDef.java
@@ -75,38 +75,6 @@ public class KeyDef {
         }
         return buf.toString();
     }
-    
-    /**
-     * Read key definition XML configuration file
-     * 
-     * @param keydefFile key definition file
-     * @return list of key definitions
-     * @throws DITAOTException if reading configuration file failed
-     */
-    @Deprecated
-    public static Collection<KeyDef> readKeydef(final File keydefFile) throws DITAOTException {
-        final Collection<KeyDef> res = new ArrayList<KeyDef>();
-        try {
-            final XMLReader parser = XMLUtils.getXMLReader();
-            parser.setContentHandler(new DefaultHandler() {
-                @Override
-                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
-                    final String n = localName != null ? localName : qName;
-                    if (n.equals(ELEMENT_KEYDEF)) {
-                        res.add(new KeyDef(atts.getValue(ATTRIBUTE_KEYS),
-                                           toURI(atts.getValue(ATTRIBUTE_HREF)),
-                                           atts.getValue(ATTRIBUTE_SCOPE),
-                                           toURI(atts.getValue(ATTRIUBTE_SOURCE)),
-                                           null));
-                    }
-                }
-            });
-            parser.parse(keydefFile.toURI().toString());
-        } catch (final Exception e) {
-            throw new DITAOTException("Failed to read key definition file " + keydefFile + ": " + e.getMessage(), e);
-        }
-        return res;
-    }
 
     /**
      * Write key definition XML configuration file
@@ -115,7 +83,6 @@ public class KeyDef {
      * @param keydefs list of key definitions
      * @throws DITAOTException if writing configuration file failed
      */
-    @Deprecated
     public static void writeKeydef(final File keydefFile, final Collection<KeyDef> keydefs) throws DITAOTException {
         OutputStream out = null;
         XMLStreamWriter keydef = null;

--- a/src/main/java/org/dita/dost/util/KeyDef.java
+++ b/src/main/java/org/dita/dost/util/KeyDef.java
@@ -20,6 +20,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.dita.dost.exception.DITAOTException;
+import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -41,6 +42,7 @@ public class KeyDef {
     public final URI href;
     public final String scope;
     public final URI source;
+    public final Element element;
     
     /**
      * Construct new key definition.
@@ -50,13 +52,15 @@ public class KeyDef {
      * @param scope link scope, may be {@code null}
      * @param source key definition source, may be {@code null}
      */
-    public KeyDef(final String keys, final URI href, final String scope, final URI source) {
+    public KeyDef(final String keys, final URI href, final String scope, final URI source, final Element element) {
+        //assert href.isAbsolute();
         this.keys = keys;
         this.href = href;
         this.scope = scope;
         this.source = source;
+        this.element = element;
     }
-    
+
     @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder().append(keys).append(EQUAL);
@@ -79,6 +83,7 @@ public class KeyDef {
      * @return list of key definitions
      * @throws DITAOTException if reading configuration file failed
      */
+    @Deprecated
     public static Collection<KeyDef> readKeydef(final File keydefFile) throws DITAOTException {
         final Collection<KeyDef> res = new ArrayList<KeyDef>();
         try {
@@ -91,7 +96,8 @@ public class KeyDef {
                         res.add(new KeyDef(atts.getValue(ATTRIBUTE_KEYS),
                                            toURI(atts.getValue(ATTRIBUTE_HREF)),
                                            atts.getValue(ATTRIBUTE_SCOPE),
-                                           toURI(atts.getValue(ATTRIUBTE_SOURCE))));
+                                           toURI(atts.getValue(ATTRIUBTE_SOURCE)),
+                                           null));
                     }
                 }
             });
@@ -109,6 +115,7 @@ public class KeyDef {
      * @param keydefs list of key definitions
      * @throws DITAOTException if writing configuration file failed
      */
+    @Deprecated
     public static void writeKeydef(final File keydefFile, final Collection<KeyDef> keydefs) throws DITAOTException {
         OutputStream out = null;
         XMLStreamWriter keydef = null;

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -122,7 +122,6 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     private int keyrefLeval;
 
-    private Map<String, KeyDef> keyMap;
 
     /**
      * It is used to indicate whether the keyref is valid.
@@ -161,7 +160,6 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         keyrefLevalStack = new Stack<Integer>();
         validKeyref = new Stack<Boolean>();
         empty = true;
-        keyMap = new HashMap<String, KeyDef>();
         elemName = new Stack<String>();
         hasSubElem = new Stack<Boolean>();
     }
@@ -175,14 +173,6 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     public void setCurrentFile(final File inputFile) {
         this.inputFile = inputFile;
-    }
-    
-    /**
-     * Set key map.
-     * @param map key map
-     */
-    public void setKeyMap(final Map<String, KeyDef> map) {
-        keyMap = map;
     }
     
     /**
@@ -390,7 +380,6 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                     final NamedNodeMap attrs = elem.getAttributes();
                     // first resolve the keyref attribute
                     if (currentElement.refAttr != null) {
-                        final KeyDef keyDef = keyMap.get(keyName);
                         final URI target = keyDef != null ? keyDef.href : null;
                         if (target != null && target.toString().length() != 0) {
                             URI target_output = target;

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -103,7 +103,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         keyrefInfos = Collections.unmodifiableList(ki);
     }
         
-    private Map<String, Element> definitionMap;
+    private Map<String, KeyDef> definitionMap;
     /** File name with relative path to the temporary directory of input file. */
     private File inputFile;
 
@@ -148,7 +148,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     private final Stack<Boolean> hasSubElem;
 
     /** Current key definition. */
-    private Element elem;
+    private KeyDef keyDef;
 
     /** Set of link targets which are not resource-only */
     private Set<URI> normalProcessingRoleTargets;
@@ -166,7 +166,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         hasSubElem = new Stack<Boolean>();
     }
     
-    public void setKeyDefinition(final Map<String, Element> definitionMap) {
+    public void setKeyDefinition(final Map<String, KeyDef> definitionMap) {
         this.definitionMap = definitionMap;
     }
 
@@ -227,6 +227,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     @Override
     public void endElement(final String uri, final String localName, final String name) throws SAXException {
         if (keyrefLeval != 0 && empty && !elemName.peek().equals(MAP_TOPICREF.localName)) {
+            final Element elem = keyDef.element;
             // If current element is in the scope of key reference element
             // and the element is empty
             if (!validKeyref.isEmpty() && validKeyref.peek()) {
@@ -379,10 +380,12 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 keyName = keyrefValue.substring(0, slashIndex);
                 elementId = keyrefValue.substring(slashIndex);
             }
-            elem = definitionMap.get(keyName);
+
+            keyDef = definitionMap.get(keyName);
+            final Element elem = keyDef != null ? keyDef.element : null;
 
             // If definition is not null
-            if (elem != null) {
+            if (keyDef != null) {
                 if (currentElement != null) {
                     final NamedNodeMap attrs = elem.getAttributes();
                     // first resolve the keyref attribute

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -177,24 +177,6 @@ public class TestGenMapAndTopicListModule {
         
         final Job job = new Job(tempDirParallel);
         assertEquals(".." + File.separator, job.getProperty("uplevels"));
-
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        final Document document = builder.parse(new File(tempDirParallel, KEYDEF_LIST_FILE));
-        final Element elem = document.getDocumentElement();
-        final NodeList nodeList = elem.getElementsByTagName("keydef");
-        final Map<String, List<String>> expKeyDef = new HashMap<String, List<String>>();
-        expKeyDef.put("target_topic_2", Arrays.asList("target_topic_2", "topics" + URI_SEPARATOR + "target-topic-c.xml", "maps" + URI_SEPARATOR + "root-map-01.ditamap"));
-        expKeyDef.put("target_topic_1", Arrays.asList("target_topic_1", "topics" + URI_SEPARATOR + "target-topic%20a.xml", "maps" + URI_SEPARATOR + "root-map-01.ditamap"));
-        expKeyDef.put("target_topic_3", Arrays.asList("target_topic_3", "topics" + URI_SEPARATOR + "target-topic-c.xml", "maps" + URI_SEPARATOR + "root-map-01.ditamap"));
-        expKeyDef.put("target_topic_4", Arrays.asList("target_topic_4", "http://www.example.com/?foo=bar&baz=qux#quxx", "maps" + URI_SEPARATOR + "root-map-01.ditamap"));
-        for(int i = 0; i< nodeList.getLength();i++){
-            final Element el = (Element) nodeList.item(i);
-            final List<String> exp = expKeyDef.get(el.getAttribute("keys"));
-            assertEquals(exp.get(0), el.getAttribute("keys"));
-            assertEquals(exp.get(1), el.getAttribute("href"));
-            assertEquals(exp.get(2), el.getAttribute("source"));
-        }
     }
     
     @Test
@@ -267,24 +249,6 @@ public class TestGenMapAndTopicListModule {
                 
         final Job job = new Job(tempDirAbove);
         assertEquals("", job.getProperty("uplevels"));
-        
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        final Document document = builder.parse(new File(tempDirAbove, KEYDEF_LIST_FILE));
-        final Element elem = document.getDocumentElement();
-        final NodeList nodeList = elem.getElementsByTagName("keydef");
-        final Map<String, List<String>> expKeyDef = new HashMap<String, List<String>>();
-        expKeyDef.put("target_topic_2", Arrays.asList("target_topic_2", "topics" + URI_SEPARATOR + "target-topic-c.xml", "root-map-02.ditamap"));
-        expKeyDef.put("target_topic_1", Arrays.asList("target_topic_1", "topics" + URI_SEPARATOR + "target-topic%20a.xml", "root-map-02.ditamap"));
-        expKeyDef.put("target_topic_3", Arrays.asList("target_topic_3", "topics" + URI_SEPARATOR + "target-topic-c.xml", "root-map-02.ditamap"));
-        expKeyDef.put("target_topic_4", Arrays.asList("target_topic_4", "http://www.example.com/?foo=bar&baz=qux#quxx", "root-map-02.ditamap"));
-        for(int i = 0; i< nodeList.getLength();i++){
-            final Element el = (Element) nodeList.item(i);
-            final List<String> exp = expKeyDef.get(el.getAttribute("keys"));
-            assertEquals(exp.get(0), el.getAttribute("keys"));
-            assertEquals(exp.get(1), el.getAttribute("href"));
-            assertEquals(exp.get(2), el.getAttribute("source"));
-        }
     }
         
     private Properties readProperties(final File f)

--- a/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
+++ b/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
@@ -56,12 +56,12 @@ public class KeydefFilterTest {
         parser.parse(new File(rootFile.getPath()).toURI().toString());
         
         final Map<String, KeyDef> expKeyDefMap = new HashMap<String, KeyDef>();
-        expKeyDefMap.put("target_topic_1", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null));
-        expKeyDefMap.put("target_topic_2", new KeyDef("target_topic_2", new File(srcDir, "topics" + File.separator + "target-topic-c.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null));
-        expKeyDefMap.put("target_topic_3", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null));
-        expKeyDefMap.put("target_topic_4", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null));
-        expKeyDefMap.put("peer", new KeyDef("peer", toURI("../topics/peer.xml"), ATTR_SCOPE_VALUE_PEER, null));
-        expKeyDefMap.put("external", new KeyDef("external", toURI("http://www.example.com/external.xml"), ATTR_SCOPE_VALUE_EXTERNAL, null));
+        expKeyDefMap.put("target_topic_1", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null));
+        expKeyDefMap.put("target_topic_2", new KeyDef("target_topic_2", new File(srcDir, "topics" + File.separator + "target-topic-c.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null));
+        expKeyDefMap.put("target_topic_3", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null));
+        expKeyDefMap.put("target_topic_4", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null));
+        expKeyDefMap.put("peer", new KeyDef("peer", toURI("../topics/peer.xml"), ATTR_SCOPE_VALUE_PEER, null, null));
+        expKeyDefMap.put("external", new KeyDef("external", toURI("http://www.example.com/external.xml"), ATTR_SCOPE_VALUE_EXTERNAL, null, null));
         
         assertEquals(expKeyDefMap, reader.getKeysDMap());                
     }

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.dita.dost.util.KeyDef;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -52,7 +53,7 @@ public class TestKeyrefReader {
         final KeyrefReader keyrefreader = new KeyrefReader();
 //        keyrefreader.setKeys(set);
         keyrefreader.read(toURI(filename.getAbsolutePath()));
-        final Map<String, Element> act= keyrefreader.getKeyDefinition();
+        final Map<String, KeyDef> act= keyrefreader.getKeyDefinition();
 
         final Map<String, String> exp = new HashMap<String, String>();
         exp.put("blatfeference", "<topicref keys='blatview blatfeference blatintro' href='blatview.dita' navtitle='blatview' locktitle='yes' class='- map/topicref '/>");
@@ -68,7 +69,7 @@ public class TestKeyrefReader {
         assertEquals(exp.keySet(), act.keySet());
         for (Map.Entry<String, String> e: exp.entrySet()) {
             final Document ev = keyDefToDoc(e.getValue());
-            final Document av = act.get(e.getKey()).getOwnerDocument();
+            final Document av = act.get(e.getKey()).element.getOwnerDocument();
             assertXMLEqual(ev, av);
         }
     }
@@ -79,7 +80,7 @@ public class TestKeyrefReader {
 
         final KeyrefReader keyrefreader = new KeyrefReader();
         keyrefreader.read(toURI(filename.getAbsolutePath()));
-        final Map<String, Element> act= keyrefreader.getKeyDefinition();
+        final Map<String, KeyDef> act= keyrefreader.getKeyDefinition();
 
         final Map<String, String> exp = new HashMap<String, String>();
         exp.put("toner-specs", "<keydef class=\"+ map/topicref mapgropup-d/keydef \" keys=\"toner-specs\" href=\"toner-type-a-specs.dita\"/>");
@@ -91,7 +92,7 @@ public class TestKeyrefReader {
         assertEquals(exp.keySet(), act.keySet());
         for (Map.Entry<String, String> e: exp.entrySet()) {
             final Document ev = keyDefToDoc(e.getValue());
-            final Document av = act.get(e.getKey()).getOwnerDocument();
+            final Document av = act.get(e.getKey()).element.getOwnerDocument();
             assertXMLEqual(ev, av);
         }
     }

--- a/src/test/java/org/dita/dost/util/KeyDefTest.java
+++ b/src/test/java/org/dita/dost/util/KeyDefTest.java
@@ -12,12 +12,12 @@ public class KeyDefTest {
 
     @Test
     public void testKeyDefStringStringString() throws URISyntaxException {
-        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope", toURI("baz"));
+        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope", toURI("baz"), null);
         assertEquals("foo", k.keys);
         assertEquals(new URI("bar"), k.href);
         assertEquals("scope", k.scope);
         assertEquals(new URI("baz"), k.source);
-        final KeyDef n = new KeyDef("foo", (URI) null, null, (URI) null);
+        final KeyDef n = new KeyDef("foo", (URI) null, null, (URI) null, null);
         assertEquals("foo", n.keys);
         assertNull(n.href);
         assertNull(n.scope);
@@ -26,9 +26,9 @@ public class KeyDefTest {
     
     @Test
     public void testKeyDefToString() {
-        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope", toURI("baz"));
+        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope", toURI("baz"), null);
         assertEquals("foo=bar(scope)(baz)", k.toString());
-        final KeyDef n = new KeyDef("foo", (URI) null, null, (URI) null);
+        final KeyDef n = new KeyDef("foo", (URI) null, null, (URI) null, null);
         assertEquals("foo=", n.toString());
     }
 

--- a/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
@@ -32,7 +32,7 @@ public class ConkeyrefFilterTest {
     @Test
     public void testKey() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"))));
+        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"), null)));
         f.setContentHandler(new DefaultHandler() {
             @Override
             public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
@@ -48,7 +48,7 @@ public class ConkeyrefFilterTest {
     @Test
     public void testKeyAndElement() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"))));
+        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"), null)));
         f.setContentHandler(new DefaultHandler() {
             @Override
             public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
@@ -64,7 +64,7 @@ public class ConkeyrefFilterTest {
     @Test
     public void testElementInTarget() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita#baz"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"))));
+        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("library.dita#baz"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"), null)));
         f.setContentHandler(new DefaultHandler() {
             @Override
             public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
@@ -81,7 +81,7 @@ public class ConkeyrefFilterTest {
     public void testRelativePaths() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setCurrentFile(new File("product/sub folder/this.dita"));
-        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"))));
+        f.setKeyDefinitions(toMap(new KeyDef("foo", toURI("common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, toURI("main.ditamap"), null)));
         f.setContentHandler(new DefaultHandler() {
             @Override
             public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -49,7 +49,7 @@ public class KeyrefPaserTest {
     private static final File expDir = new File(resourceDir, "exp");
     private static CatalogResolver resolver;
 
-    private static Map<String, Element> keyDefinition;
+    private static Map<String, KeyDef> keyDefinition;
     private final static Map<String, KeyDef> keymap = new HashMap<String, KeyDef>();
 
     @BeforeClass
@@ -152,13 +152,13 @@ public class KeyrefPaserTest {
         final NodeList keydefs = document.getElementsByTagName("keydef");
         for (int i = 0; i < keydefs.getLength(); i++) {
             final Element elem = (Element) keydefs.item(i);
-            final KeyDef keyDef = new KeyDef(elem.getAttribute("keys"), new URI(elem.getAttribute("href")), null, null);
-            keymap.put(keyDef.keys, keyDef);
             final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
             doc.appendChild(doc.importNode(elem, true));
             keys.put(elem.getAttribute("keys"), elem);
+            final KeyDef keyDef = new KeyDef(elem.getAttribute("keys"), new URI(elem.getAttribute("href")), null, null, elem);
+            keymap.put(keyDef.keys, keyDef);
         }
-        keyDefinition = Collections.unmodifiableMap(keys);
+        keyDefinition = Collections.unmodifiableMap(keymap);
     }
     
 }

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -50,7 +50,6 @@ public class KeyrefPaserTest {
     private static CatalogResolver resolver;
 
     private static Map<String, KeyDef> keyDefinition;
-    private final static Map<String, KeyDef> keymap = new HashMap<String, KeyDef>();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -77,7 +76,6 @@ public class KeyrefPaserTest {
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File("a.xml"));
-        parser.setKeyMap(keymap);
         parser.write(new File("a.xml"));
 
         assertXMLEqual(new InputSource(new File(expDir, "a.xml").toURI().toString()),
@@ -91,7 +89,6 @@ public class KeyrefPaserTest {
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File("b.ditamap"));
-        parser.setKeyMap(keymap);
         parser.write(new File("b.ditamap"));
 
         assertXMLEqual(new InputSource(new File(expDir, "b.ditamap").toURI().toString()),
@@ -150,6 +147,7 @@ public class KeyrefPaserTest {
 
         final Map<String, Element> keys = new HashMap<String, Element>();
         final NodeList keydefs = document.getElementsByTagName("keydef");
+        final Map<String, KeyDef> keymap = new HashMap<>();
         for (int i = 0; i < keydefs.getLength(); i++) {
             final Element elem = (Element) keydefs.item(i);
             final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();


### PR DESCRIPTION
Move key definition reading from gen-list to keyref module. This improves code modularity and spec compliancy.