### PR TITLE
Do not preserve @type from mapref #2321

### DIFF
--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -19,7 +19,7 @@
   <xsl:param name="file-being-processed" as="xs:string"/>
   <xsl:param name="child-topicref-warning" as="xs:string" select="'true'"/>
 
-  <!-- list of attributes that can be overided. -->
+  <!-- list of attributes that can be overidden. -->
   <xsl:variable name="special-atts" select="('href', 'copy-to', 'class', 'linking', 'toc', 'print', 'audience', 'product', 'platform', 'otherprops', 'props')" as="xs:string*"/>
 
   <!-- the xsl:key to get all maprefs in the document in order to get reltable -->
@@ -166,7 +166,7 @@
                   <xsl:value-of select="normalize-space($keyscope)"/>
                 </xsl:attribute>
               </xsl:if>
-              <xsl:apply-templates select="@* except (@class, @href, @dita-ot:orig-href, @format, @dita-ot:orig-format, @keys, @keyscope)"/>
+              <xsl:apply-templates select="@* except (@class, @href, @dita-ot:orig-href, @format, @dita-ot:orig-format, @keys, @keyscope, @type)"/>
               <xsl:apply-templates select="*[contains(@class, ' ditavalref-d/ditavalref ')]"/>
               <xsl:apply-templates select="$contents">
                 <xsl:with-param name="refclass" select="$refclass"/>


### PR DESCRIPTION
As discussed in #2321 - the `@type` attribute is used to describe the type of the target. When specified explicitly on a map reference, it should describe the target of that reference, not the target of the items that are referenced. This is why the value defaults to "topicset" on `<topicsetref>`. Similarly the following would be appropriate with a reference to a `<chapter>` element:
```<chapter href="other.ditamap#chap" type="chapter" format="ditamap"/>```

Current processing passes `@type` on to the resolved values, meaning that everything in that reference is tagged with `type="chapter"`, even when the target is likely a DITA topic. Originally noted because after resolving `<topicsetref>`, everything referenced by the resolved branch generates errors due to the preserved `type="topicset"`.

[Also fixing a typo noticed in a comment, because I was already in the file.]