### PR TITLE
Recursively ignore `.gradle/` & `build/` folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Gradle task artifacts & build results
-.gradle/*
-/build/
+.gradle/
+build/
 target/
 *.iml
 
@@ -27,19 +27,14 @@ src/main/plugins/org.dita.html5/css/commonrtl.css
 src/main/plugins/org.dita.htmlhelp/xsl/map2hhc.xsl
 src/main/plugins/org.dita.htmlhelp/xsl/map2hhp.xsl
 src/main/plugins/org.dita.odt/xsl/dita2odt.xsl
-src/main/plugins/org.dita.pdf2.axf/build/
 src/main/plugins/org.dita.pdf2.axf/lib/axf.jar
 src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic2fo_shell_axf.xsl
-src/main/plugins/org.dita.pdf2.fop/.gradle/
 src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop.xsl
-src/main/plugins/org.dita.pdf2.xep/build/
 src/main/plugins/org.dita.pdf2.xep/lib/
 src/main/plugins/org.dita.pdf2.xep/lib/
 src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic2fo_shell_xep.xsl
 src/main/plugins/org.dita.pdf2/**/*.class
-src/main/plugins/org.dita.pdf2/.gradle/
 src/main/plugins/org.dita.pdf2/build.xml
-src/main/plugins/org.dita.pdf2/build/
 src/main/plugins/org.dita.pdf2/cfg/catalog.xml
 src/main/plugins/org.dita.pdf2/lib/fo.jar
 src/main/plugins/org.dita.pdf2/xsl/common/topicmerge.xsl


### PR DESCRIPTION
The current patterns miss `src/main/plugins/org.dita.html5/build/` and the 1000+ files there, but it seems silly to add folders for individual plugins when we can ignore them all with simpler patterns.