### PR TITLE
Improve setting of default language

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -454,6 +454,7 @@
         <param name="TABLELINK" expression="${args.tablelink.style}" if="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if="args.figurelink.style" />
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if="onlytopic.in.map"/>
+        <param name="defaultLanguage" expression="${default.language}"/>
         <dita:extension id="dita.preprocess.topicpull.param" behavior="org.dita.dost.platform.InsertAction"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
@@ -488,6 +489,7 @@
         <param name="BASEDIR" expression="${basedir}"/>
         <param name="OUTPUTDIR" expression="${output.dir}"/>
         <param name="DBG" expression="${args.debug}" if="args.debug"/>
+        <param name="defaultLanguage" expression="${default.language}"/>
         <dita:extension id="dita.preprocess.flag-module.param" behavior="org.dita.dost.platform.InsertAction"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>

--- a/src/main/plugins/org.dita.docbook/build_dita2docbook.xml
+++ b/src/main/plugins/org.dita.docbook/build_dita2docbook.xml
@@ -41,6 +41,7 @@
       classpathref="dost.class.path"
       style="${args.xsl}">
       <param name="outputdir" expression="${outputDir}" />
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -104,6 +104,7 @@
         	<excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
+            <param name="defaultLanguage" expression="${default.language}"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
     </target>
@@ -120,6 +121,7 @@
         	<excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
+            <param name="defaultLanguage" expression="${default.language}"/>
             <dita:extension behavior="org.dita.dost.platform.InsertAction" id="dita.conductor.eclipse.toc.param"/>
             <mapper type="regexp"
                 from="^(${tempdirToinputmapdir.relative.value})(.*?)(\.ditamap)$$" 
@@ -144,6 +146,7 @@
             <param name="indexclass" value="${dita.eclipsehelp.index.class}"/>
             <param name="eclipse.indexsee" value="${args.eclipsehelp.indexsee}"/>
             <param name="encoding" value="${args.dita.locale}" if="args.dita.locale"/>
+            <param name="defaultLanguage" expression="${default.language}"/>
     	    </module>
     	  </pipeline>
     </target>
@@ -164,6 +167,7 @@
             <param name="indexclass" value="${dita.eclipsehelp.index.class}"/>
             <param name="eclipse.indexsee" value="${args.eclipsehelp.indexsee}"/>
             <param name="encoding" value="${args.dita.locale}" if="args.dita.locale"/>
+            <param name="defaultLanguage" expression="${default.language}"/>
           </module>
         </pipeline>
     </target>

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp.xml
@@ -67,6 +67,7 @@
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
       <param name="HHCNAME" expression="${dita.map.filename.root}.hhc"/>
       <param name="INCLUDEFILE" expression="${args.htmlhelp.includefile}" if="args.htmlhelp.includefile"/>
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
       <mergemapper to="${dita.map.filename.root}.hhp"/>
     </xslt>
@@ -103,6 +104,7 @@
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhc.xsl">
       <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
       <mergemapper to="${dita.map.filename.root}.hhc"/>
     </xslt>
@@ -136,6 +138,7 @@
         <param name="targetext" value="${out.ext}"/>
         <param name="indextype" value="htmlhelp"/>
         <param name="encoding" value="${args.dita.locale}" if="args.dita.locale"/>
+        <param name="defaultLanguage" expression="${default.language}"/>
       </module>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.odt/build_dita2odt.xml
+++ b/src/main/plugins/org.dita.odt/build_dita2odt.xml
@@ -99,6 +99,7 @@
       <param name="include.rellinks" expression="${include.rellinks}"/>
       <param name="INDEXSHOW" expression="${args.indexshow}" if="args.indexshow"/>
       <param name="DBG" expression="${args.debug}" if="args.debug"/>
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -316,6 +316,7 @@ with those set forth herein.
       <param name="figurelink.style" expression="${args.figurelink.style}"/>
       <param name="tablelink.style" expression="${args.tablelink.style}"/>
       <param name="variableFiles.url" expression="${variable.file.url}" if="variable.file.exists"/>
+      <param name="defaultLanguage" expression="${default.language}"/>
       <dita:extension id="dita.conductor.pdf2.param" behavior="org.dita.dost.platform.InsertAction"/>
       <xmlcatalog>
         <catalogpath path="${xml.catalog.files}"/>

--- a/src/main/plugins/org.dita.troff/build_dita2troff.xml
+++ b/src/main/plugins/org.dita.troff/build_dita2troff.xml
@@ -25,6 +25,7 @@
       classpathref="dost.class.path"
       style="${troff-ast.xsl}">
     	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+        <param name="defaultLanguage" expression="${default.language}"/>
       <mapper type="glob" from="*" to="*.ast" />
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
@@ -42,6 +43,7 @@
       style="${troff.step2.xsl}">
     	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
       <param name="OUTFORMAT" expression="${troff.outformat}" if="troff.outformat"/>
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>

--- a/src/main/plugins/org.dita.wordrtf/build_dita2wordrtf.xml
+++ b/src/main/plugins/org.dita.wordrtf/build_dita2wordrtf.xml
@@ -81,6 +81,7 @@
       out="${output}" style="${args.xsl}">
       <param name="DRAFT" expression="${args.draft}" if="args.draft" />
       <param name="OUTPUTDIR" expression="${dita.rtf.outputdir}" />
