### PR TITLE
Make Path to project relative to chunk file

### DIFF
--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -328,9 +328,9 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                 }
                 writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET_URI, workDir.toString());
 
-                if (conflictTable.get(outputFileName) != null) {
+                if (outputFileName != null) {
                     final String relativePath = getRelativeUnixPath(new File(filePath) + UNIX_SEPARATOR + FILE_NAME_STUB_DITAMAP,
-                            new File(conflictTable.get(outputFileName)).getAbsolutePath());
+                            new File(outputFileName).getAbsolutePath());
                     String path2project = getRelativeUnixPath(relativePath);
                     if (null == path2project) {
                         path2project = "";


### PR DESCRIPTION
Possible fix for:
https://github.com/dita-ot/dita-ot/issues/2298

The path to project PI inside the chunk file needs to be computed relative to the chunk file and not to the original file location.