### PR TITLE
Synchronize task string use from PDF2 with common

### DIFF
--- a/src/main/plugins/org.dita.odt/xsl/xslodt/dita2odt-task.xsl
+++ b/src/main/plugins/org.dita.odt/xsl/xslodt/dita2odt-task.xsl
@@ -136,7 +136,12 @@
     <xsl:apply-templates select="." mode="generate-task-label">
       <xsl:with-param name="use-label">
         <xsl:call-template name="getVariable">
-          <xsl:with-param name="id" select="'task_procedure'"/>
+          <xsl:with-param name="id">
+            <xsl:choose>
+              <xsl:when test="contains(@class,' task/steps ')">task_procedure</xsl:when>
+              <xsl:otherwise>task_procedure_unordered</xsl:otherwise>
+            </xsl:choose>
+          </xsl:with-param>
         </xsl:call-template>
       </xsl:with-param>
     </xsl:apply-templates>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -294,15 +294,16 @@ See the accompanying license.txt file for applicable licenses.
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>
+    <variable id="Required Step">Erforderlich:</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">Vorbereitungen</variable>
-    <variable id="Task Context">Warum und wann dieser Vorgang ausgeführt wird</variable>
-    <variable id="Task Steps">Prozedur</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">Ergebnisse</variable>
-    <variable id="Task Example">Beispiel</variable>
-    <variable id="Task Postreq">Nächste Maßnahme</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -330,15 +330,16 @@ See the accompanying license.txt file for applicable licenses.
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>
+    <variable id="Required Step">Required:</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">Before you begin</variable>
-    <variable id="Task Context">About this task</variable>
-    <variable id="Task Steps">Procedure</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">Results</variable>
-    <variable id="Task Example">Example</variable>
-    <variable id="Task Postreq">What to do next</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
     
     <!--Glossary Variables-->
     <!-- The footer that appears on the odd-numbered glossary pages. -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -294,15 +294,16 @@ See the accompanying license.txt file for applicable licenses.
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>
+    <variable id="Required Step">Necesario:</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">Antes de empezar</variable>
-    <variable id="Task Context">Por qué y cuándo se efectúa esta tarea</variable>
-    <variable id="Task Steps">Procedimiento</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">Resultados</variable>
-    <variable id="Task Example">Ejemplo</variable>
-    <variable id="Task Postreq">Qué hacer a continuación</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -80,14 +80,16 @@
   <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>
   
   <variable id="Index multiple entries separator">, </variable>
-  <variable id="Optional Step"><!--TODO:Optional:--></variable>
-  <variable id="Task Prereq">Ennen aloitusta</variable>
-  <variable id="Task Context">Tietoja tästä tehtävästä</variable>
-  <variable id="Task Steps">Toimintosarja</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Tulokset</variable>
-  <variable id="Task Example">Esimerkki</variable>
-  <variable id="Task Postreq">Seuraavat toimet</variable>
+  <variable id="Optional Step">Valinnainen:</variable>
+  <variable id="Required Step">Pakollinen:</variable>
+  <!--Labels for task sections, now reused from common-->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -294,15 +294,16 @@ See the accompanying license.txt file for applicable licenses.
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Facultatif :</variable>
+    <variable id="Required Step">Obligatoire :</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">Avant de commencer</variable>
-    <variable id="Task Context">Pourquoi et quand exécuter cette tâche</variable>
-    <variable id="Task Steps">Procédure</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">Résultats</variable>
-    <variable id="Task Example">Exemple</variable>
-    <variable id="Task Postreq">Que faire ensuite</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -80,14 +80,16 @@
   <variable id="Related references">תיעוד קשור</variable>
   
   <variable id="Index multiple entries separator">, </variable>
-  <variable id="Optional Step"><!--TODO:Optional:--></variable>
-  <variable id="Task Prereq">לפני שתתחילו</variable>
-  <variable id="Task Context">אודות משימה זו</variable>
-  <variable id="Task Steps">נוהל</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">תוצאות</variable>
-  <variable id="Task Example">דוגמה</variable>
-  <variable id="Task Postreq">איך להמשיך</variable>
+  <variable id="Optional Step">אופציונלי:</variable>
+  <variable id="Required Step">דרוש:</variable>
+  <!--Labels for task sections, now reused from common-->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -294,15 +294,16 @@ See the accompanying license.txt file for applicable licenses.
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opzionale:</variable>
+    <variable id="Optional Step">Richiesto:</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">Prima di iniziare</variable>
-    <variable id="Task Context">Informazioni su questa attività</variable>
-    <variable id="Task Steps">Procedura</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">Risultati</variable>
-    <variable id="Task Example">Esempio</variable>
-    <variable id="Task Postreq">Operazioni successive</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -328,15 +328,17 @@ See the accompanying license.txt file for applicable licenses.
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">オプション:</variable>
+    <variable id="Required Step">必須:</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">始める前に</variable>
-    <variable id="Task Context">このタスクについて</variable>
-    <variable id="Task Steps">手順</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">タスクの結果</variable>
-    <variable id="Task Example">例</variable>
-    <variable id="Task Postreq">次のタスク</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
+
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -105,13 +105,15 @@
   <variable id="Search Search in Progress Message">De zoekactie loopt...</variable>
   <variable id="Search Search Give No Results Message">Geen treffers gevonden.</variable>
   <variable id="Optional Step">Optioneel:</variable>
