### PR TITLE
PDF: Indent stepsections to `$side-col-width`

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
@@ -137,7 +137,7 @@ See the accompanying license.txt file for applicable licenses.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="stepsection__body" use-attribute-sets="ul.li__body">
-        <xsl:attribute name="start-indent">9mm</xsl:attribute>
+        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="stepsection__content" use-attribute-sets="ul.li__content">


### PR DESCRIPTION
The `stepsection__body` attribute set currently hard-codes the `start-indent` attribute to 9mm, which doesn't align with anything.

Stepsection bodies should honor the `$side-col-width` value from `basic-settings.xsl` to use the same  indent relative to the page margin and align with other body text.