### PR TITLE
Use stable ID generation in HTML5

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl
@@ -38,10 +38,11 @@
     <xsl:param name="element" as="element()"/>
     
     <xsl:variable name="topic" select="$element/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]" as="element()"/>
-    <xsl:variable name="topic-id" select="$topic/@id" as="xs:string"/>
-    <xsl:variable name="index" select="count($topic/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
+    <xsl:variable name="parent-element" select="$element/ancestor-or-self::*[@id][1][not(. is $topic)]" as="element()?"/>
+    <xsl:variable name="closest" select="($parent-element, $topic)[1]" as="element()"/>
+    <xsl:variable name="index" select="count($closest/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
     
-    <xsl:sequence select="dita-ot:generate-id($topic-id, string-join(($element, string($index)), $HTML_ID_SEPARATOR))"/>
+    <xsl:sequence select="dita-ot:generate-id($topic/@id, string-join(($parent-element/@id, local-name($element), string($index)), $HTML_ID_SEPARATOR))"/>
   </xsl:function>
 
   <xsl:function name="table:is-tbody-entry" as="xs:boolean">

--- a/src/main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl
@@ -9,6 +9,41 @@
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot table">
 
+  <xsl:variable name="HTML_ID_SEPARATOR" select="'__'"/>
+
+  <xsl:function name="dita-ot:generate-html-id" as="xs:string">
+    <xsl:param name="element" as="element()"/>
+    
+    <xsl:sequence
+      select="if (exists($element/@id))
+              then dita-ot:get-prefixed-id($element, $element/@id)
+              else dita-ot:generate-stable-id($element)"/>
+  </xsl:function>
+  
+  <xsl:function name="dita-ot:generate-id" as="xs:string">
+    <xsl:param name="topic" as="xs:string?"/>
+    <xsl:param name="element" as="xs:string?"/>
+    
+    <xsl:value-of select="string-join(($topic, $element), $HTML_ID_SEPARATOR)"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:get-prefixed-id" as="xs:string">
+    <xsl:param name="element" as="element()"/>
+    <xsl:param name="id" as="xs:string"/>
+    
+    <xsl:sequence select="dita-ot:generate-id($element/ancestor::*[contains(@class, ' topic/topic ')][1]/@id, $id)"/>
+  </xsl:function>
+
+  <xsl:function name="dita-ot:generate-stable-id" as="xs:string">
+    <xsl:param name="element" as="element()"/>
+    
+    <xsl:variable name="topic" select="$element/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]" as="element()"/>
+    <xsl:variable name="topic-id" select="$topic/@id" as="xs:string"/>
+    <xsl:variable name="index" select="count($topic/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
+    
+    <xsl:sequence select="dita-ot:generate-id($topic-id, string-join(($element, string($index)), $HTML_ID_SEPARATOR))"/>
+  </xsl:function>
+
   <xsl:function name="table:is-tbody-entry" as="xs:boolean">
     <xsl:param name="el" as="element()"/>
 

--- a/src/test/xsl/plugins/org.dita.html5/xsl/xslhtml/functions.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/xslhtml/functions.xspec
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-               xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-               xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
-               xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-               stylesheet="../../../../../../main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl">
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="../../../../../../main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl">
 
   <x:scenario label="dita-ot:get-prefixed-id">
     <x:scenario label="p in topic">
@@ -21,15 +18,14 @@
         </x:param>
         <x:param name="id" select="'p'"/>
       </x:call>
-      
+
       <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
     </x:scenario>
   </x:scenario>
-  
   <x:scenario label="dita-ot:generate-html-id">
     <x:scenario label="element with id">
       <x:call function="dita-ot:generate-html-id">
-        <x:param name="element" select="//p">
+        <x:param name="element" select="(//p)[1]">
           <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
             domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
             id="topic" ditaarch:DITAArchVersion="1.3">
@@ -40,12 +36,12 @@
           </topic>
         </x:param>
       </x:call>
-      
+
       <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
     </x:scenario>
     <x:scenario label="element without id">
       <x:call function="dita-ot:generate-html-id">
-        <x:param name="element" select="//p">
+        <x:param name="element" select="(//p)[1]">
           <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
             domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
             id="topic" ditaarch:DITAArchVersion="1.3">
@@ -56,35 +52,74 @@
           </topic>
         </x:param>
       </x:call>
-      
-      <x:expect label="return element id prefixed with topic id" select="'topic__para__1'"/>
+
+      <x:expect label="return element id prefixed with topic id" select="'topic__p__1'"/>
     </x:scenario>
   </x:scenario>
