### PR TITLE
Add consistent headings, lang values, number group #2074

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/de.xml
@@ -33,10 +33,11 @@ See the accompanying license.txt file for applicable licenses.
 
 <index.configuration.set>
 <index.configuration>
+<language>de</language>
 <index.groups>
 <index.group>
 <group.key>Specials</group.key>
-<group.label/>
+<group.label>Sonderzeichen</group.label>
 <group.members>
 <char.set>\</char.set>
 <char.set>`</char.set>
@@ -72,8 +73,8 @@ See the accompanying license.txt file for applicable licenses.
 </group.members>
 </index.group>
 <index.group>
-<group.key/>
-<group.label/>
+<group.key>Numbers</group.key>
+<group.label>Numerische Stichwörter</group.label>
 <group.members>
 <char.set>0</char.set>
 <char.set>０</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/en.xml
@@ -38,7 +38,7 @@ See the accompanying license.txt file for applicable licenses.
         <index.groups>
             <index.group>
                 <group.key>Specials</group.key>
-                <group.label></group.label>
+                <group.label>Special Characters</group.label>
                 <group.members>
                     <char.set>\</char.set>
                     <char.set>`</char.set>
@@ -75,22 +75,30 @@ See the accompanying license.txt file for applicable licenses.
                 </group.members>
             </index.group>
             <index.group>
-
                 <group.key>Numbers</group.key>
-                <group.label></group.label>
+                <group.label>Numerics</group.label>
                 <group.members>
                     <char.set>0</char.set>
+                    <char.set>０</char.set>
                     <char.set>1</char.set>
+                    <char.set>１</char.set>
                     <char.set>2</char.set>
+                    <char.set>２</char.set>
                     <char.set>3</char.set>
+                    <char.set>３</char.set>
                     <char.set>4</char.set>
+                    <char.set>４</char.set>
                     <char.set>5</char.set>
+                    <char.set>５</char.set>
                     <char.set>6</char.set>
+                    <char.set>６</char.set>
                     <char.set>7</char.set>
+                    <char.set>７</char.set>
                     <char.set>8</char.set>
+                    <char.set>８</char.set>
                     <char.set>9</char.set>
+                    <char.set>９</char.set>
                 </group.members>
-
             </index.group>
             <index.group>
                 <group.key>A</group.key>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/es.xml
@@ -33,11 +33,11 @@ See the accompanying license.txt file for applicable licenses.
 
 <index.configuration.set>
     <index.configuration>
-        <language>en</language>
+        <language>es</language>
         <index.groups>
             <index.group>
                 <group.key>Specials</group.key>
