### PR TITLE
Add ditaFileset to replace list files

### DIFF
--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -9,6 +9,7 @@ import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.Job.FileInfo;
 
 /**
  * Abstract class for modules.
@@ -17,6 +18,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
 
     protected DITAOTLogger logger;
     protected Job job;
+    protected FileInfo.Filter<FileInfo> fileInfoFilter;
 
     @Override
     public void setLogger(final DITAOTLogger logger) {
@@ -30,4 +32,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     
     abstract public AbstractPipelineOutput execute(AbstractPipelineInput input) throws DITAOTException;
 
+    public void setFileInfoFilter(FileInfo.Filter<FileInfo> fileInfoFilter) {
+        this.fileInfoFilter = fileInfoFilter;
+    }
 }

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -8,7 +8,6 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.Job.FileInfo.Filter;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.XMLFilter;
@@ -25,7 +24,6 @@ import java.util.List;
 public final class XmlFilterModule extends AbstractPipelineModuleImpl {
 
     private List<AbstractXMLFilter> pipe;
-    private Filter<FileInfo> fileInfoFilter;
 
     /**
      * Filter files through XML filters.
@@ -69,9 +67,5 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
             res.add(f);
         }
         return res;
-    }
-
-    public void setFileInfoFilter(final Filter<FileInfo> fileInfoFilter) {
-        this.fileInfoFilter = fileInfoFilter;
     }
 }

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -2,6 +2,7 @@ package org.dita.dost.module;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +19,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Configuration;
+import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -67,6 +69,15 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
 		}
         parser.setEntityResolver(xmlcatalog);
         
+        if (fileInfoFilter != null) {
+            final Collection<Job.FileInfo> res = job.getFileInfo(fileInfoFilter);
+            includes = new ArrayList<>(res.size());
+            for (final Job.FileInfo f : res) {
+                includes.add(f.file);
+            }
+            baseDir = job.tempDir;
+        }
+
     	Transformer t = null;
         for (final File include: includes) {
         	if (reloadstylesheet || t == null) {

--- a/src/main/java/org/dita/dost/util/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/util/JobSourceSet.java
@@ -18,9 +18,14 @@ import java.util.Iterator;
 
 import static org.dita.dost.util.Constants.ANT_REFERENCE_JOB;
 
+/**
+ * Resource collection that finds matching resources from job configuration.
+ */
 public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
 
     private String format;
+    private Boolean hasConref;
+    private Boolean isResourceOnly;
     private Collection<Resource> res;
     private boolean isFilesystemOnly = true;
 