-  <variable id="Task Prereq">Voordat u begint</variable>
-  <variable id="Task Context">Over deze taak</variable>
-  <variable id="Task Steps">Procedure</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Resultaten</variable>
-  <variable id="Task Example">Voorbeeld</variable>
-  <variable id="Task Postreq">Volgende stappen</variable>
+  <variable id="Required Step">Vereist:</variable>
+  <!-- Task strings now reused from common -->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
 
   <variable id="#menucascade-separator"> &gt; </variable>
   <variable id="#quote-start">“</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -80,14 +80,16 @@
   <variable id="Related references">Referinţe înrudite</variable>
   
   <variable id="Index multiple entries separator">, </variable>
-  <variable id="Optional Step"><!--TODO:Optional:--></variable>
-  <variable id="Task Prereq">Înainte de a începe</variable>
-  <variable id="Task Context">Despre acest task</variable>
-  <variable id="Task Steps">Procedură</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Rezultate</variable>
-  <variable id="Task Example">Exemplu</variable>
-  <variable id="Task Postreq">Ce se face în continuare</variable>
+  <variable id="Optional Step">Opţional:</variable>
+  <variable id="Required Step">Necesar:</variable>
+  <!-- Task strings now reused from common -->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -80,14 +80,16 @@
   <variable id="Related references">Ссылки, связанные с данной</variable>
   
   <variable id="Index multiple entries separator">, </variable>
-  <variable id="Optional Step"><!--TODO:Optional:--></variable>
-  <variable id="Task Prereq">Подготовка</variable>
-  <variable id="Task Context">Об этой задаче</variable>
-  <variable id="Task Steps">Процедура</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Результат</variable>
-  <variable id="Task Example">Пример</variable>
-  <variable id="Task Postreq">Дальнейшие действия</variable>
+  <variable id="Optional Step">Необязательно:</variable>
+  <variable id="Required Step">Обязательно:</variable>
+  <!-- Task strings now reused from common -->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -106,13 +106,18 @@ See the accompanying license.txt file for applicable licenses.
   <variable id="Search Search in Progress Message">Iskanje v teku...</variable>
   <variable id="Search Search Give No Results Message">Ni ujemanj.</variable>
   <variable id="Optional Step">Izbiren:</variable>
-  <variable id="Task Prereq">Predzahteva</variable>
-  <variable id="Task Context">O tem opravilu</variable>
-  <variable id="Task Steps">Postopek</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Rezultati</variable>
-  <variable id="Task Example">Primer</variable>
-  <variable id="Task Postreq">Kaj storiti zatem</variable>
+  <variable id="Required Step">Zahtevano:</variable>
+  <!-- Prereq was "Predzahteva", changing to common string, currently "Preden začnete" -->
+  <variable id="Task Prereq"></variable>
+  <!-- Context was "O tem opravilu", changing to common string, currently "O tej nalogi" -->
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <!-- Example was "Primer", changing to common string, currently "Zgled" -->
+  <variable id="Task Example"></variable>
+  <!-- Postreq was "Kaj storiti zatem", changing to common string, currently "Kako naprej?" -->
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -80,14 +80,16 @@
   <variable id="Related references">Närliggande referens</variable>
   
   <variable id="Index multiple entries separator">, </variable>
-  <variable id="Optional Step"><!--TODO:Optional:--></variable>
-  <variable id="Task Prereq">Innan du börjar</variable>
-  <variable id="Task Context">Den här uppgiften</variable>
-  <variable id="Task Steps">Arbetsordning</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-  <variable id="Task Result">Resultat</variable>
-  <variable id="Task Example">Exempel</variable>
-  <variable id="Task Postreq">Och sedan då?</variable>
+  <variable id="Optional Step">Valfritt:</variable>
+  <variable id="Required Step">Krävs:</variable>
+  <!--Labels for task sections, now reused from common-->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
   <variable id="Glossary odd footer"/>
   <variable id="Glossary even footer"/>
   <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -294,15 +294,17 @@ See the accompanying license.txt file for applicable licenses.
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">可选：</variable>
+    <variable id="Required Step">必需：</variable>
 
