### PR TITLE
Remove obsolete info from codepage list

### DIFF
--- a/src/main/resources/org/dita/dost/util/codepages.xml
+++ b/src/main/resources/org/dita/dost/util/codepages.xml
@@ -1,267 +1,214 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <codepages>
   <language lang="en-us">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="ar-eg">
-    <cp format="ibmiddoc" encoding="864"/>
     <cp format="html" encoding="1256" charset="windows-1256"/>
     <cp format="windows" encoding="1256" charset="windows-1256"/>
   </language>
   <language lang="be-by">
-    <cp format="ibmiddoc" encoding="1251"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="bg-bg">
-    <cp format="ibmiddoc" encoding="915"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="ca-es">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="cs-cz">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="da-dk">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="de-ch">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="de-de">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="el-gr">
-    <cp format="ibmiddoc" encoding="813"/>
     <cp format="html" encoding="813" charset="iso-8859-7"/>
     <cp format="windows" encoding="1253" charset="windows-1253"/>
   </language>
   <language lang="en-ca">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="en-gb">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="es-es">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="et-ee">
-    <cp format="ibmiddoc" encoding="922"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1257" charset="windows-1257"/>
   </language>
   <language lang="fi-fi">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="fr-be">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="fr-ca">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="fr-ch">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="fr-fr">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="he-il">
-    <cp format="ibmiddoc" encoding="1255"/>
     <cp format="html" encoding="1255" charset="windows-1255"/>
     <cp format="windows" encoding="1255" charset="windows-1255"/>
   </language>
   <language lang="hi-in">
-    <cp format="ibmiddoc" encoding="utf-8"/>
     <cp format="html" encoding="utf-8" charset="utf-8"/>
     <cp format="windows" encoding="utf-8" charset="utf-8"/>
   </language>
   <language lang="hr-hr">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="hu-hu">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="is-is">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="it-ch">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="it-it">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="ja-jp">
-    <cp format="ibmiddoc" encoding="943"/>
     <cp format="html" encoding="943" charset="Windows-31J"/>
     <cp format="windows" encoding="943" charset="Windows-31J"/>
   </language>
   <language lang="kk-kz">
-    <cp format="ibmiddoc" encoding="utf-8"/>
     <cp format="html" encoding="utf-8" charset="utf-8"/>
     <cp format="windows" encoding="utf-8" charset="utf-8"/>
   </language>
   <language lang="ko-kr">
-    <cp format="ibmiddoc" encoding="1363"/>
     <cp format="html" encoding="1363" charset="euc-kr"/>
     <cp format="windows" encoding="1363" charset="euc-kr"/>
   </language>
   <language lang="lt-lt">
-    <cp format="ibmiddoc" encoding="921"/>
     <cp format="html" encoding="1257" charset="windows-1257"/>
     <cp format="windows" encoding="1257" charset="windows-1257"/>
   </language>
   <language lang="lv-lv">
-    <cp format="ibmiddoc" encoding="921"/>
     <cp format="html" encoding="1257" charset="windows-1257"/>
     <cp format="windows" encoding="1257" charset="windows-1257"/>
   </language>
   <language lang="mk-mk">
-    <cp format="ibmiddoc" encoding="855"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="nl-be">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="nl-nl">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="no-no">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="pl-pl">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="pt-br">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="pt-pt">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="ro-ro">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="ru-ru">
-    <cp format="ibmiddoc" encoding="866"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="sk-sk">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="sl-si">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="sr-sp">
-    <cp format="ibmiddoc" encoding="855"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="sr-rs">
-    <cp format="ibmiddoc" encoding="855"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="sr-latn-rs">
-    <cp format="ibmiddoc" encoding="852"/>
     <cp format="html" encoding="912" charset="iso-8859-2"/>
     <cp format="windows" encoding="1250" charset="windows-1250"/>
   </language>
   <language lang="sr-cs">
-    <cp format="ibmiddoc" encoding="855"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="sv-se">
-    <cp format="ibmiddoc" encoding="850"/>
     <cp format="html" encoding="819" charset="iso-8859-1"/>
     <cp format="windows" encoding="1252" charset="windows-1252"/>
   </language>
   <language lang="th-th">
-    <cp format="ibmiddoc" encoding="874"/>
     <cp format="html" encoding="874" charset="tis-620"/>
     <cp format="windows" encoding="874" charset="tis-620"/>
   </language>
   <language lang="tr-tr">
-    <cp format="ibmiddoc" encoding="857"/>
     <cp format="html" encoding="920" charset="iso-8859-9"/>
     <cp format="windows" encoding="1254" charset="windows-1254"/>
   </language>
   <language lang="uk-ua">
-    <cp format="ibmiddoc" encoding="1251"/>
     <cp format="html" encoding="1251" charset="windows-1251"/>
     <cp format="windows" encoding="1251" charset="windows-1251"/>
   </language>
   <language lang="ur-pk">
-    <cp format="ibmiddoc" encoding="utf-8"/>
     <cp format="html" encoding="utf-8" charset="utf-8"/>
     <cp format="windows" encoding="1256" charset="windows-1256"/>
   </language>
   <language lang="zh-cn">
-    <cp format="ibmiddoc" encoding="1386"/>
     <cp format="html" encoding="1386" charset="gb2312"/>
     <cp format="windows" encoding="1386" charset="gb2312"/>
   </language>
   <language lang="zh-tw">
-    <cp format="ibmiddoc" encoding="950"/>
     <cp format="html" encoding="950" charset="big5"/>
     <cp format="windows" encoding="950" charset="big5"/>
   </language>


### PR DESCRIPTION
It looks like this file is based on one I maintain inside IBM, with codepages for various formats I support. Not sure how all of the IBMIDDoc info ended up inside DITA-OT -- either I checked in the full file by mistake, or I sent it to an earlier DITA-OT contributor to use as background and instead it was just renamed and uploaded. Either way, the IBMIDDoc entries are meaningless inside DITA-OT.

Very minor item, but should be cleaned up as the IBMIDDoc entries don't belong in the package today.