### PR TITLE
Build distribution package in CI and upload to Github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
+- oraclejdk7
 before_script:
-  - git submodule update --init --recursive
+- git submodule update --init --recursive
 script:
-  - ./gradlew check integrationTest --info --stacktrace --no-daemon
+- "./gradlew check integrationTest --info --stacktrace --no-daemon"
+- "./gradlew dist --info --stacktrace --no-daemon"
 branches:
   only:
-  - /^(master|develop|hotfix\/.*|feature\/.*|release\/.*)$/
+  - "/^(master|develop|hotfix\\/.*|feature\\/.*|release\\/.*)$/"
+  - "/^\\d+(\\.\\d+)+$/"
 notifications:
   slack:
     secure: IAA4d9O2Dw1hkpY9cwxJz++VMjkgbV3EuaS09DGFujvHl2eQtpKTloE0/CDF+NZA4tcbH1dNqsGw3ETLmrqA581CLpmiiq3LG02cDMoSXZeOKB/9vo6tvLFg0UMawzo+FomJS/hvCmS5KirrFqZQKE5g6SCC05UBM5nwI5d0vOw=

--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ task generateDocs(type: JavaExec, dependsOn: integrateDistTemp) {
     args file("${distTempDir}/docsrc/build.xml")
     args "-Dbasedir=" + file("${distTempDir}/docsrc")
     args "-Ddita.home=" + distTempDir
+    args "dist"
 }
 
 task distZip(type: Zip, dependsOn: [jar, generateDocs]) {

--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ task distTarGz(type: Tar, dependsOn: [jar, generateDocs]) {
     }
     archiveName "dita-ot-${project.version}.tar.gz"
 }
-task dist(dependsOn: [distZip, distTarGz]) << {
+task dist(dependsOn: [distZip]) << {
     // NOOP
 }
 


### PR DESCRIPTION
Implementation for #2260.

- [x] #2130 Remove HTMLHelp output from distribution package docs
- [x] #2269 Remove .tar.gz distribution package
- [x] Add `dist` task to CI build