-    <!--Labels for task sections-->
-    <variable id="Task Prereq">开始之前</variable>
-    <variable id="Task Context">关于此任务</variable>
-    <variable id="Task Steps">过程</variable>
-  <variable id="#steps-unordered-label"><variable id="Task Steps"/></variable>
-    <variable id="Task Result">结果</variable>
-    <variable id="Task Example">示例</variable>
-    <variable id="Task Postreq">下一步做什么</variable>
+    <!--Labels for task sections, now reused from common-->
+    <variable id="Task Prereq"></variable>
+    <variable id="Task Context"></variable>
+    <variable id="Task Steps"></variable>
+    <variable id="#steps-unordered-label"></variable>
+    <variable id="Task Result"></variable>
+    <variable id="Task Example"></variable>
+    <variable id="Task Postreq"></variable>
+
     <variable id="Glossary odd footer"/>
     <variable id="Glossary even footer"/>
     <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -70,10 +70,11 @@ See the accompanying license.txt file for applicable licenses.
         <fo:block xsl:use-attribute-sets="prereq">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
-                <xsl:with-param name="use-label">
-                    <xsl:call-template name="getVariable">
-                        <xsl:with-param name="id" select="'Task Prereq'"/>
-                    </xsl:call-template>
+                  <xsl:with-param name="use-label">
+                    <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                      <xsl:with-param name="pdf2-string">Task Prereq</xsl:with-param>
+                      <xsl:with-param name="common-string">task_prereq</xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:with-param>
             </xsl:apply-templates>
             <fo:block xsl:use-attribute-sets="prereq__content">
@@ -87,9 +88,10 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
-                    <xsl:call-template name="getVariable">
-                        <xsl:with-param name="id" select="'Task Context'"/>
-                    </xsl:call-template>
+                    <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                      <xsl:with-param name="pdf2-string">Task Context</xsl:with-param>
+                      <xsl:with-param name="common-string">task_context</xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:with-param>
             </xsl:apply-templates>
             <fo:block xsl:use-attribute-sets="context__content">
@@ -104,6 +106,12 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:if test="../@importance='optional'">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Optional Step'"/>
+                </xsl:call-template>
+                <xsl:text> </xsl:text>
+            </xsl:if>
+            <xsl:if test="../@importance='required'">
+                <xsl:call-template name="getVariable">
+                    <xsl:with-param name="id" select="'Required Step'"/>
                 </xsl:call-template>
                 <xsl:text> </xsl:text>
             </xsl:if>
@@ -137,9 +145,10 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
-                    <xsl:call-template name="getVariable">
-                        <xsl:with-param name="id" select="'Task Result'"/>
-                    </xsl:call-template>
+                    <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                      <xsl:with-param name="pdf2-string">Task Result</xsl:with-param>
+                      <xsl:with-param name="common-string">task_result</xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:with-param>
             </xsl:apply-templates>
             <fo:block xsl:use-attribute-sets="result__content">
@@ -159,9 +168,10 @@ See the accompanying license.txt file for applicable licenses.
               <xsl:otherwise>
                 <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                   <xsl:with-param name="use-label">
-                      <xsl:call-template name="getVariable">
-                          <xsl:with-param name="id" select="'Task Example'"/>
-                      </xsl:call-template>
+                      <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                        <xsl:with-param name="pdf2-string">Task Example</xsl:with-param>
+                        <xsl:with-param name="common-string">task_example</xsl:with-param>
+                      </xsl:apply-templates>
                   </xsl:with-param>
                 </xsl:apply-templates>
               </xsl:otherwise>
@@ -177,9 +187,10 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
-                    <xsl:call-template name="getVariable">
-                        <xsl:with-param name="id" select="'Task Postreq'"/>
-                    </xsl:call-template>
+                    <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                      <xsl:with-param name="pdf2-string">Task Postreq</xsl:with-param>
+                      <xsl:with-param name="common-string">task_postreq</xsl:with-param>
+                    </xsl:apply-templates>
                 </xsl:with-param>
             </xsl:apply-templates>
             <fo:block xsl:use-attribute-sets="postreq__content">
@@ -202,9 +213,10 @@ See the accompanying license.txt file for applicable licenses.
               <fo:block>
                   <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                       <xsl:with-param name="use-label">
-                          <xsl:call-template name="getVariable">
-                              <xsl:with-param name="id" select="'Task Steps'"/>
-                          </xsl:call-template>
+                        <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                          <xsl:with-param name="pdf2-string">Task Steps</xsl:with-param>
+                          <xsl:with-param name="common-string">task_procedure</xsl:with-param>
+                        </xsl:apply-templates>
                       </xsl:with-param>
                   </xsl:apply-templates>
                   <fo:list-block xsl:use-attribute-sets="steps">
