### PR TITLE
Support PDF bookmarks for index letter headings

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/invoker/ExtensibleAntInvoker.java
@@ -8,18 +8,16 @@
  */
 package org.dita.dost.invoker;
 
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
 import static org.dita.dost.util.Constants.*;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
@@ -28,10 +26,12 @@ import org.apache.tools.ant.types.XMLCatalog;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.module.AbstractPipelineModule;
+import org.dita.dost.module.XmlFilterModule;
 import org.dita.dost.module.XsltModule;
 import org.dita.dost.pipeline.PipelineFacade;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Job;
+import org.dita.dost.writer.AbstractXMLFilter;
 
 /**
  * Ant task for executing pipeline modules.
@@ -109,6 +109,11 @@ public final class ExtensibleAntInvoker extends Task {
     public void addConfiguredXslt(final Xslt xslt) {
         modules.add(xslt);
     }
+
+    public void addConfiguredSax(final Filters filters) {
+        filters.setProject(getProject());
+        modules.add(filters);
+    }
     
     /**
      * Execution point of this invoker.
@@ -150,32 +155,51 @@ public final class ExtensibleAntInvoker extends Task {
                     final XsltModule x = new XsltModule();
                     x.setStyle(xm.style);
                     if (xm.in != null) {
-                    	x.setSource(xm.in);
-                    	x.setResult(xm.out);
+                        x.setSource(xm.in);
+                        x.setResult(xm.out);
                     } else {
-	                    final Set<File> inc = readListFile(xm.includes, logger); 
-	                    inc.removeAll(readListFile(xm.excludes, logger));
-	                    x.setIncludes(inc);
-	                    x.setDestinationDir(xm.destDir != null ? xm.destDir : xm.baseDir);
-	                    x.setSorceDir(xm.baseDir);
+                        final Set<File> inc = readListFile(xm.includes, logger);
+                        inc.removeAll(readListFile(xm.excludes, logger));
+                        x.setIncludes(inc);
+                        x.setDestinationDir(xm.destDir != null ? xm.destDir : xm.baseDir);
+                        x.setSorceDir(xm.baseDir);
                     }
                     x.setFilenameParam(xm.filenameparameter);
                     x.setFiledirParam(xm.filedirparameter);
                     x.setReloadstylesheet(xm.reloadstylesheet);
                     x.setXMLCatalog(xm.xmlcatalog);
                     if (xm.mapper != null) {
-                    	x.setMapper(xm.mapper.getImplementation());
+                        x.setMapper(xm.mapper.getImplementation());
                     }
                     for (final Param p : m.params) {
                         if (!p.isValid()) {
                             throw new BuildException("Incomplete parameter");
                         }
-                        if (isValid(p.getIf(), p.getUnless())) {
+                        if (isValid(getProject(), p.getIf(), p.getUnless())) {
                             x.setParam(p.getName(), p.getValue());
                         }
                     }
                     start = System.currentTimeMillis();
                     pipeline.execute(x, pipelineInput);
+                    end = System.currentTimeMillis();
+                } else if (m instanceof Filters) {
+                    final Filters fm = (Filters) m;
+                    final XmlFilterModule module = new XmlFilterModule();
+                    final List<String> format = fm.getFormat();
+                    module.setFileInfoFilter(new Job.FileInfo.Filter<Job.FileInfo>() {
+                             @Override
+                             public boolean accept(final Job.FileInfo f) {
+                                 return format.contains(f.format);
+                             }
+                         }
+                    );
+                    try {
+                        module.setProcessingPipe(fm.getFilters());
+                    } catch (final InstantiationException | IllegalAccessException e) {
+                        throw new BuildException(e);
+                    }
+                    start = System.currentTimeMillis();
+                    pipeline.execute(module, pipelineInput);
                     end = System.currentTimeMillis();
                 } else {
                     for (final Param p : m.params) {
@@ -227,7 +251,7 @@ public final class ExtensibleAntInvoker extends Task {
     private Set<File> readListFile(final List<Xslt.IncludesFile> includes, final DITAOTAntLogger logger) {
     	final Set<File> inc = new HashSet<>();
     	for (final Xslt.IncludesFile i: includes) {
-            if (!isValid(i.ifProperty, null)) {
+            if (!isValid(getProject(), i.ifProperty, null)) {
                 continue;
             }
             BufferedReader r = null;
@@ -249,9 +273,9 @@ public final class ExtensibleAntInvoker extends Task {
     	return inc;
     }
     
-    private boolean isValid(final String ifProperty, final String unlessProperty) {
-        return (ifProperty == null || getProject().getProperties().containsKey(ifProperty))
-                && (unlessProperty == null || !getProject().getProperties().containsKey(unlessProperty));
+    private static boolean isValid(final Project project, final String ifProperty, final String unlessProperty) {
+        return (ifProperty == null || project.getProperties().containsKey(ifProperty))
+                && (unlessProperty == null || !project.getProperties().containsKey(unlessProperty));
     }
     
     /**
@@ -275,13 +299,11 @@ public final class ExtensibleAntInvoker extends Task {
         public Class<? extends AbstractPipelineModule> getImplementation() {
             return cls;
         }
-
     }
     
     /**
      * Nested pipeline XSLT element configuration.
      * @author jelovirt
-     *
      */
     public static class Xslt extends Module {
         
@@ -389,6 +411,106 @@ public final class ExtensibleAntInvoker extends Task {
             }
         }*/
         
