### PR TITLE
Mark AbstractPipelineModuleImpl members as protected... 

### DIFF
--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -15,8 +15,8 @@ import org.dita.dost.util.Job;
  */
 public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModule {
 
-    DITAOTLogger logger;
-    Job job;
+    protected DITAOTLogger logger;
+    protected Job job;
 
     @Override
     public void setLogger(final DITAOTLogger logger) {


### PR DESCRIPTION
...to allow them being accessed in a derived class being implemented in a plugin.