### PR TITLE
Add axf.jar into log-processor taskdef classpath

### DIFF
--- a/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
@@ -5,6 +5,11 @@
 -->
 <project name="org.dita.pdf2.axf">
 
+  <path id="axf.class.path">
+    <path refid="project.class.path"/>
+    <pathelement location="${dita.plugin.org.dita.pdf2.axf.dir}/lib/axf.jar"/>
+  </path>
+
   <target name="transform.fo2pdf.ah.test-use">
     <condition property="use.ah.pdf.formatter">
       <equals arg1="${pdf.formatter}" arg2="ah"/>
@@ -13,7 +18,7 @@
 
   <target name="transform.fo2pdf.ah.init" depends="transform.fo2pdf.ah.test-use" if="use.ah.pdf.formatter">
     <taskdef name="log-processor" classname="org.dita.dost.pdf2.AhfLogProcessorTask"
-             classpathref="project.class.path"/>
+             classpathref="axf.class.path"/>
     
     <condition property="temp.transformation.file" value="${dita.plugin.org.dita.pdf2.axf.dir}/xsl/fo/topic2fo_shell_axf.xsl">
       <isset property="use.ah.pdf.formatter"/>


### PR DESCRIPTION
The `dita` command works without this change because `axf.jar` is imported into the classpath in `org.dita.pdf2.axf/plugin.xml`, but running DITA-OT via Ant will fail because it can't find the `org.dita.dost.pdf2.AhfLogProcessorTask` class.