### PR TITLE
Fix conref performance issue #2307

### DIFF
--- a/src/main/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/xsl/preprocess/conrefImpl.xsl
@@ -73,9 +73,7 @@
   </xsl:template>
 
   <xsl:template match="@*" mode="get-source-attribute" as="xs:string?">
-    <xsl:if test="not(. = '')">
-      <xsl:value-of select="name()"/>
-    </xsl:if>
+    <xsl:value-of select="name()"/>
   </xsl:template>
 
   <xsl:template match="@xtrc | @xtrf" mode="get-source-attribute" priority="10"/>
@@ -144,7 +142,7 @@
         <xsl:when test="contains(@conrefend, '/')">
           <xsl:value-of select="substring-after(@conrefend, '/')"/>
         </xsl:when>
-        <xsl:when test="not(@conrefend = '')">
+        <xsl:when test="exists(@conrefend)">
           <xsl:value-of select="@conrefend"/>
         </xsl:when>
       </xsl:choose>
@@ -192,7 +190,7 @@
 
     <xsl:variable name="conref-source-topic" as="xs:string">
       <xsl:choose>
-        <xsl:when test="exists($conref-source-topicid) and not($conref-source-topicid = '')">
+        <xsl:when test="normalize-space($conref-source-topicid)">
           <xsl:value-of select="$conref-source-topicid"/>
         </xsl:when>
         <xsl:otherwise>
@@ -877,11 +875,9 @@
   <xsl:template match="*" mode="original-attributes">
     <xsl:apply-templates select="@*" mode="original-attributes"/>
   </xsl:template>
+
   <xsl:template match="@*" mode="original-attributes">
-    <xsl:if test="not(. = '')">
-      <!-- XXX: Why ignore empty attribute value? -->
-      <xsl:copy/>
-    </xsl:if>
+    <xsl:copy/>
   </xsl:template>
 
   <!-- If an attribute is required, it must be specified on the original source element to avoid parsing errors.


### PR DESCRIPTION
`not(@conrefend = '')` returns `true` even for elements that don't have the `@conrefend` attribute. That would cause the expensive XPath expression at [conrefImpl.xsl#L435][1] to be evaluated every time, which
would cause the stylesheet execution to become prohibitively slow in cases where there are thousands of following siblings.

I also fixed other similar XPath expressions in the same stylesheet.

This change doesn't address cases where `@conrefend` is actually used, so the XPath expression at [conrefImpl.xsl#L435][1] should probably be refactored, too.

[1]:  https://github.com/dita-ot/dita-ot/blob/876053c933975fd4744a049dbb3c4c7433d3f417/src/main/xsl/preprocess/conrefImpl.xsl#L435