+      <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -166,6 +166,7 @@
         <param name="BASEDIR" expression="${basedir}"/>
         <param name="OUTPUTDIR" expression="${output.dir}"/>
         <param name="DBG" expression="${args.debug}" if="args.debug"/>
+        <param name="defaultLanguage" expression="${default.language}"/>
         <params/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -12,7 +12,10 @@
 
   <xsl:include href="functions.xsl"/>
 
-  <xsl:param name="DEFAULTLANG">en-us</xsl:param>
+  <xsl:param name="defaultLanguage" select="'en'" as="xs:string"/>
+
+  <xsl:param name="DEFAULTLANG" select="if (/*/@xml:lang) then /*/@xml:lang else $defaultLanguage" as="xs:string"/>
+
   <xsl:param name="variableFiles.url" select="'plugin:org.dita.base:xsl/common/strings.xml'"/>
   
   <xsl:variable name="pixels-per-inch" select="number(96)"/>

--- a/src/main/xsl/common/functions.xsl
+++ b/src/main/xsl/common/functions.xsl
@@ -96,10 +96,11 @@
   </xsl:function>
 
   <xsl:function name="dita-ot:get-first-topic-language" as="xs:string">
+    <!-- $ctx should contain the root element.
+         If toot element is <dita>, check first topic. Otherwise, root element. Otherwise, default. -->
     <xsl:param name="ctx" as="node()"/>
-
     <xsl:sequence select="
-      lower-case(($ctx/*/@xml:lang, $ctx/dita/*/@xml:lang, $DEFAULTLANG)[1])
+      lower-case(($ctx/self::dita/*[1]/@xml:lang, $ctx/@xml:lang, $DEFAULTLANG)[1])
     "/>
   </xsl:function>
 

--- a/src/test/xsl/common/dita-utilities.xspec
+++ b/src/test/xsl/common/dita-utilities.xspec
@@ -309,13 +309,13 @@
     <x:scenario label="@xml:lang of first child">
       <x:call function="dita-ot:get-first-topic-language">
         <x:param name="ctx">
-          <topic id="foo" xml:lang="en-us">
+          <topic id="foo" xml:lang="is-is">
             <title>foo</title>
           </topic>
         </x:param>
       </x:call>
 
-      <x:expect label="return @xml:lang" select="'en-us'"/>
+      <x:expect label="return @xml:lang" select="'is-is'"/>
     </x:scenario>
 
     <x:scenario label="@xml:lang of dita element child">
@@ -335,13 +335,13 @@
     <x:scenario label="upper-case @xml:lang">
       <x:call function="dita-ot:get-first-topic-language">
         <x:param name="ctx">
-          <topic id="foo" xml:lang="en-US">
+          <topic id="foo" xml:lang="pt-BR">
             <title>foo</title>
           </topic>
         </x:param>
       </x:call>
 
-      <x:expect label="return @xml:lang" select="'en-us'"/>
+      <x:expect label="return @xml:lang" select="'pt-br'"/>
     </x:scenario>
 
     <x:scenario label="no @xml:lang">
@@ -353,7 +353,7 @@
         </x:param>
       </x:call>
 
-      <x:expect label="return $DEFAULTLANG" select="'en-us'"/>
+      <x:expect label="return $DEFAULTLANG" select="'en'"/>
     </x:scenario>
   </x:scenario>
 
@@ -379,7 +379,7 @@
         </x:param>
       </x:call>
 
-      <x:expect label="return $DEFAULTLANG" select="'en-us'"/>
+      <x:expect label="return $DEFAULTLANG" select="'en'"/>
     </x:scenario>
   </x:scenario>
 


### PR DESCRIPTION
Our common language detection has a few problems today:

- We have a configuration property `default.language` but it is not used by any of our XSLT processing steps
- XSLT (in `dita-utilities.xsl`) hard codes a default of `en-us` (which conflicts slightly with the shipped value `en` in `configuration.properties`)
- Even when a topic or map sets `@xml:lang` on the root element, it is ignored for any variable that is pulled from the `/` context in XSLT. This is the case for several PDF variables, most noticeable are the strings for `Chapter` and `Index` within the PDF bookmarks. The reason is that processing looks for `@xml:lang` on ancestor or self, so no language is found from `/`.

This pull request makes the following updates:

- Pass in the configuration default to any XSLT step that is likely to do any language based processing. I've added it to `topicpull` and `flag` from the pre-process (both pull variables); it is also passed to all of the XSLT rendering steps that have any real NLS support today.
- Continue using the XSLT variable `$DEFAULTLANG` that has been used since DITA-OT 1.0, but with new logic:
 - If `@xml:lang` is present on the root element, that is the default. This fixes the problem of pulling variables from the `/` context.
 - Otherwise, use the configured DITA-OT default.

Worth noting: as a side effect, it is now much easier to test generated strings / variables in XHTML, by using a common set of topics with no `@xml:lang` and building with the property `default.language` to override the configured default.