### PR TITLE
Inconsistency in naming of flow name, region definition

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/layout-masters.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/layout-masters.xsl
@@ -81,21 +81,21 @@ See the accompanying license.txt file for applicable licenses.
       <xsl:if test="$mirror-page-margins">
         <fo:simple-page-master master-name="back-cover-even" xsl:use-attribute-sets="simple-page-master">
           <fo:region-body xsl:use-attribute-sets="region-body__backcover.even"/>
-          <fo:region-before region-name="even-backcover-header" xsl:use-attribute-sets="region-before"/>
-          <fo:region-after region-name="even-backcover-footer" xsl:use-attribute-sets="region-after"/>
+          <fo:region-before region-name="even-back-cover-header" xsl:use-attribute-sets="region-before"/>
+          <fo:region-after region-name="even-back-cover-footer" xsl:use-attribute-sets="region-after"/>
         </fo:simple-page-master>
       </xsl:if>
       
       <fo:simple-page-master master-name="back-cover-odd" xsl:use-attribute-sets="simple-page-master">
         <fo:region-body xsl:use-attribute-sets="region-body__backcover.odd"/>
-        <fo:region-before region-name="odd-backcover-header" xsl:use-attribute-sets="region-before"/>
-        <fo:region-after region-name="odd-backcover-footer" xsl:use-attribute-sets="region-after"/>
+        <fo:region-before region-name="odd-back-cover-header" xsl:use-attribute-sets="region-before"/>
+        <fo:region-after region-name="odd-back-cover-footer" xsl:use-attribute-sets="region-after"/>
       </fo:simple-page-master>
       
       <fo:simple-page-master master-name="back-cover-last" xsl:use-attribute-sets="simple-page-master">
         <fo:region-body xsl:use-attribute-sets="region-body__backcover.even"/>
-        <fo:region-before region-name="last-backcover-header" xsl:use-attribute-sets="region-before"/>
-        <fo:region-after region-name="last-backcover-footer" xsl:use-attribute-sets="region-after"/>
+        <fo:region-before region-name="last-back-cover-header" xsl:use-attribute-sets="region-before"/>
+        <fo:region-after region-name="last-back-cover-footer" xsl:use-attribute-sets="region-after"/>
       </fo:simple-page-master>
     </xsl:if>
     

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
@@ -127,6 +127,7 @@ See the accompanying license.txt file for applicable licenses.
     </xsl:template>
 
     <xsl:template name="createBackCoverContents">
+      <fo:block></fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' bookmap/bookmeta ')]" priority="1">


### PR DESCRIPTION
Submitting on behalf of @simalot, who was working with back covers and noticed the inconsistency. In `xsl\fo\static-content.xsl` the back covers are created with a flow name as follows:
`<fo:static-content flow-name="odd-back-cover-header">`

In `cfg\fo\layout-masters.xsl` the regions are actually defined without a hyphen in back-cover:
`<fo:region-before region-name="odd-backcover-header" xsl:use-attribute-sets="region-before"/>`

This pull request fixes the defined regions so that they match the references. Additionally, for back covers the default code calls the empty template `createBackCoverContents` from inside of an `<fo:block-container>` element, resulting in a container with no blocks inside. This pull request adds an empty block to fix some warnings caused by the empty container.