+    }
+
+    /**
+     * Nested pipeline SAX filter pipe element configuration.
+     * @author jelovirt
+     */
+    public static class Filters extends Module {
+
+        private List<Filter> filters = new ArrayList<>();
+        private Project project;
+        private List<String> format;
+
+        // Ant setters
+
+        public void setFormat(final String format) {
+            this.format = asList(format);
+        }
+
+        public void addConfiguredFilter(final Filter filter) {
+            filters.add(filter);
+        }
+
+        public List<AbstractXMLFilter> getFilters() throws IllegalAccessException, InstantiationException {
+            final List<AbstractXMLFilter> res = new ArrayList<>();
+            for (final Filter f: filters) {
+                final String ifProperty = f.getIf();
+                final String unlessProperty = f.getUnless();
+                if (isValid(getProject(), ifProperty, unlessProperty)) {
+                    final AbstractXMLFilter fc = f.getImplementation().newInstance();
+                    for (final Param p : f.params) {
+                        if (!p.isValid()) {
+                            throw new BuildException("Incomplete parameter");
+                        }
+                        if (isValid(getProject(), p.getIf(), p.getUnless())) {
+                            fc.setParam(p.getName(), p.getValue());
+                        }
+                    }
+                    res.add(fc);
+                }
+            }
+            return res;
+        }
+
+        public List<String> getFormat() {
+            if (format != null) {
+                return unmodifiableList(format);
+            } else {
+                return unmodifiableList(asList(ATTR_FORMAT_VALUE_DITA, ATTR_FORMAT_VALUE_DITAMAP));
+            }
+
+        }
+
+        public void setProject(final Project project) {
+            this.project = project;
+        }
+
+        public Project getProject() {
+            return project;
+        }
+    }
+
+    /** Nested pipeline SAX filter element configuration. */
+    public static class Filter {
+
+        public final List<Param> params = new ArrayList<>();
+        private Class<? extends AbstractXMLFilter> cls;
+        private String ifProperty;
+        private String unlessProperty;
+
+        public void setClass(final Class<? extends AbstractXMLFilter> cls) {
+            this.cls = cls;
+        }
+
+        public void addConfiguredParam(final Param p) {
+            params.add(p);
+        }
+
+        public Class<? extends AbstractXMLFilter> getImplementation() {
+            if (cls == null) {
+                throw new IllegalArgumentException("class not defined");
+            }
+            return cls;
+        }
+
+        public String getIf() {
+            return ifProperty;
+        }
+
+        public void setIf(final String p) {
+            ifProperty = p;
+        }
+
+        public String getUnless() {
+            return unlessProperty;
+        }
+
+        public void setUnless(final String p) {
+            unlessProperty = p;
+        }
+
     }
 
     /** Nested parameters. */