@@ -228,9 +240,13 @@ See the accompanying license.txt file for applicable licenses.
         <fo:block>
           <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
             <xsl:with-param name="use-label">
-              <xsl:call-template name="getVariable">
+              <!--<xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'#steps-unordered-label'"/>
-              </xsl:call-template>
+              </xsl:call-template>-->
+              <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+                <xsl:with-param name="pdf2-string">#steps-unordered-label</xsl:with-param>
+                <xsl:with-param name="common-string">task_procedure_unordered</xsl:with-param>
+              </xsl:apply-templates>
             </xsl:with-param>
           </xsl:apply-templates>
           <fo:list-block xsl:use-attribute-sets="steps-unordered">
@@ -519,6 +535,29 @@ See the accompanying license.txt file for applicable licenses.
                 <fo:inline><xsl:copy-of select="$use-label"/></fo:inline>
             </fo:block>
         </xsl:if>
+    </xsl:template>
+
+    <!-- Set up to allow string retrieval based on the original PDF2 string;
+         if not found, fall back to the common string -->
+    <xsl:template match="*" mode="dita2xslfo:retrieve-task-heading">
+      <xsl:param name="pdf2-string"/>
+      <xsl:param name="common-string"/>
+      <xsl:variable name="retrieved-pdf2-string">
+        <!-- By default, will return the lookup value -->
+        <xsl:call-template name="getVariable">
+            <xsl:with-param name="id" select="$pdf2-string"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:choose>
+        <xsl:when test="$retrieved-pdf2-string!=$pdf2-string and $retrieved-pdf2-string!=''">
+          <xsl:value-of select="$retrieved-pdf2-string"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="getVariable">
+              <xsl:with-param name="id" select="$common-string"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -115,7 +115,12 @@
   <xsl:apply-templates select="." mode="generate-task-label">
     <xsl:with-param name="use-label">
       <xsl:call-template name="getVariable">
-        <xsl:with-param name="id" select="'task_procedure'"/>
+        <xsl:with-param name="id">
+          <xsl:choose>
+            <xsl:when test="contains(@class,' task/steps ')">task_procedure</xsl:when>
+            <xsl:otherwise>task_procedure_unordered</xsl:otherwise>
+          </xsl:choose>
+        </xsl:with-param>
       </xsl:call-template>
     </xsl:with-param>
   </xsl:apply-templates>

--- a/src/main/xsl/common/strings-ar-eg.xml
+++ b/src/main/xsl/common/strings-ar-eg.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">ما تريد القيام به بعد الآن</str>
 <str name="task_prereq">قبل البدء</str>
 <str name="task_procedure">اجراء</str>
+<str name="task_procedure_unordered">اجراء</str>
 <str name="task_results">النتائج</str>
 
 <str name="Copyright">حقوق النشر لشركة</str>

--- a/src/main/xsl/common/strings-be-by.xml
+++ b/src/main/xsl/common/strings-be-by.xml
@@ -59,6 +59,7 @@
   <str name="task_postreq">Далейшыя дзеяннi</str>
   <str name="task_prereq">Перад пачаткам работы</str>
   <str name="task_procedure">Парадак выканання</str>
+  <str name="task_procedure_unordered">Парадак выканання</str>
   <str name="task_results">Рэзультаты</str>
 
   <str name="Copyright">Copyright</str> 

--- a/src/main/xsl/common/strings-bg-bg.xml
+++ b/src/main/xsl/common/strings-bg-bg.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Какво да направим после</str>
 <str name="task_prereq">Преди да започнете</str>
 <str name="task_procedure">Процедура</str>
+<str name="task_procedure_unordered">Процедура</str>
 <str name="task_results">Резултати</str>
 
 <str name="Copyright">Авторско право</str>

--- a/src/main/xsl/common/strings-ca-es.xml
+++ b/src/main/xsl/common/strings-ca-es.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Què cal fer posteriorment</str>
 <str name="task_prereq">Abans de començar</str>
 <str name="task_procedure">Procediment</str>
+<str name="task_procedure_unordered">Procediment</str>
 <str name="task_results">Resultats</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-cs-cz.xml
+++ b/src/main/xsl/common/strings-cs-cz.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Jak pokračovat dále</str>
 <str name="task_prereq">Než začnete</str>
 <str name="task_procedure">Procedura</str>
+<str name="task_procedure_unordered">Procedura</str>
 <str name="task_results">Výsledky</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-da-dk.xml
+++ b/src/main/xsl/common/strings-da-dk.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Næste trin</str>
 <str name="task_prereq">Inden du begynder</str>
 <str name="task_procedure">Fremgangsmåde</str>
+<str name="task_procedure_unordered">Fremgangsmåde</str>
 <str name="task_results">Resultater</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-de-ch.xml
