### PR TITLE
Add default classpath to FOP Ant task

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_fop.xml
+++ b/src/main/plugins/org.dita.pdf2/build_fop.xml
@@ -153,7 +153,7 @@
   <target name="transform.fo2pdf.fop" depends="transform.fo2pdf.fop.test-use, transform.fo2pdf.fop.init" if="use.fop.pdf.formatter">
     <!--Check fop lib-->
     <antcall target="checkFOPLib"/>
-    <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop">
+    <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop" classpathref="dost.class.path">
       <classpath>
         <fileset dir="${fop.home}/lib">
           <include name="*.jar"/>


### PR DESCRIPTION
A manual cherry-pick of acef62a from the 2.x branch.

Just a heads-up: this change doesn't cause the tests to fail, but #2045 does.