### PR TITLE
Fix table and figure list to include number, title

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -81,7 +81,7 @@
           
           <fo:inline xsl:use-attribute-sets="__lotf__title">
             <xsl:call-template name="getVariable">
-              <xsl:with-param name="id" select="'Table'"/>
+              <xsl:with-param name="id" select="'Table.title'"/>
               <xsl:with-param name="params">
                 <number>
                   <xsl:variable name="id">
@@ -157,7 +157,7 @@
           
           <fo:inline xsl:use-attribute-sets="__lotf__title">
             <xsl:call-template name="getVariable">
-              <xsl:with-param name="id" select="'Figure'"/>
+              <xsl:with-param name="id" select="'Figure.title'"/>
               <xsl:with-param name="params">
                 <number>
                   <xsl:variable name="id">


### PR DESCRIPTION
Looks like a bug introduced in 2.0 (If we create a hotfix branch for 2.1.3 I'd like to add it there, but this file has already been updated in `develop` for 2.2).

In 2.0 the figure and table variables were split to allow reference by title or by number. The use of that variable in the Figure list and Table list didn't change, so the request for "Figure" that previously returned "Figure N: Title" now just returns the standalone translation of "Figure".

This update restores the previous (correct) behavior of placing the full figure/table number and title in the list.