### PR TITLE
Add initial implementation DITA 1.3 branch filtering

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -1,0 +1,565 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ * See the accompanying license.txt file for applicable licenses.
+ */
+package org.dita.dost.module;
+
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.StringUtils.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.XMLUtils;
+import org.dita.dost.writer.ProfilingFilter;
+import org.w3c.dom.*;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.reader.DitaValReader;
+import org.dita.dost.util.DitaClass;
+import org.dita.dost.util.FilterUtils;
+import org.dita.dost.util.Job.FileInfo;
+import org.xml.sax.XMLFilter;
+
+/**
+ * Branch filter module.
+ *
+ * <p>Branch filtering is done with the following steps:</p>
+ * <ol>
+ *   <li>Split braches so that each branch will only contain a single ditavalref</li>
+ *   <li>Generate copy-to attribute for each brach generated topicref</li>
+ *   <li>Filter map based on branch filters</li>
+ *   <li>Rewrite duplicate generated copy-to targets</li>
+ *   <li>Copy and filter generated copy-to targets</li>
+ *   <li>Filter topics that were not branch generated</li>
+ * </ol>
+ *
+ * @since 2.2
+ */
+final class BranchFilterModule extends AbstractPipelineModuleImpl {
+
+    private static final String SKIP_FILTER = "skip-filter";
+
+    private final DocumentBuilder builder;
+    private final DitaValReader ditaValReader;
+    private final Map<URI, FilterUtils> filterCache = new HashMap<>();
+    /** Current map being processed. */
+    private URI map;
+
+    public BranchFilterModule() {
+        try {
+            builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        } catch (final ParserConfigurationException e) {
+            throw new RuntimeException("Failed to build parser: " + e.getMessage(), e);
+        }
+        ditaValReader = new DitaValReader();
+        ditaValReader.initXMLReader(true);
+    }
+    
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        ditaValReader.setLogger(logger);
+    }
+
+    @Override
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
+        processMap(job.getInputMap());
+
+        try {
+            job.write();
+        } catch (final IOException e) {
+            throw new DITAOTException("Failed to serialize job configuration: " + e.getMessage(), e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Process map for branch replication.
+     */
+    protected void processMap(final URI map) {
+        this.map = map;
+        // parse
+        final URI mapFile = job.tempDir.toURI().resolve(map);
+        logger.info("Processing " + mapFile);
+        final Document doc;
+        try {
+            logger.debug("Reading " + mapFile);
+            doc = builder.parse(new InputSource(mapFile.toString()));
+        } catch (final SAXException | IOException e) {
+            logger.error("Failed to parse " + mapFile, e);
+            return;
+        }
+
+        logger.debug("Split branches and generate copy-to");
+        splitBranches(doc.getDocumentElement(), Branch.EMPTY);
+        logger.debug("Filter map");
+        filterBranches(doc.getDocumentElement());
+        logger.debug("Rewrite duplicate topic references");
+        rewriteDuplicates(doc.getDocumentElement());
+        logger.debug("Filter topics and generate copies");
+        generateCopies(doc.getDocumentElement(), Collections.<FilterUtils>emptyList());
+        logger.debug("Filter existing topics");
+        filterTopics(doc.getDocumentElement(), Collections.<FilterUtils>emptyList());
+
+        logger.debug("Writing " + mapFile);
+        StreamResult result = null;
+        try {
+            Transformer serializer = TransformerFactory.newInstance().newTransformer();
+            result = new StreamResult(mapFile.toString());
+            serializer.transform(new DOMSource(doc), result);
+        } catch (final TransformerConfigurationException | TransformerFactoryConfigurationError e) {
+            throw new RuntimeException(e);
+        } catch (final TransformerException e) {
+            logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
+        } finally {
+            try {
+                close(result);
+            } catch (final IOException e) {
+                logger.error("Failed to close result stream for " + map.toString() + ": " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /** Rewrite href or copy-to if duplicates exist. */
+    private void rewriteDuplicates(final Element root) {
+        // collect href and copy-to
+        final Map<URI, List<Attr>> refs = new HashMap<>();
+        for (final Element e: getChildElements(root, MAP_TOPICREF, true)) {
+            if (!isDitaFormat(e.getAttributeNode(ATTRIBUTE_NAME_FORMAT))) {
+                continue;
+            }
+            final Attr copyTo = e.getAttributeNode(ATTRIBUTE_NAME_COPY_TO);
+            if (copyTo != null) {
+                final URI h = map.resolve(copyTo.getValue());
+                List<Attr> attrs = refs.get(h);
+                if (attrs == null) {
+                    attrs = new ArrayList<>();
+                }
+                attrs.add(copyTo);
+                refs.put(h, attrs);
+            } else {
+                final Attr href = e.getAttributeNode(ATTRIBUTE_NAME_HREF);
+                if (href != null) {
+                    final URI h = map.resolve(href.getValue());
+                    List<Attr> attrs = refs.get(h);
+                    if (attrs == null) {
+                        attrs = new ArrayList<>();
+                    }
+                    attrs.add(href);
+                    refs.put(h, attrs);
+                }
+            }
+        }
+        // check and rewrite
+        for (final Map.Entry<URI, List<Attr>> ref: refs.entrySet()) {
+            final List<Attr> attrs = ref.getValue();
+            if (attrs.size() > 1) {
+                Attr first = null;
+                // TODO: Choose plain topic that is not part of branch as best choice
+                for (final Attr attr: attrs) {
+                    if (attr.getName().equals(ATTRIBUTE_NAME_HREF)) {
+                        first = attr;
+                        break;
+                    }
+                }
+                if (first == null) {
+                    first = attrs.get(0);
+                }
+                attrs.remove(first);
+                for (int i = 0; i < attrs.size(); i++) {
+                    final Attr attr = attrs.get(i);
+                    String gen = attr.getValue();
+                    final String suffix = "-" + (i + 1);
+                    final int idx = gen.lastIndexOf(".");
+                    gen = idx != -1
+                        ? (gen.substring(0, idx) + suffix + gen.substring(idx))
+                        : (gen + suffix);
+                    logger.error(MessageUtils.getInstance().getMessage("DOTJ065E", attr.getValue() ,gen)
+                            .setLocation((Element) attr.getOwnerElement()).toString());
+                    if (attr.getName().equals(ATTRIBUTE_NAME_HREF)) {
+                        attr.getOwnerElement().setAttribute(ATTRIBUTE_NAME_COPY_TO, gen);
+                    } else {
+                        attr.setValue(gen);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isDitaFormat(final Attr formatAttr) {
+        return formatAttr == null ||
+                ATTR_FORMAT_VALUE_DITA.equals(formatAttr.getNodeValue()) ||
+                ATTR_FORMAT_VALUE_DITAMAP.equals(formatAttr.getNodeValue());
+    }
+
+    /** Filter map and remove excluded content. */
+    private void filterBranches(final Element root) {
+        final String[][] props = getExtProps(root.getAttribute(ATTRIBUTE_NAME_DOMAINS));
+        filterBranches(root, Collections.<FilterUtils>emptyList(), props);
+    }
+
+    private void filterBranches(final Element elem, final List<FilterUtils> filters, final String[][] props) {
+        final List<FilterUtils> fs = combineFilterUtils(elem, filters);
+
+        boolean exclude = false;
+        for (final FilterUtils f: fs) {
+            exclude = exclude(elem, f, props);
+            if (exclude) {
+                break;
+            }
+        }
+
+        if (exclude) {
+            elem.getParentNode().removeChild(elem);
+        } else {
+            for (final Element child : getChildElements(elem)) {
+                filterBranches(child, fs, props);
+            }
+        }
+    }
+
+    private List<FilterUtils> combineFilterUtils(final Element topicref, final List<FilterUtils> filters) {
+        final List<Element> ditavalRefs = getChildElements(topicref, DITAVAREF_D_DITAVALREF);
+        assert ditavalRefs.size() <= 1;
+        if (!ditavalRefs.isEmpty()) {
+            List<FilterUtils> fs = new ArrayList<>(filters);
+            final FilterUtils f = getFilterUtils(ditavalRefs.get(0));
+            if (f != null) {
+                fs = new ArrayList<>(fs);
+                fs.add(f);
+            }
+            return fs;
+        } else {
+            return filters;
+        }
+    }
+
+    /** Test if element should be excluded based on fiter. */
+    private boolean exclude(final Element element, final FilterUtils filterUtils, final String[][] props) {
+        final AttributesBuilder buf = new AttributesBuilder();
+        final NamedNodeMap attrs = element.getAttributes();
+        for (int i = 0; i < attrs.getLength() ; i++) {
+            final Node attr = attrs.item(i);
+            if (attr.getNodeType() == Node.ATTRIBUTE_NODE) {
+                buf.add((Attr) attr);
+            }
+        }
+        return filterUtils.needExclude(buf.build(), props);
+    }
+
+    /** Copy and filter topics for branches. These topics have a new name and will be added to job configuration. */
+    private void generateCopies(final Element topicref, final List<FilterUtils> filters) {
+        final List<FilterUtils> fs = combineFilterUtils(topicref, filters);
+
+        final String copyTo = topicref.getAttribute(ATTRIBUTE_NAME_COPY_TO);
+        if (!copyTo.isEmpty()) {
+            final URI dstUri = map.resolve(copyTo);
+            final URI dstAbsUri = job.tempDir.toURI().resolve(dstUri);
+            final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
+            final URI srcUri = map.resolve(href);
+            final URI srcAbsUri = job.tempDir.toURI().resolve(srcUri);
+            final FileInfo srcFileInfo = job.getFileInfo(srcUri);
+            if (srcFileInfo != null) {
+                final FileInfo fi = new FileInfo.Builder(srcFileInfo).uri(dstUri).build();
+                // TODO: Maybe Job should be updated earlier?
+                job.add(fi);
+                logger.info("Filtering " + srcAbsUri + " to " + dstAbsUri);
+                final List<XMLFilter> pipe = new ArrayList<>();
+                // TODO: replace multiple profiling filters with a merged filter utils
+                for (final FilterUtils f : fs) {
+                    final ProfilingFilter writer = new ProfilingFilter();
+                    writer.setLogger(logger);
+                    writer.setJob(job);
+                    writer.setFilterUtils(f);
+                    pipe.add(writer);
+                }
+                try {
+                    XMLUtils.transform(srcAbsUri,
+                                       dstAbsUri,
+                                       pipe);
+                } catch (final DITAOTException e) {
+                    logger.error("Failed to filter " + srcAbsUri + " to " + dstAbsUri + ": " + e.getMessage(), e);
+                }
+                topicref.setAttribute(ATTRIBUTE_NAME_HREF, copyTo);
+                topicref.removeAttribute(ATTRIBUTE_NAME_COPY_TO);
+                // disable filtering again
+                topicref.setAttribute(SKIP_FILTER, Boolean.TRUE.toString());
+            }
+        }
+        for (final Element child: getChildElements(topicref, MAP_TOPICREF)) {
+            if (DITAVAREF_D_DITAVALREF.matches(child)) {
+                continue;
+            }
+            generateCopies(child, fs);
+        }
+    }
+
+    /** Modify and filter topics for branches. These files use an existing file name. */
+    private void filterTopics(final Element topicref, final List<FilterUtils> filters) {
+        final List<FilterUtils> fs = combineFilterUtils(topicref, filters);
+
+        final Attr skipFilter = topicref.getAttributeNode(SKIP_FILTER);
+        if (!fs.isEmpty() && skipFilter == null) {
+            final List<XMLFilter> pipe = new ArrayList<>();
+            // TODO: replace multiple profiling filters with a merged filter utils
+            for (final FilterUtils f : fs) {
+                final ProfilingFilter writer = new ProfilingFilter();
+                writer.setLogger(logger);
+                writer.setJob(job);
+                writer.setFilterUtils(f);
+                pipe.add(writer);
+            }
+            final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
+            final URI srcAbsUri = job.tempDir.toURI().resolve(map.resolve(href));
+            logger.info("Filtering " + srcAbsUri);
+            try {
+                XMLUtils.transform(toFile(srcAbsUri),
+                        pipe);
+            } catch (final DITAOTException e) {
+                logger.error("Failed to filter " + srcAbsUri + ": " + e.getMessage(), e);
+            }
+        }
+        if (skipFilter != null) {
+            topicref.removeAttributeNode(skipFilter);
+        }
+
+        for (final Element child: getChildElements(topicref, MAP_TOPICREF)) {
+            if (DITAVAREF_D_DITAVALREF.matches(child)) {
+                continue;
+            }
+            filterTopics(child, fs);
+        }
+    }
+
+    /**
+     * Read and cache filter.
+     **/
+    private FilterUtils getFilterUtils(final Element ditavalRef) {
+        final URI ditaval = job.getFileInfo(map).src.resolve(ditavalRef.getAttribute(ATTRIBUTE_NAME_HREF));
+        FilterUtils f = filterCache.get(ditaval);
+        if (f == null) {
+            ditaValReader.filterReset();
+            ditaValReader.read(ditaval);
+            Map<FilterUtils.FilterKey, FilterUtils.Action> filterMap = ditaValReader.getFilterMap();
+            f = new FilterUtils(filterMap);
+            f.setLogger(logger);
+            filterCache.put(ditaval, f);
+        }
+        return f;
+    }
+
+    /**
+     * Duplicate branches so that each {@code ditavalref} will in a separate branch.
+     */
+    private void splitBranches(final Element elem, final Branch filter) {
+        final List<Element> ditavalRefs = getChildElements(elem, DITAVAREF_D_DITAVALREF);
+        if (ditavalRefs.size() > 0) {
+            // remove ditavalrefs
+            for (final Element branch: ditavalRefs) {
+                elem.removeChild(branch);
+            }
+            // create additional branches after current element
+            final List<Element> branches = new ArrayList<>(ditavalRefs.size());
+            branches.add(elem);
+            final Node next = elem.getNextSibling();
+            for (int i = 1; i < ditavalRefs.size(); i++) {
+                final Element clone = (Element) elem.cloneNode(true);
+                if (next != null) {
+                    elem.getParentNode().insertBefore(clone, next);
+                } else {
+                    elem.getParentNode().appendChild(clone);
+                }
+                branches.add(clone);
+            }
+            // insert ditavalrefs
+            for (int i = 0; i < branches.size(); i++) {
+                final Element branch = branches.get(i);
+                final Element ditavalref = ditavalRefs.get(i);
+                branch.insertBefore(ditavalref, branch.getFirstChild());
+                final Branch currentFilter = filter.merge(ditavalref);
+                processAttributes(branch, currentFilter);
+                // process children of all branches
+                for (final Element child: getChildElements(branch, MAP_TOPICREF)) {
+                    if (DITAVAREF_D_DITAVALREF.matches(child)) {
+                        continue;
+                    }
+                    splitBranches(child, currentFilter);
+                }
+            }
+        } else {
+            processAttributes(elem, filter);
+            for (final Element child: getChildElements(elem, MAP_TOPICREF)) {
+                splitBranches(child, filter);
+            }
+        }
+    }
+    
+    /** Immutable branch definition. */
+    private static class Branch {
+        /** Empty root branch */
+        static final Branch EMPTY = new Branch();
+        final String resourcePrefix;
+        final String resourceSuffix;
+        final String keyscopePrefix;
+        final String keyscopeSuffix;
+        private Branch() {
+            this.resourcePrefix = null;
+            this.resourceSuffix = null;
+            this.keyscopePrefix = null;
+            this.keyscopeSuffix = null;
+        }
+        private Branch(String resourcePrefix, String resourceSuffix, String keyscopePrefix, String keyscopeSuffix) {
+//            final URI prefix = toURI(resourcePrefix).normalize();
+//            if (prefix.toString().startsWith("..")) {
+//                throw new Exception("ERROR: Resource prefix may not start with ..");
+//            }
+            this.resourcePrefix = resourcePrefix;
+            this.resourceSuffix = resourceSuffix;
+            this.keyscopePrefix = keyscopePrefix;
+            this.keyscopeSuffix = keyscopeSuffix;
+        }
+        @Override
+        public String toString() {
+            return "{" + resourcePrefix + "," + resourceSuffix + ";" + keyscopePrefix + ", " + keyscopeSuffix + "}";
+        }
+        private Branch merge(final Element ditavalref) {
+            return new Branch(
+                getPrefix(ditavalref, this.resourcePrefix),
+                getSuffix(ditavalref, this.resourceSuffix),
+                getKeyscopePrefix(ditavalref, this.keyscopePrefix),
+                getKeyscopeSuffix(ditavalref, this.keyscopeSuffix)
+            );
+        }
+        private String get(final Element ditavalref, final DitaClass cls) {
+            for (final Element ditavalmeta: getChildElements(ditavalref, DITAVAREF_D_DITAVALMETA)) {
+                for (final Element resoucePrefix: getChildElements(ditavalmeta, cls)) {
+                    return getStringValue(resoucePrefix);
+                }
+            }
+            return null;
+        }
+        private String getPrefix(final Element ditavalref, final String oldValue) {
+            final String v = get(ditavalref, DITAVAREF_D_DVR_RESOURCEPREFIX);
+            if (v != null) {
+                return (oldValue != null ? oldValue : "") + v;
+            } 
+            return oldValue;
+        }
+        private String getSuffix(final Element ditavalref, final String oldValue) {
+            final String v = get(ditavalref, DITAVAREF_D_DVR_RESOURCESUFFIX);
+            if (v != null) {
+                return v + (oldValue != null ? oldValue : "");
+            }
+            return oldValue;
+        }
+        private String getKeyscopePrefix(final Element ditavalref, final String oldValue) {
+            final String v = get(ditavalref, DITAVAREF_D_DVR_KEYSCOPEPREFIX);
+            if (v != null) {
+                return (oldValue != null ? oldValue : "") + v;
+            }
+            return oldValue;
+        }
+        private String getKeyscopeSuffix(final Element ditavalref, final String oldValue) {
+            final String v = get(ditavalref, DITAVAREF_D_DVR_KEYSCOPESUFFIX);
+            if (v != null) {
+                return v + (oldValue != null ? oldValue : "");
+            }
+            return oldValue;
+        }
+    }
+    
+    private void processAttributes(final Element elem, final Branch filter) {
+        if (filter.resourcePrefix != null || filter.resourceSuffix != null) {
+            final String href = elem.getAttribute(ATTRIBUTE_NAME_HREF);
+            if (!href.isEmpty()) {
+                // TODO: Should this use a custom attribute since there may be copy-to attributes already in the source?
+                elem.setAttribute(ATTRIBUTE_NAME_COPY_TO,
+                        generateCopyTo(href, filter).toString());
+            }
+        }
+
+        if ((filter.keyscopePrefix != null || filter.keyscopeSuffix != null)) {
+            final String keyscope = elem.getAttribute(ATTRIBUTE_NAME_KEYSCOPE);
+            if (!keyscope.isEmpty()) {
+                final StringBuilder buf = new StringBuilder();
+                for (final String key : keyscope.trim().split("\\s+")) {
+                    if (filter.keyscopePrefix != null) {
+                        buf.append(filter.keyscopePrefix);
+                    }
+                    buf.append(key);
+                    if (filter.keyscopeSuffix != null) {
+                        buf.append(filter.keyscopeSuffix);
+                    }
+                    buf.append(' ');
+                }
+                elem.setAttribute(ATTRIBUTE_NAME_KEYSCOPE, buf.toString().trim());
+            }
+        }
+    }
+    
+    private URI generateCopyTo(final String href, final Branch filter) {
+        final StringBuilder buf = new StringBuilder(href);
+        final String suffix = filter.resourceSuffix;
+        if (suffix != null) {
+            buf.insert(buf.lastIndexOf("."), suffix);
+        }
+        final String prefix = filter.resourcePrefix;
+        if (prefix != null) {
+            final int i = buf.lastIndexOf(URI_SEPARATOR);
+            if (i != -1) {
+                buf.insert(i, prefix);
+            } else {
+                buf.insert(0, prefix);
+            }
+        }
+        return toURI(buf.toString());
+    }
+
+    /** List descendant elements by DITA class. */
+    private static List<Element> getChildElements(final Element elem, final DitaClass cls, final boolean deep) {
+        final NodeList children = deep ? elem.getElementsByTagName("*") : elem.getChildNodes();
+        final List<Element> res = new ArrayList<>(children.getLength());
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node child = children.item(i);
+            if (cls.matches(child)) {
+                res.add((Element) child);
+            }
+        }
+        return res;
+    }
+
+    private static List<Element> getChildElements(final Element elem, final DitaClass cls) {
+        return getChildElements(elem, cls, false);
+    }
+
+    /** List all child elements. */
+    private static List<Element> getChildElements(final Element elem) {
+        final NodeList children = elem.getChildNodes();
+        final List<Element> res = new ArrayList<>(children.getLength());
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node child = children.item(i);
+            if (child.getNodeType() == Node.ELEMENT_NODE) {
+                res.add((Element) child);
+            }
+        }
+        return res;
+    }
+    
+}

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -211,7 +211,9 @@ final class BranchFilterModule extends AbstractPipelineModuleImpl {
     /** Walker to collect topicrefs that are part of a branch. */
     private void walkBranchTopicref(final Element elem, final boolean inBranch, final List<Element> res) {
         final boolean b = inBranch || !getChildElements(elem, DITAVAREF_D_DITAVALREF).isEmpty();
-        if (b && MAP_TOPICREF.matches(elem) && isDitaFormat(elem.getAttributeNode(ATTRIBUTE_NAME_FORMAT))) {
+        if (b && MAP_TOPICREF.matches(elem)
+                && isDitaFormat(elem.getAttributeNode(ATTRIBUTE_NAME_FORMAT))
+                && !elem.getAttribute(ATTRIBUTE_NAME_SCOPE).equals(ATTR_SCOPE_VALUE_EXTERNAL)) {
             res.add(elem);
         }
         for (final Element child: getChildElements(elem)) {
@@ -504,7 +506,8 @@ final class BranchFilterModule extends AbstractPipelineModuleImpl {
     private void processAttributes(final Element elem, final Branch filter) {
         if (filter.resourcePrefix != null || filter.resourceSuffix != null) {
             final String href = elem.getAttribute(ATTRIBUTE_NAME_HREF);
-            if (!href.isEmpty()) {
+            final String scope = elem.getAttribute(ATTRIBUTE_NAME_SCOPE);
+            if (!href.isEmpty() && !scope.equals(ATTR_SCOPE_VALUE_EXTERNAL)) {
                 elem.setAttribute(BRANCH_COPY_TO,
                         generateCopyTo(href, filter).toString());
             }

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -91,7 +91,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
     private final Set<URI> coderefSet;
 
     /** Set of all images */
-    private final Set<URI> imageSet;
+    private final Set<Reference> formatSet;
 
     /** Set of all images used for flagging */
     private final Set<URI> flagImageSet;
@@ -195,7 +195,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         chunkTopicSet = new HashSet<URI>(128);
         schemeSet = new HashSet<URI>(128);
         conrefSet = new HashSet<URI>(128);
-        imageSet = new HashSet<URI>(128);
+        formatSet = new HashSet<>();
         flagImageSet = new LinkedHashSet<URI>(128);
         htmlSet = new HashSet<URI>(128);
         hrefTargetSet = new HashSet<URI>(128);
@@ -647,10 +647,12 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         if (isFormatDita(file.format) || ATTR_FORMAT_VALUE_DITAMAP.equals(file.format)) {
             addToWaitList(file);
         } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
-            imageSet.add(file.filename);
-            if (!exists(file.filename)){
+            formatSet.add(file);
+            if (!exists(file.filename)) {
                 logger.warn(MessageUtils.getInstance().getMessage("DOTX008W", file.filename.toString()).toString());
             }
+        } else if (ATTR_FORMAT_VALUE_DITAVAL.equals(file.format)) {
+            formatSet.add(file);
         } else {
             htmlSet.add(file.filename);
         }
@@ -918,8 +920,8 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         for (final URI file: conrefSet) {
             getOrCreateFileInfo(fileinfos, file).hasConref = true;
         }
-        for (final URI file: imageSet) {
-            getOrCreateFileInfo(fileinfos, file).format = ATTR_FORMAT_VALUE_IMAGE;
+        for (final Reference file: formatSet) {
+            getOrCreateFileInfo(fileinfos, file.filename).format = file.format;
         }
         for (final URI file: flagImageSet) {
             final FileInfo f = getOrCreateFileInfo(fileinfos, file);

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -641,7 +641,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
                 && (atts.getValue(ATTRIBUTE_NAME_COPY_TO) == null
                     || (atts.getValue(ATTRIBUTE_NAME_CHUNK) != null && atts.getValue(ATTRIBUTE_NAME_CHUNK).contains(CHUNK_TO_CONTENT)))
                 && (followLinks()
-                    || (TOPIC_IMAGE.matches(attrClass) || TOPIC_OBJECT.matches(attrClass)))) {
+                    || (TOPIC_IMAGE.matches(attrClass) || TOPIC_OBJECT.matches(attrClass) || DITAVAREF_D_DITAVALREF.matches(attrClass)))) {
             nonConrefCopytoTargets.add(new Reference(filename, attrFormat));
         }
 

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -590,7 +590,13 @@ public final class Constants {
     public static final DitaClass XNAL_D_THOROUGHFARE = new DitaClass("+ topic/ph xnal-d/thoroughfare ");
     public static final DitaClass XNAL_D_URL = new DitaClass("+ topic/data xnal-d/url ");
     public static final DitaClass XNAL_D_URLS = new DitaClass("+ topic/data xnal-d/urls ");
-
+    public static final DitaClass DITAVAREF_D_DITAVALREF = new DitaClass("+ map/topicref ditavalref-d/ditavalref ");
+    public static final DitaClass DITAVAREF_D_DITAVALMETA = new DitaClass("+ map/topicmeta ditavalref-d/ditavalmeta ");
+    public static final DitaClass DITAVAREF_D_DVR_RESOURCEPREFIX = new DitaClass("+ topic/data ditavalref-d/dvrResourcePrefix ");
+    public static final DitaClass DITAVAREF_D_DVR_RESOURCESUFFIX = new DitaClass("+ topic/data ditavalref-d/dvrResourceSuffix ");
+    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPEPREFIX = new DitaClass("+ topic/data ditavalref-d/dvrKeyscopePrefix ");
+    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPESUFFIX = new DitaClass("+ topic/data ditavalref-d/dvrKeyscopeSuffix ");
+    
     /**maplinks element.*/
     public static final String ELEMENT_NAME_MAPLINKS = "maplinks";
     /**prop element.*/
@@ -873,6 +879,7 @@ public final class Constants {
     public static final String ATTR_FORMAT_VALUE_DITA = "dita";
     /**ATTR_FORMAT_VALUE_DITAMAP.*/
     public static final String ATTR_FORMAT_VALUE_DITAMAP = "ditamap";
+    public static final String ATTR_FORMAT_VALUE_DITAVAL = "ditaval";
     public static final String ATTR_FORMAT_VALUE_IMAGE = "image";
     public static final String ATTR_FORMAT_VALUE_HTML = "html";
     /**ATTRIBUTE_NAME_DITAARCHVERSION.*/

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -53,7 +53,8 @@ public final class FilterUtils {
     private final Set<FilterKey> notMappingRules = new HashSet<FilterKey>();
     private boolean logMissingAction;
 
-    private FilterUtils(final Map<FilterKey, Action> filterMap) {
+    public FilterUtils(final Map<FilterKey, Action> filterMap) {
+        this.logMissingAction = !filterMap.isEmpty();
         this.filterMap = new HashMap<FilterKey, Action>(filterMap);
     }
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -19,6 +19,7 @@
                   gen-list,
                   debug-filter,
                   mapref,
+                  branch-filter,
                   copy-files,
                   keyref,
                   conrefpush,
@@ -208,6 +209,12 @@
       </not-->
       <istrue value="${filter-on-parse}"/>
     </condition>
+  </target>
+  
+  <target name="branch-filter">
+    <pipeline tempdir="${dita.temp.dir}" taskname="branch-filter" message="Filter branches">
+      <module class="org.dita.dost.module.BranchFilterModule"/>
+    </pipeline>
   </target>
   
   <!-- conref push

--- a/src/main/resources/messages_template.xml
+++ b/src/main/resources/messages_template.xml
@@ -299,6 +299,11 @@
     <response>Ignoring "by-topic" token.</response>
   </message>
 
+  <message id="DOTJ065E" type="ERROR">
+    <reason>Branch filter generated topic %1 used more than once.</reason>
+    <response>Renaming %1 to %2.</response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -1,11 +1,12 @@
 package org.dita.dost.module;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.*;
+import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 
 import org.custommonkey.xmlunit.XMLUnit;
 import org.dita.dost.TestUtils;
@@ -38,13 +39,21 @@ public class BranchFilterModuleTest {
         job.add(new Job.FileInfo.Builder()
                 .src(new File(tempDir, "input.ditamap").toURI())
                 .uri(new URI("input.ditamap"))
+                .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
+        for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita")) {
+            job.add(new Job.FileInfo.Builder()
+                    .src(new File(tempDir, uri).toURI())
+                    .uri(new URI(uri))
+                    .format(ATTR_FORMAT_VALUE_DITA)
+                    .build());
+        }
     }
 
     @After
     public void tearDown() throws Exception {
-        TestUtils.forceDelete(tempDir);
-        //System.err.println(tempDir.getAbsolutePath());
+//        TestUtils.forceDelete(tempDir);
+        System.err.println(tempDir.getAbsolutePath());
     }
 
     @Test

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -1,0 +1,61 @@
+package org.dita.dost.module;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import org.custommonkey.xmlunit.XMLUnit;
+import org.dita.dost.TestUtils;
+import org.dita.dost.log.DITAOTJavaLogger;
+import org.dita.dost.util.Job;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class BranchFilterModuleTest {
+
+    private final File resourceDir = TestUtils.getResourceDir(BranchFilterModuleTest.class);
+    private final File expDir = new File(resourceDir, "exp");
+    private File tempDir;
+    private Job job;
+
+    
+    @Before
+    public void setUp() throws Exception {
+        tempDir = TestUtils.createTempDir(getClass());
+        TestUtils.copy(new File(resourceDir, "src"), tempDir);
+        
+        TestUtils.resetXMLUnit();
+        XMLUnit.setIgnoreWhitespace(true);
+        XMLUnit.setIgnoreComments(true);
+
+        job = new Job(tempDir);
+        job.add(new Job.FileInfo.Builder()
+                .src(new File(tempDir, "input.ditamap").toURI())
+                .uri(new URI("input.ditamap"))
+                .build());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtils.forceDelete(tempDir);
+        //System.err.println(tempDir.getAbsolutePath());
+    }
+
+    @Test
+    public void testProcessMap() throws SAXException, IOException {
+        final BranchFilterModule m = new BranchFilterModule();
+        m.setJob(job);
+        m.setLogger(new DITAOTJavaLogger());
+        
+        m.processMap(new File(tempDir, "input.ditamap").toURI());
+        assertXMLEqual(new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
+                       new InputSource(new File(tempDir, "input.ditamap").toURI().toString()));
+    }
+
+}

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -52,8 +52,7 @@ public class BranchFilterModuleTest {
 
     @After
     public void tearDown() throws Exception {
-//        TestUtils.forceDelete(tempDir);
-        System.err.println(tempDir.getAbsolutePath());
+        TestUtils.forceDelete(tempDir);
     }
 
     @Test

--- a/src/test/resources/BranchFilterModuleTest/exp/conflict.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/conflict.ditamap
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map "
+     domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+     ditaarch:DITAArchVersion="1.3">
+   <topicref class="- map/topicref " href="a.dita" keyscope="a">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval"/>
+      <topicref class="- map/topicref " href="b.dita" keyscope="b"/>
+   </topicref>
+   <topicref class="- map/topicref " href="a.dita" keyscope="a">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval"/>
+      <topicref class="- map/topicref " href="b.dita" keyscope="b"/>
+   </topicref>
+   <topicref class="- map/topicref " href="a.dita"/>
+   <topicref copy-to="ctoken.dita"
+             class="- map/topicref "
+             href="c.dita"
+             keyscope="c">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval">
+         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta "/>
+      </ditavalref>
+   </topicref>
+   <topicref copy-to="ctoken.dita"
+             class="- map/topicref "
+             href="c.dita"
+             keyscope="c">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval">
+         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta "/>
+      </ditavalref>
+   </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/exp/ditaval-specific-to-branch.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/ditaval-specific-to-branch.ditamap
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map "
+     domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+     ditaarch:DITAArchVersion="1.3">
+   <topicref class="- map/topicref " href="intro.dita"/>
+   <topicref class="- map/topicref " href="install.dita">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="novice.ditaval"/>
+      <topicref class="- map/topicref " href="do-stuff.dita"/>
+      <topicref class="- map/topicref " href="advanced-stuff.dita" audience="admin"/>
+      <!-- more topics -->
+   </topicref>
+   <!-- Several chapters worth of other material -->
+</map>

--- a/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
@@ -1,0 +1,75 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">DITA Topic Map</title>
+  <topicref class="- map/topicref " href="install.dita" keyscope="install">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
+    <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
+    <topicref class="- map/topicref " copy-to="configure-novice.dita" href="configure.dita" keyscope="novice-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">novice-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+    <topicref class="- map/topicref " copy-to="configure-admin.dita" href="configure.dita" keyscope="admin-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">admin-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " copy-to="install-mac.dita" href="install.dita" keyscope="mac-install">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <topicref class="- map/topicref " copy-to="perform-install-mac.dita" href="perform-install.dita" keyscope="mac-perform-install"/>
+    <topicref class="- map/topicref " copy-to="configure-novice-mac.dita" href="configure.dita" keyscope="mac-novice-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">novice-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+    <topicref class="- map/topicref " copy-to="configure-admin-mac.dita" href="configure.dita" keyscope="mac-admin-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">admin-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " copy-to="install-win.dita" href="install.dita" keyscope="win-install">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-win</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">win-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <topicref class="- map/topicref " copy-to="perform-install-win.dita" href="perform-install.dita" keyscope="win-perform-install"/>
+    <topicref class="- map/topicref " copy-to="configure-novice-win.dita" href="configure.dita" keyscope="win-novice-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">novice-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+    <topicref class="- map/topicref " copy-to="configure-admin-win.dita" href="configure.dita" keyscope="win-admin-configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">admin-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
@@ -21,6 +21,7 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
+    <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
   <topicref class="- map/topicref " href="install-mac.dita" keyscope="mac-install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
@@ -46,6 +47,7 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
+    <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
   <topicref class="- map/topicref " href="install-win.dita" keyscope="win-install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
@@ -71,5 +73,6 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
+    <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
 </map>

--- a/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
@@ -5,7 +5,7 @@
   <topicref class="- map/topicref " href="install.dita" keyscope="install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
     <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
-    <topicref class="- map/topicref " copy-to="configure-novice.dita" href="configure.dita" keyscope="novice-configure">
+    <topicref class="- map/topicref " href="configure-novice.dita" keyscope="novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
@@ -13,7 +13,7 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
-    <topicref class="- map/topicref " copy-to="configure-admin.dita" href="configure.dita" keyscope="admin-configure">
+    <topicref class="- map/topicref " href="configure-admin.dita" keyscope="admin-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
@@ -22,15 +22,15 @@
       </ditavalref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " copy-to="install-mac.dita" href="install.dita" keyscope="mac-install">
+  <topicref class="- map/topicref " href="install-mac.dita" keyscope="mac-install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
       <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
         <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
         <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
       </ditavalmeta>
     </ditavalref>
-    <topicref class="- map/topicref " copy-to="perform-install-mac.dita" href="perform-install.dita" keyscope="mac-perform-install"/>
-    <topicref class="- map/topicref " copy-to="configure-novice-mac.dita" href="configure.dita" keyscope="mac-novice-configure">
+    <topicref class="- map/topicref " href="perform-install-mac.dita" keyscope="mac-perform-install"/>
+    <topicref class="- map/topicref " href="configure-novice-mac.dita" keyscope="mac-novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
@@ -38,7 +38,7 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
-    <topicref class="- map/topicref " copy-to="configure-admin-mac.dita" href="configure.dita" keyscope="mac-admin-configure">
+    <topicref class="- map/topicref " href="configure-admin-mac.dita" keyscope="mac-admin-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
@@ -47,15 +47,15 @@
       </ditavalref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " copy-to="install-win.dita" href="install.dita" keyscope="win-install">
+  <topicref class="- map/topicref " href="install-win.dita" keyscope="win-install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
       <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
         <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-win</dvrResourceSuffix>
         <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">win-</dvrKeyscopePrefix>
       </ditavalmeta>
     </ditavalref>
-    <topicref class="- map/topicref " copy-to="perform-install-win.dita" href="perform-install.dita" keyscope="win-perform-install"/>
-    <topicref class="- map/topicref " copy-to="configure-novice-win.dita" href="configure.dita" keyscope="win-novice-configure">
+    <topicref class="- map/topicref " href="perform-install-win.dita" keyscope="win-perform-install"/>
+    <topicref class="- map/topicref " href="configure-novice-win.dita" keyscope="win-novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
@@ -63,7 +63,7 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
-    <topicref class="- map/topicref " copy-to="configure-admin-win.dita" href="configure.dita" keyscope="win-admin-configure">
+    <topicref class="- map/topicref " href="configure-admin-win.dita" keyscope="win-admin-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
           <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>

--- a/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
@@ -5,6 +5,7 @@
   <topicref class="- map/topicref " href="install.dita" keyscope="install">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
     <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
+    <topicref class="- map/topicref " href="perform-install.dita" copy-to="installation-procedure.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="configure-novice.dita" keyscope="novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
@@ -31,6 +32,7 @@
       </ditavalmeta>
     </ditavalref>
     <topicref class="- map/topicref " href="perform-install-mac.dita" keyscope="mac-perform-install"/>
+    <topicref class="- map/topicref " href="installation-procedure-mac.dita" keyscope="mac-perform-install"/>
     <topicref class="- map/topicref " href="configure-novice-mac.dita" keyscope="mac-novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
@@ -57,6 +59,7 @@
       </ditavalmeta>
     </ditavalref>
     <topicref class="- map/topicref " href="perform-install-win.dita" keyscope="win-perform-install"/>
+    <topicref class="- map/topicref " href="installation-procedure-win.dita" keyscope="win-perform-install"/>
     <topicref class="- map/topicref " href="configure-novice-win.dita" keyscope="win-novice-configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
@@ -75,4 +78,5 @@
     </topicref>
     <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
+  <topicref class="- map/topicref " href="install.dita" copy-to="getting-started.dita"/>
 </map>

--- a/src/test/resources/BranchFilterModuleTest/exp/mapref.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/mapref.ditamap
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map "
+     domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+     ditaarch:DITAArchVersion="1.3">
+   <topicref class="- map/topicref " href="a.dita">
+      <mapref copy-to="submap-one.ditamap"
+              class="+ map/topicref mapgroup-d/mapref "
+              href="submap.ditamap"
+              format="ditamap">
+         <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval">
+            <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta "/>
+         </ditavalref>
+      </mapref>
+      <mapref copy-to="submap-two.ditamap"
+              class="+ map/topicref mapgroup-d/mapref "
+              href="submap.ditamap"
+              format="ditamap">
+         <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval">
+            <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta "/>
+         </ditavalref>
+      </mapref>
+   </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/exp/submap.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/submap.ditamap
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     copy-to="-subone."
+     class="- map/map "
+     domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+     ditaarch:DITAArchVersion="1.3">
+   <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="subone.ditaval">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+         <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-subone</dvrResourceSuffix>
+      </ditavalmeta>
+   </ditavalref>
+   <topicref copy-to="a-subone-subtwo.dita"
+             class="- map/topicref "
+             href="a.dita">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="subtwo.ditaval">
+         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+            <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-subtwo</dvrResourceSuffix>
+         </ditavalmeta>
+      </ditavalref>
+   </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/advanced.ditaval
+++ b/src/test/resources/BranchFilterModuleTest/src/advanced.ditaval
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="audience" val="advanced"/>
+  <prop action="exclude" att="audience" val="novice"/>
+</val>

--- a/src/test/resources/BranchFilterModuleTest/src/configure.dita
+++ b/src/test/resources/BranchFilterModuleTest/src/configure.dita
@@ -1,0 +1,19 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="install" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Configure</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">All platforms, all audience</p>
+    <p class="- topic/p " platform="linux">Linux, all audience</p>
+    <p class="- topic/p " platform="mac">OS X, all audience</p>
+    <p class="- topic/p " platform="win">Windows, all audience</p>
+    <p audience="novice" class="- topic/p ">All platforms, novice</p>
+    <p audience="novice" class="- topic/p " platform="linux">Linux, novice</p>
+    <p audience="novice" class="- topic/p " platform="mac">OS X, novice</p>
+    <p audience="novice" class="- topic/p " platform="win">Windows, novice</p>
+    <p audience="advanced" class="- topic/p ">All platforms, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="linux">Linux, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="mac">OS X, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="win">Windows, advanced</p>
+  </body>
+</topic>

--- a/src/test/resources/BranchFilterModuleTest/src/conflict.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/conflict.ditamap
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="a.dita" keyscope="a">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval"/>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval"/>
+    <topicref class="- map/topicref " href="b.dita" keyscope="b"/>
+  </topicref>
+  <topicref class="- map/topicref " href="a.dita"/>
+  <topicref class="- map/topicref " href="c.dita" keyscope="c">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">token</dvrResourceSuffix>
+        <dvrKeyscopeSuffix class="+ topic/data ditavalref-d/dvrKeyscopeSuffix ">token</dvrKeyscopeSuffix>
+      </ditavalmeta>
+    </ditavalref>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">token</dvrResourceSuffix>
+        <dvrKeyscopeSuffix class="+ topic/data ditavalref-d/dvrKeyscopeSuffix ">token</dvrKeyscopeSuffix>
+      </ditavalmeta>
+    </ditavalref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/ditaval-specific-to-branch.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/ditaval-specific-to-branch.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="intro.dita"/>
+  <topicref class="- map/topicref " href="install.dita">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="novice.ditaval"/>
+    <topicref class="- map/topicref " href="do-stuff.dita"/>
+    <topicref class="- map/topicref " href="advanced-stuff.dita" audience="admin"/>
+    <!-- more topics -->
+  </topicref>
+  <!-- Several chapters worth of other material -->
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/input.ditamap
@@ -17,6 +17,7 @@
       </ditavalmeta>
     </ditavalref>
     <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
+    <topicref class="- map/topicref " href="perform-install.dita" copy-to="installation-procedure.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="configure.dita" keyscope="configure">
       <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
         <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
@@ -33,4 +34,5 @@
     </topicref>
     <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
+  <topicref class="- map/topicref " href="install.dita" copy-to="getting-started.dita"/>
 </map>

--- a/src/test/resources/BranchFilterModuleTest/src/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/input.ditamap
@@ -31,5 +31,6 @@
         </ditavalmeta>
       </ditavalref>
     </topicref>
+    <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
   </topicref>
 </map>

--- a/src/test/resources/BranchFilterModuleTest/src/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/input.ditamap
@@ -1,0 +1,35 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">DITA Topic Map</title>
+  <topicref class="- map/topicref " href="install.dita" keyscope="install">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-win</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">win-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
+    <topicref class="- map/topicref " href="configure.dita" keyscope="configure">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="novice.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-novice</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">novice-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="advanced.ditaval" processing-role="resource-only">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-admin</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">admin-</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/input.xsl
+++ b/src/test/resources/BranchFilterModuleTest/src/input.xsl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:x="x"
+  exclude-result-prefixes="xs x"
+  version="2.0">
+  
+  <xsl:output indent="yes"/>
+  
+  <xsl:strip-space elements="*"/>
+  
+  <xsl:template match="*[ditavalref]">
+    <xsl:param name="resourcePrefix" tunnel="yes"/>
+    <xsl:param name="resourceSuffix" tunnel="yes"/>
+    <xsl:param name="keynamePrefix" tunnel="yes"/>
+    <xsl:param name="keynameSuffix" tunnel="yes"/>
+    <xsl:variable name="parent" select="."/>
+    <xsl:for-each select="ditavalref">
+      <xsl:variable name="ditavalref" select="."/>
+      <xsl:variable name="current-resourcePrefix" select="concat($resourcePrefix, ditavalmeta/dvr-resourcePrefix)"/>
+      <xsl:variable name="current-resourceSuffix" select="concat($resourceSuffix, ditavalmeta/dvr-resourceSuffix)"/>
+      <xsl:for-each select="$parent">
+        <xsl:copy>
+          <xsl:if test="string($current-resourcePrefix) or string($current-resourceSuffix)">
+            <xsl:attribute name="copy-to" select="x:addSuffix($parent/@href, $current-resourcePrefix, $current-resourceSuffix)"/>
+          </xsl:if>
+          <xsl:apply-templates select="@* | node()[(self::ditavalref and . is $ditavalref) or not(self::ditavalref)]">
+            <xsl:with-param name="resourcePrefix" select="$current-resourcePrefix" tunnel="yes"/>
+            <xsl:with-param name="resourceSuffix" select="$current-resourceSuffix" tunnel="yes"/>
+            <xsl:with-param name="keynamePrefix" select="concat($keynamePrefix, ditavalmeta/dvr-keynamePrefix)" tunnel="yes"/>
+            <xsl:with-param name="keynameSuffix" select="concat($keynameSuffix, ditavalmeta/dvr-keynameSuffix)" tunnel="yes"/>
+          </xsl:apply-templates>
+        </xsl:copy>  
+      </xsl:for-each>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <xsl:function name="x:addSuffix">
+    <xsl:param name="href"/>
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:variable name="suffixTokens" select="tokenize($href, '\.')"/>
+    <xsl:variable name="buf"
+                  select="concat(string-join($suffixTokens[position() lt count($suffixTokens)], '.'),
+                                 $suffix,
+                                 '.',
+                                 $suffixTokens[last()])"/>
+    <xsl:variable name="prefixTokens" select="tokenize($buf, '/')"/>
+    <xsl:for-each select="$prefixTokens[position() ne last()]">
+      <xsl:value-of select="."/>
+      <xsl:text>/</xsl:text>
+    </xsl:for-each>
+    <xsl:value-of select="$prefixTokens[last()]"/>
+  </xsl:function>
+    
+  <xsl:template match="@keys">
+    <xsl:param name="keynamePrefix" tunnel="yes"/>
+    <xsl:param name="keynameSuffix" tunnel="yes"/>
+    <xsl:attribute name="{local-name()}">
+      <xsl:for-each select="tokenize(normalize-space(.), '\s+')">
+        <xsl:if test="position() ne 1">
+          <xsl:text> </xsl:text>
+        </xsl:if>
+        <xsl:value-of select="concat($keynamePrefix, ., $keynameSuffix)"/>
+      </xsl:for-each>
+    </xsl:attribute>
+  </xsl:template>
+  
+  <xsl:template match="node() | @*">
+    <xsl:copy>
+      <xsl:apply-templates select="node() | @*"/>
+    </xsl:copy>
+  </xsl:template>
+  
+</xsl:stylesheet>

--- a/src/test/resources/BranchFilterModuleTest/src/install.dita
+++ b/src/test/resources/BranchFilterModuleTest/src/install.dita
@@ -1,0 +1,19 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="install" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Install</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">All platforms, all audience</p>
+    <p class="- topic/p " platform="linux">Linux, all audience</p>
+    <p class="- topic/p " platform="mac">OS X, all audience</p>
+    <p class="- topic/p " platform="win">Windows, all audience</p>
+    <p audience="novice" class="- topic/p ">All platforms, novice</p>
+    <p audience="novice" class="- topic/p " platform="linux">Linux, novice</p>
+    <p audience="novice" class="- topic/p " platform="mac">OS X, novice</p>
+    <p audience="novice" class="- topic/p " platform="win">Windows, novice</p>
+    <p audience="advanced" class="- topic/p ">All platforms, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="linux">Linux, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="mac">OS X, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="win">Windows, advanced</p>
+  </body>
+</topic>

--- a/src/test/resources/BranchFilterModuleTest/src/keys.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/keys.ditamap
@@ -1,0 +1,35 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">DITA Topic Map</title>
+  <topicref class="- map/topicref " href="install.dita" keys="install">
+    <ditavalref href="linux.ditaval" class="+ map/topicref ditavalref-d/ditavalref "/>
+    <ditavalref href="mac.ditaval" class="+ map/topicref ditavalref-d/ditavalref ">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">mac</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix ">mac</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <ditavalref href="win.ditaval" class="+ map/topicref ditavalref-d/ditavalref ">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">win</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix ">win</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+    <topicref class="- map/topicref " href="perform-install.dita" keys="perform-install"/> 
+    <topicref class="- map/topicref " href="configure.dita" keys="configure">
+      <ditavalref href="novice.ditaval" class="+ map/topicref ditavalref-d/ditavalref ">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">novice</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix ">novice</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+      <ditavalref href="advanced.ditaval" class="+ map/topicref ditavalref-d/ditavalref ">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">admin</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix ">admin</dvrKeyscopePrefix>
+        </ditavalmeta>
+      </ditavalref>
+    </topicref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/linux.ditaval
+++ b/src/test/resources/BranchFilterModuleTest/src/linux.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="platform" val="linux" />
+  <prop action="exclude" att="platform" val="mac" />
+  <prop action="exclude" att="platform" val="win" />
+</val>

--- a/src/test/resources/BranchFilterModuleTest/src/mac.ditaval
+++ b/src/test/resources/BranchFilterModuleTest/src/mac.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="platform" val="mac" />
+  <prop action="exclude" att="platform" val="win" />
+  <prop action="exclude" att="platform" val="linux" />
+</val>

--- a/src/test/resources/BranchFilterModuleTest/src/mapref.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/mapref.ditamap
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="a.dita">
+    <mapref class="+ map/topicref mapgroup-d/mapref " href="submap.ditamap" format="ditamap">
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="one.ditaval">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-one</dvrResourceSuffix>
+        </ditavalmeta>
+      </ditavalref>
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="two.ditaval">
+        <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-two</dvrResourceSuffix>
+        </ditavalmeta>
+      </ditavalref>
+    </mapref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/novice.ditaval
+++ b/src/test/resources/BranchFilterModuleTest/src/novice.ditaval
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="audience" val="novice"/>
+  <prop action="exclude" att="audience" val="advanced"/>
+</val>

--- a/src/test/resources/BranchFilterModuleTest/src/perform-install.dita
+++ b/src/test/resources/BranchFilterModuleTest/src/perform-install.dita
@@ -1,0 +1,19 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="topic_onl_r5l_qs" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Perform install</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">All platforms, all audience</p>
+    <p class="- topic/p " platform="linux">Linux, all audience</p>
+    <p class="- topic/p " platform="mac">OS X, all audience</p>
+    <p class="- topic/p " platform="win">Windows, all audience</p>
+    <p audience="novice" class="- topic/p ">All platforms, novice</p>
+    <p audience="novice" class="- topic/p " platform="linux">Linux, novice</p>
+    <p audience="novice" class="- topic/p " platform="mac">OS X, novice</p>
+    <p audience="novice" class="- topic/p " platform="win">Windows, novice</p>
+    <p audience="advanced" class="- topic/p ">All platforms, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="linux">Linux, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="mac">OS X, advanced</p>
+    <p audience="advanced" class="- topic/p " platform="win">Windows, advanced</p>
+  </body>
+</topic>

--- a/src/test/resources/BranchFilterModuleTest/src/submap.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/submap.ditamap
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="subone.ditaval">
+    <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+      <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-subone</dvrResourceSuffix>
+    </ditavalmeta>
+  </ditavalref>
+  <topicref class="- map/topicref " href="a.dita">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " href="subtwo.ditaval">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix ">-subtwo</dvrResourceSuffix>
+      </ditavalmeta>
+    </ditavalref>
+  </topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/win.ditaval
+++ b/src/test/resources/BranchFilterModuleTest/src/win.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="platform" val="win" />
+  <prop action="exclude" att="platform" val="mac" />
+  <prop action="exclude" att="platform" val="linux" />
+</val>

--- a/src/test/resources/messages.xml
+++ b/src/test/resources/messages.xml
@@ -403,6 +403,11 @@
     <reason>Chunk attribute uses both "to-content" and "by-topic" that conflict with each other.</reason>
     <response>Ignoring "by-topic" token.</response>
   </message>
+  
+  <message id="DOTJ065E" type="ERROR">
+    <reason>Branch filter generated topic %1 used more than once.</reason>
+    <response>Renaming %1 to %2.</response>
+  </message>
 
   <!-- End of Java Messages -->
     


### PR DESCRIPTION
Add DITA 1.3 branch filtering support for #1637

The implementation is a separate module that is ran before keyref processing. The process will

-   Initially split braches so that each branch will only contain a single `ditavalref`
-   Generate `copy-to` attributes for each branch generated `topicref`
-   Filter the map based on branch filters
-   Rewrite duplicate generated `copy-to´ targets with `-#` suffix
-   Copy and filter generated `copy-to` targets
-   Filter topics that were not branch generated