--- a/src/main/java/org/dita/dost/module/CoderefModule.java
+++ b/src/main/java/org/dita/dost/module/CoderefModule.java
@@ -19,7 +19,9 @@ import org.dita.dost.writer.CoderefResolver;
 /**
  * Coderef Module class.
  *
+ * @deprecated since 2.3
  */
+@Deprecated
 final class CoderefModule extends AbstractPipelineModuleImpl {
 
     /**
@@ -38,7 +40,7 @@ final class CoderefModule extends AbstractPipelineModuleImpl {
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input)
             throws DITAOTException {
-        final Collection<FileInfo> fis = job.getFileInfo(new Filter() {
+        final Collection<FileInfo> fis = job.getFileInfo(new Filter<FileInfo>() {
             @Override
             public boolean accept(final FileInfo f) {
                 return f.hasCoderef;

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -31,7 +31,7 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input)
             throws DITAOTException {
-        final Collection<FileInfo> fis = job.getFileInfo(new Filter() {
+        final Collection<FileInfo> fis = job.getFileInfo(new Filter<FileInfo>() {
             @Override
             public boolean accept(FileInfo f) {
                 return f.isConrefPush;

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -60,7 +60,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input)
             throws DITAOTException {
-        final Collection<FileInfo> fis = new HashSet(job.getFileInfo(new Filter() {
+        final Collection<FileInfo> fis = new HashSet(job.getFileInfo(new Filter<FileInfo>() {
             @Override
             public boolean accept(final FileInfo f) {
                 return f.hasKeyref;

--- a/src/main/java/org/dita/dost/module/TopicFragmentModule.java
+++ b/src/main/java/org/dita/dost/module/TopicFragmentModule.java
@@ -25,6 +25,8 @@ import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_PROCESSING_MODE
 import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
 import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
 
+/** @deprecated since 2.3 */
+@Deprecated
 final class TopicFragmentModule extends AbstractPipelineModuleImpl {
 
     public static final String SKIP_CODEREF = "preprocess.coderef.skip";
@@ -45,7 +47,7 @@ final class TopicFragmentModule extends AbstractPipelineModuleImpl {
         processingMode = mode != null ? Configuration.Mode.valueOf(mode.toUpperCase()) : Configuration.Mode.LAX;
         resolveCoderef = !Boolean.parseBoolean(input.getAttribute(SKIP_CODEREF));
 
-        final Collection<FileInfo> fis = job.getFileInfo(new Filter() {
+        final Collection<FileInfo> fis = job.getFileInfo(new Filter<FileInfo>() {
             @Override
             public boolean accept(final FileInfo f) {
                 return ATTR_FORMAT_VALUE_DITA.equals(f.format);

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ * See the accompanying license.txt file for applicable licenses.
+ */
+package org.dita.dost.module;
+
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.Job.FileInfo.Filter;
+import org.dita.dost.util.XMLUtils;
+import org.dita.dost.writer.AbstractXMLFilter;
+import org.xml.sax.XMLFilter;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Map processes topics through XML filters. Filters are reused and should reset internal state on
+ * {@code startDocument} event.
+ */
+public final class XmlFilterModule extends AbstractPipelineModuleImpl {
+
+    private List<AbstractXMLFilter> pipe;
+    private Filter<FileInfo> fileInfoFilter;
+
+    /**
+     * Filter files through XML filters.
+     * 
+     * @param input Input parameters and resources.
+     * @return always returns {@code null}
+     */
+    @Override
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input)
+            throws DITAOTException {
+        final Collection<FileInfo> fis = job.getFileInfo(fileInfoFilter);
+        for (final FileInfo f: fis) {
+            final URI file = job.tempDir.toURI().resolve(f.uri);
+            logger.info("Processing " + file);
+            try {
+                XMLUtils.transform(file, getProcessingPipe(file));
+            } catch (final DITAOTException e) {
+                logger.error("Failed to process XML filter: " + e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    public void setProcessingPipe(final List<AbstractXMLFilter> pipe) {
+        this.pipe = pipe;
+    }
+
+    /**
+     * Get pipe line filters
+     *
+     * @param fileToParse absolute URI to current file being processed
+     */
+    private List<XMLFilter> getProcessingPipe(final URI fileToParse) {
+        assert fileToParse.isAbsolute();
+        final List<XMLFilter> res = new ArrayList<>();
+        for (final AbstractXMLFilter f: pipe) {
+            logger.debug("Configure filter " + f.getClass().getCanonicalName());
+            f.setCurrentFile(fileToParse);
+            f.setJob(job);
+            f.setLogger(logger);
+            res.add(f);
+        }
+        return res;
+    }
+
+    public void setFileInfoFilter(final Filter<FileInfo> fileInfoFilter) {
+        this.fileInfoFilter = fileInfoFilter;
+    }
+}

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -658,9 +658,9 @@ public final class Job {
                     '}';
         }
 
-        public interface Filter {
+        public interface Filter<T> {
             
-            boolean accept(FileInfo f);
+            boolean accept(T f);
             
         }
         

--- a/src/main/java/org/dita/dost/util/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/util/JobSourceSet.java
@@ -38,7 +38,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
                 throw new IllegalStateException();
             }
             res = new ArrayList<>();
-            for (final Job.FileInfo f : job.getFileInfo(new Job.FileInfo.Filter() {
+            for (final Job.FileInfo f : job.getFileInfo(new Job.FileInfo.Filter<Job.FileInfo>() {
                 @Override
                 public boolean accept(final Job.FileInfo f) {
                     return f.format != null && f.format.equals(format);

--- a/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
@@ -9,6 +9,8 @@ import static java.util.Arrays.asList;
 import java.io.File;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
@@ -29,6 +31,7 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
     Job job;
     /** Absolute system path to file being processed */
     protected URI currentFile;
+    protected Map<String, String> params = new HashMap<>();
 
     @Override
     public void write(final File filename) throws DITAOTException {
@@ -51,5 +54,7 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
         this.currentFile = currentFile;
     }
 
-
+    public void setParam(final String name, final String value) {
+        params.put(name, value);
+    }
 }

--- a/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
@@ -89,11 +89,22 @@ public final class NormalizeTableFilter extends AbstractXMLFilter {
         depth = 0;
     }
 
+    /** @deprecated since 2.3 */
+    @Deprecated
     public void setProcessingMode(final Configuration.Mode processingMode) {
         this.processingMode = processingMode;
     }
 
     // SAX methods
+
+    @Override
+    public void startDocument() throws SAXException {
+        final String mode = params.get(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
+        processingMode = mode != null ? Configuration.Mode.valueOf(mode.toUpperCase()) : Configuration.Mode.LAX;
+
+        getContentHandler().startDocument();
+    }
+
 
     @Override
     public void startElement(final String uri, final String localName, final String qName, final Attributes atts)

--- a/src/main/java/org/dita/dost/writer/TopicFragmentFilter.java
+++ b/src/main/java/org/dita/dost/writer/TopicFragmentFilter.java
@@ -16,12 +16,19 @@ import org.xml.sax.helpers.XMLFilterImpl;
 /**
  * Resolves same topic fragment identifies in topics.
  */
-public final class TopicFragmentFilter extends XMLFilterImpl {
+public final class TopicFragmentFilter extends AbstractXMLFilter {
+
+    public static final String PARAM_ATTRIBUTES = "attributes";
 
     private final Deque<DitaClass> classes = new LinkedList<>();
     private final Deque<String> topics = new ArrayDeque<>();
     
-    final List<String> attrNames;
+    List<String> attrNames;
+
+    public TopicFragmentFilter() {
+        super();
+        this.attrNames = Arrays.asList(ATTRIBUTE_NAME_HREF);
+    }
 
     public TopicFragmentFilter(final String... attrNames) {
         super();
@@ -30,8 +37,12 @@ public final class TopicFragmentFilter extends XMLFilterImpl {
 
     @Override
     public void startDocument() throws SAXException {
+        if (attrNames == null) {
+            attrNames = Arrays.asList(params.get(PARAM_ATTRIBUTES).split(","));
+        }
         classes.clear();
         topics.clear();
+
         super.startDocument();
     }
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -282,12 +282,17 @@
   <target name="topic-fragment"
           dita:depends="{depend.preprocess.coderef.pre}"
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
-          description="Normalize same topic fragment identifiers and table column names">
+          description="Normalize same topic fragment identifiers and table column names, and resolve coderef">
     <pipeline message="Resolve topic fragment." taskname="topic-fragment">
-      <module class="org.dita.dost.module.TopicFragmentModule">
-        <param name="processing-mode" value="${processing-mode}" if="processing-mode"/>
-        <param name="preprocess.coderef.skip" value="true" if="preprocess.coderef.skip"/>
-      </module>
+      <sax format="dita">
+        <filter class="org.dita.dost.writer.TopicFragmentFilter">
+          <param name="attributes" value="href"/>
+        </filter>
+        <filter class="org.dita.dost.writer.NormalizeTableFilter">
+          <param name="processing-mode" value="${processing-mode}" if="processing-mode"/>
+        </filter>
+        <filter class="org.dita.dost.writer.CoderefResolver" unless="preprocess.coderef.skip"/>
+      </sax>
     </pipeline>
   </target>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
@@ -316,7 +316,7 @@ list just like regular named attribute sets.
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
-            <xsl:when test="document('cfg:fo/attrs/custom.xsl')//xsl:attribute-set[@name = $attrSet]">
+            <xsl:when test="doc-available('cfg:fo/attrs/custom.xsl') and document('cfg:fo/attrs/custom.xsl')//xsl:attribute-set[@name = $attrSet]">
                 <xsl:apply-templates select="document('cfg:fo/attrs/custom.xsl')//xsl:attribute-set[@name = $attrSet]"/>
             </xsl:when>
             <xsl:otherwise>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -217,7 +217,7 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:template>
 
   <xsl:template match="opentopic-index:label" mode="index-postprocess">
-    <fo:block xsl:use-attribute-sets="__index__letter-group">
+    <fo:block xsl:use-attribute-sets="__index__letter-group" id="{generate-id(.)}">
       <xsl:value-of select="."/>
     </fo:block>
   </xsl:template>


### PR DESCRIPTION
Many of the indexes I work with can grow quite large, spanning many pages. Currently, when using an index, the PDF bookmarks only have a single entry for the index. This pull request adds support for letter headings under the "Index" bookmark, with one entry for each letter heading that appears in the index.

Details:

There is a new parameter in the XSL, `INDEX-BOOKMARKS`. 
* When set to 0, no letter bookmarks will appear.
* When set to any other number, bookmarks will appear if the total number of entries equals or exceeds the value of `INDEX-BOOKMARKS`. Default is currently set to 100, so that if the index only spans one or two pages, no extra bookmarks will appear.
* Setting to 1 will force bookmarks to appear for any document that uses an index.

While doing this, I refactored `bookmarks.xsl` just slightly, to move index processing out of the larger `createBookmarks` named template. This makes it easier to override or customize, should anyone need to do so.

The only change for `index.xsl` is to add an ID to each letter group, which is needed to enable the bookmarks.