-                <group.label></group.label>
+                <group.label>Caracteres Especiales</group.label>
                 <group.members>
                     <char.set>\</char.set>
                     <char.set>`</char.set>
@@ -74,22 +74,30 @@ See the accompanying license.txt file for applicable licenses.
                 </group.members>
             </index.group>
             <index.group>
-
                 <group.key>Numbers</group.key>
-                <group.label></group.label>
+                <group.label>Números</group.label>
                 <group.members>
                     <char.set>0</char.set>
+                    <char.set>０</char.set>
                     <char.set>1</char.set>
+                    <char.set>１</char.set>
                     <char.set>2</char.set>
+                    <char.set>２</char.set>
                     <char.set>3</char.set>
+                    <char.set>３</char.set>
                     <char.set>4</char.set>
+                    <char.set>４</char.set>
                     <char.set>5</char.set>
+                    <char.set>５</char.set>
                     <char.set>6</char.set>
+                    <char.set>６</char.set>
                     <char.set>7</char.set>
+                    <char.set>７</char.set>
                     <char.set>8</char.set>
+                    <char.set>８</char.set>
                     <char.set>9</char.set>
+                    <char.set>９</char.set>
                 </group.members>
-
             </index.group>
             <index.group>
                 <group.key>A</group.key>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/fi.xml
@@ -9,7 +9,7 @@
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>Erikoismerkit</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -46,7 +46,7 @@
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>Numerot</group.label>
         <group.members>
           <char.set>0</char.set>
           <char.set>０</char.set>
@@ -72,7 +72,7 @@
       </index.group>
       <index.group>
         <group.key>A</group.key>
-        <group.label/>
+        <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
           <char.set>A</char.set>
@@ -80,7 +80,7 @@
       </index.group>
       <index.group>
         <group.key>B</group.key>
-        <group.label/>
+        <group.label>B</group.label>
         <group.members>
           <char.set>b</char.set>
           <char.set>B</char.set>
@@ -88,7 +88,7 @@
       </index.group>
       <index.group>
         <group.key>C</group.key>
-        <group.label/>
+        <group.label>C</group.label>
         <group.members>
           <char.set>c</char.set>
           <char.set>C</char.set>
@@ -96,7 +96,7 @@
       </index.group>
       <index.group>
         <group.key>D</group.key>
-        <group.label/>
+        <group.label>D</group.label>
         <group.members>
           <char.set>d</char.set>
           <char.set>D</char.set>
@@ -104,7 +104,7 @@
       </index.group>
       <index.group>
         <group.key>E</group.key>
-        <group.label/>
+        <group.label>E</group.label>
         <group.members>
           <char.set>e</char.set>
           <char.set>E</char.set>
@@ -112,7 +112,7 @@
       </index.group>
       <index.group>
         <group.key>F</group.key>
-        <group.label/>
+        <group.label>F</group.label>
         <group.members>
           <char.set>f</char.set>
           <char.set>F</char.set>
@@ -120,7 +120,7 @@
       </index.group>
       <index.group>
         <group.key>G</group.key>
-        <group.label/>
+        <group.label>G</group.label>
         <group.members>
           <char.set>g</char.set>
           <char.set>G</char.set>
@@ -128,7 +128,7 @@
       </index.group>
       <index.group>
         <group.key>H</group.key>
-        <group.label/>
+        <group.label>H</group.label>
         <group.members>
           <char.set>h</char.set>
           <char.set>H</char.set>
@@ -136,7 +136,7 @@
       </index.group>
       <index.group>
         <group.key>I</group.key>
-        <group.label/>
+        <group.label>I</group.label>
         <group.members>
           <char.set>i</char.set>
           <char.set>I</char.set>
@@ -144,7 +144,7 @@
       </index.group>
       <index.group>
         <group.key>J</group.key>
-        <group.label/>
+        <group.label>J</group.label>
         <group.members>
           <char.set>j</char.set>
           <char.set>J</char.set>
@@ -152,7 +152,7 @@
       </index.group>
       <index.group>
         <group.key>K</group.key>
-        <group.label/>
+        <group.label>K</group.label>
         <group.members>
           <char.set>k</char.set>
           <char.set>K</char.set>
@@ -160,7 +160,7 @@
       </index.group>
       <index.group>
         <group.key>L</group.key>
-        <group.label/>
+        <group.label>L</group.label>
         <group.members>
           <char.set>l</char.set>
           <char.set>L</char.set>
@@ -168,7 +168,7 @@
       </index.group>
       <index.group>
         <group.key>M</group.key>
-        <group.label/>
+        <group.label>M</group.label>
         <group.members>
           <char.set>m</char.set>
           <char.set>M</char.set>
@@ -176,7 +176,7 @@
       </index.group>
       <index.group>
         <group.key>N</group.key>
-        <group.label/>
+        <group.label>N</group.label>
         <group.members>
           <char.set>n</char.set>
           <char.set>N</char.set>
@@ -184,7 +184,7 @@
       </index.group>
       <index.group>
         <group.key>O</group.key>
-        <group.label/>
+        <group.label>O</group.label>
         <group.members>
           <char.set>o</char.set>
           <char.set>O</char.set>
@@ -192,7 +192,7 @@
       </index.group>
       <index.group>
         <group.key>P</group.key>
-        <group.label/>
+        <group.label>P</group.label>
         <group.members>
           <char.set>p</char.set>
           <char.set>P</char.set>
@@ -200,7 +200,7 @@
       </index.group>
       <index.group>
         <group.key>Q</group.key>
-        <group.label/>
+        <group.label>Q</group.label>
         <group.members>
           <char.set>q</char.set>
           <char.set>Q</char.set>
@@ -208,7 +208,7 @@
       </index.group>
       <index.group>
         <group.key>R</group.key>
-        <group.label/>
+        <group.label>R</group.label>
         <group.members>
           <char.set>r</char.set>
           <char.set>R</char.set>
@@ -216,7 +216,7 @@
       </index.group>
       <index.group>
         <group.key>S</group.key>
-        <group.label/>
+        <group.label>S</group.label>
         <group.members>
           <char.set>s</char.set>
           <char.set>S</char.set>
@@ -224,7 +224,7 @@
       </index.group>
       <index.group>
         <group.key>T</group.key>
-        <group.label/>
+        <group.label>T</group.label>
         <group.members>
           <char.set>t</char.set>
           <char.set>T</char.set>
@@ -232,7 +232,7 @@
       </index.group>
       <index.group>
         <group.key>U</group.key>
-        <group.label/>
+        <group.label>U</group.label>
         <group.members>
           <char.set>u</char.set>
           <char.set>U</char.set>
@@ -240,7 +240,7 @@
       </index.group>
       <index.group>
         <group.key>V</group.key>
-        <group.label/>
+        <group.label>V</group.label>
         <group.members>
           <char.set>v</char.set>
           <char.set>V</char.set>
@@ -248,7 +248,7 @@
       </index.group>
       <index.group>
         <group.key>W</group.key>
-        <group.label/>
+        <group.label>W</group.label>
         <group.members>
           <char.set>w</char.set>
           <char.set>W</char.set>
@@ -256,7 +256,7 @@
       </index.group>
       <index.group>
         <group.key>X</group.key>
-        <group.label/>
+        <group.label>X</group.label>
         <group.members>
           <char.set>x</char.set>
           <char.set>X</char.set>
@@ -264,7 +264,7 @@
       </index.group>
       <index.group>
         <group.key>Y</group.key>
-        <group.label/>
+        <group.label>Y</group.label>
         <group.members>
           <char.set>y</char.set>
           <char.set>Y</char.set>
@@ -272,7 +272,7 @@
       </index.group>
       <index.group>
         <group.key>Z</group.key>
-        <group.label/>
+        <group.label>Z</group.label>
         <group.members>
           <char.set>z</char.set>
           <char.set>Z</char.set>
@@ -280,7 +280,7 @@
       </index.group>
       <index.group>
         <group.key>Å</group.key>
-        <group.label/>
+        <group.label>Å</group.label>
         <group.members>
           <char.set>å</char.set>
           <char.set>Å</char.set>
@@ -288,7 +288,7 @@
       </index.group>
       <index.group>
         <group.key>Ä</group.key>
-        <group.label/>
+        <group.label>Ä</group.label>
         <group.members>
           <char.set>ä</char.set>
           <char.set>Ä</char.set>
@@ -296,7 +296,7 @@
       </index.group>
       <index.group>
         <group.key>Ö</group.key>
-        <group.label/>
+        <group.label>Ö</group.label>
         <group.members>
           <char.set>ö</char.set>
           <char.set>Ö</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/fr.xml
@@ -33,10 +33,11 @@ See the accompanying license.txt file for applicable licenses.
 
 <index.configuration.set>
 <index.configuration>
+<language>fr</language>
 <index.groups>
 <index.group>
 <group.key>Specials</group.key>
-<group.label/>
+<group.label>Caractères spéciaux</group.label>
 <group.members>
 <char.set>\</char.set>
 <char.set>`</char.set>
@@ -72,8 +73,8 @@ See the accompanying license.txt file for applicable licenses.
 </group.members>
 </index.group>
 <index.group>
-<group.key/>
-<group.label/>
+<group.key>Numbers</group.key>
+<group.label>Nombres</group.label>
 <group.members>
 <char.set>0</char.set>
 <char.set>０</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/he.xml
@@ -9,7 +9,7 @@
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>תווים מיוחדים</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -47,7 +47,7 @@
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>מספרים</group.label>
         <group.members>
           <char.set>0</char.set>
           <char.set>０</char.set>
@@ -73,7 +73,7 @@
       </index.group>
       <index.group>
         <group.key>A</group.key>
-        <group.label/>
+        <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
           <char.set>A</char.set>
@@ -81,7 +81,7 @@
       </index.group>
       <index.group>
         <group.key>B</group.key>
-        <group.label/>
+        <group.label>B</group.label>
         <group.members>
           <char.set>b</char.set>
           <char.set>B</char.set>
@@ -89,7 +89,7 @@
       </index.group>
       <index.group>
         <group.key>C</group.key>
-        <group.label/>
+        <group.label>C</group.label>
         <group.members>
           <char.set>c</char.set>
           <char.set>C</char.set>
@@ -97,7 +97,7 @@
       </index.group>
       <index.group>
         <group.key>D</group.key>
-        <group.label/>
+        <group.label>D</group.label>
         <group.members>
           <char.set>d</char.set>
           <char.set>D</char.set>
@@ -105,7 +105,7 @@
       </index.group>
       <index.group>
         <group.key>E</group.key>
-        <group.label/>
+        <group.label>E</group.label>
         <group.members>
           <char.set>e</char.set>
           <char.set>E</char.set>
@@ -113,7 +113,7 @@
       </index.group>
       <index.group>
         <group.key>F</group.key>
-        <group.label/>
+        <group.label>F</group.label>
         <group.members>
           <char.set>f</char.set>
           <char.set>F</char.set>
@@ -121,7 +121,7 @@
       </index.group>
       <index.group>
         <group.key>G</group.key>
-        <group.label/>
+        <group.label>G</group.label>
         <group.members>
           <char.set>g</char.set>
           <char.set>G</char.set>
@@ -129,7 +129,7 @@
       </index.group>
       <index.group>
         <group.key>H</group.key>
