### PR TITLE
Stop setting default lang on topics in merge file #1476

### DIFF
--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -39,7 +39,6 @@ public final class MergeTopicParser extends XMLFilterImpl {
 
     private File dirPath = null;
     private String filePath = null;
-    private boolean isFirstTopic = false;
     private String rootLang = null;
 
     private final XMLReader reader;
@@ -196,7 +195,6 @@ public final class MergeTopicParser extends XMLFilterImpl {
     @Override
     public void startDocument() throws SAXException {
         firstTopicId = null;
-        isFirstTopic = true;
         rootLang = null;
     }
 
@@ -211,16 +209,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
         final AttributesImpl atts = new AttributesImpl(attributes);
         final String classValue = atts.getValue(ATTRIBUTE_NAME_CLASS);
 
-        // Add default language
         if (TOPIC_TOPIC.matches(classValue)) {
-            if (isFirstTopic) {
-                if (atts.getIndex(XML_NS_URI, "lang") == -1) {
-                    atts.addAttribute(XML_NS_URI, "lang", XML_NS_PREFIX + ":lang", "CDATA", rootLang != null ? rootLang
-                            : Configuration.configuration.get("default.language"));
-                    rootLang = null;
-                }
-                isFirstTopic = false;
-            }
             handleID(classValue, atts);
             if (firstTopicId == null) {
                 firstTopicId = atts.getValue(ATTRIBUTE_NAME_ID);

--- a/src/test/resources/TestTopicMergeModule/compare.xml
+++ b/src/test/resources/TestTopicMergeModule/compare.xml
@@ -42,7 +42,7 @@
   <task xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" oid="configA" id="unique_1"
     domains="(topic shortdescReq-c)" ditaarch:DITAArchVersion="1.2" class="- topic/topic task/task "
     xtrf="C:\DITA-OT1.5\SAXONIBMJDK\testcase\12008\..\..\testdata\12008\case1_allow\componentA\configA.dita"
-    xtrc="task:1" xml:lang="en">
+    xtrc="task:1">
     <title class="- topic/title "
       xtrf="C:\DITA-OT1.5\SAXONIBMJDK\testcase\12008\..\..\testdata\12008\case1_allow\componentA\configA.dita"
       xtrc="title:1">ABC</title>


### PR DESCRIPTION
The `topic-merge` function adds `xml:lang="en"` to topics that have no language. Dropping this default allows PDF to use the map language as a default.