### PR TITLE
Allow specializations of the link element

### DIFF
--- a/src/main/xsl/common/related-links.xsl
+++ b/src/main/xsl/common/related-links.xsl
@@ -81,7 +81,7 @@
 
     <!-- Ungrouped links have the default-mode template applied to them. (Can be overridden.) -->
     <xsl:template match="*[contains(@class, ' topic/link ')]" mode="related-links:link" name="related-links:link"
-                  as="element(link)">
+                  as="element()*">
       <xsl:sequence select="."/>
     </xsl:template>
 

--- a/src/main/xsl/common/related-links.xsl
+++ b/src/main/xsl/common/related-links.xsl
@@ -80,7 +80,7 @@
     </xsl:template>
 
     <!-- Ungrouped links have the default-mode template applied to them. (Can be overridden.) -->
-    <xsl:template match="*[contains(@class, ' topic/link ')]" mode="related-links:link" name="related-links:link."
+    <xsl:template match="*[contains(@class, ' topic/link ')]" mode="related-links:link" name="related-links:link"
                   as="element(link)">
       <xsl:sequence select="."/>
     </xsl:template>


### PR DESCRIPTION
This should solve [issue 2197 -  Specializing the link element does not work](https://github.com/dita-ot/dita-ot/issues/2197).