-        <group.label/>
+        <group.label>H</group.label>
         <group.members>
           <char.set>h</char.set>
           <char.set>H</char.set>
@@ -137,7 +137,7 @@
       </index.group>
       <index.group>
         <group.key>I</group.key>
-        <group.label/>
+        <group.label>I</group.label>
         <group.members>
           <char.set>i</char.set>
           <char.set>I</char.set>
@@ -145,7 +145,7 @@
       </index.group>
       <index.group>
         <group.key>J</group.key>
-        <group.label/>
+        <group.label>J</group.label>
         <group.members>
           <char.set>j</char.set>
           <char.set>J</char.set>
@@ -153,7 +153,7 @@
       </index.group>
       <index.group>
         <group.key>K</group.key>
-        <group.label/>
+        <group.label>K</group.label>
         <group.members>
           <char.set>k</char.set>
           <char.set>K</char.set>
@@ -161,7 +161,7 @@
       </index.group>
       <index.group>
         <group.key>L</group.key>
-        <group.label/>
+        <group.label>L</group.label>
         <group.members>
           <char.set>l</char.set>
           <char.set>L</char.set>
@@ -169,7 +169,7 @@
       </index.group>
       <index.group>
         <group.key>M</group.key>
-        <group.label/>
+        <group.label>M</group.label>
         <group.members>
           <char.set>m</char.set>
           <char.set>M</char.set>
@@ -177,7 +177,7 @@
       </index.group>
       <index.group>
         <group.key>N</group.key>
-        <group.label/>
+        <group.label>N</group.label>
         <group.members>
           <char.set>n</char.set>
           <char.set>N</char.set>
@@ -185,7 +185,7 @@
       </index.group>
       <index.group>
         <group.key>O</group.key>
-        <group.label/>
+        <group.label>O</group.label>
         <group.members>
           <char.set>o</char.set>
           <char.set>O</char.set>
@@ -193,7 +193,7 @@
       </index.group>
       <index.group>
         <group.key>P</group.key>
-        <group.label/>
+        <group.label>P</group.label>
         <group.members>
           <char.set>p</char.set>
           <char.set>P</char.set>
@@ -201,7 +201,7 @@
       </index.group>
       <index.group>
         <group.key>Q</group.key>
-        <group.label/>
+        <group.label>Q</group.label>
         <group.members>
           <char.set>q</char.set>
           <char.set>Q</char.set>
@@ -209,7 +209,7 @@
       </index.group>
       <index.group>
         <group.key>R</group.key>
-        <group.label/>
+        <group.label>R</group.label>
         <group.members>
           <char.set>r</char.set>
           <char.set>R</char.set>
@@ -217,7 +217,7 @@
       </index.group>
       <index.group>
         <group.key>S</group.key>
-        <group.label/>
+        <group.label>S</group.label>
         <group.members>
           <char.set>s</char.set>
           <char.set>S</char.set>
@@ -225,7 +225,7 @@
       </index.group>
       <index.group>
         <group.key>T</group.key>
-        <group.label/>
+        <group.label>T</group.label>
         <group.members>
           <char.set>t</char.set>
           <char.set>T</char.set>
@@ -233,7 +233,7 @@
       </index.group>
       <index.group>
         <group.key>U</group.key>
-        <group.label/>
+        <group.label>U</group.label>
         <group.members>
           <char.set>u</char.set>
           <char.set>U</char.set>
@@ -241,7 +241,7 @@
       </index.group>
       <index.group>
         <group.key>V</group.key>
-        <group.label/>
+        <group.label>V</group.label>
         <group.members>
           <char.set>v</char.set>
           <char.set>V</char.set>
@@ -249,7 +249,7 @@
       </index.group>
       <index.group>
         <group.key>W</group.key>
-        <group.label/>
+        <group.label>W</group.label>
         <group.members>
           <char.set>w</char.set>
           <char.set>W</char.set>
@@ -257,7 +257,7 @@
       </index.group>
       <index.group>
         <group.key>X</group.key>
-        <group.label/>
+        <group.label>X</group.label>
         <group.members>
           <char.set>x</char.set>
           <char.set>X</char.set>
@@ -265,7 +265,7 @@
       </index.group>
       <index.group>
         <group.key>Y</group.key>
-        <group.label/>
+        <group.label>Y</group.label>
         <group.members>
           <char.set>y</char.set>
           <char.set>Y</char.set>
@@ -273,7 +273,7 @@
       </index.group>
       <index.group>
         <group.key>Z</group.key>
-        <group.label/>
+        <group.label>Z</group.label>
         <group.members>
           <char.set>z</char.set>
           <char.set>Z</char.set>
@@ -281,77 +281,77 @@
       </index.group>
       <index.group>
         <group.key>א</group.key>
-        <group.label/>
+        <group.label>א</group.label>
         <group.members>
           <char.set>א</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ב</group.key>
-        <group.label/>
+        <group.label>ב</group.label>
         <group.members>
           <char.set>ב</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ג</group.key>
-        <group.label/>
+        <group.label>ג</group.label>
         <group.members>
           <char.set>ג</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ד</group.key>
-        <group.label/>
+        <group.label>ד</group.label>
         <group.members>
           <char.set>ד</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ה</group.key>
-        <group.label/>
+        <group.label>ה</group.label>
         <group.members>
           <char.set>ה</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ו</group.key>
-        <group.label/>
+        <group.label>ו</group.label>
         <group.members>
           <char.set>ו</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ז</group.key>
-        <group.label/>
+        <group.label>ז</group.label>
         <group.members>
           <char.set>ז</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ח</group.key>
-        <group.label/>
+        <group.label>ח</group.label>
         <group.members>
           <char.set>ח</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ט</group.key>
-        <group.label/>
+        <group.label>ט</group.label>
         <group.members>
           <char.set>ט</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>י</group.key>
-        <group.label/>
+        <group.label>י</group.label>
         <group.members>
           <char.set>י</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>כ</group.key>
-        <group.label/>
+        <group.label>כ</group.label>
         <group.members>
           <char.set>כ</char.set>
           <char.set>ך</char.set>
@@ -359,14 +359,14 @@
       </index.group>
       <index.group>
         <group.key>ל</group.key>
-        <group.label/>
+        <group.label>ל</group.label>
         <group.members>
           <char.set>ל</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>מ</group.key>
-        <group.label/>
+        <group.label>מ</group.label>
         <group.members>
           <char.set>מ</char.set>
           <char.set>ם</char.set>
@@ -374,7 +374,7 @@
       </index.group>
       <index.group>
         <group.key>נ</group.key>
-        <group.label/>
+        <group.label>נ</group.label>
         <group.members>
           <char.set>נ</char.set>
           <char.set>ן</char.set>
@@ -382,21 +382,21 @@
       </index.group>
       <index.group>
         <group.key>ס</group.key>
-        <group.label/>
+        <group.label>ס</group.label>
         <group.members>
           <char.set>ס</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ע</group.key>
-        <group.label/>
+        <group.label>ע</group.label>
         <group.members>
           <char.set>ע</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>פ</group.key>
