### PR TITLE
Update OASIS catalogs #2266

### DIFF
--- a/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/catalog.xml
@@ -67,8 +67,6 @@
            uri="dtd/mapGroup.ent"/>
    <public publicId="-//OASIS//ENTITIES DITA Map Group Domain//EN"
            uri="dtd/mapGroup.ent"/>
-   <public publicId="-//OASIS//ENTITIES DITA 1.3 Map//EN" uri="dtd/map.ent"/>
-   <public publicId="-//OASIS//ENTITIES DITA Map//EN" uri="dtd/map.ent"/>
    <public publicId="-//OASIS//ELEMENTS DITA 1.3 Map//EN" uri="dtd/map.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA Map//EN" uri="dtd/map.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA 1.3 Metadata//EN"
@@ -78,8 +76,8 @@
            uri="dtd/tblDecl.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA Exchange Table Model//EN"
            uri="dtd/tblDecl.mod"/>
-   <public publicId="-//OASIS//ENTITIES DITA 1.3 Topic//EN" uri="dtd/topic.ent"/>
-   <public publicId="-//OASIS//ENTITIES DITA Topic//EN" uri="dtd/topic.ent"/>
+   <public publicId="-//OASIS//ENTITIES DITA 1.3 Topic Definitions//EN" uri="dtd/topicDefn.ent"/>
+   <public publicId="-//OASIS//ENTITIES DITA Topic Definitions//EN" uri="dtd/topicDefn.ent"/>
    <public publicId="-//OASIS//ELEMENTS DITA 1.3 Topic//EN" uri="dtd/topic.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA Topic//EN" uri="dtd/topic.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA 1.3 Utilities Domain//EN"

--- a/src/main/plugins/org.oasis-open.dita.v1_3/dtd/machineryIndustry/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/dtd/machineryIndustry/catalog.xml
@@ -10,8 +10,4 @@
            uri="dtd/machineryTaskbodyConstraint.mod"/>
    <public publicId="-//OASIS//ELEMENTS DITA Taskbody Constraint//EN"
            uri="dtd/machineryTaskbodyConstraint.mod"/>
-   <public publicId="-//OASIS//ENTITIES DITA 1.3 Taskbody Constraint//EN"
-           uri="dtd/machineryTaskbodyConstraint.ent"/>
-   <public publicId="-//OASIS//ENTITIES DITA Taskbody Constraint//EN"
-           uri="dtd/machineryTaskbodyConstraint.ent"/>
 </catalog>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/learning/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/learning/catalog.xml
@@ -11,10 +11,6 @@
               uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintMod.xsd"
               uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd:1.3"
-              uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd"
-              uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd:1.3"
               uri="xsd/learningAssessment.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd"
@@ -153,10 +149,6 @@
            uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintMod.xsd"
            uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
-      <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd:1.3"
-           uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
-      <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd"
-           uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd:1.3"
            uri="xsd/learningAssessment.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd"

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/technicalContent/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/technicalContent/catalog.xml
@@ -60,9 +60,8 @@
       <system systemId="urn:oasis:names:tc:dita:xsd:glossgroup.xsd"
               uri="xsd/glossgroup.xsd"/>
       
-      <!-- DITA 1.2 versions of the URNs for glossgroup shell. -->
-      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="glossgroup.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd:1.2" uri="glossgroup.xsd"/>
+      <!-- DITA 1.2 version of the URNs for glossgroup shell. -->
+      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="xsd/glossgroup.xsd"/>
      
       <system systemId="urn:oasis:names:tc:dita:xsd:glossgroupMod.xsd:1.3"
               uri="xsd/glossgroupMod.xsd"/>
@@ -210,9 +209,8 @@
            uri="xsd/glossgroup.xsd"/>
       <uri name="urn:oasis:names:tc:dita:xsd:glossgroup.xsd"
            uri="xsd/glossgroup.xsd"/>