+++ b/src/main/xsl/common/strings-de-ch.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">Vorbereitungen</str>
 <str name="task_postreq">Nächste Maßnahme</str>
 <str name="task_procedure">Prozedur</str>
+<str name="task_procedure_unordered">Prozedur</str>
 <str name="task_results">Ergebnisse</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-de-de.xml
+++ b/src/main/xsl/common/strings-de-de.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">Vorbereitungen</str>
 <str name="task_postreq">Nächste Maßnahme</str>
 <str name="task_procedure">Prozedur</str>
+<str name="task_procedure_unordered">Prozedur</str>
 <str name="task_results">Ergebnisse</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-el-gr.xml
+++ b/src/main/xsl/common/strings-el-gr.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Επόμενες ενέργειες</str>
 <str name="task_prereq">Πριν ξεκινήσετε</str>
 <str name="task_procedure">Διαδικασία</str>
+<str name="task_procedure_unordered">Διαδικασία</str>
 <str name="task_results">Αποτελέσματα</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-en-ca.xml
+++ b/src/main/xsl/common/strings-en-ca.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">What to do next</str>
 <str name="task_prereq">Before you begin</str>
 <str name="task_procedure">Procedure</str>
+<str name="task_procedure_unordered">Procedure</str>
 <str name="task_results">Results</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-en-gb.xml
+++ b/src/main/xsl/common/strings-en-gb.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">What to do next</str>
 <str name="task_prereq">Before you begin</str>
 <str name="task_procedure">Procedure</str>
+<str name="task_procedure_unordered">Procedure</str>
 <str name="task_results">Results</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-en-us.xml
+++ b/src/main/xsl/common/strings-en-us.xml
@@ -65,6 +65,7 @@
 <str name="task_postreq">What to do next</str>
 <str name="task_prereq">Before you begin</str>
 <str name="task_procedure">Procedure</str>
+<str name="task_procedure_unordered">Procedure</str>
 <str name="task_results">Results</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-es-es.xml
+++ b/src/main/xsl/common/strings-es-es.xml
@@ -64,6 +64,7 @@
 <str name="task_example">Ejemplo</str>
 <str name="task_postreq">Qué hacer a continuación</str>
 <str name="task_procedure">Procedimiento</str>
+<str name="task_procedure_unordered">Procedimiento</str>
 <str name="task_results">Resultados</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-et-ee.xml
+++ b/src/main/xsl/common/strings-et-ee.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Mis saab edasi?</str>
 <str name="task_prereq">Enne alustamist</str>
 <str name="task_procedure">Toimimisviis</str>
+<str name="task_procedure_unordered">Toimimisviis</str>
 <str name="task_results">Tulemused</str>
 
 <str name="Copyright">Autoriõigus</str>

--- a/src/main/xsl/common/strings-fi-fi.xml
+++ b/src/main/xsl/common/strings-fi-fi.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Seuraavat toimet</str>
 <str name="task_prereq">Ennen aloitusta</str>
 <str name="task_procedure">Toimintosarja</str>
+<str name="task_procedure_unordered">Toimintosarja</str>
 <str name="task_results">Tulokset</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-fr-be.xml
+++ b/src/main/xsl/common/strings-fr-be.xml
@@ -61,6 +61,7 @@
    <str name="task_prereq">Avant de commencer</str>
    <str name="task_postreq">Que faire ensuite</str>
    <str name="task_procedure">Procédure</str>
+   <str name="task_procedure_unordered">Procédure</str>
    <str name="task_results">Résultats</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-fr-ca.xml
+++ b/src/main/xsl/common/strings-fr-ca.xml
@@ -61,6 +61,7 @@
    <str name="task_prereq">Avant de commencer</str>
    <str name="task_postreq">Que faire ensuite</str>
    <str name="task_procedure">Procédure</str>
+   <str name="task_procedure_unordered">Procédure</str>
    <str name="task_results">Résultats</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-fr-ch.xml
+++ b/src/main/xsl/common/strings-fr-ch.xml
@@ -61,6 +61,7 @@
    <str name="task_prereq">Avant de commencer</str>
    <str name="task_postreq">Que faire ensuite</str>
    <str name="task_procedure">Procédure</str>
+   <str name="task_procedure_unordered">Procédure</str>
    <str name="task_results">Résultats</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-fr-fr.xml
+++ b/src/main/xsl/common/strings-fr-fr.xml
@@ -62,6 +62,7 @@
    <str name="task_prereq">Avant de commencer</str>
    <str name="task_postreq">Que faire ensuite</str>
    <str name="task_procedure">Procédure</str>
+   <str name="task_procedure_unordered">Procédure</str>
    <str name="task_results">Résultats</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-he-il.xml
