### PR TITLE
Fix `base-html` description for generated docs

### DIFF
--- a/src/main/plugins/org.dita.xhtml/plugin.xml
+++ b/src/main/plugins/org.dita.xhtml/plugin.xml
@@ -12,7 +12,7 @@
   <extension-point id="dita.xsl.htmltoc" name="HTML/XHTML TOC XSLT import"/>
   <extension-point id="dita.xsl.html.cover" name="HTML/XHTML Cover XSLT import"/>
   <!-- extensions -->
-  <transtype name="base-html" abstract="true" desc="HTML-based output formats">
+  <transtype name="base-html" abstract="true" desc="HTML-based output">
     <param name="args.artlbl" desc="Specifies whether to generate a label for each image; the label will contain the image file name." type="enum">
       <val>yes</val>
       <val default="true">no</val>


### PR DESCRIPTION
After [removing](https://github.com/dita-ot/docs/commit/1dbb3147aac2c9909efc0dfab968b5673c519ab8#diff-f7ba90227a330f8f7cac9e6fab83097bL59) the _“Ant parameters: ”_ prefix in dita-ot/docs@1dbb314, the description of the `base-html` transtype should be changed to correct the title of the generated docs topic:

This commit changes the resulting topic title
* _“HTML-based output formats parameters”_ to 
* _“HTML-based output parameters”_
