### PR TITLE
Retain classpath order when generating env files

### DIFF
--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -298,7 +298,7 @@ public final class Integrator {
             }
         }
 
-        final Collection<File> jars = featureTable.containsKey(FEAT_LIB_EXTENSIONS) ? relativize(new HashSet<>(featureTable.get(FEAT_LIB_EXTENSIONS))) : Collections.EMPTY_SET;
+        final Collection<File> jars = featureTable.containsKey(FEAT_LIB_EXTENSIONS) ? relativize(new LinkedHashSet<>(featureTable.get(FEAT_LIB_EXTENSIONS))) : Collections.EMPTY_SET;
         writeEnvShell(jars);
         writeEnvBatch(jars);
     }


### PR DESCRIPTION
Currently, any `<feature extension="dita.conductor.lib.import">` entries
in a `plugin.xml` file are inserted into `env.sh`/`env.bat` in random order.
After this commit, the insertion order is retained.

This is necessary when a plugin that uses Java libraries presupposes a
certain classpath order.