+++ b/src/main/xsl/common/strings-he-il.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">איך להמשיך</str>
 <str name="task_prereq">לפני שתתחילו</str>
 <str name="task_procedure">נוהל</str>
+<str name="task_procedure_unordered">נוהל</str>
 <str name="task_results">תוצאות</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-hi-in.xml
+++ b/src/main/xsl/common/strings-hi-in.xml
@@ -63,6 +63,7 @@
 <str name="task_postreq">क्या करने के लिए अगले</str>
 <str name="task_prereq">इससे पहले कि आप शुरू</str>
 <str name="task_procedure">प्रक्रिया</str>
+<str name="task_procedure_unordered">प्रक्रिया</str>
 <str name="task_results">परिणाम</str>
 
 <str name="Copyright">कॉपीराइट</str>

--- a/src/main/xsl/common/strings-hr-hr.xml
+++ b/src/main/xsl/common/strings-hr-hr.xml
@@ -64,6 +64,7 @@
    <str name="task_postreq">Što napraviti sljedeće</str>
    <str name="task_prereq">Prije nego počnete</str>
    <str name="task_procedure">Postupak</str>
+   <str name="task_procedure_unordered">Postupak</str>
    <str name="task_results">Rezultati</str>
 
    <str name="Copyright">Autorska prava</str>

--- a/src/main/xsl/common/strings-hu-hu.xml
+++ b/src/main/xsl/common/strings-hu-hu.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Mi a következő lépés?</str>
 <str name="task_prereq">Mielőtt elkezdené</str>
 <str name="task_procedure">Eljárás</str>
+<str name="task_procedure_unordered">Eljárás</str>
 <str name="task_results">Eredmények</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-id-id.xml
+++ b/src/main/xsl/common/strings-id-id.xml
@@ -59,6 +59,7 @@
 <str name="task_postreq">Yang harus dilakukan berikutnya</str>
 <str name="task_prereq">Sebelum Anda mulai</str>
 <str name="task_procedure">Prosedur</str>
+<str name="task_procedure_unordered">Prosedur</str>
 <str name="task_results">Hasil</str>
 
 <str name="Copyright">Hak cipta</str>

--- a/src/main/xsl/common/strings-is-is.xml
+++ b/src/main/xsl/common/strings-is-is.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Það sem gera þarf næst</str>
 <str name="task_prereq">Áður en þú byrjar</str>
 <str name="task_procedure">Aðferð</str>
+<str name="task_procedure_unordered">Aðferð</str>
 <str name="task_results">Niðurstöður</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-it-ch.xml
+++ b/src/main/xsl/common/strings-it-ch.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">Prima di iniziare</str>
 <str name="task_postreq">Operazioni successive</str>
 <str name="task_procedure">Procedura</str>
+<str name="task_procedure_unordered">Procedura</str>
 <str name="task_results">Risultati</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-it-it.xml
+++ b/src/main/xsl/common/strings-it-it.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">Prima di iniziare</str>
 <str name="task_postreq">Operazioni successive</str>
 <str name="task_procedure">Procedura</str>
+<str name="task_procedure_unordered">Procedura</str>
 <str name="task_results">Risultati</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-ja-jp.xml
+++ b/src/main/xsl/common/strings-ja-jp.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">始める前に</str>
 <str name="task_postreq">次のタスク</str>
 <str name="task_procedure">手順</str>
+<str name="task_procedure_unordered">手順</str>
 <str name="task_results">タスクの結果</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-kk-kz.xml
+++ b/src/main/xsl/common/strings-kk-kz.xml
@@ -59,6 +59,7 @@
 <str name="task_postreq">Келесі әрекет</str>
 <str name="task_prereq">Бастаудан бұрын</str>
 <str name="task_procedure">Процедура</str>
+<str name="task_procedure_unordered">Процедура</str>
 <str name="task_results">Нәтижелер</str>
 
 <str name="Copyright">авторлық құқықтары</str>

--- a/src/main/xsl/common/strings-ko-kr.xml
+++ b/src/main/xsl/common/strings-ko-kr.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">시작하기 전에</str>
 <str name="task_postreq">다음에 수행할 작업</str>
 <str name="task_procedure">프로시저</str>
+<str name="task_procedure_unordered">프로시저</str>
 <str name="task_results">결과</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-lt-lt.xml
+++ b/src/main/xsl/common/strings-lt-lt.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Ką daryti toliau</str>
 <str name="task_prereq">Prieš pradedant</str>
 <str name="task_procedure">Procedūra</str>
+<str name="task_procedure_unordered">Procedūra</str>
 <str name="task_results">Rezultatai</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-lv-lv.xml
+++ b/src/main/xsl/common/strings-lv-lv.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Kā rīkoties tālāk</str>
 <str name="task_prereq">Pirms sākt darbu</str>
 <str name="task_procedure">Procedūra</str>