-        <group.label/>
+        <group.label>פ</group.label>
         <group.members>
           <char.set>פ</char.set>
           <char.set>ף</char.set>
@@ -404,7 +404,7 @@
       </index.group>
       <index.group>
         <group.key>צ</group.key>
-        <group.label/>
+        <group.label>צ</group.label>
         <group.members>
           <char.set>צ</char.set>
           <char.set>ץ</char.set>
@@ -412,28 +412,28 @@
       </index.group>
       <index.group>
         <group.key>ק</group.key>
-        <group.label/>
+        <group.label>ק</group.label>
         <group.members>
           <char.set>ק</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ר</group.key>
-        <group.label/>
+        <group.label>ר</group.label>
         <group.members>
           <char.set>ר</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ש</group.key>
-        <group.label/>
+        <group.label>ש</group.label>
         <group.members>
           <char.set>ש</char.set>
         </group.members>
       </index.group>
       <index.group>
         <group.key>ת</group.key>
-        <group.label/>
+        <group.label>ת</group.label>
         <group.members>
           <char.set>ת</char.set>
         </group.members>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/it.xml
@@ -33,10 +33,11 @@ See the accompanying license.txt file for applicable licenses.
 
 <index.configuration.set>
 <index.configuration>
+<language>it</language>
 <index.groups>
 <index.group>
 <group.key>Specials</group.key>
-<group.label/>
+<group.label>Caratteri speciali</group.label>
 <group.members>
 <char.set>\</char.set>
 <char.set>`</char.set>
@@ -72,8 +73,8 @@ See the accompanying license.txt file for applicable licenses.
 </group.members>
 </index.group>
 <index.group>
-<group.key/>
-<group.label/>
+<group.key>Numbers</group.key>
+<group.label>Numerico</group.label>
 <group.members>
 <char.set>0</char.set>
 <char.set>０</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/ja.xml
@@ -33,6 +33,7 @@ See the accompanying license.txt file for applicable licenses.
 
 <index.configuration.set>
 <index.configuration>
+<language>ja</language>
 <index.groups>
 <index.group>
 <group.key>Specials</group.key>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/nl.xml
@@ -8,7 +8,7 @@
         <index.groups>
             <index.group>
                 <group.key>Specials</group.key>
-                <group.label></group.label>
+                <group.label>Speciale tekens</group.label>
                 <group.members>
                     <char.set>\</char.set>
                     <char.set>`</char.set>
@@ -46,18 +46,28 @@
             </index.group>
             <index.group>
                 <group.key>Numbers</group.key>
-                <group.label></group.label>
+                <group.label>Numerieke tekens</group.label>
                 <group.members>
                     <char.set>0</char.set>
+                    <char.set>０</char.set>
                     <char.set>1</char.set>
+                    <char.set>１</char.set>
                     <char.set>2</char.set>
+                    <char.set>２</char.set>
                     <char.set>3</char.set>
+                    <char.set>３</char.set>
                     <char.set>4</char.set>
+                    <char.set>４</char.set>
                     <char.set>5</char.set>
+                    <char.set>５</char.set>
                     <char.set>6</char.set>
+                    <char.set>６</char.set>
                     <char.set>7</char.set>
+                    <char.set>７</char.set>
                     <char.set>8</char.set>
+                    <char.set>８</char.set>
                     <char.set>9</char.set>
+                    <char.set>９</char.set>
                 </group.members>
             </index.group>
             <index.group>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/ro.xml
@@ -9,7 +9,7 @@
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>Caractere speciale</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -46,7 +46,7 @@
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>Numerice</group.label>
         <group.members>
           <char.set>0</char.set>
           <char.set>０</char.set>
@@ -72,7 +72,7 @@
       </index.group>
       <index.group>
         <group.key>A</group.key>
-        <group.label/>
+        <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
           <char.set>ă</char.set>
@@ -84,7 +84,7 @@
       </index.group>
       <index.group>
         <group.key>B</group.key>
-        <group.label/>
+        <group.label>B</group.label>
         <group.members>
           <char.set>b</char.set>
           <char.set>B</char.set>
@@ -92,7 +92,7 @@
       </index.group>
       <index.group>
         <group.key>C</group.key>
-        <group.label/>
+        <group.label>C</group.label>
         <group.members>
           <char.set>c</char.set>
           <char.set>C</char.set>
@@ -100,7 +100,7 @@
       </index.group>
       <index.group>
         <group.key>D</group.key>
-        <group.label/>
+        <group.label>D</group.label>
         <group.members>
           <char.set>d</char.set>
           <char.set>D</char.set>
@@ -108,7 +108,7 @@
       </index.group>
       <index.group>
         <group.key>E</group.key>
-        <group.label/>
+        <group.label>E</group.label>
         <group.members>
           <char.set>e</char.set>
           <char.set>E</char.set>
@@ -116,7 +116,7 @@
       </index.group>
       <index.group>
         <group.key>F</group.key>
-        <group.label/>
+        <group.label>F</group.label>
         <group.members>
           <char.set>f</char.set>
           <char.set>F</char.set>
@@ -124,7 +124,7 @@
       </index.group>
       <index.group>
         <group.key>G</group.key>
-        <group.label/>
+        <group.label>G</group.label>
         <group.members>
           <char.set>g</char.set>
           <char.set>G</char.set>
@@ -132,7 +132,7 @@
       </index.group>
       <index.group>
         <group.key>H</group.key>
-        <group.label/>
+        <group.label>H</group.label>
         <group.members>
           <char.set>h</char.set>
           <char.set>H</char.set>
@@ -140,7 +140,7 @@
       </index.group>
       <index.group>
         <group.key>I</group.key>
-        <group.label/>
+        <group.label>I</group.label>
         <group.members>
           <char.set>i</char.set>
           <char.set>I</char.set>
@@ -148,7 +148,7 @@
       </index.group>
       <index.group>
         <group.key>Î</group.key>
-        <group.label/>
+        <group.label>Î</group.label>
         <group.members>
           <char.set>î</char.set>
           <char.set>Î</char.set>
@@ -156,7 +156,7 @@
       </index.group>
       <index.group>
         <group.key>J</group.key>
-        <group.label/>
+        <group.label>J</group.label>
         <group.members>
           <char.set>j</char.set>
           <char.set>J</char.set>
@@ -164,7 +164,7 @@
       </index.group>
       <index.group>
         <group.key>K</group.key>
-        <group.label/>
+        <group.label>K</group.label>
         <group.members>
           <char.set>k</char.set>
           <char.set>K</char.set>
@@ -172,7 +172,7 @@
       </index.group>
       <index.group>
         <group.key>L</group.key>
-        <group.label/>
+        <group.label>L</group.label>
         <group.members>
           <char.set>l</char.set>
           <char.set>L</char.set>
@@ -180,7 +180,7 @@
       </index.group>
       <index.group>
         <group.key>M</group.key>
