### PR TITLE
Avoid double dependency on copy-css task

### DIFF
--- a/src/main/plugins/org.dita.javahelp/build_dita2javahelp.xml
+++ b/src/main/plugins/org.dita.javahelp/build_dita2javahelp.xml
@@ -12,7 +12,7 @@
 
     <target name="dita2javahelp"
             unless="noMap"
-            depends="dita2javahelp.init, build-init, preprocess, copy-css, 
+            depends="dita2javahelp.init, build-init, preprocess, 
                      xhtml.topics,
                      copy-css">
           <antcall target="dita.map.javahelp"/>


### PR DESCRIPTION
The copy-css task was called too early, before the user.csspath param was computed, leading to the CSSs being copied to a folder called "${user.csspath}" and not being used at all in the JavaHelp output.