### PR TITLE
Use fo:wrapper instead of fo:inline for ID containers

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -720,14 +720,14 @@ See the accompanying license.txt file for applicable licenses.
                       <xsl:with-param name="marker-class-name" as="xs:string">current-h2</xsl:with-param>
                     </xsl:apply-templates>
                 </xsl:if>
-                <fo:inline id="{parent::node()/@id}"/>
-                <fo:inline>
+                <fo:wrapper id="{parent::node()/@id}"/>
+                <fo:wrapper>
                     <xsl:attribute name="id">
                         <xsl:call-template name="generate-toc-id">
                             <xsl:with-param name="element" select=".."/>
                         </xsl:call-template>
                     </xsl:attribute>
-                </fo:inline>
+                </fo:wrapper>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:apply-templates select="." mode="getTitle"/>
             </fo:block>


### PR DESCRIPTION
With Antenna House, if you customize the `getTitle` template to generate an `<fo:block>` element (a pretty common scenario, I'd imagine) and add `space-before` to that `<fo:block>` element, the `<fo:inline>` elements whose sole purpose is to serve as reference targets affect the space before the title. Here are two screenshots that illustrate the issue:

#### `fo:inline`

<img width="695" alt="inline" src="https://cloud.githubusercontent.com/assets/31859/12976098/348d688a-d0ca-11e5-9916-351b50e89961.png">

#### `fo:wrapper`

<img width="696" alt="wrapper" src="https://cloud.githubusercontent.com/assets/31859/12976099/36381f0e-d0ca-11e5-84ff-e8be8b634e8a.png">

The red rectangle that delineates the area generated by the title is larger in the `fo:inline` example.

I don't think the reference target elements should affect spacing in any way, so fixing this issue follows the path of least surprise, I think. I wasted quite many hours trying to figure out what was going on until I realized that it was the `fo:inline` elements that were the culprit.

This issue doesn't affect FOP — both `fo:inline` and `fo:wrapper` yield the same result with FOP. I don't have a XEP license to test with.

(This might be an Antenna House issue, but I doubt it. And even if it is, using `fo:wrapper` seems like a good workaround to me.)