### PR TITLE
Skip check for subelements in map #1549

### DIFF
--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -85,7 +85,7 @@
           </xsl:if>
         </xsl:variable>
         <xsl:choose>
-          <xsl:when test="empty($file) or empty($file/*/*)">
+          <xsl:when test="empty($file)">
             <xsl:variable name="filename" as="xs:string?">
               <xsl:choose>
                 <xsl:when test="empty($href)"/>


### PR DESCRIPTION
We currently issue a message that a map cannot be loaded when this test fails:
`<xsl:when test="empty($file) or empty($file/*/*)">`

We should only generate the message when the file cannot be loaded - when it has no contents - not when it has no children of the map.

Tested my pull request with:
```
<map>
<topicref href="empty.ditamap" format="ditamap"/>
<topicref href="reallyempty.ditamap" format="ditamap"/>
<topicref href="missing.ditamap" format="ditamap"/>
</map>
```

* `empty.ditamap` is just the `<map/>` element. Generates the message in 2.2.4, does not with this update, no other issues with output.
* `reallyempty.ditamap` is just the XML PI with no DTD, no elements. Throws errors during parsing (as it should). Throws more errors during mappull with or without this PR.
* `missing.ditamap` is of course missing. Throws errors during several steps, starting with the initial attempt to parse, and including mapref with or without this PR.