-        <group.label/>
+        <group.label>M</group.label>
         <group.members>
           <char.set>m</char.set>
           <char.set>M</char.set>
@@ -188,7 +188,7 @@
       </index.group>
       <index.group>
         <group.key>N</group.key>
-        <group.label/>
+        <group.label>N</group.label>
         <group.members>
           <char.set>n</char.set>
           <char.set>N</char.set>
@@ -196,7 +196,7 @@
       </index.group>
       <index.group>
         <group.key>O</group.key>
-        <group.label/>
+        <group.label>O</group.label>
         <group.members>
           <char.set>o</char.set>
           <char.set>O</char.set>
@@ -204,7 +204,7 @@
       </index.group>
       <index.group>
         <group.key>P</group.key>
-        <group.label/>
+        <group.label>P</group.label>
         <group.members>
           <char.set>p</char.set>
           <char.set>P</char.set>
@@ -212,7 +212,7 @@
       </index.group>
       <index.group>
         <group.key>Q</group.key>
-        <group.label/>
+        <group.label>Q</group.label>
         <group.members>
           <char.set>q</char.set>
           <char.set>Q</char.set>
@@ -220,7 +220,7 @@
       </index.group>
       <index.group>
         <group.key>R</group.key>
-        <group.label/>
+        <group.label>R</group.label>
         <group.members>
           <char.set>r</char.set>
           <char.set>R</char.set>
@@ -228,7 +228,7 @@
       </index.group>
       <index.group>
         <group.key>S</group.key>
-        <group.label/>
+        <group.label>S</group.label>
         <group.members>
           <char.set>s</char.set>
           <char.set>S</char.set>
@@ -236,7 +236,7 @@
       </index.group>
       <index.group>
         <group.key>Ş</group.key>
-        <group.label/>
+        <group.label>Ş</group.label>
         <group.members>
           <char.set>ş</char.set>
           <char.set>Ş</char.set>
@@ -244,7 +244,7 @@
       </index.group>
       <index.group>
         <group.key>T</group.key>
-        <group.label/>
+        <group.label>T</group.label>
         <group.members>
           <char.set>t</char.set>
           <char.set>T</char.set>
@@ -252,7 +252,7 @@
       </index.group>
       <index.group>
         <group.key>Ţ</group.key>
-        <group.label/>
+        <group.label>Ţ</group.label>
         <group.members>
           <char.set>ţ</char.set>
           <char.set>Ţ</char.set>
@@ -260,7 +260,7 @@
       </index.group>
       <index.group>
         <group.key>U</group.key>
-        <group.label/>
+        <group.label>U</group.label>
         <group.members>
           <char.set>u</char.set>
           <char.set>U</char.set>
@@ -268,7 +268,7 @@
       </index.group>
       <index.group>
         <group.key>V</group.key>
-        <group.label/>
+        <group.label>V</group.label>
         <group.members>
           <char.set>v</char.set>
           <char.set>V</char.set>
@@ -276,7 +276,7 @@
       </index.group>
       <index.group>
         <group.key>W</group.key>
-        <group.label/>
+        <group.label>W</group.label>
         <group.members>
           <char.set>w</char.set>
           <char.set>W</char.set>
@@ -284,7 +284,7 @@
       </index.group>
       <index.group>
         <group.key>X</group.key>
-        <group.label/>
+        <group.label>X</group.label>
         <group.members>
           <char.set>x</char.set>
           <char.set>X</char.set>
@@ -292,7 +292,7 @@
       </index.group>
       <index.group>
         <group.key>Y</group.key>
-        <group.label/>
+        <group.label>Y</group.label>
         <group.members>
           <char.set>y</char.set>
           <char.set>Y</char.set>
@@ -300,7 +300,7 @@
       </index.group>
       <index.group>
         <group.key>Z</group.key>
-        <group.label/>
+        <group.label>Z</group.label>
         <group.members>
           <char.set>z</char.set>
           <char.set>Z</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/ru.xml
@@ -9,7 +9,7 @@
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>Спец. символы</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -47,7 +47,7 @@
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>Числа</group.label>
         <group.members>
           <char.set>0</char.set>
           <char.set>０</char.set>
@@ -73,7 +73,7 @@
       </index.group>
       <index.group>
         <group.key>A</group.key>
-        <group.label/>
+        <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
           <char.set>A</char.set>
@@ -81,7 +81,7 @@
       </index.group>
       <index.group>
         <group.key>B</group.key>
-        <group.label/>
+        <group.label>B</group.label>
         <group.members>
           <char.set>b</char.set>
           <char.set>B</char.set>
@@ -89,7 +89,7 @@
       </index.group>
       <index.group>
         <group.key>C</group.key>
-        <group.label/>
+        <group.label>C</group.label>
         <group.members>
           <char.set>c</char.set>
           <char.set>C</char.set>
@@ -97,7 +97,7 @@
       </index.group>
       <index.group>
         <group.key>D</group.key>
-        <group.label/>
+        <group.label>D</group.label>
         <group.members>
           <char.set>d</char.set>
           <char.set>D</char.set>
@@ -105,7 +105,7 @@
       </index.group>
       <index.group>
         <group.key>E</group.key>
-        <group.label/>
+        <group.label>E</group.label>
         <group.members>
           <char.set>e</char.set>
           <char.set>E</char.set>
@@ -113,7 +113,7 @@
       </index.group>
       <index.group>
         <group.key>F</group.key>
-        <group.label/>
+        <group.label>F</group.label>
         <group.members>
           <char.set>f</char.set>
           <char.set>F</char.set>
@@ -121,7 +121,7 @@
       </index.group>
       <index.group>
         <group.key>G</group.key>
-        <group.label/>
+        <group.label>G</group.label>
         <group.members>
           <char.set>g</char.set>
           <char.set>G</char.set>
@@ -129,7 +129,7 @@
       </index.group>
       <index.group>
         <group.key>H</group.key>
-        <group.label/>
+        <group.label>H</group.label>
         <group.members>
           <char.set>h</char.set>
           <char.set>H</char.set>
@@ -137,7 +137,7 @@
       </index.group>
       <index.group>
         <group.key>I</group.key>
-        <group.label/>
+        <group.label>I</group.label>
         <group.members>
           <char.set>i</char.set>
           <char.set>I</char.set>
@@ -145,7 +145,7 @@
       </index.group>
       <index.group>
         <group.key>J</group.key>
-        <group.label/>
+        <group.label>J</group.label>
         <group.members>
           <char.set>j</char.set>
           <char.set>J</char.set>
@@ -153,7 +153,7 @@
       </index.group>
       <index.group>
         <group.key>K</group.key>
-        <group.label/>
+        <group.label>K</group.label>
         <group.members>
           <char.set>k</char.set>
           <char.set>K</char.set>
@@ -163,7 +163,7 @@
       </index.group>
       <index.group>
         <group.key>L</group.key>
-        <group.label/>
+        <group.label>L</group.label>
         <group.members>
           <char.set>l</char.set>
           <char.set>L</char.set>
