### PR TITLE
Fix keyref resolving bug #2190

### DIFF
--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -57,6 +57,7 @@ public final class KeyrefReader implements AbstractReader {
     private DITAOTLogger logger;
     private final DocumentBuilder builder;
     private KeyScope rootScope;
+    private URI currentFile;
 
     /**
      * Constructor.
@@ -90,6 +91,7 @@ public final class KeyrefReader implements AbstractReader {
      * @param filename absolute URI to DITA map with key definitions
      */
     public void read(final URI filename, final Document doc) throws DITAOTException {
+        currentFile = filename;
         rootScope = null;
         // TODO: use KeyScope implementation that retains order
         KeyScope keyScope = readScopes(doc);
@@ -184,7 +186,7 @@ public final class KeyrefReader implements AbstractReader {
                     final URI href = h.isEmpty() ? null : toURI(h);
                     final String s = copy.getAttribute(ATTRIBUTE_NAME_SCOPE);
                     final String scope = s.isEmpty() ? null : s;
-                    final KeyDef keyDef = new KeyDef(key, href, scope, null, copy);
+                    final KeyDef keyDef = new KeyDef(key, href, scope, currentFile, copy);
                     keyDefs.put(key, keyDef);
                 }
             }

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -384,17 +384,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 if (keyDef != null) {
                     if (currentElement != null) {
                         final NamedNodeMap attrs = elem.getAttributes();
-                        final URI target = keyDef != null ? keyDef.href : null;
-                        if (target != null && !target.toString().isEmpty()) {
+                        final URI href = keyDef.href;
+
+                        if (href != null && !href.toString().isEmpty()) {
                             if (TOPIC_IMAGE.matches(currentElement.type)) {
                                 valid = true;
-                                final URI targetOutput = normalizeHrefValue(URLUtils.getRelativePath(currentFile, job.tempDir.toURI().resolve(target)), elementId);
+                                final URI targetOutput = normalizeHrefValue(URLUtils.getRelativePath(currentFile, job.tempDir.toURI().resolve(href)), elementId);
                                 XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
-                            } else if (isLocalDita(elem)) {
-                                final File topicFile = toFile(job.tempDir.toURI().resolve(stripFragment(target)));
+                            } else if (isLocalDita(elem) && keyDef.source != null) {
+                                final File topicFile = toFile(currentFile.resolve(stripFragment(keyDef.source.resolve(href))));
                                 valid = true;
                                 final String topicId = getFirstTopicId(topicFile);
-                                final URI targetOutput = normalizeHrefValue(URLUtils.getRelativePath(currentFile, job.tempDir.toURI().resolve(target)), elementId, topicId);
+                                final URI targetOutput = normalizeHrefValue(URLUtils.getRelativePath(currentFile, topicFile.toURI()), elementId, topicId);
                                 XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
                                 // TODO: This should be a separate SAX filter
                                 if (!ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(atts.getValue(ATTRIBUTE_NAME_PROCESSING_ROLE))) {
@@ -403,10 +404,10 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 }
                             } else {
                                 valid = true;
-                                final URI targetOutput = normalizeHrefValue(target, elementId);
+                                final URI targetOutput = normalizeHrefValue(href, elementId);
                                 XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
                             }
-                        } else if (target == null || target.toString().isEmpty()) {
+                        } else if (href == null || href.toString().isEmpty()) {
                             // Key definition does not carry an href or href equals "".
                             valid = true;
                             XMLUtils.removeAttribute(resAtts, ATTRIBUTE_NAME_SCOPE);


### PR DESCRIPTION
Previously, the target file URI was resolved against the root of the
temp directory. Now it's resolved against the source file URI, which
should always yield the correct result.

`KeyrefPaser.java` is a bit different in `develop` and `hotfix/2.2.3`, which is why I'm submitting this to `develop` for now, but I can backport this fix to `hotfix/2.2.3` and submit a separate PR if necessary.