### PR TITLE
Generate link to page also for parent index terms

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -376,6 +376,7 @@ See the accompanying license.txt file for applicable licenses.
                         </xsl:variable>
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
+                            <xsl:with-param name="idxs" select="opentopic-index:refID"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
                             <xsl:with-param name="no-page" select="$isNoPage"/>
                           </xsl:apply-templates>


### PR DESCRIPTION
Possible fix for:
https://github.com/dita-ot/dita-ot/issues/2126