### PR TITLE
Remove obsolete parameter args.eclipsehelp.toc

### DIFF
--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -41,11 +41,6 @@
 
     <target name="dita.map.eclipse.plugin.init"
             description="Init properties for EclipseHelp">
-        <condition property="args.eclipsehelp.toc" value="${dita.map.filename.root}">
-            <not>
-                <isset property="args.eclipsehelp.toc" />
-            </not>
-        </condition>
         <condition property="out.ext" value=".html">
             <not>
                 <isset property="out.ext" />
@@ -182,7 +177,7 @@
               out="${dita.map.output.dir}/plugin.xml"
               classpathref="dost.class.path"
               style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
-            <param name="TOCROOT" expression="${args.eclipsehelp.toc}" />
+            <param name="TOCROOT" expression="${dita.map.filename.root}" />
             <param name="version"
                    expression="${args.eclipse.version}"
                    if="args.eclipse.version" />
@@ -208,7 +203,7 @@
             out="${output.dir}/plugin.xml"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
-            <param name="TOCROOT" expression="${args.eclipsehelp.toc}" />
+            <param name="TOCROOT" expression="${dita.map.filename.root}" />
             <param name="version"
                 expression="${args.eclipse.version}"
                 if="args.eclipse.version" />

--- a/src/main/plugins/org.dita.eclipsehelp/plugin.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/plugin.xml
@@ -11,7 +11,6 @@
   <extension-point id="dita.conductor.eclipse.toc.param" name="Eclipse Help TOC XSLT parameter"/>
   <!-- extensions -->
   <transtype name="eclipsehelp" extends="base-html" desc="Eclipse Help">
-    <param name="args.eclipsehelp.toc" desc="Specifies the name of the TOC file." type="file"/>
     <param name="args.eclipsehelp.country" desc="Specifies the region for the language that is specified by the args." type="string"/> 
     <param name="args.eclipsehelp.language" desc="Specifies the base language for translated content, such as en for English." type="string"/> 
     <param name="args.eclipse.provider" desc="Specifies the name of the person or organization that provides the Eclipse help." type="string">


### PR DESCRIPTION
As discussed in #1116, removing an obsolete parameter that has not been broken since 1.3.