@@ -171,7 +171,7 @@
       </index.group>
       <index.group>
         <group.key>M</group.key>
-        <group.label/>
+        <group.label>M</group.label>
         <group.members>
           <char.set>m</char.set>
           <char.set>M</char.set>
@@ -179,7 +179,7 @@
       </index.group>
       <index.group>
         <group.key>N</group.key>
-        <group.label/>
+        <group.label>N</group.label>
         <group.members>
           <char.set>n</char.set>
           <char.set>N</char.set>
@@ -187,7 +187,7 @@
       </index.group>
       <index.group>
         <group.key>O</group.key>
-        <group.label/>
+        <group.label>O</group.label>
         <group.members>
           <char.set>o</char.set>
           <char.set>O</char.set>
@@ -197,7 +197,7 @@
       </index.group>
       <index.group>
         <group.key>P</group.key>
-        <group.label/>
+        <group.label>P</group.label>
         <group.members>
           <char.set>p</char.set>
           <char.set>P</char.set>
@@ -205,7 +205,7 @@
       </index.group>
       <index.group>
         <group.key>Q</group.key>
-        <group.label/>
+        <group.label>Q</group.label>
         <group.members>
           <char.set>q</char.set>
           <char.set>Q</char.set>
@@ -213,7 +213,7 @@
       </index.group>
       <index.group>
         <group.key>R</group.key>
-        <group.label/>
+        <group.label>R</group.label>
         <group.members>
           <char.set>r</char.set>
           <char.set>R</char.set>
@@ -221,7 +221,7 @@
       </index.group>
       <index.group>
         <group.key>S</group.key>
-        <group.label/>
+        <group.label>S</group.label>
         <group.members>
           <char.set>s</char.set>
           <char.set>ß</char.set>
@@ -230,7 +230,7 @@
       </index.group>
       <index.group>
         <group.key>T</group.key>
-        <group.label/>
+        <group.label>T</group.label>
         <group.members>
           <char.set>t</char.set>
           <char.set>T</char.set>
@@ -238,7 +238,7 @@
       </index.group>
       <index.group>
         <group.key>U</group.key>
-        <group.label/>
+        <group.label>U</group.label>
         <group.members>
           <char.set>u</char.set>
           <char.set>U</char.set>
@@ -246,7 +246,7 @@
       </index.group>
       <index.group>
         <group.key>V</group.key>
-        <group.label/>
+        <group.label>V</group.label>
         <group.members>
           <char.set>v</char.set>
           <char.set>V</char.set>
@@ -254,7 +254,7 @@
       </index.group>
       <index.group>
         <group.key>W</group.key>
-        <group.label/>
+        <group.label>W</group.label>
         <group.members>
           <char.set>w</char.set>
           <char.set>W</char.set>
@@ -262,7 +262,7 @@
       </index.group>
       <index.group>
         <group.key>X</group.key>
-        <group.label/>
+        <group.label>X</group.label>
         <group.members>
           <char.set>x</char.set>
           <char.set>X</char.set>
@@ -270,7 +270,7 @@
       </index.group>
       <index.group>
         <group.key>Y</group.key>
-        <group.label/>
+        <group.label>Y</group.label>
         <group.members>
           <char.set>y</char.set>
           <char.set>Y</char.set>
@@ -278,7 +278,7 @@
       </index.group>
       <index.group>
         <group.key>Z</group.key>
-        <group.label/>
+        <group.label>Z</group.label>
         <group.members>
           <char.set>z</char.set>
           <char.set>Z</char.set>
@@ -286,7 +286,7 @@
       </index.group>
       <index.group>
         <group.key>А</group.key>
-        <group.label/>
+        <group.label>А</group.label>
         <group.members>
           <char.set>а</char.set>
           <char.set>А</char.set>
@@ -294,7 +294,7 @@
       </index.group>
       <index.group>
         <group.key>Б</group.key>
-        <group.label/>
+        <group.label>Б</group.label>
         <group.members>
           <char.set>б</char.set>
           <char.set>Б</char.set>
@@ -302,7 +302,7 @@
       </index.group>
       <index.group>
         <group.key>В</group.key>
-        <group.label/>
+        <group.label>В</group.label>
         <group.members>
           <char.set>в</char.set>
           <char.set>В</char.set>
@@ -310,7 +310,7 @@
       </index.group>
       <index.group>
         <group.key>Г</group.key>
-        <group.label/>
+        <group.label>Г</group.label>
         <group.members>
           <char.set>г</char.set>
           <char.set>Г</char.set>
@@ -320,7 +320,7 @@
       </index.group>
       <index.group>
         <group.key>Д</group.key>
-        <group.label/>
+        <group.label>Д</group.label>
         <group.members>
           <char.set>д</char.set>
           <char.set>Д</char.set>
@@ -328,7 +328,7 @@
       </index.group>
       <index.group>
         <group.key>Е</group.key>
-        <group.label/>
+        <group.label>Е</group.label>
         <group.members>
           <char.set>е</char.set>
           <char.set>Е</char.set>
@@ -336,7 +336,7 @@
       </index.group>
       <index.group>
         <group.key>Ё</group.key>
-        <group.label/>
+        <group.label>Ё</group.label>
         <group.members>
           <char.set>ё</char.set>
           <char.set>Ё</char.set>
@@ -344,7 +344,7 @@
       </index.group>
       <index.group>
         <group.key>Ж</group.key>
-        <group.label/>
+        <group.label>Ж</group.label>
         <group.members>
           <char.set>ж</char.set>
           <char.set>Ж</char.set>
@@ -352,7 +352,7 @@
       </index.group>
       <index.group>
         <group.key>З</group.key>
-        <group.label/>
+        <group.label>З</group.label>
         <group.members>
           <char.set>з</char.set>
           <char.set>З</char.set>
@@ -360,7 +360,7 @@
       </index.group>
       <index.group>
         <group.key>И</group.key>
-        <group.label/>
+        <group.label>И</group.label>
         <group.members>
           <char.set>и</char.set>
           <char.set>И</char.set>
@@ -368,7 +368,7 @@
       </index.group>
       <index.group>
         <group.key>Й</group.key>
-        <group.label/>
+        <group.label>Й</group.label>
         <group.members>
           <char.set>й</char.set>
           <char.set>Й</char.set>
@@ -376,7 +376,7 @@
       </index.group>
       <index.group>
         <group.key>К</group.key>
-        <group.label/>
+        <group.label>К</group.label>
         <group.members>
           <char.set>к</char.set>
           <char.set>К</char.set>
@@ -384,7 +384,7 @@
       </index.group>
       <index.group>
         <group.key>Л</group.key>
-        <group.label/>
+        <group.label>Л</group.label>
         <group.members>
           <char.set>л</char.set>
           <char.set>Л</char.set>
@@ -392,7 +392,7 @@
       </index.group>
       <index.group>
         <group.key>М</group.key>
-        <group.label/>
+        <group.label>М</group.label>
         <group.members>
           <char.set>м</char.set>
           <char.set>М</char.set>
