### PR TITLE
Missing `.tar.gz` distribution package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ task distTarGz(type: Tar, dependsOn: [jar, generateDocs]) {
         include "bin/ant"
         include "bin/ant.*"
     }
-    archiveName "dita-ot-${project.version}.zip"
+    archiveName "dita-ot-${project.version}.tar.gz"
 }
 task dist(dependsOn: [distZip, distTarGz]) << {
     // NOOP


### PR DESCRIPTION
Looks like a copy & paste error in `build.gradle`:

Both `task distZip` & `task distTarGz` write `archiveName "dita-ot-${project.version}.zip"`, so `task distTarGz` is overwriting the Zip task result rather than placing a .tar.gz file alongside it.