-  
+
   <x:scenario label="dita-ot:generate-stable-id">
-    <x:call function="dita-ot:generate-stable-id">
-      <x:param name="element" select="//p">
-        <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-          domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
-          id="topic" ditaarch:DITAArchVersion="1.3">
-          <title class="- topic/title ">Title</title>
-          <body class="- topic/body ">
-            <p class="- topic/p ">para</p>
-          </body>
-        </topic>
-      </x:param>
-    </x:call>
-    
-    <x:expect label="return element id prefixed with topic id" select="'topic__para__1'"/>
+    <x:scenario label="first without ancestor element with id">
+      <x:call function="dita-ot:generate-stable-id">
+        <x:param name="element" select="//p[1]">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p ">para 1 B</p>
+              <p class="- topic/p ">para 2 B</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return element id prefixed with topic id" select="'topic__p__1'"/>
+    </x:scenario>
+    <x:scenario label="second without ancestor element with id">
+      <x:call function="dita-ot:generate-stable-id">
+        <x:param name="element" select="(//p)[2]">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p ">para 1 A</p>
+              <p class="- topic/p ">para 2 A</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return element id prefixed with topic id" select="'topic__p__2'"/>
+    </x:scenario>
+    <x:scenario label="with ancestor element with id">
+      <x:call function="dita-ot:generate-stable-id">
+        <x:param name="element" select="(//p)[2]">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p ">para</p>
+              <section class="- topic/section " id="section">
+                <p class="- topic/p ">para</p>
+              </section>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+
+      <x:expect label="return element id prefixed with topic id" select="'topic__section__p__1'"/>
+    </x:scenario>
   </x:scenario>
-  
+
   <x:scenario label="dita-ot:generate-id">
     <x:scenario label="both topic and element id">
       <x:call function="dita-ot:generate-id">
         <x:param name="topic" select="'foo'"/>
         <x:param name="element" select="'bar'"/>
       </x:call>
-      
+
       <x:expect label="return element id prefixed with topic id" select="'foo__bar'"/>
     </x:scenario>
     <x:scenario label="only topic id">
@@ -92,7 +127,7 @@
         <x:param name="topic" select="'foo'"/>
         <x:param name="element" select="()"/>
       </x:call>
-      
+
       <x:expect label="return topic id" select="'foo'"/>
     </x:scenario>
     <x:scenario label="only element id">
@@ -100,7 +135,7 @@
         <x:param name="topic" select="()"/>
         <x:param name="element" select="'bar'"/>
       </x:call>
-      
+
       <x:expect label="return element id" select="'bar'"/>
     </x:scenario>
     <x:scenario label="both ids are empty">
@@ -108,7 +143,7 @@
         <x:param name="topic" select="()"/>
         <x:param name="element" select="()"/>
       </x:call>
-      
+
       <x:expect label="return empty string" select="''"/>
     </x:scenario>
   </x:scenario>
@@ -121,12 +156,12 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <thead class="- topic/thead ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </thead>
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </tbody>
             </tgroup>
@@ -144,12 +179,12 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <thead class="- topic/thead ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </thead>
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </tbody>
             </tgroup>
@@ -169,12 +204,12 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <thead class="- topic/thead ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </thead>
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </tbody>
             </tgroup>
@@ -192,12 +227,12 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <thead class="- topic/thead ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </thead>
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry "></entry>
+                  <entry class="- topic/entry "/>
                 </row>
               </tbody>
             </tgroup>
@@ -217,7 +252,7 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry " dita-ot:x="1"></entry>
+                  <entry class="- topic/entry " dita-ot:x="1"/>
                 </row>
               </tbody>
             </tgroup>
@@ -235,7 +270,7 @@
             <tgroup cols="1" class="- topic/tgroup ">
               <tbody class="- topic/tbody ">
                 <row class="- topic/row ">
-                  <entry class="- topic/entry " dita-ot:x="1"></entry>
+                  <entry class="- topic/entry " dita-ot:x="1"/>
                 </row>
               </tbody>
             </tgroup>
@@ -253,10 +288,10 @@
         <x:param name="el" select="//strow/stentry[1]">
           <simpletable class="- topic/simpletable ">
             <sthead class="- topic/sthead ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </sthead>
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>
@@ -270,10 +305,10 @@
         <x:param name="el" select="//sthead/stentry[1]">
           <simpletable class="- topic/simpletable ">
             <sthead class="- topic/sthead ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </sthead>
             <strow class="- topic/strow ">
