### PR TITLE
Support page expanse from display attributes #2317

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -426,6 +426,21 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:attribute-set name="__border__all" use-attribute-sets="__border__right __border__left __border__top __border__bot">
     </xsl:attribute-set>
 
+    <xsl:attribute-set name="__expanse__page">
+        <xsl:attribute name="start-indent">0</xsl:attribute>
+        <xsl:attribute name="end-indent">0</xsl:attribute>
+        <xsl:attribute name="width">auto</xsl:attribute>
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__expanse__column">
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__expanse__textline">
+    </xsl:attribute-set>
+
+    <xsl:attribute-set name="__expanse__spread">
+    </xsl:attribute-set>
+
     <xsl:attribute-set name="lines" use-attribute-sets="base-font">
         <xsl:attribute name="space-before">0.8em</xsl:attribute>
         <xsl:attribute name="space-after">0.8em</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -1653,6 +1653,7 @@ See the accompanying license.txt file for applicable licenses.
         <fo:block xsl:use-attribute-sets="fig">
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
+            <xsl:call-template name="setExpanse"/>
             <xsl:if test="not(@id)">
               <xsl:attribute name="id">
                 <xsl:call-template name="get-id"/>
@@ -1676,6 +1677,7 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
+            <xsl:call-template name="setExpanse"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -1722,12 +1724,33 @@ See the accompanying license.txt file for applicable licenses.
       <xsl:sequence select="$container/@*"/>
     </xsl:template>
 
+    <xsl:template name="setExpanse" as="attribute()*">
+      <xsl:variable name="container" as="element()*">
+        <xsl:choose>
+         <xsl:when test="@expanse = 'page'">
+           <element xsl:use-attribute-sets="__expanse__page"/>
+         </xsl:when>
+         <xsl:when test="@expanse = 'column'">
+           <element xsl:use-attribute-sets="__expanse__column"/>
+         </xsl:when>
+         <xsl:when test="@expanse = 'spread'">
+           <element xsl:use-attribute-sets="__expanse__spread"/>
+         </xsl:when>
+         <xsl:when test="@expanse = 'column'">
+           <element xsl:use-attribute-sets="__expanse__textline"/>
+         </xsl:when>
+        </xsl:choose>
+      </xsl:variable>
+      <xsl:sequence select="$container/@*"/>
+    </xsl:template>
+
     <xsl:template match="*[contains(@class,' topic/lines ')]">
         <xsl:call-template name="setSpecTitle"/>
         <fo:block xsl:use-attribute-sets="lines">
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
+            <xsl:call-template name="setExpanse"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -55,6 +55,7 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
+            <xsl:call-template name="setExpanse"/>
             <xsl:variable name="codeblock.line-number" as="xs:boolean">
               <xsl:apply-templates select="." mode="codeblock.generate-line-number"/>
             </xsl:variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
@@ -46,6 +46,9 @@ See the accompanying license.txt file for applicable licenses.
       <xsl:call-template name="generateAttrLabel"/>
       <fo:block xsl:use-attribute-sets="msgblock">
         <xsl:call-template name="commonattributes"/>
+        <xsl:call-template name="setFrame"/>
+        <xsl:call-template name="setScale"/>
+        <xsl:call-template name="setExpanse"/>
         <xsl:apply-templates/>
       </fo:block>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -749,6 +749,12 @@
           </xsl:choose>
         </xsl:variable>
 
+        <xsl:if test="$element/@expanse">
+          <xsl:for-each select="$element">
+            <xsl:call-template name="setExpanse"/>
+          </xsl:for-each>
+        </xsl:if>
+
         <xsl:choose>
             <xsl:when test="$frame = 'all'">
                 <xsl:call-template name="processAttrSetReflection">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
@@ -78,6 +78,7 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
+            <xsl:call-template name="setExpanse"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>


### PR DESCRIPTION
Fix support for `expanse="page"` on elements that use the attribute. Set up attribute sets for other values, though they are empty for now.