### PR TITLE
Added support for small-caps

### DIFF
--- a/src/main/plugins/org.dita.xhtml/resource/commonltr.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonltr.css
@@ -281,6 +281,9 @@ ul.simple {
 .shortcut {
   text-decoration: underline;
 }
+.sc {
+  font-variant: small-caps;
+}
 /* Default of bold for definition list terms */
 .dlterm {
   font-weight: bold;

--- a/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
@@ -284,6 +284,9 @@ ul.simple {
 .shortcut {
   text-decoration: underline;
 }
+.sc {
+  font-variant: small-caps;
+}
 /* Default of bold for definition list terms */
 .dlterm {
   font-weight: bold;


### PR DESCRIPTION
* Added support for small-caps as: span class="sc"
* Will (should) cover transformations from other formats "passing
  through" DITA.
* Will also match the DITA for Publishers output when encountering its
  own transformations from the sc specialisation.