@@ -30,9 +35,6 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     private Collection<Resource> getResults() {
         if (res == null) {
-            if (format == null) {
-                throw new IllegalStateException();
-            }
             final Job job = getProject().getReference(ANT_REFERENCE_JOB);
             if (job == null) {
                 throw new IllegalStateException();
@@ -41,7 +43,9 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
             for (final Job.FileInfo f : job.getFileInfo(new Job.FileInfo.Filter<Job.FileInfo>() {
                 @Override
                 public boolean accept(final Job.FileInfo f) {
-                    return f.format != null && f.format.equals(format);
+                    return (format == null || format.equals(f.format)) &&
+                            (hasConref == null || f.hasConref == hasConref) &&
+                            (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
                 }
             })) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
@@ -92,6 +96,14 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     public void setFormat(final String format) {
         this.format = format;
+    }
+
+    public void setConref(final boolean conref) {
+        this.hasConref = conref;
+    }
+
+    public void setProcessingRole(final String processingRole) {
+        this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
     }
 
     private static class JobResource extends URLResource {

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -72,8 +72,7 @@
     unless="preprocess.gen-list.skip"
     description="Generate file list">
     <pipeline message="Generate list." taskname="gen-list"
-      inputmap="${args.input}"
-      tempdir="${dita.temp.dir}">
+      inputmap="${args.input}">
       <module class="org.dita.dost.module.GenMapAndTopicListModule">
         <param name="inputdir" location="${args.input.dir}" if="args.input.dir"/>
         <param name="ditadir" location="${dita.dir}"/>
@@ -101,8 +100,7 @@
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.debug-filter.skip"
     description="Debug and filter input files" >
-    <pipeline message="Debug and filtering." taskname="filter"
-      tempdir="${dita.temp.dir}">
+    <pipeline message="Debug and filtering." taskname="filter">
       <module class="org.dita.dost.module.DebugAndFilterModule">
         <param name="ditaval" location="${dita.input.valfile}" if="dita.input.valfile"/>
         <param name="ditadir" location="${dita.dir}"/>
@@ -178,8 +176,7 @@
           unless="preprocess.profile.skip"
           description="Profile input files">
     <pipeline message="Profile filtering." taskname="profile"
-              inputmap="${args.input}"
-              tempdir="${dita.temp.dir}">
+              inputmap="${args.input}">
       <module class="org.dita.dost.module.FilterModule">
         <!--param name="ditadir" location="${dita.dir}"/-->
         <param name="ditaval" location="${dita.input.valfile}" if="dita.input.valfile"/>
@@ -211,7 +208,7 @@
   </target>
   
   <target name="branch-filter">
-    <pipeline tempdir="${dita.temp.dir}" taskname="branch-filter" message="Filter branches">
+    <pipeline taskname="branch-filter" message="Filter branches">
       <module class="org.dita.dost.module.BranchFilterModule"/>
     </pipeline>
   </target>
@@ -223,8 +220,7 @@
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.conrefpush.skip"
     description="Resolve conref push">
-    <pipeline message="Resolve conref push." taskname="conref-push"
-      tempdir="${dita.temp.dir}">
+    <pipeline message="Resolve conref push." taskname="conref-push">
       <module class="org.dita.dost.module.ConrefPushModule"/>
     </pipeline>
     <job-helper file="conref.list" property="conreflist"/>
@@ -239,8 +235,7 @@
     unless="preprocess.move-meta-entries.skip"
     description="Move metadata entries">
     <pipeline message="Move metadata entries." taskname="move-meta"
-      inputmap="${user.input.file}"
-      tempdir="${dita.temp.dir}">
+      inputmap="${user.input.file}">
       <module class="org.dita.dost.module.MoveMetaModule">
         <param name="style" location="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mappull.xsl"/>
         <param name="conserve-memory" expression="${conserve-memory}" if="conserve-memory"/>
@@ -264,7 +259,7 @@
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl" filenameparameter="file-being-processed">
-        <includesfile name="${dita.temp.dir}/${conreffile}"/>
+        <ditaFileset conref="true"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -320,7 +315,7 @@
       <xslt basedir="${dita.temp.dir}"
           reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl" filenameparameter="file-being-processed">
-        <includesfile name="${dita.temp.dir}/${fullditamapfile}"/>
+        <ditafileset format="ditamap"/>
         <dita:extension id="dita.preprocess.mapref.param" behavior="org.dita.dost.platform.InsertAction"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
@@ -340,8 +335,7 @@
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.keyref.skip"
     description="Resolve keyref">
-    <pipeline message="Resolve keyref." taskname="keyref"
-      tempdir="${dita.temp.dir}">
+    <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.KeyrefModule">
         <param name="transtype" value="${transtype}"/>
       </module>
@@ -351,7 +345,7 @@
             reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"
             filenameparameter="file-being-processed">
-        <includesfile name="${dita.temp.dir}/${fullditamapfile}"/>
+        <ditaFileset format="ditamap"/>
         <param name="TRANSTYPE" expression="${transtype}" />
         <param name="child-topicref-warning" expression="false"/>
         <param name="keep-submap-href" expression="false"/>
@@ -362,8 +356,7 @@
   </target>
 
   <target name="copy-to">
-    <pipeline message="Resolve keyref." taskname="keyref"
-              tempdir="${dita.temp.dir}">
+    <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.CopyToModule"/>
     </pipeline>
   </target>
@@ -394,8 +387,7 @@
     unless="preprocess.chunk.skip"
     description="Process chunks">
     <pipeline message="Process chunks." taskname="chunk"
-      inputmap="${user.input.file}"
-      tempdir="${dita.temp.dir}">
+      inputmap="${user.input.file}">
       <module class="org.dita.dost.module.ChunkModule">
         <param name="transtype" value="${transtype}"/>
         <param name="root-chunk-override" value="${root-chunk-override}" if="root-chunk-override"/>
@@ -430,7 +422,7 @@
       <not><isset property="dita.preprocess.reloadstylesheet.maplink"/></not>
     </condition>
     <pipeline message="Move related links" taskname="maplink"
-              inputmap="${user.input.file}" tempdir="${dita.temp.dir}">
+              inputmap="${user.input.file}">
       <module class="org.dita.dost.module.MoveLinksModule">
         <param name="style" location="${dita.plugin.org.dita.base.dir}/xsl/preprocess/maplink.xsl"/>
         <param name="include.rellinks" expression="${include.rellinks}" if="include.rellinks"/>
@@ -459,7 +451,7 @@
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl">
-        <includesfile name="${dita.temp.dir}/${fullditatopicfile}"/>
+        <ditaFileset format="dita"/>
         <param name="TABLELINK" expression="${args.tablelink.style}" if="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if="args.figurelink.style" />
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if="onlytopic.in.map"/>
@@ -490,8 +482,7 @@
           style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/flag.xsl"
           filenameparameter="FILENAME" 
           filedirparameter="FILEDIR">
-        <includesfile name="${dita.temp.dir}/${fullditatopicfile}"/>
-        <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+        <ditaFileset format="dita" processing-role="normal"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <param name="FILTERFILEURL" expression="${dita.input.filterfile.url}"/>
         <param name="DRAFT" expression="${args.draft}" if="args.draft"/>
@@ -527,7 +518,7 @@
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.clean-map}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/clean-map.xsl">
-        <includesfile name="${dita.temp.dir}/${fullditamapfile}"/>
+        <ditaFileset format="ditamap"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
     </pipeline>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -147,6 +147,7 @@
     <property name="fullditatopicfile" value="fullditatopic.list"/>
     <property name="fullditamapfile" value="fullditamap.list"/>
     <property name="hrefditatopicfile" value="hrefditatopic.list"/>
+    <!-- Deprecated since 2.3 -->
     <property name="conreffile" value="conref.list"/>
     <!-- Deprecated since 2.1 -->
     <property name="imagefile" value="image.list"/>
@@ -268,10 +269,8 @@
     </pipeline>
   </target>
   
+  <!-- Deprecated since 2.3 -->
   <target name="conref-check">
-    <condition property="preprocess.conref.skip">
-      <length file="${dita.temp.dir}/${conreffile}" length="0"/>
-    </condition>
   </target>
   
   <target name="topic-fragment"


### PR DESCRIPTION
Add ditaFileset to Ant script files to replace list files. The ditaFileset resource collection uses the job configuration to compile a list of resources to process. The final result is the same as with the old list files, thus this doesn't add new functionality.