### PR TITLE
Add PFD2 index groups for a-breve, a-circ in Romanian

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/index/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/index/ro.xml
@@ -75,10 +75,22 @@
         <group.label>A</group.label>
         <group.members>
           <char.set>a</char.set>
-          <char.set>ă</char.set>
-          <char.set>â</char.set>
           <char.set>A</char.set>
+        </group.members>
+      </index.group>
+      <index.group>
+        <group.key>Ă</group.key>
+        <group.label>Ă</group.label>
+        <group.members>
+          <char.set>ă</char.set>
           <char.set>Ă</char.set>
+        </group.members>
+      </index.group>
+      <index.group>
+        <group.key>Â</group.key>
+        <group.label>Â</group.label>
+        <group.members>
+          <char.set>â</char.set>
           <char.set>Â</char.set>
         </group.members>
       </index.group>


### PR DESCRIPTION
Romanian sort in the PDF2 index currently groups A, Ă, and Â under the letter A. These should be collated separately. I'm basing this change on our existing sort programs, see also this reference: http://developer.mimer.com/charts/romanian.htm

Tested with index entries that include:
```xml
<ul>
<li>A <indexterm>A letter</indexterm></li>
<li>a <indexterm>a letter</indexterm></li>
<li>Az <indexterm>Az sequence</indexterm></li>
<li>a-breve Ă<indexterm>Ă a-breve</indexterm></li>
<li>a-breve ă<indexterm>ă a-breve</indexterm></li>
<li>a-circ Â<indexterm>Â a-circ</indexterm></li>
<li>a-circ â<indexterm>â a-circ</indexterm></li>
</ul>
```