@@ -400,7 +400,7 @@
       </index.group>
       <index.group>
         <group.key>Н</group.key>
-        <group.label/>
+        <group.label>Н</group.label>
         <group.members>
           <char.set>н</char.set>
           <char.set>Н</char.set>
@@ -408,7 +408,7 @@
       </index.group>
       <index.group>
         <group.key>О</group.key>
-        <group.label/>
+        <group.label>О</group.label>
         <group.members>
           <char.set>о</char.set>
           <char.set>О</char.set>
@@ -416,7 +416,7 @@
       </index.group>
       <index.group>
         <group.key>П</group.key>
-        <group.label/>
+        <group.label>П</group.label>
         <group.members>
           <char.set>п</char.set>
           <char.set>П</char.set>
@@ -424,7 +424,7 @@
       </index.group>
       <index.group>
         <group.key>Р</group.key>
-        <group.label/>
+        <group.label>Р</group.label>
         <group.members>
           <char.set>р</char.set>
           <char.set>Р</char.set>
@@ -432,7 +432,7 @@
       </index.group>
       <index.group>
         <group.key>С</group.key>
-        <group.label/>
+        <group.label>С</group.label>
         <group.members>
           <char.set>с</char.set>
           <char.set>С</char.set>
@@ -440,7 +440,7 @@
       </index.group>
       <index.group>
         <group.key>Т</group.key>
-        <group.label/>
+        <group.label>Т</group.label>
         <group.members>
           <char.set>т</char.set>
           <char.set>Т</char.set>
@@ -448,7 +448,7 @@
       </index.group>
       <index.group>
         <group.key>У</group.key>
-        <group.label/>
+        <group.label>У</group.label>
         <group.members>
           <char.set>у</char.set>
           <char.set>У</char.set>
@@ -458,7 +458,7 @@
       </index.group>
       <index.group>
         <group.key>Ф</group.key>
-        <group.label/>
+        <group.label>Ф</group.label>
         <group.members>
           <char.set>ф</char.set>
           <char.set>Ф</char.set>
@@ -466,7 +466,7 @@
       </index.group>
       <index.group>
         <group.key>Х</group.key>
-        <group.label/>
+        <group.label>Х</group.label>
         <group.members>
           <char.set>х</char.set>
           <char.set>Х</char.set>
@@ -474,7 +474,7 @@
       </index.group>
       <index.group>
         <group.key>Ц</group.key>
-        <group.label/>
+        <group.label>Ц</group.label>
         <group.members>
           <char.set>ц</char.set>
           <char.set>Ц</char.set>
@@ -482,7 +482,7 @@
       </index.group>
       <index.group>
         <group.key>Ч</group.key>
-        <group.label/>
+        <group.label>Ч</group.label>
         <group.members>
           <char.set>ч</char.set>
           <char.set>Ч</char.set>
@@ -490,7 +490,7 @@
       </index.group>
       <index.group>
         <group.key>Ш</group.key>
-        <group.label/>
+        <group.label>Ш</group.label>
         <group.members>
           <char.set>ш</char.set>
           <char.set>Ш</char.set>
@@ -498,7 +498,7 @@
       </index.group>
       <index.group>
         <group.key>Щ</group.key>
-        <group.label/>
+        <group.label>Щ</group.label>
         <group.members>
           <char.set>щ</char.set>
           <char.set>Щ</char.set>
@@ -506,7 +506,7 @@
       </index.group>
       <index.group>
         <group.key>Ъ</group.key>
-        <group.label/>
+        <group.label>Ъ</group.label>
         <group.members>
           <char.set>ъ</char.set>
           <char.set>Ъ</char.set>
@@ -514,7 +514,7 @@
       </index.group>
       <index.group>
         <group.key>Ы</group.key>
-        <group.label/>
+        <group.label>Ы</group.label>
         <group.members>
           <char.set>ы</char.set>
           <char.set>Ы</char.set>
@@ -522,7 +522,7 @@
       </index.group>
       <index.group>
         <group.key>Ь</group.key>
-        <group.label/>
+        <group.label>Ь</group.label>
         <group.members>
           <char.set>ь</char.set>
           <char.set>Ь</char.set>
@@ -530,7 +530,7 @@
       </index.group>
       <index.group>
         <group.key>Э</group.key>
-        <group.label/>
+        <group.label>Э</group.label>
         <group.members>
           <char.set>э</char.set>
           <char.set>Э</char.set>
@@ -538,7 +538,7 @@
       </index.group>
       <index.group>
         <group.key>Ю</group.key>
-        <group.label/>
+        <group.label>Ю</group.label>
         <group.members>
           <char.set>ю</char.set>
           <char.set>Ю</char.set>
@@ -546,7 +546,7 @@
       </index.group>
       <index.group>
         <group.key>Я</group.key>
-        <group.label/>
+        <group.label>Я</group.label>
         <group.members>
           <char.set>я</char.set>
           <char.set>Я</char.set>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/sl.xml
@@ -5,11 +5,11 @@ See the accompanying license.txt file for applicable licenses.
 -->
 <index.configuration.set>
   <index.configuration>
-    <language>en</language>
+    <language>sl</language>
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>Posebni znaki</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -47,18 +47,28 @@ See the accompanying license.txt file for applicable licenses.
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>Številke</group.label>
         <group.members>
           <char.set>0</char.set>
+          <char.set>０</char.set>
           <char.set>1</char.set>
+          <char.set>１</char.set>
           <char.set>2</char.set>
+          <char.set>２</char.set>
           <char.set>3</char.set>
+          <char.set>３</char.set>
           <char.set>4</char.set>
+          <char.set>４</char.set>
           <char.set>5</char.set>
+          <char.set>５</char.set>
           <char.set>6</char.set>
+          <char.set>６</char.set>
           <char.set>7</char.set>
+          <char.set>７</char.set>
           <char.set>8</char.set>
+          <char.set>８</char.set>
           <char.set>9</char.set>
+          <char.set>９</char.set>
         </group.members>
       </index.group>
       <index.group>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/sv.xml
@@ -9,7 +9,7 @@
     <index.groups>
       <index.group>
         <group.key>Specials</group.key>
