### PR TITLE
Refactor PDF flagging to use common preprocessing #2047

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -324,12 +324,13 @@ with those set forth herein.
       <not><isset property="_org.dita.pdf2.valfile"/></not>
     </condition>
     <makeurl property="_org.dita.pdf2.valfile.url" file="${_org.dita.pdf2.valfile}" validate="no"/>
-    <xslt in="${dita.temp.dir}/stage1.xml" out="${dita.temp.dir}/stage1a.xml" style="${xsl.fo.dir}/flagging-preprocess.xsl">
+    <copy file="${dita.temp.dir}/stage1.xml" tofile="${dita.temp.dir}/stage1a.xml"/>
+    <!--<xslt in="${dita.temp.dir}/stage1.xml" out="${dita.temp.dir}/stage1a.xml" style="${xsl.fo.dir}/flagging-preprocess.xsl">
       <param name="filterFile" expression="${_org.dita.pdf2.valfile.url}"/>
       <xmlcatalog>
         <catalogpath path="${xml.catalog.files}"/>
       </xmlcatalog>
-    </xslt>
+    </xslt>-->
   </target>
   <target name="transform.topic2fo.flagging.no-filter" unless="dita.input.valfile">
     <copy file="${dita.temp.dir}/stage1.xml" tofile="${dita.temp.dir}/stage1a.xml"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -2041,6 +2041,8 @@ See the accompanying license.txt file for applicable licenses.
     <!-- Process common attributes -->
     <xsl:template name="commonattributes">
       <xsl:apply-templates select="@id"/>