+<str name="task_procedure_unordered">Procedūra</str>
 <str name="task_results">Rezultāti</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-mk-mk.xml
+++ b/src/main/xsl/common/strings-mk-mk.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Што да направите следно</str>
 <str name="task_prereq">Пред да започнете</str>
 <str name="task_procedure">Процедура</str>
+<str name="task_procedure_unordered">Процедура</str>
 <str name="task_results">Резултати</str>
 
 <str name="Copyright">Авторски права</str>

--- a/src/main/xsl/common/strings-ms-my.xml
+++ b/src/main/xsl/common/strings-ms-my.xml
@@ -59,6 +59,7 @@
 <str name="task_postreq">Apa perlu dilakukan seterusnya</str>
 <str name="task_prereq">Sebelum anda bermula</str>
 <str name="task_procedure">Prosedur</str>
+<str name="task_procedure_unordered">Prosedur</str>
 <str name="task_results">Hasil</str>
 
 <str name="Copyright">Hak Cipta</str>

--- a/src/main/xsl/common/strings-nl-be.xml
+++ b/src/main/xsl/common/strings-nl-be.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Volgende stappen</str>
 <str name="task_prereq">Voordat u begint</str>
 <str name="task_procedure">Procedure</str>
+<str name="task_procedure_unordered">Procedure</str>
 <str name="task_results">Resultaten</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-nl-nl.xml
+++ b/src/main/xsl/common/strings-nl-nl.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Volgende stappen</str>
 <str name="task_prereq">Voordat u begint</str>
 <str name="task_procedure">Procedure</str>
+<str name="task_procedure_unordered">Procedure</str>
 <str name="task_results">Resultaten</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-no-no.xml
+++ b/src/main/xsl/common/strings-no-no.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Neste oppgave</str>
 <str name="task_prereq">Før du begynner</str>
 <str name="task_procedure">Prosedyre</str>
+<str name="task_procedure_unordered">Prosedyre</str>
 <str name="task_results">Resultater</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-pl-pl.xml
+++ b/src/main/xsl/common/strings-pl-pl.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Co dalej</str>
 <str name="task_prereq">Zanim rozpoczniesz</str>
 <str name="task_procedure">Procedura</str>
+<str name="task_procedure_unordered">Procedura</str>
 <str name="task_results">Wyniki</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-pt-br.xml
+++ b/src/main/xsl/common/strings-pt-br.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">Antes de Iniciar</str>
 <str name="task_postreq">O que Fazer Depois</str>
 <str name="task_procedure">Procedimento</str>
+<str name="task_procedure_unordered">Procedimento</str>
 <str name="task_results">Resultados</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-pt-pt.xml
+++ b/src/main/xsl/common/strings-pt-pt.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Como proceder a seguir</str>
 <str name="task_prereq">Antes de começar</str>
 <str name="task_procedure">Procedimento</str>
+<str name="task_procedure_unordered">Procedimento</str>
 <str name="task_results">Resultados</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-ro-ro.xml
+++ b/src/main/xsl/common/strings-ro-ro.xml
@@ -64,6 +64,7 @@
    <str name="task_postreq">Ce se face în continuare</str>
    <str name="task_prereq">Înainte de a începe</str>
    <str name="task_procedure">Procedură</str>
+   <str name="task_procedure_unordered">Procedură</str>
    <str name="task_results">Rezultate</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-ru-ru.xml
+++ b/src/main/xsl/common/strings-ru-ru.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Дальнейшие действия</str>
 <str name="task_prereq">Подготовка</str>
 <str name="task_procedure">Процедура</str>
+<str name="task_procedure_unordered">Процедура</str>
 <str name="task_results">Результат</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-sk-sk.xml
+++ b/src/main/xsl/common/strings-sk-sk.xml
@@ -64,6 +64,7 @@
    <str name="task_postreq">Ako ďalej</str>
    <str name="task_prereq">Skôr ako začnete</str>
    <str name="task_procedure">Procedúra</str>
+   <str name="task_procedure_unordered">Procedúra</str>
    <str name="task_results">Výsledky</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-sl-si.xml
+++ b/src/main/xsl/common/strings-sl-si.xml
@@ -64,6 +64,7 @@
    <str name="task_postreq">Kako naprej?</str>
    <str name="task_prereq">Preden začnete</str>
    <str name="task_procedure">Postopek</str>
+   <str name="task_procedure_unordered">Postopek</str>
    <str name="task_results">Rezultati</str>
 
    <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-sr-latn-rs.xml
+++ b/src/main/xsl/common/strings-sr-latn-rs.xml
@@ -63,6 +63,7 @@
 <str name="task_postreq">Šta uraditi sledeće</str>
 <str name="task_prereq">Pre nego što počnete</str>
 <str name="task_procedure">Postupak</str>
