### PR TITLE
Add reference to PDF2 catalog into catalog-dita.xml

### DIFF
--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -49,6 +49,7 @@
   <feature extension="dita.xsl.messages" file="resource/messages.xml"/>
   <feature extension="dita.conductor.pdf2.formatter.check" value="ah"/>
   <feature extension="dita.xsl.strings" file="cfg/common/vars/strings.xml"/>
+  <feature extension="dita.specialization.catalog.relative" file="cfg/catalog.xml"/>
   <template file="build_template.xml"/>
   <template file="cfg/catalog_template.xml"/>
   <template file="xsl/fo/flagging-preprocess_template.xsl"/>


### PR DESCRIPTION
This is useful e.g. when profiling XSLT stylesheets. Without this,
running topic2fo_shell.xsl directly fails because the XSLT processor
can't resolve paths that use the cfg: scheme.