### PR TITLE
UTF-8 encoding in CHM for en-us languages

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -1244,7 +1244,7 @@ See the accompanying license.txt file for applicable licenses.
         </xsl:variable>
         <xsl:choose>
             <!--  Disable chapter summary processing when mini TOC is created -->
-            <xsl:when test="$topicType = ('topicChapter', 'topicAppendix')"/>
+            <xsl:when test="($topicType = 'topicChapter' and $chapterLayout != 'BASIC') or ($topicType = 'topicAppendix' and $appendixLayout != 'BASIC')"/>
             <!--   Normal processing         -->
             <xsl:otherwise>
                 <xsl:apply-templates select="." mode="format-shortdesc-as-block"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -224,7 +224,8 @@ See the accompanying license.txt file for applicable licenses.
           <xsl:call-template name="startPageNumbering"/>
           <xsl:call-template name="insertBodyStaticContents"/>
           <fo:flow flow-name="xsl-region-body">
-            <xsl:for-each select="opentopic:map/*[contains(@class, ' map/topicref ')]">
+            <!-- For each top level topicref (topicref which does not have an ancestor topicref) + for each topicref inside a mapgroup. -->
+            <xsl:for-each select="opentopic:map//*[contains(@class, ' map/topicref ')][not(contains(@class, ' mapgroup-d/topicgroup '))][not(ancestor::*[contains(@class, ' map/topicref ') and not(contains(@class, ' mapgroup-d/topicgroup '))])]">
               <xsl:for-each select="key('topic-id', @id)">
                 <xsl:apply-templates select="." mode="processTopic"/>
               </xsl:for-each>

--- a/src/main/resources/org/dita/dost/util/codepages.xml
+++ b/src/main/resources/org/dita/dost/util/codepages.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <codepages>
   <language lang="en-us">
-    <cp format="ibmiddoc" encoding="850"/>
-    <cp format="html" encoding="819" charset="iso-8859-1"/>
-    <cp format="windows" encoding="1252" charset="windows-1252"/>
+    <cp format="ibmiddoc" encoding="utf-8"/>
+    <cp format="html" encoding="utf-8" charset="utf-8"/>
+    <cp format="windows" encoding="utf-8" charset="utf-8"/>
   </language>
   <language lang="ar-eg">
     <cp format="ibmiddoc" encoding="864"/>


### PR DESCRIPTION
Possible fix for:
https://github.com/dita-ot/dita-ot/issues/2020