### PR TITLE
Ignore files generated from templates since #2313

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ src/main/plugins/org.dita.html5/.sass-cache
 src/main/plugins/org.dita.html5/build_dita2html5.xml
 src/main/plugins/org.dita.html5/css/commonltr.css
 src/main/plugins/org.dita.html5/css/commonrtl.css
+src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
+src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl
+src/main/plugins/org.dita.html5/xsl/map2html5toc.xsl
 src/main/plugins/org.dita.htmlhelp/xsl/map2hhc.xsl
 src/main/plugins/org.dita.htmlhelp/xsl/map2hhp.xsl
 src/main/plugins/org.dita.odt/xsl/dita2odt.xsl


### PR DESCRIPTION
* `src/main/plugins/org.dita.html5/xsl/dita2html5.xsl`
* `src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl`
* `src/main/plugins/org.dita.html5/xsl/map2html5toc.xsl`