### PR TITLE
Read domains attribute on maps as well as topics.

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -844,7 +844,7 @@ public final class GenListModuleReader extends AbstractXMLReader {
             logger.logInfo(MessageUtils.getInstance().getMessage("DOTJ030I", localName).toString());
         }
 
-        if (classValue != null && TOPIC_TOPIC.matches(classValue)) {
+        if (classValue != null && (TOPIC_TOPIC.matches(classValue) || MAP_MAP.matches(classValue))) {
             domains = atts.getValue(ATTRIBUTE_NAME_DOMAINS);
             if (domains == null) {
                 logger.logInfo(MessageUtils.getInstance().getMessage("DOTJ029I", localName).toString());


### PR DESCRIPTION
GenListModuleReader updates the list of props specializations when reading a topic, but not when reading a map.

This appears as a problem when reading a map like:

```
<map id="map">
  <title>Map</title>
  <keydef keys="some" blah="value">
    ...
  </keydef>
</map>
```

where blah is a specialization of props.

I have a test (junit) I could add, but several other unrelated tests fail so I thought I should check if this change is wanted before adding a test.