+<str name="task_procedure_unordered">Postupak</str>
 <str name="task_results">Rezultat</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-sr-sp.xml
+++ b/src/main/xsl/common/strings-sr-sp.xml
@@ -66,6 +66,7 @@
 <str name="task_postreq">Шта урадити следеће</str>
 <str name="task_prereq">Пре него што почнете</str>
 <str name="task_procedure">Поступак</str>
+<str name="task_procedure_unordered">Поступак</str>
 <str name="task_results">Резултат</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-sv-se.xml
+++ b/src/main/xsl/common/strings-sv-se.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Och sedan då?</str>
 <str name="task_prereq">Innan du börjar</str>
 <str name="task_procedure">Arbetsordning</str>
+<str name="task_procedure_unordered">Arbetsordning</str>
 <str name="task_results">Resultat</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-th-th.xml
+++ b/src/main/xsl/common/strings-th-th.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">สิ่งที่ต้องทำต่อไป</str>
 <str name="task_prereq">ก่อนเริ่มต้นภารกิจ</str>
 <str name="task_procedure">กระบวนการ</str>
+<str name="task_procedure_unordered">กระบวนการ</str>
 <str name="task_results">ผลลัพธ์</str>
 
 <str name="Copyright">ลิขสิทธิ์ของ</str>

--- a/src/main/xsl/common/strings-tr-tr.xml
+++ b/src/main/xsl/common/strings-tr-tr.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Sonraki adım</str>
 <str name="task_prereq">Başlamadan önce</str>
 <str name="task_procedure">Yordam</str>
+<str name="task_procedure_unordered">Yordam</str>
 <str name="task_results">Sonuçlar</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-uk-ua.xml
+++ b/src/main/xsl/common/strings-uk-ua.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">Подальші дії</str>
 <str name="task_prereq">Підготовчі дії</str>
 <str name="task_procedure">Процедура</str>
+<str name="task_procedure_unordered">Процедура</str>
 <str name="task_results">Результати</str>
 
 <str name="Copyright">Copyright</str>

--- a/src/main/xsl/common/strings-ur-pk.xml
+++ b/src/main/xsl/common/strings-ur-pk.xml
@@ -63,6 +63,7 @@
 <str name="task_postreq">آکے کیا کرنا ہے</str>
 <str name="task_prereq">قبل اس کے کہ آپ شروع کریں</str>
 <str name="task_procedure">طریق عمل</str>
+<str name="task_procedure_unordered">طریق عمل</str>
 <str name="task_results">نتائج</str>
 
 <str name="Copyright">حقوق</str>

--- a/src/main/xsl/common/strings-zh-cn.xml
+++ b/src/main/xsl/common/strings-zh-cn.xml
@@ -64,6 +64,7 @@
 <str name="task_postreq">下一步做什么</str>
 <str name="task_prereq">开始之前</str>
 <str name="task_procedure">过程</str>
+<str name="task_procedure_unordered">过程</str>
 <str name="task_results">结果</str>
 
 <str name="Copyright">版权</str>

--- a/src/main/xsl/common/strings-zh-tw.xml
+++ b/src/main/xsl/common/strings-zh-tw.xml
@@ -64,6 +64,7 @@
 <str name="task_prereq">開始之前</str>
 <str name="task_postreq">下一步</str>
 <str name="task_procedure">程序</str>
+<str name="task_procedure_unordered">程序</str>
 <str name="task_results">結果</str>
 
 <str name="Copyright">Copyright</str>


### PR DESCRIPTION
Currently, PDF2 variable files contain their own copy of all task headings (About this task, Procedure, etc). These should be reused from the common string files (which also makes adding new languages just a bit easier). Unfortunately they use a different ID for each string, and they also have a unique ID for unordered steps (as opposed to regular steps), though in all cases the string currently matches.

In addition, the X/HTML code supports flags for both Optional and Required steps; PDF2 currently only flags Optional steps. PDF2 should flag Required steps just as X/HTML does. This is harder to reuse because PDF2 uses one variable (including the colon) while X/HTML uses two; to avoid ugly little backwards incompatible changes, I'm not going to try to reuse the strings here.

This pull request includes the following changes:
* In common string files, add an entry for `task_procedure_unordered` alongside `task_procedure`, allowing any transform type to customize these as PDF2 can today
* In XHTML and ODT, add support for this new string when using `<steps-unordered>`
* In PDF2:
  * Remove current translations for "Task NNN".
  * Add translation for "Required step"
  * For languages that listed it as "TODO", add translation for "Optional step"
  * In rendering code, check first for the old PDF2 string; anybody customizing the string gets their value. If no value is found, use the common string.