### PR TITLE
Add basic DITA-OT support for Bosnian, Montenegrin strings

### DIFF
--- a/src/main/xsl/common/common-strings.xml
+++ b/src/main/xsl/common/common-strings.xml
@@ -9,6 +9,8 @@
   <lang xml:lang="be-by" filename="strings-be-by.xml"/>
   <lang xml:lang="bg"    filename="strings-bg-bg.xml"/>
   <lang xml:lang="bg-bg" filename="strings-bg-bg.xml"/>
+  <lang xml:lang="bs"    filename="strings-bs-ba.xml"/>
+  <lang xml:lang="bs-ba" filename="strings-bs-ba.xml"/>
   <lang xml:lang="ca"    filename="strings-ca-es.xml"/>
   <lang xml:lang="ca-es" filename="strings-ca-es.xml"/>
   <lang xml:lang="cs"    filename="strings-cs-cz.xml"/>
@@ -87,6 +89,7 @@
   <lang xml:lang="sr-rs" filename="strings-sr-sp.xml"/>
   <lang xml:lang="sr-sp" filename="strings-sr-sp.xml"/>
   <lang xml:lang="sr-latn-rs" filename="strings-sr-latn-rs.xml"/>
+  <lang xml:lang="sr-latn-me" filename="strings-sr-latn-me.xml"/>
   <lang xml:lang="sv"    filename="strings-sv-se.xml"/>
   <lang xml:lang="sv-se" filename="strings-sv-se.xml"/>
   <lang xml:lang="th"    filename="strings-th-th.xml"/>

--- a/src/main/xsl/common/strings-bs-ba.xml
+++ b/src/main/xsl/common/strings-bs-ba.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is part of the DITA Open Toolkit project hosted on 
+ Sourceforge.net. See the accompanying license.txt file for 
+ applicable licenses.-->
+<!-- (c) Copyright IBM Corp. 2004, 2005 All Rights Reserved. -->
+
+<strings xml:lang="bs-ba">
+   <!-- Bosnian -->
+   <!-- various labels (not author controlled) -->
+   <str name="Figure">Slika</str>
+   <str name="Table">Tabela</str>
+   <str name="Next topic">Slijedeće poglavlje</str>
+   <str name="Previous topic">Prethodno poglavlje</str>
+   <str name="Parent topic">Nadređeno poglavlje</str>
+   <str name="Required cleanup">Potrebno čišćenje</str>
+   <str name="Draft comment">Komentar nacrta</str>
+   <str name="Option">Opcija</str>
+   <str name="Description">Opis</str>
+   <str name="Optional">Opcionalno</str>
+   <str name="Required">Potrebno</str>
+   <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
+   <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
+   <str name="Start of change">Početak promjene</str>
+   <str name="End of change">Kraj promjene</str>
+   <str name="Index">Indeks</str>
+   <str name="Special characters">Posebni znakovi</str>
+   <str name="Numerics">Brojevi</str>
+   <str name="End notes">Završne napomene</str>
+   <str name="Artwork">Ilustracija</str>
+   <str name="Syntax">Sintaksa</str>
+   <str name="Type">Tip</str>
+   <str name="Value">Vrijednost</str>
+   <!-- Text that goes before a link to a topic -->
+   <str name="intro-to-topic-link"></str>
+
+   <!-- peril notice labels -->
+   <str name="Note">Bilješka</str>
+   <str name="Notes">Bilješke</str>
+   <str name="Tip">Savjet</str>
+   <str name="Fastpath">Brza staza</str>
+   <str name="Important">Važno</str>
+   <str name="Attention">Upozorenje</str>
+   <str name="Caution">Oprez</str>
+   <str name="Danger">OPASNOST</str>
+   <str name="Remember">Zapamtite</str>
+   <str name="Restriction">Ograničenje</str>
+   <str name="Warning">Upozorenje</str>
+<str name="Trouble">Trouble</str> <!-- MISSING-->
+
+   <!-- default title text for section level generated sections -->
+   <str name="Contents">Sadržaj</str>
+   <str name="Related concepts">Srodni koncepti</str>
+   <str name="Related tasks">Srodni zadaci</str>
+   <str name="Related reference">Srodne reference</str>
+   <str name="Related information">Srodne informacije</str>
+
+   <str name="Prerequisite">Preduslov</str>
+   <str name="Prerequisites">Preduslovi</str>
+   <str name="or">or</str>
+<str name="figure-number-separator"> </str>
+
+   <!--Task section labels -->
+   <str name="task_context">O ovom zadatku</str>
+   <str name="task_example">Primjer</str>
+   <str name="task_postreq">Šta uraditi sljedeće</str>
+   <str name="task_prereq">Prije nego što počnete</str>
+   <str name="task_procedure">Postupak</str>
+   <str name="task_procedure_unordered">Postupak</str>
+   <str name="task_results">Rezultati</str>
+
+<str name="Copyright">Copyright</str>
+
+<!-- Symbols -->
+<str name="OpenQuote">"</str>
+<str name="CloseQuote">"</str>
+<str name="ColonSymbol">:</str>
+
+</strings>

