### PR TITLE
Fix dita.bat

### DIFF
--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -20,55 +20,21 @@ REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 REM  See the License for the specific language governing permissions and
 REM  limitations under the License.
 
-if "%HOME%"=="" goto homeDrivePathPre
-if exist "%HOME%\antrc_pre.bat" call "%HOME%\antrc_pre.bat"
-
-:homeDrivePathPre
-if "%HOMEDRIVE%%HOMEPATH%"=="" goto userProfilePre
-if "%HOMEDRIVE%%HOMEPATH%"=="%HOME%" goto userProfilePre
-if exist "%HOMEDRIVE%%HOMEPATH%\antrc_pre.bat" call "%HOMEDRIVE%%HOMEPATH%\antrc_pre.bat"
-
-:userProfilePre
-if "%USERPROFILE%"=="" goto alpha
-if "%USERPROFILE%"=="%HOME%" goto alpha
-if "%USERPROFILE%"=="%HOMEDRIVE%%HOMEPATH%" goto alpha
-if exist "%USERPROFILE%\antrc_pre.bat" call "%USERPROFILE%\antrc_pre.bat"
-
-:alpha
-
 if "%OS%"=="Windows_NT" @setlocal
 if "%OS%"=="WINNT" @setlocal
 
-if "%DITA_HOME%"=="" goto setDefaultAntHome
+if "%DITA_HOME%"=="" goto setDefaultDitaHome
 
-:stripAntHome
-if not _%DITA_HOME:~-1%==_\ goto checkClasspath
-set DITA_HOME=%DITA_HOME:~0,-1%
-goto stripAntHome
-
-:setDefaultAntHome
+:setDefaultDitaHome
 rem %~dp0 is expanded pathname of the current script under NT
-set DITA_HOME=%~dp0..
-
-:checkClasspath
-set _USE_CLASSPATH=yes
-rem CLASSPATH must not be used if it is equal to ""
-if "%CLASSPATH%"=="""" set _USE_CLASSPATH=no
-if "%CLASSPATH%"=="" set _USE_CLASSPATH=no
+set DITA_HOME="%~dp0.."
 
 rem Slurp the command line arguments. This loop allows for an unlimited number
 rem of arguments (up to the command line limit, anyway).
 set DITA_CMD_LINE_ARGS=
 :setupArgs
 if ""%1""=="""" goto doneStart
-if ""%1""==""-noclasspath"" goto clearclasspath
 set DITA_CMD_LINE_ARGS=%DITA_CMD_LINE_ARGS% %1
-shift
-goto setupArgs
-
-rem here is there is a -noclasspath in the options
-:clearclasspath
-set _USE_CLASSPATH=no
 shift
 goto setupArgs
 
@@ -76,39 +42,6 @@ rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
 :doneStart
-
-if "%_USE_CLASSPATH%"=="no" goto findDitaHome
-
-:stripClasspath
-if not _%CLASSPATH:~-1%==_\ goto findDitaHome
-set CLASSPATH=%CLASSPATH:~0,-1%
-goto stripClasspath
-
-:findDitaHome
-rem find DITA_HOME if it does not exist due to either an invalid value passed
-rem by the user or the %0 problem on Windows 9x
-if exist "%DITA_HOME%\lib\ant.jar" goto checkJava
-
-rem check for ant in Program Files
-if not exist "%ProgramFiles%\ant" goto checkSystemDrive
-set DITA_HOME=%ProgramFiles%\ant
-goto checkJava
-
-:checkSystemDrive
-rem check for ant in root directory of system drive
-if not exist %SystemDrive%\ant\lib\ant.jar goto checkCDrive
-set DITA_HOME=%SystemDrive%\ant
-goto checkJava
-
-:checkCDrive
-rem check for ant in C:\ant for Win9X users
-if not exist C:\ant\lib\ant.jar goto noAntHome
-set DITA_HOME=C:\ant
-goto checkJava
-
-:noAntHome
-echo DITA_HOME is set incorrectly or ant could not be located. Please set DITA_HOME.
-goto end
 
 :checkJava
 rem Set environment variables
@@ -124,16 +57,7 @@ if "%_JAVACMD%" == "" set _JAVACMD=%JAVA_HOME%\bin\java.exe
 if "%_JAVACMD%" == "" set _JAVACMD=java.exe
 
 :runAnt
-if "%_USE_CLASSPATH%"=="no" goto runAntNoClasspath
-:runAntWithClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%DITA_HOME%\lib\ant-launcher.jar" "-Dant.home=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
-rem Check the error code of the Ant build
-if not "%OS%"=="Windows_NT" goto onError
-set ANT_ERROR=%ERRORLEVEL%
-goto end
-
-:runAntNoClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%DITA_HOME%\lib\ant-launcher.jar" "-Dant.home=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
+"%_JAVACMD%" %ANT_OPTS% -classpath "%DITA_HOME%\lib\ant-launcher.jar" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%
@@ -172,20 +96,6 @@ goto omega
 rem If there were no errors, we run the post script.
 if "%OS%"=="Windows_NT" @endlocal
 if "%OS%"=="WINNT" @endlocal
-
-if "%HOME%"=="" goto homeDrivePathPost
-if exist "%HOME%\antrc_post.bat" call "%HOME%\antrc_post.bat"
-
-:homeDrivePathPost
-if "%HOMEDRIVE%%HOMEPATH%"=="" goto userProfilePost
-if "%HOMEDRIVE%%HOMEPATH%"=="%HOME%" goto userProfilePost
-if exist "%HOMEDRIVE%%HOMEPATH%\antrc_post.bat" call "%HOMEDRIVE%%HOMEPATH%\antrc_post.bat"
-
-:userProfilePost
-if "%USERPROFILE%"=="" goto omega
-if "%USERPROFILE%"=="%HOME%" goto omega
-if "%USERPROFILE%"=="%HOMEDRIVE%%HOMEPATH%" goto omega
-if exist "%USERPROFILE%\antrc_post.bat" call "%USERPROFILE%\antrc_post.bat"
 
 :omega
 


### PR DESCRIPTION
[ll. 80-111 of `dita.bat`](https://github.com/dita-ot/dita-ot/blob/8046200e40884f63d0ee8f159286d66e0fddcd18/src/main/bin/dita.bat#L80-L111) set the `DITA_HOME` variable to point to the wrong location. This commit fixes that.

It also removes a lot of Ant-specific chaff that I don't think we need, as well as sets the `dita.dir` property as mentioned in https://groups.google.com/forum/#!topic/dita-ot-users/QCKhHPXnRTo.
