### PR TITLE
HTML5: Use Sass `// comment` syntax per #2218

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
@@ -1,3 +1,3 @@
-/* inline */
+// inline 
 .abbreviated-form {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .abbrevlist {
 }
 
@@ -149,7 +149,7 @@
 .volume {
 }
 
-/* inline */
+// inline 
 .booklibrary {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .subjectCell {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .conbody {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
@@ -1,11 +1,11 @@
-/* block */
+// block 
 .equation-block {
 }
 
 .equation-figure {
 }
 
-/* inline */
+// inline 
 .equation-inline {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .glossAbbreviation {
 }
 
@@ -38,7 +38,7 @@
 .glossUsage {
 }
 
-/* inline */
+// inline 
 .glossAlternateFor {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
@@ -1,3 +1,3 @@
-/* block */
+// block 
 .glossgroup {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
@@ -1,3 +1,3 @@
-/* block */
+// block 
 .glossref {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .consequence {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
@@ -1,4 +1,4 @@
-/* inline */
+// inline 
 .b {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .index-see {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .lcAnswerContent {
 }
 
@@ -167,7 +167,7 @@
 .lcTrueFalse2 {
 }
 
-/* inline */
+// inline 
 .lcAreaCoords {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .lcLom {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningAssessment {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .lcAudience {
 }
 
@@ -56,7 +56,7 @@
 .learningBasebody {
 }
 
-/* inline */
+// inline 
 .lcObjectivesStem {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningContent {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningOverview {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .lcAge {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningSummary {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningContentRef {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .learningGroupMap {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_map.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_map.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .linktext {
 }
 
@@ -31,7 +31,7 @@
 
 .topicref {
 }
-/*  */
+// inline 
 .anchor {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .anchorref {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
@@ -1,3 +1,3 @@
-/* inline */
+// inline 
 .markupname {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .codeblock {
   font-family: monospace;
 }
@@ -36,7 +36,7 @@
 .syntaxdiagram {
 }
 
-/* inline */
+// inline 
 .apiname {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .propdesc {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .defaultSubject {
 }
 
@@ -50,7 +50,7 @@
 .subjectScheme {
 }
 
-/* block */
+// block 
 .attributedef {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
@@ -1,8 +1,8 @@
-/* block */
+// block 
 .msgblock {
 }
 
-/* inline */
+// inline 
 .cmdname {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_task.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_task.scss
@@ -11,7 +11,7 @@ h6.tasklabel {
   font-size: 100%;
 }
 
-/* block */
+// block 
 .chdesc {
 }
 
@@ -84,7 +84,7 @@ h6.tasklabel {
 .tasktroubleshooting {
 }
 
-/* inline */
+// inline 
 .cmd {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .closereqs {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .abstract {
 }
 
@@ -269,7 +269,7 @@
 .vrmlist {
 }
 
-/* inline */
+// inline 
 .boolean {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .cause {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .screen {
   padding: 5px 5px 5px 5px;
   border: outset;
@@ -8,7 +8,7 @@
   white-space: pre;
 }
 
-/* inline */
+// inline 
 .menucascade {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .area {
 }
 
@@ -8,7 +8,7 @@
 .sort-as {
 }
 
-/* inline */
+// inline 
 .coords {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
@@ -8,7 +8,7 @@ $markup-color: #663399;
   font-family: $code-fonts;
 }
 
-/* inline */
+// inline 
 .numcharref {
   @include markupname;
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
@@ -1,4 +1,4 @@
-/* block */
+// block 
 .addressdetails {
 }
 


### PR DESCRIPTION
This PR replaces the C-style (multi-line) `/* comment */` syntax used to mark inline/block elements in the generated Sass partials for DITA domains, as these comments are passed through to the output even when empty rules that follow them are dropped by the compiler.

Switching these to Sass C++-style (single-line) `// comment` syntax reduces noise in the CSS output.

The old CSS comments have been preserved in the Sass source and are passed through to the CSS output on the assumption that they may be useful to users developing custom stylesheets.