--- a/src/main/xsl/common/strings-sr-latn-me.xml
+++ b/src/main/xsl/common/strings-sr-latn-me.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is part of the DITA Open Toolkit project hosted on 
+ Sourceforge.net. See the accompanying license.txt file for 
+ applicable licenses.-->
+<!-- (c) Copyright IBM Corp. 2004, 2005 All Rights Reserved. -->
+
+<strings xml:lang="sr-latn-me">        <!-- Montenegrin -->
+
+   <!-- various labels (not author controlled) -->
+   <str name="Figure">Slika</str>
+   <str name="Table">Tabela</str>
+   <str name="Next topic">Slijedeće poglavlje</str>
+   <str name="Previous topic">Prethodno poglavlje</str>
+   <str name="Parent topic">Nadređeno poglavlje</str>
+   <str name="Required cleanup">Potrebno čišćenje</str>
+   <str name="Draft comment">Komentar nacrta</str>
+   <str name="Option">Opcija</str>
+   <str name="Description">Opis</str>
+   <str name="Optional">Opcionalno</str>
+   <str name="Required">Potrebno</str>
+   <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
+   <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
+   <str name="Start of change">Početak promijene</str>
+   <str name="End of change">Kraj promijene</str>
+   <str name="Index">Indeks</str>
+   <str name="Special characters">Posebni znakovi</str>
+   <str name="Numerics">Brojevi</str>
+   <str name="End notes">Završne napomene</str>
+   <str name="Artwork">Ilustracija</str>
+   <str name="Syntax">Sintaksa</str>
+   <str name="Type">Tip</str>
+   <str name="Value">Vrijednost</str>
+   <!-- Text that goes before a link to a topic -->
+   <str name="intro-to-topic-link"></str>
+
+   <!-- peril notice labels -->
+   <str name="Note">Zabilješka</str>
+   <str name="Notes">Zabilješke</str>
+   <str name="Tip">Savjet</str>
+   <str name="Fastpath">Brza staza</str>
+   <str name="Important">Važno</str>
+   <str name="Attention">Pažnja</str>
+   <str name="Caution">Oprez</str>
+   <str name="Danger">OPASNOST</str>
+   <str name="Remember">Zapamtite</str>
+   <str name="Restriction">Ograničenje</str>
+   <str name="Warning">Upozorenje</str>
+   <str name="Trouble">Trouble</str>  <!-- MISSING -->
+
+   <!-- default title text for section level generated sections -->
+   <str name="Contents">Sadržaj</str>
+   <str name="Related concepts">Srodni koncepti</str>
+   <str name="Related tasks">Srodni zadaci</str>
+   <str name="Related reference">Srodne reference</str>
+   <str name="Related information">Srodne informacije</str>
+
+   <str name="Prerequisite">Preduslov</str>
+   <str name="Prerequisites">Preduslovi</str>
+   <str name="or">or</str>
+<str name="figure-number-separator"> </str>
+
+   <!--Task section labels -->
+   <str name="task_context">O ovom zadatku</str>
+   <str name="task_example">Primjer</str>
+   <str name="task_postreq">Šta uraditi sljedeće</str>
+   <str name="task_prereq">Prije nego što počnete</str>
+   <str name="task_procedure">Postupak</str>
+   <str name="task_procedure_unordered">Postupak</str>
+   <str name="task_results">Rezultati</str>
+
+<str name="Copyright">Copyright</str>
+
+<!-- Symbols -->
+<str name="OpenQuote">"</str>
+<str name="CloseQuote">"</str>
+<str name="ColonSymbol">:</str>
+
+</strings>


### PR DESCRIPTION
Adding in support for generated text for Bosnian and Montenegrin.

For Bosnian, the expected `xml:lang` values are "bs" or "bs-BA".

For Montenegrin, the expected `xml:lang` value is "sr-Latn-ME". (Default "sr" is Serbian-Cyrillic, this is the Montenegrin variant with Latin character set.)

As usual, values in `xml:lang` should not be case sensitive.