-        <group.label/>
+        <group.label>Specialtecken</group.label>
         <group.members>
           <char.set>\</char.set>
           <char.set>`</char.set>
@@ -46,7 +46,7 @@
       </index.group>
       <index.group>
         <group.key>Numbers</group.key>
-        <group.label/>
+        <group.label>Siffror</group.label>
         <group.members>
           <char.set>0</char.set>
           <char.set>０</char.set>
@@ -72,7 +72,7 @@
       </index.group>
       <index.group>
         <group.key>A</group.key>
-        <group.label/>
+        <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
           <char.set>A</char.set>
@@ -80,7 +80,7 @@
       </index.group>
       <index.group>
         <group.key>B</group.key>
-        <group.label/>
+        <group.label>B</group.label>
         <group.members>
           <char.set>b</char.set>
           <char.set>B</char.set>
@@ -88,7 +88,7 @@
       </index.group>
       <index.group>
         <group.key>C</group.key>
-        <group.label/>
+        <group.label>C</group.label>
         <group.members>
           <char.set>c</char.set>
           <char.set>C</char.set>
@@ -96,7 +96,7 @@
       </index.group>
       <index.group>
         <group.key>D</group.key>
-        <group.label/>
+        <group.label>D</group.label>
         <group.members>
           <char.set>d</char.set>
           <char.set>D</char.set>
@@ -104,7 +104,7 @@
       </index.group>
       <index.group>
         <group.key>E</group.key>
-        <group.label/>
+        <group.label>E</group.label>
         <group.members>
           <char.set>e</char.set>
           <char.set>E</char.set>
@@ -112,7 +112,7 @@
       </index.group>
       <index.group>
         <group.key>F</group.key>
-        <group.label/>
+        <group.label>F</group.label>
         <group.members>
           <char.set>f</char.set>
           <char.set>F</char.set>
@@ -120,7 +120,7 @@
       </index.group>
       <index.group>
         <group.key>G</group.key>
-        <group.label/>
+        <group.label>G</group.label>
         <group.members>
           <char.set>g</char.set>
           <char.set>G</char.set>
@@ -128,7 +128,7 @@
       </index.group>
       <index.group>
         <group.key>H</group.key>
-        <group.label/>
+        <group.label>H</group.label>
         <group.members>
           <char.set>h</char.set>
           <char.set>H</char.set>
@@ -136,7 +136,7 @@
       </index.group>
       <index.group>
         <group.key>I</group.key>
-        <group.label/>
+        <group.label>I</group.label>
         <group.members>
           <char.set>i</char.set>
           <char.set>I</char.set>
@@ -144,7 +144,7 @@
       </index.group>
       <index.group>
         <group.key>J</group.key>
-        <group.label/>
+        <group.label>J</group.label>
         <group.members>
           <char.set>j</char.set>
           <char.set>J</char.set>
@@ -152,7 +152,7 @@
       </index.group>
       <index.group>
         <group.key>K</group.key>
-        <group.label/>
+        <group.label>K</group.label>
         <group.members>
           <char.set>k</char.set>
           <char.set>K</char.set>
@@ -160,7 +160,7 @@
       </index.group>
       <index.group>
         <group.key>L</group.key>
-        <group.label/>
+        <group.label>L</group.label>
         <group.members>
           <char.set>l</char.set>
           <char.set>L</char.set>
@@ -168,7 +168,7 @@
       </index.group>
       <index.group>
         <group.key>M</group.key>
-        <group.label/>
+        <group.label>M</group.label>
         <group.members>
           <char.set>m</char.set>
           <char.set>M</char.set>
@@ -176,7 +176,7 @@
       </index.group>
       <index.group>
         <group.key>N</group.key>
-        <group.label/>
+        <group.label>N</group.label>
         <group.members>
           <char.set>n</char.set>
           <char.set>N</char.set>
@@ -184,7 +184,7 @@
       </index.group>
       <index.group>
         <group.key>O</group.key>
-        <group.label/>
+        <group.label>O</group.label>
         <group.members>
           <char.set>o</char.set>
           <char.set>O</char.set>
@@ -192,7 +192,7 @@
       </index.group>
       <index.group>
         <group.key>P</group.key>
-        <group.label/>
+        <group.label>P</group.label>
         <group.members>
           <char.set>p</char.set>
           <char.set>P</char.set>
@@ -200,7 +200,7 @@
       </index.group>
       <index.group>
         <group.key>Q</group.key>
-        <group.label/>
+        <group.label>Q</group.label>
         <group.members>
           <char.set>q</char.set>
           <char.set>Q</char.set>
@@ -208,7 +208,7 @@
       </index.group>
       <index.group>
         <group.key>R</group.key>
-        <group.label/>
+        <group.label>R</group.label>
         <group.members>
           <char.set>r</char.set>
           <char.set>R</char.set>
@@ -216,7 +216,7 @@
       </index.group>
       <index.group>
         <group.key>S</group.key>
-        <group.label/>
+        <group.label>S</group.label>
         <group.members>
           <char.set>s</char.set>
           <char.set>S</char.set>
@@ -224,7 +224,7 @@
       </index.group>
       <index.group>
         <group.key>T</group.key>
-        <group.label/>
+        <group.label>T</group.label>
         <group.members>
           <char.set>t</char.set>
           <char.set>T</char.set>
@@ -232,7 +232,7 @@
       </index.group>
       <index.group>
         <group.key>U</group.key>
-        <group.label/>
+        <group.label>U</group.label>
         <group.members>
           <char.set>u</char.set>
           <char.set>U</char.set>
@@ -240,7 +240,7 @@
       </index.group>
       <index.group>
         <group.key>V</group.key>
-        <group.label/>
+        <group.label>V</group.label>
         <group.members>
           <char.set>v</char.set>
           <char.set>V</char.set>
@@ -248,7 +248,7 @@
       </index.group>
       <index.group>
         <group.key>W</group.key>
-        <group.label/>
+        <group.label>W</group.label>
         <group.members>
           <char.set>w</char.set>
           <char.set>W</char.set>
@@ -256,7 +256,7 @@
       </index.group>
       <index.group>
         <group.key>X</group.key>
-        <group.label/>
+        <group.label>X</group.label>
         <group.members>
           <char.set>x</char.set>
           <char.set>X</char.set>
@@ -264,7 +264,7 @@
       </index.group>
       <index.group>
         <group.key>Y</group.key>
-        <group.label/>
+        <group.label>Y</group.label>
         <group.members>
           <char.set>y</char.set>
           <char.set>Y</char.set>
@@ -272,7 +272,7 @@
       </index.group>
       <index.group>
         <group.key>Z</group.key>
-        <group.label/>
+        <group.label>Z</group.label>
         <group.members>
           <char.set>z</char.set>
           <char.set>Z</char.set>
@@ -280,7 +280,7 @@
       </index.group>
       <index.group>
         <group.key>Å</group.key>
-        <group.label/>
+        <group.label>Å</group.label>
         <group.members>
           <char.set>å</char.set>
           <char.set>Å</char.set>
@@ -288,7 +288,7 @@
       </index.group>
       <index.group>
         <group.key>Ä</group.key>
-        <group.label/>
+        <group.label>Ä</group.label>
         <group.members>
           <char.set>ä</char.set>
           <char.set>Ä</char.set>
@@ -296,7 +296,7 @@
       </index.group>
       <index.group>
         <group.key>Ö</group.key>
-        <group.label/>
+        <group.label>Ö</group.label>
         <group.members>
           <char.set>ö</char.set>
           <char.set>Ö</char.set>


### PR DESCRIPTION
Changes for PDF2 index output:
- All languages now have a heading for the "Specials" and "Numbers" groups
- All languages now have headings for each letter
- All languages include the (correct) `<language>` identifier in the metadata
- All languages include Unicode numbers with other numbers (previously missing in 3 languages)