### PR TITLE
Ensuring @chunk inside topicgroups functions as expected.

### DIFF
--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -137,7 +137,9 @@ public final class ChunkMapReader extends AbstractDomFilter {
                     final Element currentElem = (Element) node;
                     if (MAP_RELTABLE.matches(currentElem)) {
                         updateReltable(currentElem);
-                    } else if (MAP_TOPICREF.matches(currentElem) && !MAPGROUP_D_TOPICGROUP.matches(currentElem)) {
+                    } else if (MAPGROUP_D_TOPICGROUP.matches(currentElem)) {
+                    	processChildTopicref(currentElem);
+                    } else if (MAP_TOPICREF.matches(currentElem)) {
                         processTopicref(currentElem);
                     }
 


### PR DESCRIPTION
Currently if @chunk is set on a topicref inside a topicgroup, it is not being processed. Since when chunking occurs, submaps are represented as topicgroups, this means that chunk instructions in sub-maps are also ignored. This attempts to resolve the issue.