-      <!-- DITA 1.2 versions of the URNs for glossgroup shell. -->
-     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="glossgroup.xsd"/>
-     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd:1.2" uri="glossgroup.xsd"/>    
+      <!-- DITA 1.2 version of the URNs for glossgroup shell. -->
+     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="xsd/glossgroup.xsd"/>
      
      <uri name="urn:oasis:names:tc:dita:xsd:glossgroupMod.xsd:1.3"
            uri="xsd/glossgroupMod.xsd"/>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema/learning/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema/learning/catalog.xml
@@ -11,10 +11,6 @@
               uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintMod.xsd"
               uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd:1.3"
-              uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd"
-              uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd:1.3"
               uri="xsd/learningAssessment.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd"
@@ -153,10 +149,6 @@
            uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintMod.xsd"
            uri="xsd/learningAggregationsTopicrefConstraintMod.xsd"/>
-      <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd:1.3"
-           uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
-      <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAggregationsTopicrefConstraintGrp.xsd"
-           uri="xsd/learningAggregationsTopicrefConstraintGrp.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd:1.3"
            uri="xsd/learningAssessment.xsd"/>
       <uri name="urn:oasis:names:tc:dita:spec:learning:xsd:learningAssessment.xsd"

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema/technicalContent/catalog.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema/technicalContent/catalog.xml
@@ -60,9 +60,8 @@
       <system systemId="urn:oasis:names:tc:dita:xsd:glossgroup.xsd"
               uri="xsd/glossgroup.xsd"/>
       
-      <!-- DITA 1.2 versions of the URNs for glossgroup shell. -->
-      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="glossgroup.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd:1.2" uri="glossgroup.xsd"/>
+      <!-- DITA 1.2 version of the URNs for glossgroup shell. -->
+      <system systemId="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="xsd/glossgroup.xsd"/>
      
       <system systemId="urn:oasis:names:tc:dita:xsd:glossgroupMod.xsd:1.3"
               uri="xsd/glossgroupMod.xsd"/>
@@ -155,6 +154,10 @@
               uri="xsd/xmlDomain.xsd"/>
       <system systemId="urn:oasis:names:tc:dita:xsd:xmlDomain.xsd"
               uri="xsd/xmlDomain.xsd"/>
+      <system systemId="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd:1.3"
+              uri="xsd/ditabaseMod.xsd"/>
+      <system systemId="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd"
+              uri="xsd/ditabaseMod.xsd"/>
    </group>
    <group><!-- Public ID (URN) catalog entries -->
       <uri name="urn:oasis:names:tc:dita:xsd:abbreviateDomain.xsd:1.3"
@@ -211,9 +214,8 @@
       <uri name="urn:oasis:names:tc:dita:xsd:glossgroup.xsd"
            uri="xsd/glossgroup.xsd"/>
      
-     <!-- DITA 1.2 versions of the URNs for glossgroup shell. -->
-     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="glossgroup.xsd"/>
-     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd:1.2" uri="glossgroup.xsd"/>    
+     <!-- DITA 1.2 version of the URNs for glossgroup shell. -->
+     <uri name="urn:oasis:names:tc:dita:xsd:glossarygroup.xsd" uri="xsd/glossgroup.xsd"/>   
      
      <uri name="urn:oasis:names:tc:dita:xsd:glossgroupMod.xsd:1.3"
            uri="xsd/glossgroupMod.xsd"/>
@@ -303,12 +305,9 @@
            uri="xsd/xmlDomain.xsd"/>
       <uri name="urn:oasis:names:tc:dita:xsd:xmlDomain.xsd"
            uri="xsd/xmlDomain.xsd"/>
-      <system systemId="ditabaseMod.xsd" uri="ditabaseMod.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd"
-              uri="xsd/ditabaseMod.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd:1.x"
-              uri="xsd/ditabaseMod.xsd"/>
-      <system systemId="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd:1.2"
-              uri="xsd/ditabaseMod.xsd"/>
+      <uri name="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd:1.3"
+           uri="xsd/ditabaseMod.xsd"/>
+      <uri name="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd"
+           uri="xsd/ditabaseMod.xsd"/>
    </group>
 </catalog>


### PR DESCRIPTION
Note - might seem odd that this removes a `1.x` entry for `ditabaseMod.xsd`, and I'd agree, except that it was the only `1.x` entry in that entire catalog. It's now consistent with all the other entries, and with fixed path.