### PR TITLE
Add missing variables to original string files

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -132,11 +132,15 @@ See the accompanying license.txt file for applicable licenses.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Anhang <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Teil <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Einleitung </variable>
+
+    <!-- The string used to label Notices within the table of contents. -->
+    <variable id="Table of Contents Notices"/>
+
     <variable id="Preface title">Einleitung</variable>
 
     <!-- The heading to put at the top of a chapter when creating a

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -132,11 +132,15 @@ See the accompanying license.txt file for applicable licenses.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Apéndice <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prefacio </variable>
+
+    <!-- The string used to label Notices within the table of contents. -->
+    <variable id="Table of Contents Notices"/>
+
     <variable id="Preface title">Prefacio</variable>
 
     <!-- The heading to put at the top of a chapter when creating a

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -132,11 +132,15 @@ See the accompanying license.txt file for applicable licenses.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Annexe <param ref-name="number"/> : </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Partie <param ref-name="number"/> : </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Préface </variable>
+
+    <!-- The string used to label Notices within the table of contents. -->
+    <variable id="Table of Contents Notices"/>
+
     <variable id="Preface title">Préface</variable>
 
     <!-- The heading to put at the top of a chapter when creating a

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -132,11 +132,15 @@ See the accompanying license.txt file for applicable licenses.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Appendice <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Introduzione </variable>
+
+    <!-- The string used to label Notices within the table of contents. -->
+    <variable id="Table of Contents Notices"/>
+
     <variable id="Preface title">Introduzione</variable>
 
     <!-- The heading to put at the top of a chapter when creating a

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -115,6 +115,22 @@
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
 
+  <!--Glossary Variables-->
+  <!-- The footer that appears on the odd-numbered glossary pages. -->
+  <variable id="Glossary odd footer"/>
+  <!-- The footer that appears on the even-numbered glossary pages. -->
+  <variable id="Glossary even footer"/>
+  <!-- The header that appears on the odd-numbered glossary pages. -->
+  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
+  <!-- The header that appears on the even-numbered glossary pages. -->
+  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+  <!-- The heading string to put at the top of the Glossary -->
+  <variable id="Glossary">Verklarende woordenlijst</variable>
+  <!-- The heading string to put at the top of the List of Tables -->
+  <variable id="List of Tables">Tabellen</variable>
+  <!-- The heading string to put at the top of the List of Figures -->
+  <variable id="List of Figures">Figuren</variable>
+
   <variable id="#menucascade-separator"> &gt; </variable>
   <variable id="#quote-start">“</variable>
   <variable id="#quote-end">”</variable>


### PR DESCRIPTION
The Dutch variables file for PDF has always been missing a few strings, which will throw `DOTX001W` when these constructs are used:
- All strings for Glossary (translated heading, and header/footer variables)
- List of tables
- List of figures

In addition, German, Italian, French, and Spanish are missing the variable "Table of Contents Notices" that will cause `DOTX001W` when using a notices topic. Most other languages define this variable but leave it empty, so doing the same here. 