### PR TITLE
Fix for issue #2321

### DIFF
--- a/src/main/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/xsl/preprocess/mappullImpl.xsl
@@ -562,6 +562,20 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
     </xsl:choose>
   </xsl:template>
+  
+  <xsl:template match="*[ancestor-or-self::*[contains(@class,' mapgroup-d/topicsetref ')]]" 
+    mode="mappull:get-stuff_get-type" as="attribute()?">
+    <!-- <topicsetref> should not return a type -->
+    <xsl:param name="type" as="xs:string"/>
+    <xsl:param name="scope" as="xs:string"/>
+    <xsl:param name="topicpos" as="xs:string"/>
+    <xsl:param name="format" as="xs:string"/>
+    <xsl:param name="file" as="xs:string"/>
+    <xsl:param name="classval" as="xs:string"/>
+    <xsl:param name="topicid" as="xs:string"/>
+    <xsl:param name="doc" as="document-node()?"/>
+    <xsl:attribute name="type">#none#</xsl:attribute>
+  </xsl:template>
 
   <!-- Get the navtitle from the target topic, if available. -->
   <xsl:template match="*" mode="mappull:get-stuff_get-navtitle" as="item()*">


### PR DESCRIPTION
This addresses #2321 by returning a `#none#` type for the targets of topicsetref elements (and their descendants). Current processing returns 'topicset' which causes build warnings because the referenced topics are concept, task, reference, etc.