### PR TITLE
PDF: Remove background color from keycol

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
@@ -24,7 +24,6 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:attribute-set>
 
   <xsl:attribute-set name="property.entry__keycol-content" use-attribute-sets="common.table.body.entry common.table.head.entry">
-      <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="property.entry__content" use-attribute-sets="common.table.body.entry">
@@ -40,7 +39,6 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:attribute-set>
 
   <xsl:attribute-set name="prophead.entry__keycol-content" use-attribute-sets="common.table.body.entry common.table.head.entry">
-      <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="prophead.entry__content" use-attribute-sets="common.table.body.entry common.table.head.entry">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -231,14 +231,12 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:attribute-set>
 
   <xsl:attribute-set name="sthead.stentry__keycol-content" use-attribute-sets="common.table.body.entry common.table.head.entry">
-    <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="strow.stentry__content" use-attribute-sets="common.table.body.entry">
   </xsl:attribute-set>
 
   <xsl:attribute-set name="strow.stentry__keycol-content" use-attribute-sets="common.table.body.entry common.table.head.entry">
-    <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="strow.stentry">


### PR DESCRIPTION
Currently, an `antiquewhite` background color is inconsistently applied to key column contents of `<simpletable>` and `<properties>`, but not in `<choicetable>`. 

Instead of filling the entire table cell, the background color is limited to the text content of the entry, leaving white artifacts in the cell padding as shown in the example below:

<img width="411" alt="simpletable-keycol-bg-issue" src="https://cloud.githubusercontent.com/assets/129995/15485732/42e10528-2141-11e6-9675-911cd106e003.png">

This PR removes the background color from `<simpletable>` and `<properties>` key columns to sync presentation with `<choicetable>` and align PDF output with HTML-based formats.
