### PR TITLE
PDF: Use roman page numbers for ToC to agree w/ Preface

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -248,7 +248,7 @@ See the accompanying license.txt file for applicable licenses.
             </xsl:choose>
         </xsl:variable>
         <xsl:if test="count($toc/*) > 0">
-            <fo:page-sequence master-reference="toc-sequence" xsl:use-attribute-sets="__force__page__count">
+            <fo:page-sequence master-reference="toc-sequence" format="i" xsl:use-attribute-sets="__force__page__count">
                 <xsl:call-template name="insertTocStaticContents"/>
                 <fo:flow flow-name="xsl-region-body">
                     <xsl:call-template name="createTocHeader"/>


### PR DESCRIPTION
Currently, the bookmap `<toc>` uses arabic page numbers, while roman is defined for `<preface>`, which is also in contained in `<frontmatter>`.

Consistent numbering styles should be used for all frontmatter components to prevent numbering from switching back and forth between styles in bookmaps where Preface follows ToC.

Currently, this use case yields numbering sequences like 1,2,3,4,v,vi,7,8.