+      <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')] |
+                                   *[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="flag-attributes"/>
     </xsl:template>
 
     <!-- Get ID for an element, generate ID if not explicitly set. -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -1798,6 +1798,7 @@ See the accompanying license.txt file for applicable licenses.
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/image ')]">
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <xsl:choose>
             <xsl:when test="empty(@href)"/>
             <xsl:when test="@placement = 'break'">
@@ -1823,6 +1824,7 @@ See the accompanying license.txt file for applicable licenses.
                 </fo:inline>
             </xsl:otherwise>
         </xsl:choose>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
   <!-- Test whether URI is absolute -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+See the accompanying license.txt file for applicable licenses.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    version="2.0">
+
+  <!-- For reference, flagging info as it appears in the topics: -->
+  <!--<ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop ">
+    <prop action="flag" att="audience" val="p">
+      <startflag imageref="yukface.jpg"><alt-text>Start P</alt-text></startflag>
+    </prop>
+    <prop action="flag" att="audience" backcolor="aqua" color="blue" style="italics" val="meep"/>
+    <revprop action="flag" backcolor="maroon" changebar="|" color="olive" style="underline" val="testrev"/>
+  </ditaval-startprop>
+  <ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop ">
+    <prop action="flag" att="audience" val="p">
+      <endflag imageref="smileface.jpg"><alt-text>End P</alt-text></endflag>
+    </prop>
+  </ditaval-endprop>
+  -->
+
+  <xsl:template match="*[contains(@class,' topic/image ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/table ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/simpletable ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/thead ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/tgroup ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/tbody ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/row ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/strow ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/sthead ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
+
+
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]
+                        [parent::*[contains(@class,' topic/ol ') or contains(@class,' topic/ul ') or
+                                   contains(@class,' topic/sl ')]]" priority="10">
+    <!-- Process with "outofline" in lists.xsl -->
+  </xsl:template>
+
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')] |
+                         *[contains(@class,' ditaot-d/ditaval-endprop ')]">
+      <!-- Style flags called from common attributes -->
+      <!--<xsl:apply-templates select="." mode="flag-attributes"/>-->
+      <xsl:apply-templates select="revprop[@changebar]" mode="changebar">
+        <xsl:with-param name="changebar-id" select="concat(generate-id(parent::*),'-cbar')"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="." mode="flag-images"/>
+    </xsl:template>
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')] |
+                         *[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline">
+      <xsl:apply-templates select="revprop[@changebar]" mode="changebar">
+        <xsl:with-param name="changebar-id" select="concat(generate-id(parent::*),'-cbar')"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="." mode="flag-images"/>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes">
+      <xsl:apply-templates select=".//prop/@backcolor | .//prop/@color | .//prop/@style |
+                                   .//revprop/@backcolor | .//revprop/@color | .//revprop/@style" mode="flag-attributes"/>
+    </xsl:template>
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="flag-attributes">
+      <!-- No flagging at end -->
+    </xsl:template>
+
+    <xsl:template match="@backcolor" mode="flag-attributes">
+      <xsl:attribute name="background-color"><xsl:value-of select="."/></xsl:attribute>
+    </xsl:template>
+    <xsl:template match="@color" mode="flag-attributes">
+      <xsl:attribute name="color"><xsl:value-of select="."/></xsl:attribute>
+    </xsl:template>
+    <xsl:template match="@style" mode="flag-attributes">
+      <xsl:choose>
+        <xsl:when test=".='bold'">
+          <xsl:attribute name="font-weight">bold</xsl:attribute>
+        </xsl:when>
+        <xsl:when test=".='italics' or .='italic'">
+          <xsl:attribute name="font-style">italic</xsl:attribute>
+        </xsl:when>
+        <xsl:when test=".='double-underline'">
+          <xsl:attribute name="text-decoration">underline</xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="text-decoration"><xsl:value-of select="."/></xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop" mode="changebar">
+      <xsl:param name="changebar-id"/>
+      <xsl:param name="changebar-style">
+        <xsl:choose>
+          <xsl:when test="@changebar='none' or @changebar='hidden' or @changebar='dotted' or
+                          @changebar='dashed' or @changebar='solid' or @changebar='double' or
+                          @changebar='groove' or @changebar='ridge' or @changebar='inset' or @changebar='outset'">
+            <xsl:value-of select="@changebar"/>
+          </xsl:when>
+          <xsl:otherwise>groove</xsl:otherwise>
+        </xsl:choose>
+      </xsl:param>
+      <xsl:param name="changebar-color">
+        <!-- Could take color from @changebar, but for now take from @color to allow @changebar to set style; bar color matches text -->
+        <xsl:choose>
+          <xsl:when test="@color"><xsl:value-of select="@color"/></xsl:when>
+          <xsl:otherwise>black</xsl:otherwise>
+        </xsl:choose>
+      </xsl:param>
+      <fo:change-bar-begin 
+        change-bar-class="{$changebar-id}" 
+        change-bar-style="{$changebar-style}" 
+        change-bar-color="{$changebar-color}" 
+        change-bar-offset="2mm"/>
+    </xsl:template>
+    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop" mode="changebar">
+      <xsl:param name="changebar-id"/>
+      <fo:change-bar-end change-bar-class="{$changebar-id}"/>
+    </xsl:template>
+
+    <xsl:template match="*" mode="flag-images">
+      <xsl:if test="*//startflag|*//endflag">
+        <xsl:variable name="flags" as="element()*">
+          <xsl:for-each select=".//startflag|.//endflag">
+            <xsl:choose>
+              <xsl:when test="@imageref">
+                <image class="+ topic/image ditaot-d/flagimage " href="{@imageref}" placement="inline">
+                  <alt class="- topic/alt "><xsl:value-of select="alt-text"/></alt>
+                </image>
+              </xsl:when>
+              <xsl:when test="alt-text">
+                <text class="+ topic/text ditaot-d/flagtext "> [<xsl:value-of select="alt-text"/>] </text>
+              </xsl:when>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:apply-templates select="$flags"/>
+      </xsl:if>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -22,21 +22,55 @@ See the accompanying license.txt file for applicable licenses.
   </ditaval-endprop>
   -->
 
-  <xsl:template match="*[contains(@class,' topic/image ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/table ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/simpletable ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/thead ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/tgroup ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/tbody ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/row ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/strow ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-  <xsl:template match="*[contains(@class,' topic/sthead ')]/*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]" priority="10"/>
-
-
   <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]
                         [parent::*[contains(@class,' topic/ol ') or contains(@class,' topic/ul ') or
                                    contains(@class,' topic/sl ')]]" priority="10">
     <!-- Process with "outofline" in lists.xsl -->
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]
+                        [parent::*[contains(@class,' topic/dl ') or contains(@class,' topic/dlhead ') or
+                                   contains(@class,' topic/dlentry ')]]" priority="10">
+    <!-- Process with "outofline" in tables.xsl -->
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]
+                        [parent::*[contains(@class,' topic/table ') or contains(@class,' topic/simpletable ') or
+                                   contains(@class,' topic/tgroup ') or contains(@class,' topic/tbody ') or
+                                   contains(@class,' topic/thead ') or contains(@class,' topic/sthead ') or
+                                   contains(@class,' topic/row ') or contains(@class,' topic/strow ')]]" priority="10">
+    <!-- Process with "outofline" in tables.xsl -->
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ') or contains(@class,' ditaot-d/ditaval-endprop ')]
+                        [parent::*[contains(@class,' topic/image ')]]" priority="10">
+    <!-- Process with "outofline" in commons.xsl -->
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class,' topic/stentry ')]" mode="ancestor-start-flag">
+    <!-- If first stentry in a row, pick up start flag from the row -->
+    <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/stentry ')])">
+      <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' topic/stentry ')]" mode="ancestor-end-flag">
+    <!-- If last stentry in a row, pick up end flag from the row -->
+    <xsl:if test="not(following-sibling::*[contains(@class,' topic/stentry ')])">
+      <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' topic/entry ')]" mode="ancestor-start-flag">
+    <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/entry ')])">
+      <!-- check tgroup, tbody or thead, row -->
+      <xsl:apply-templates select="../../../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+      <xsl:apply-templates select="../../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+      <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' topic/entry ')]" mode="ancestor-end-flag">
+    <xsl:if test="not(following-sibling::*[contains(@class,' topic/entry ')])">
+      <!-- check row, tbody or thead, tgroup -->
+      <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+      <xsl:apply-templates select="../../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+      <xsl:apply-templates select="../../../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+    </xsl:if>
   </xsl:template>
 
     <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')] |
@@ -133,7 +167,17 @@ See the accompanying license.txt file for applicable licenses.
             </xsl:choose>
           </xsl:for-each>
         </xsl:variable>
-        <xsl:apply-templates select="$flags"/>
+        <xsl:choose>
+          <xsl:when test="parent::*[contains(@class,' topic/dl ') or
+                                    contains(@class,' topic/image ')]">
+            <fo:inline xsl:use-attribute-sets="image__inline">
+              <xsl:apply-templates select="$flags"/>
+            </fo:inline>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="$flags"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:if>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging_fop.xsl
@@ -12,6 +12,9 @@
   <!-- FOP crashes if changebar elements appear in fo:block or fo:inline,
        which is where all are currently generated -->
   <xsl:template match="suitesol:changebar-start"/>
-  <xsl:template match="suitesol:changebar-end"/>      
+  <xsl:template match="suitesol:changebar-end"/>   
+     
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop" mode="changebar"/>
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop" mode="changebar"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -46,25 +46,30 @@ See the accompanying license.txt file for applicable licenses.
 
     <!--Lists-->
     <xsl:template match="*[contains(@class, ' topic/ul ')]">
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ul">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/ul ')][empty(*[contains(@class, ' topic/li ')])]" priority="10"/>
 
     <xsl:template match="*[contains(@class, ' topic/ol ')]">
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ol">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/ol ')][empty(*[contains(@class, ' topic/li ')])]" priority="10"/>
 
     <xsl:template match="*[contains(@class, ' topic/ul ')]/*[contains(@class, ' topic/li ')]">
         <fo:list-item xsl:use-attribute-sets="ul.li">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ul.li__label">
                 <fo:block xsl:use-attribute-sets="ul.li__label__content">
                     <fo:inline>
@@ -85,6 +90,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <xsl:template match="*[contains(@class, ' topic/ol ')]/*[contains(@class, ' topic/li ')]">
         <fo:list-item xsl:use-attribute-sets="ol.li">
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
                     <fo:inline>
@@ -123,16 +129,19 @@ See the accompanying license.txt file for applicable licenses.
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/sl ')]">
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="sl">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/sl ')][empty(*[contains(@class, ' topic/sli ')])]" priority="10"/>
 
     <xsl:template match="*[contains(@class, ' topic/sl ')]/*[contains(@class, ' topic/sli ')]">
         <fo:list-item xsl:use-attribute-sets="sl.sli">
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="sl.sli__label">
                 <fo:block xsl:use-attribute-sets="sl.sli__label__content">
                     <fo:inline>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -20,6 +20,7 @@
 
     <!--Definition list-->
     <xsl:template match="*[contains(@class, ' topic/dl ')]">
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:table xsl:use-attribute-sets="dl">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="*[contains(@class, ' topic/dlhead ')]"/>
@@ -36,6 +37,7 @@
                 </xsl:choose>
             </fo:table-body>
         </fo:table>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/dl ')]/*[contains(@class, ' topic/dlhead ')]">
@@ -51,6 +53,7 @@
         <fo:table-cell xsl:use-attribute-sets="dlhead.dthd__cell">
             <xsl:call-template name="commonattributes"/>
             <fo:block xsl:use-attribute-sets="dlhead.dthd__content">
+                <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
                 <xsl:apply-templates/>
             </fo:block>
         </fo:table-cell>
@@ -61,6 +64,7 @@
             <xsl:call-template name="commonattributes"/>
             <fo:block xsl:use-attribute-sets="dlhead.ddhd__content">
                 <xsl:apply-templates/>
+                <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
             </fo:block>
         </fo:table-cell>
     </xsl:template>
@@ -80,6 +84,9 @@
     <xsl:template match="*[contains(@class, ' topic/dt ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dt__content">
             <xsl:call-template name="commonattributes"/>
+            <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/dt ')])">
+              <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+            </xsl:if>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -88,6 +95,9 @@
         <fo:block xsl:use-attribute-sets="dlentry.dd__content">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
+            <xsl:if test="not(following-sibling::*[contains(@class,' topic/dd ')])">
+              <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+            </xsl:if>
         </fo:block>
     </xsl:template>
 
@@ -249,7 +259,9 @@
             <xsl:if test="exists($scale)">
                 <xsl:attribute name="font-size" select="concat($scale, '%')"/>
             </xsl:if>
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
             <xsl:apply-templates/>
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
         </fo:block>
     </xsl:template>
 
@@ -375,7 +387,9 @@
             <xsl:call-template name="applyAlignAttrs"/>
             <xsl:call-template name="generateTableEntryBorder"/>
             <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+                <xsl:apply-templates select="." mode="ancestor-start-flag"/>
                 <xsl:call-template name="processEntryContent"/>
+                <xsl:apply-templates select="." mode="ancestor-end-flag"/>
             </fo:block>
         </fo:table-cell>
     </xsl:template>
@@ -402,7 +416,9 @@
         <xsl:call-template name="applyAlignAttrs"/>
         <xsl:call-template name="generateTableEntryBorder"/>
         <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+            <xsl:apply-templates select="." mode="ancestor-start-flag"/>
             <xsl:call-template name="processEntryContent"/>
+            <xsl:apply-templates select="." mode="ancestor-end-flag"/>
         </fo:block>
     </xsl:template>
 
@@ -793,6 +809,7 @@
             <!-- Contains the number of cells in the widest row -->
             <xsl:apply-templates select="*[1]" mode="count-max-simpletable-cells"/>
         </xsl:variable>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:table xsl:use-attribute-sets="simpletable">
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="globalAtts"/>
@@ -824,6 +841,7 @@
             </fo:table-body>
 
         </fo:table>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/simpletable ')][empty(*)]" priority="10"/>
@@ -969,12 +987,16 @@
             <xsl:choose>
                 <xsl:when test="number(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@keycol) = $entryCol">
                     <fo:block xsl:use-attribute-sets="sthead.stentry__keycol-content">
+                        <xsl:apply-templates select="." mode="ancestor-start-flag"/>
                         <xsl:apply-templates/>
+                        <xsl:apply-templates select="." mode="ancestor-end-flag"/>
                     </fo:block>
                 </xsl:when>
                 <xsl:otherwise>
                     <fo:block xsl:use-attribute-sets="sthead.stentry__content">
+                        <xsl:apply-templates select="." mode="ancestor-start-flag"/>
                         <xsl:apply-templates/>
+                        <xsl:apply-templates select="." mode="ancestor-end-flag"/>
                     </fo:block>
                 </xsl:otherwise>
             </xsl:choose>
@@ -1011,12 +1033,16 @@
             <xsl:choose>
                 <xsl:when test="number(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@keycol) = $entryCol">
                     <fo:block xsl:use-attribute-sets="strow.stentry__keycol-content">
+                        <xsl:apply-templates select="." mode="ancestor-start-flag"/>
                         <xsl:apply-templates/>
+                        <xsl:apply-templates select="." mode="ancestor-end-flag"/>
                     </fo:block>
                 </xsl:when>
                 <xsl:otherwise>
                     <fo:block xsl:use-attribute-sets="strow.stentry__content">
+                        <xsl:apply-templates select="." mode="ancestor-start-flag"/>
                         <xsl:apply-templates/>
+                        <xsl:apply-templates select="." mode="ancestor-end-flag"/>
                     </fo:block>
                 </xsl:otherwise>
             </xsl:choose>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
@@ -104,6 +104,7 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:import href="learning-elements.xsl"/>
 
     <xsl:import href="flagging.xsl"/>
+    <xsl:import href="flagging-from-preprocess.xsl"/>
 
 
     <xsl:output method="xml" encoding="utf-8" indent="no"/>


### PR DESCRIPTION
Replaces the current PDF2 flagging step (currently converts `stage1.xml` to `stage1a.xml` in the PDF process) with code that takes advantage of the flagging information added during preprocess.