### PR TITLE
Add support for n-tilde in Spanish index #2068

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/es.xml
@@ -204,6 +204,14 @@ See the accompanying license.txt file for applicable licenses.
                 </group.members>
             </index.group>
             <index.group>
+                <group.key>Ñ</group.key>
+                <group.label>Ñ</group.label>
+                <group.members>
+                     <char.set>Ñ</char.set>
+                     <char.set>ñ</char.set>
+                </group.members>
+            </index.group>
+            <index.group>
                 <group.key>O</group.key>
                 <group.label>O</group.label>
                 <group.members>


### PR DESCRIPTION
Submitted first for `develop` but then realized this probably should have been treated as a fix in 2.1.2, thus the second request.