### PR TITLE
PDF: Ensure baseline alignment for list items with icons

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
@@ -56,6 +56,7 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:attribute-set name="ul.li">
         <xsl:attribute name="space-after">1.5pt</xsl:attribute>
         <xsl:attribute name="space-before">1.5pt</xsl:attribute>
+        <xsl:attribute name="relative-align">baseline</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="ul.li__label">
@@ -85,6 +86,7 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:attribute-set name="ol.li">
         <xsl:attribute name="space-after">1.5pt</xsl:attribute>
         <xsl:attribute name="space-before">1.5pt</xsl:attribute>
+        <xsl:attribute name="relative-align">baseline</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="ol.li__label">


### PR DESCRIPTION
See http://tech.groups.yahoo.com/group/dita-users/message/22362.

The original thread proposes adding the `relative-align` attribute to the attribute sets `steps-unordered.step`, `steps.step` and `substeps.substep`, but these now call the common `ol.li` & `ul.li` attribute sets, so this change modifies those to ensure all list items profit from the change.