-              <entry class="- topic/stentry "></entry>
+              <entry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>
@@ -289,10 +324,10 @@
         <x:param name="el" select="//sthead/stentry[1]">
           <simpletable class="- topic/simpletable ">
             <sthead class="- topic/sthead ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </sthead>
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>
@@ -306,10 +341,10 @@
         <x:param name="el" select="//strow/stentry[1]">
           <simpletable class="- topic/simpletable ">
             <sthead class="- topic/sthead ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </sthead>
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>
@@ -325,8 +360,8 @@
         <x:param name="entry" select="//strow/stentry[1]">
           <simpletable class="- topic/simpletable " keycol="1">
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "></stentry>
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
+              <stentry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>
@@ -340,8 +375,8 @@
         <x:param name="entry" select="//strow/stentry[2]">
           <simpletable class="- topic/simpletable " keycol="1">
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "></stentry>
-              <stentry class="- topic/stentry "></stentry>
+              <stentry class="- topic/stentry "/>
+              <stentry class="- topic/stentry "/>
             </strow>
           </simpletable>
         </x:param>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/xslhtml/functions.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/xslhtml/functions.xspec
@@ -6,6 +6,113 @@
                xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
                stylesheet="../../../../../../main/plugins/org.dita.html5/xsl/xslhtml/functions.xsl">
 
+  <x:scenario label="dita-ot:get-prefixed-id">
+    <x:scenario label="p in topic">
+      <x:call function="dita-ot:get-prefixed-id">
+        <x:param name="element" select="//p">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p " id="p">para</p>
+            </body>
+          </topic>
+        </x:param>
+        <x:param name="id" select="'p'"/>
+      </x:call>
+      
+      <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
+    </x:scenario>
+  </x:scenario>
+  
+  <x:scenario label="dita-ot:generate-html-id">
+    <x:scenario label="element with id">
+      <x:call function="dita-ot:generate-html-id">
+        <x:param name="element" select="//p">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p " id="p">para</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+      
+      <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
+    </x:scenario>
+    <x:scenario label="element without id">
+      <x:call function="dita-ot:generate-html-id">
+        <x:param name="element" select="//p">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p ">para</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+      
+      <x:expect label="return element id prefixed with topic id" select="'topic__para__1'"/>
+    </x:scenario>
+  </x:scenario>
+  
+  <x:scenario label="dita-ot:generate-stable-id">
+    <x:call function="dita-ot:generate-stable-id">
+      <x:param name="element" select="//p">
+        <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+          domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+          id="topic" ditaarch:DITAArchVersion="1.3">
+          <title class="- topic/title ">Title</title>
+          <body class="- topic/body ">
+            <p class="- topic/p ">para</p>
+          </body>
+        </topic>
+      </x:param>
+    </x:call>
+    
+    <x:expect label="return element id prefixed with topic id" select="'topic__para__1'"/>
+  </x:scenario>
+  
+  <x:scenario label="dita-ot:generate-id">
+    <x:scenario label="both topic and element id">
+      <x:call function="dita-ot:generate-id">
+        <x:param name="topic" select="'foo'"/>
+        <x:param name="element" select="'bar'"/>
+      </x:call>
+      
+      <x:expect label="return element id prefixed with topic id" select="'foo__bar'"/>
+    </x:scenario>
+    <x:scenario label="only topic id">
+      <x:call function="dita-ot:generate-id">
+        <x:param name="topic" select="'foo'"/>
+        <x:param name="element" select="()"/>
+      </x:call>
+      
+      <x:expect label="return topic id" select="'foo'"/>
+    </x:scenario>
+    <x:scenario label="only element id">
+      <x:call function="dita-ot:generate-id">
+        <x:param name="topic" select="()"/>
+        <x:param name="element" select="'bar'"/>
+      </x:call>
+      
+      <x:expect label="return element id" select="'bar'"/>
+    </x:scenario>
+    <x:scenario label="both ids are empty">
+      <x:call function="dita-ot:generate-id">
+        <x:param name="topic" select="()"/>
+        <x:param name="element" select="()"/>
+      </x:call>
+      
+      <x:expect label="return empty string" select="''"/>
+    </x:scenario>
+  </x:scenario>
+
   <x:scenario label="table:is-tbody-entry">
     <x:scenario label="entry is in tbody">
       <x:call function="table:is-tbody-entry">


### PR DESCRIPTION
The HTML5 output should use stable `@headers` and `@id` generation instead of the current one that is based on `generate-id()` which is not stable. Using a stable approach would allow e.g. DITA-OT site to have smaller change sets when `@headers` would not change between every conversion.