### PR TITLE
Extend `transtype` parameter description

### DIFF
--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -133,7 +133,7 @@
     </param>
     <param name="output.dir" desc="Specifies the name and location of the output directory." type="dir"/>
     <param name="root-chunk-override" desc="Override for map chunk attribute value." type="string"/>
-    <param name="transtype" desc="Specifies the output format." type="file" required="true"/>
+    <param name="transtype" desc="Specifies the output format (transformation type)." type="file" required="true"/>
     <param name="validate" desc="Specifies whether the DITA-OT validates the content." type="enum">
       <val default="true">true</val>
       <val>false</val>


### PR DESCRIPTION
Sync source of generated description in docs
`ant-parameters-base-transformation.dita` for
consistency w/ `dita -help` output since 0e66922
and other descriptions of `dita` command in docs.