### PR TITLE
Rewrite utility templates as functions and add XSpec tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,3 +237,10 @@ task distTarGz(type: Tar, dependsOn: [jar, generateDocs]) {
 task dist(dependsOn: [distZip, distTarGz]) << {
     // NOOP
 }
+
+test {
+    inputs.files (
+        'src/test/xsl/common/dita-utilities.xspec',
+        'src/test/xsl/preprocess/maplinkImpl.xspec'
+    )
+}

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -9,39 +9,23 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 exclude-result-prefixes="xs dita-ot">
-  
+
+  <xsl:include href="functions.xsl"/>
+
   <xsl:param name="DEFAULTLANG">en-us</xsl:param>
   <xsl:param name="variableFiles.url" select="'plugin:org.dita.base:xsl/common/strings.xml'"/>
   
   <xsl:variable name="pixels-per-inch" select="number(96)"/>
 
   <xsl:key name="id" match="*[@id]" use="@id"/>
-  
+
   <!-- Function to determine the current language, and return it in lower case -->
   <xsl:template name="getLowerCaseLang">
-    <xsl:variable name="ancestorlangUpper">
-      <!-- the current xml:lang value (en-us if none found) -->
-      <xsl:choose>
-        <xsl:when test="ancestor-or-self::*/@xml:lang">
-          <xsl:value-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$DEFAULTLANG"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:value-of select="lower-case($ancestorlangUpper)"/>
+    <xsl:value-of select="dita-ot:get-current-language(.)"/>
   </xsl:template>
 
   <xsl:template match="*" mode="get-first-topic-lang">
-    <xsl:variable name="first-topic-lang">
-      <xsl:choose>
-        <xsl:when test="/*[@xml:lang]"><xsl:value-of select="/*/@xml:lang"/></xsl:when>
-        <xsl:when test="/dita/*[@xml:lang]"><xsl:value-of select="/dita/*[@xml:lang][1]/@xml:lang"/></xsl:when>
-        <xsl:otherwise><xsl:value-of select="$DEFAULTLANG"/></xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:value-of select="lower-case($first-topic-lang)"/>
+    <xsl:sequence select="dita-ot:get-first-topic-language(.)"/>
   </xsl:template>
 
   <xsl:template match="*" mode="get-render-direction">
@@ -70,34 +54,13 @@
       <xsl:with-param name="id" select="string($stringName)"/>
     </xsl:call-template>
   </xsl:template>
-  
+
   <xsl:template name="getVariable">
     <xsl:param name="id" as="xs:string"/>
     <xsl:param name="params" as="node()*"/>
-        
-    <xsl:variable name="ancestorlang" as="xs:string*">
-      <xsl:variable name="l" as="xs:string*">
-        <xsl:call-template name="getLowerCaseLang"/>
-      </xsl:variable>
-      <xsl:value-of select="$l"/>
-      <xsl:if test="contains($l, '-')">
-        <xsl:value-of select="substring-before($l, '-')"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="defaultlang" as="xs:string*">
-      <xsl:value-of select="$DEFAULTLANG"/>
-      <xsl:if test="contains($DEFAULTLANG, '-')">
-        <xsl:value-of select="substring-before($DEFAULTLANG, '-')"/>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:call-template name="findString">
-      <xsl:with-param name="id" select="$id"/>
-      <xsl:with-param name="params" select="$params"/>
-      <xsl:with-param name="ancestorlang" select="$ancestorlang"/>
-      <xsl:with-param name="defaultlang" select="$defaultlang"/>
-    </xsl:call-template>
+    <xsl:sequence select="dita-ot:get-variable(., $id, $params)"/>
   </xsl:template>
-  
+
   <xsl:template name="findString">
     <xsl:param name="id" as="xs:string"/>
     <xsl:param name="params" as="node()*"/>
@@ -142,7 +105,7 @@
           <xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/></xsl:with-param>
         </xsl:call-template>
       </xsl:otherwise>
-    </xsl:choose>    
+    </xsl:choose>
   </xsl:template>
   
   <!-- Support legacy variable syntax -->
@@ -403,77 +366,11 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:function name="dita-ot:resolve-href-path" as="xs:anyURI">
-    <xsl:param name="href" as="attribute(href)"/>
-
-    <xsl:variable name="source" as="xs:anyURI" select="base-uri($href)"/>
-
-    <xsl:sequence
-      select="if (starts-with($href, '#'))
-            then $source
-            else resolve-uri(tokenize($href, '#')[1], $source)"/>
-  </xsl:function>
-
-  <xsl:function name="dita-ot:get-topic-id" as="xs:string?">
-    <xsl:param name="href"/>
-    <xsl:variable name="fragment" select="substring-after($href, '#')" as="xs:string"/>
-    <xsl:if test="string-length($fragment) gt 0">
-      <xsl:choose>
-        <xsl:when test="contains($fragment, '/')">
-          <xsl:value-of select="substring-before($fragment, '/')"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$fragment"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:if>
-  </xsl:function>
-  
-  <xsl:function name="dita-ot:has-topic-id" as="xs:boolean">
-    <xsl:param name="href"/>
-    <xsl:sequence select="contains($href, '#')"/>
-  </xsl:function>
-
-  <xsl:function name="dita-ot:get-element-id" as="xs:string?">
-    <xsl:param name="href"/>
-    <xsl:variable name="fragment" select="substring-after($href, '#')" as="xs:string"/>
-    <xsl:if test="contains($fragment, '/')">
-      <xsl:value-of select="substring-after($fragment, '/')"/>
-    </xsl:if>
-  </xsl:function>
-  
-  <xsl:function name="dita-ot:has-element-id" as="xs:boolean">
-    <xsl:param name="href"/>
-    <xsl:sequence select="contains(substring-after($href, '#'), '/')"/>
-  </xsl:function>
-
-  <xsl:function name="dita-ot:normalize-uri" as="xs:string">
-    <xsl:param name="uri" as="xs:string"/>
-    <xsl:call-template name="dita-ot:normalize-uri">
-      <xsl:with-param name="src" select="tokenize($uri, '/')"/>
-    </xsl:call-template>
-  </xsl:function>
-
   <xsl:function name="dita-ot:get-closest-topic" as="element()">
     <xsl:param name="n" as="node()"/>
 
     <xsl:sequence
       select="$n/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]"/>
-  </xsl:function>
-
-  <xsl:function name="dita-ot:retrieve-href-target" as="node()?">
-    <xsl:param name="href" as="attribute(href)"/>
-
-    <xsl:variable name="doc" as="document-node()"
-      select="doc(dita-ot:resolve-href-path($href))"/>
-
-    <xsl:sequence
-      select="if (dita-ot:has-element-id($href))
-            then key('id', dita-ot:get-element-id($href), $doc)
-                 [dita-ot:get-closest-topic(.)/@id eq dita-ot:get-topic-id($href)]
-            else if (dita-ot:has-topic-id($href) and not(dita-ot:has-element-id($href)))
-               then key('id', dita-ot:get-topic-id($href), $doc)
-            else $doc"/>
   </xsl:function>
 
   <xsl:template name="dita-ot:normalize-uri" as="xs:string">

--- a/src/main/xsl/common/functions.xsl
+++ b/src/main/xsl/common/functions.xsl
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- This file is part of the DITA Open Toolkit project.
+     See the accompanying license.txt file for applicable licenses.-->
+<!-- (c) Copyright IBM Corp. 2004, 2005 All Rights Reserved. -->
+
+<xsl:stylesheet version="2.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  exclude-result-prefixes="xs dita-ot">
+
+  <!-- href -->
+
+  <xsl:function name="dita-ot:resolve-href-path" as="xs:anyURI">
+    <xsl:param name="href" as="attribute(href)"/>
+
+    <xsl:variable name="source" as="xs:anyURI" select="base-uri($href)"/>
+
+    <xsl:sequence select="
+        if (starts-with($href, '#'))
+      then $source
+      else resolve-uri(tokenize($href, '#')[1], $source)
+    "/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:retrieve-href-target" as="node()?">
+    <xsl:param name="href" as="attribute(href)"/>
+
+    <xsl:variable name="doc" as="document-node()"
+      select="doc(dita-ot:resolve-href-path($href))"/>
+
+    <xsl:sequence select="
+        if (dita-ot:has-element-id($href))
+      then $doc/key('id', dita-ot:get-element-id($href))
+           [dita-ot:get-closest-topic(.)/@id eq dita-ot:get-topic-id($href)]
+      else if (dita-ot:has-topic-id($href) and not(dita-ot:has-element-id($href)))
+           then $doc/key('id', dita-ot:get-topic-id($href))
+           else $doc
+    "/>
+  </xsl:function>
+
+  <!-- ID -->
+
+  <xsl:function name="dita-ot:has-topic-id" as="xs:boolean">
+    <xsl:param name="href"/>
+    <xsl:sequence select="contains($href, '#')"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-element-id" as="xs:string?">
+    <xsl:param name="href"/>
+    <xsl:variable name="fragment" select="substring-after($href, '#')" as="xs:string"/>
+    <xsl:if test="contains($fragment, '/')">
+      <xsl:value-of select="substring-after($fragment, '/')"/>
+    </xsl:if>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:has-element-id" as="xs:boolean">
+    <xsl:param name="href"/>
+    <xsl:sequence select="contains(substring-after($href, '#'), '/')"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-topic-id" as="xs:string?">
+    <xsl:param name="href"/>
+    <xsl:variable name="fragment" select="substring-after($href, '#')" as="xs:string"/>
+    <xsl:if test="string-length($fragment) gt 0">
+      <xsl:choose>
+        <xsl:when test="contains($fragment, '/')">
+          <xsl:value-of select="substring-before($fragment, '/')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$fragment"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+
+  <!-- language -->
+
+  <xsl:function name="dita-ot:get-current-language" as="xs:string">
+    <xsl:param name="ctx" as="node()"/>
+
+    <xsl:sequence select="
+      lower-case(($ctx/ancestor-or-self::*[@xml:lang][1]/@xml:lang, $DEFAULTLANG)[1])
+    "/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-iso-language-code" as="xs:string">
+    <xsl:param name="lang" as="xs:string"/>
+    <xsl:sequence select="tokenize($lang, '-')[1]"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-language-codes" as="xs:string*">
+    <xsl:param name="lang" as="xs:string"/>
+    <xsl:sequence select="$lang, dita-ot:get-iso-language-code($lang)"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-first-topic-language" as="xs:string">
+    <xsl:param name="ctx" as="node()"/>
+
+    <xsl:sequence select="
+      lower-case(($ctx/*/@xml:lang, $ctx/dita/*/@xml:lang, $DEFAULTLANG)[1])
+    "/>
+  </xsl:function>
+
+  <!-- URI -->
+
+  <xsl:function name="dita-ot:normalize-uri" as="xs:string">
+    <xsl:param name="uri" as="xs:string"/>
+    <xsl:call-template name="dita-ot:normalize-uri">
+      <xsl:with-param name="src" select="tokenize($uri, '/')"/>
+    </xsl:call-template>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-variable" as="node()*">
+    <xsl:param name="ctx" as="node()"/>
+    <xsl:param name="id" as="xs:string"/>
+    <xsl:param name="params" as="node()*"/>
+
+    <xsl:call-template name="findString">
+      <xsl:with-param name="ctx" select="$ctx" tunnel="yes"/>
+      <xsl:with-param name="id" select="$id"/>
+      <xsl:with-param name="params" select="$params"/>
+      <xsl:with-param name="ancestorlang"
+        select="dita-ot:get-language-codes(dita-ot:get-current-language($ctx))"/>
+      <xsl:with-param name="defaultlang" select="dita-ot:get-language-codes($DEFAULTLANG)"/>
+    </xsl:call-template>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-variable" as="node()*">
+    <xsl:param name="ctx" as="node()"/>
+    <xsl:param name="id" as="xs:string"/>
+
+    <xsl:sequence select="dita-ot:get-variable($ctx, $id, ())"/>
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/src/main/xsl/common/output-message.xsl
+++ b/src/main/xsl/common/output-message.xsl
@@ -27,6 +27,7 @@
                 exclude-result-prefixes="xs">
   
   <xsl:template name="output-message">
+    <xsl:param name="ctx" select="." tunnel="yes"/>
     <xsl:param name="msg" select="'***'"/>
     <!-- Deprecated since 2.3 -->
     <xsl:param name="msgcat" select="$msgprefix"/>
@@ -57,16 +58,18 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="localclass" select="@class"/>
+    <xsl:variable name="xtrf" select="$ctx/@xtrf" as="attribute(xtrf)"/>
+    <xsl:variable name="xtrc" select="$ctx/@xtrc" as="attribute(xtrc)"/>
     <xsl:variable name="debugloc">
-      <xsl:if test="@xtrf | @xtrc">
-        <xsl:if test="@xtrf">
-          <xsl:value-of select="@xtrf"/>
+      <xsl:if test="$xtrf | $xtrc">
+        <xsl:if test="$xtrf">
+          <xsl:value-of select="$xtrf"/>
         </xsl:if>
-        <xsl:if test="@xtrf and @xtrc">
+        <xsl:if test="$xtrf and $xtrc">
           <xsl:text>:</xsl:text>
         </xsl:if>
-        <xsl:if test="@xtrc">
-          <xsl:value-of select="if (contains(@xtrc, ';')) then substring-after(@xtrc, ';') else @xtrc"/>
+        <xsl:if test="$xtrc">
+          <xsl:value-of select="if (contains($xtrc, ';')) then substring-after($xtrc, ';') else $xtrc"/>
         </xsl:if>
         <xsl:text>: </xsl:text>
       </xsl:if>

--- a/src/test/xsl/common/dita-utilities.xspec
+++ b/src/test/xsl/common/dita-utilities.xspec
@@ -153,6 +153,272 @@
     </x:scenario>
   </x:scenario>
 
+  <x:scenario label="dita-ot:has-topic-id">
+    <x:scenario label="@href has topic ID and element ID">
+      <x:call function="dita-ot:has-topic-id">
+        <x:param name="href" select="'foo.dita#bar/baz'"/>
+      </x:call>
+
+      <x:expect label="return true()" select="true()"/>
+    </x:scenario>
+
+    <x:scenario label="@href has topic ID but no element ID">
+      <x:call function="dita-ot:has-topic-id">
+        <x:param name="href" select="'foo.dita#bar'"/>
+      </x:call>
+
+      <x:expect label="return true()" select="true()"/>
+    </x:scenario>
+
+    <x:scenario label="@href has no topic ID">
+      <x:call function="dita-ot:has-topic-id">
+        <x:param name="href" select="'foo.dita'"/>
+      </x:call>
+
+      <x:expect label="return false()" select="false()"/>
+    </x:scenario>
+
+    <x:scenario label="@href is a fragment identifier">
+      <x:call function="dita-ot:has-topic-id">
+        <x:param name="href" select="'#foo'"/>
+      </x:call>
+
+      <x:expect label="return true()" select="true()"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:has-element-id">
+    <x:scenario label="@href has a path, topic ID and element ID">
+      <x:call function="dita-ot:has-element-id">
+        <x:param name="href" select="'foo.dita#bar/baz'"/>
+      </x:call>
+
+      <x:expect label="return true()" select="true()"/>
+    </x:scenario>
+
+    <x:scenario label="@href is a fragment with topic ID and element ID">
+      <x:call function="dita-ot:has-element-id">
+        <x:param name="href" select="'#bar/baz'"/>
+      </x:call>
+
+      <x:expect label="return true()" select="true()"/>
+    </x:scenario>
+
+    <x:scenario label="@href has a topic ID but no element ID">
+      <x:call function="dita-ot:has-element-id">
+        <x:param name="href" select="'foo.dita#bar'"/>
+      </x:call>
+
+      <x:expect label="return false()" select="false()"/>
+    </x:scenario>
+
+    <x:scenario label="@href has no topic ID or element ID">
+      <x:call function="dita-ot:has-element-id">
+        <x:param name="href" select="'foo.dita'"/>
+      </x:call>
+
+      <x:expect label="return false()" select="false()"/>
+    </x:scenario>
+
+    <x:scenario label="@href is a fragment identifier">
+      <x:call function="dita-ot:has-element-id">
+        <x:param name="href" select="'#foo'"/>
+      </x:call>
+
+      <x:expect label="return false()" select="false()"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-topic-id">
+    <x:scenario label="@href has topic ID and element ID">
+      <x:call function="dita-ot:get-topic-id">
+        <x:param name="href" select="'foo.dita#bar/baz'"/>
+      </x:call>
+
+      <x:expect label="return topic ID" select="'bar'"/>
+    </x:scenario>
+
+    <x:scenario label="@href has a topic ID but no element ID">
+      <x:call function="dita-ot:get-topic-id">
+        <x:param name="href" select="'foo.dita#bar'"/>
+      </x:call>
+
+      <x:expect label="return topic ID" select="'bar'"/>
+    </x:scenario>
+
+    <x:scenario label="@href has no topic ID or element ID">
+      <x:call function="dita-ot:get-topic-id">
+        <x:param name="href" select="'foo.dita'"/>
+      </x:call>
+
+      <x:expect label="return empty sequence" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="@href is a fragment identifier">
+      <x:call function="dita-ot:get-topic-id">
+        <x:param name="href" select="'#foo'"/>
+      </x:call>
+
+      <x:expect label="return topic ID" select="'foo'"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-element-id">
+    <x:scenario label="foo.dita#bar/baz">
+      <x:call function="dita-ot:get-element-id">
+        <x:param name="href" select="'foo.dita#bar/baz'"/>
+      </x:call>
+
+      <x:expect label="return element ID" select="'baz'"/>
+    </x:scenario>
+
+    <x:scenario label="#foo/bar">
+      <x:call function="dita-ot:get-element-id">
+        <x:param name="href" select="'#foo/bar'"/>
+      </x:call>
+
+      <x:expect label="return empty sequence" select="'bar'"/>
+    </x:scenario>
+
+    <x:scenario label="foo.dita#bar">
+      <x:call function="dita-ot:get-element-id">
+        <x:param name="href" select="'foo.dita#bar'"/>
+      </x:call>
+
+      <x:expect label="return empty sequence" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="foo.dita">
+      <x:call function="dita-ot:get-element-id">
+        <x:param name="href" select="'foo.dita'"/>
+      </x:call>
+
+      <x:expect label="return empty sequence" select="()"/>
+    </x:scenario>
+
+    <x:scenario label="#foo">
+      <x:call function="dita-ot:get-element-id">
+        <x:param name="href" select="'#foo'"/>
+      </x:call>
+
+      <x:expect label="return empty sequence" select="()"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-first-topic-language">
+    <x:scenario label="@xml:lang of first child">
+      <x:call function="dita-ot:get-first-topic-language">
+        <x:param name="ctx">
+          <topic id="foo" xml:lang="en-us">
+            <title>foo</title>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return @xml:lang" select="'en-us'"/>
+    </x:scenario>
+
+    <x:scenario label="@xml:lang of dita element child">
+      <x:call function="dita-ot:get-first-topic-language">
+        <x:param name="ctx">
+          <dita>
+            <topic id="foo" xml:lang="el-gr">
+              <title>foo</title>
+            </topic>
+          </dita>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return @xml:lang" select="'el-gr'"/>
+    </x:scenario>
+
+    <x:scenario label="upper-case @xml:lang">
+      <x:call function="dita-ot:get-first-topic-language">
+        <x:param name="ctx">
+          <topic id="foo" xml:lang="en-US">
+            <title>foo</title>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return @xml:lang" select="'en-us'"/>
+    </x:scenario>
+
+    <x:scenario label="no @xml:lang">
+      <x:call function="dita-ot:get-first-topic-language">
+        <x:param name="ctx">
+          <topic id="foo">
+            <title>foo</title>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return $DEFAULTLANG" select="'en-us'"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-current-language">
+    <x:scenario label="given element has @xml:lang">
+      <x:call function="dita-ot:get-current-language">
+        <x:param name="ctx">
+          <topic id="foo" xml:lang="el-gr">
+            <title>foo</title>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return @xml:lang" select="'el-gr'"/>
+    </x:scenario>
+
+    <x:scenario label="given element has no @xml:lang">
+      <x:call function="dita-ot:get-current-language">
+        <x:param name="ctx">
+          <topic id="foo">
+            <title>foo</title>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return $DEFAULTLANG" select="'en-us'"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-iso-language-code">
+    <x:scenario label="two-part code">
+      <x:call function="dita-ot:get-iso-language-code">
+        <x:param name="lang" select="'pt-br'"/>
+      </x:call>
+
+      <x:expect label="return ISO language code" select="'pt'"/>
+    </x:scenario>
+
+    <x:scenario label="one-part code">
+      <x:call function="dita-ot:get-iso-language-code">
+        <x:param name="lang" select="'fi'"/>
+      </x:call>
+
+      <x:expect label="return ISO language code" select="'fi'"/>
+    </x:scenario>
+  </x:scenario>
+
+  <x:scenario label="dita-ot:get-language-codes">
+    <x:scenario label="two-part code">
+      <x:call function="dita-ot:get-language-codes">
+        <x:param name="lang" select="'pt-br'"/>
+      </x:call>
+
+      <x:expect label="return language codes" select="('pt-br', 'pt')"/>
+    </x:scenario>
+
+    <x:scenario label="one-part code">
+      <x:call function="dita-ot:get-language-codes">
+        <x:param name="lang" select="'fi'"/>
+      </x:call>
+
+      <x:expect label="return language codes" select="('fi', 'fi')"/>
+    </x:scenario>
+  </x:scenario>
+
   <x:scenario label="dita-ot:normalize-uri">
     <x:scenario label="normalize foo/bar/baz">
       <x:call function="dita-ot:normalize-uri">
@@ -310,4 +576,5 @@
       <x:expect label="">100%</x:expect>
     </x:scenario>
   </x:scenario>
+
 </x:description>


### PR DESCRIPTION
I didn't write XSpec tests for the `@href` resolving functions even though they could really use some because I wasn't quite sure how to best do it, frankly, since the functions return absolute paths and they can obviously be different on everyone's machine.

Also, I didn't write add one for the `dita-ot:get-variable` function because I just couldn't get the test to work even though the function works correctly. Rewriting the `findStrings` template it calls to facilitate testing would probably help.

Also, a heads up: I think at least some of the tests for `length-to-pixels` don't really work properly: I changed some to have incorrect expectations and they still passed. Don't know what's up with that.