### PR TITLE
Mark deprecated variables, tweak conref variable

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">الفصل <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">اختياري:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Раздзел <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Неабавазкова:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
@@ -155,14 +155,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -180,7 +180,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Глава <param ref-name="number"/></variable>
@@ -249,60 +249,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Избираем:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcionalno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Capítol <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Volitelné:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -153,14 +153,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -178,7 +178,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Kapitel <param ref-name="number"/></variable>
@@ -247,60 +247,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Valgfrit:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -170,14 +170,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Querverweis auf: </variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Inhaltsverweis auf: </variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Unbenannter Abschnitt.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Unbenannter Abschnitt.</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -195,7 +195,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Suchtitel</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Suchtitel</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Kapitel  <param ref-name="number"/></variable>
@@ -258,43 +258,43 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Inhalt</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Inhalt</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">Index</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">Index</variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Suche</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Suche</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Zurück</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Zurück</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Vorwärts</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Vorwärts</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Hauptseite</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Hauptseite</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Vorige Seite</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Vorige Seite</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Folgende Seite</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Folgende Seite</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">On-line-Hilfe</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">On-line-Hilfe</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Suche nach dem Schlüsselwort:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Suche nach dem Schlüsselwort:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">Sehen Sie</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">Sehen Sie</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Suchhilfe für:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Suchhilfe für:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Suche</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Suche</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Κεϕάλαιο <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Προαιρετικά:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -177,14 +177,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -202,7 +202,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Chapter <param ref-name="number"/></variable>
@@ -273,60 +273,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Contents</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Contents</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">Index</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">Index</variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Search</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Search</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Back</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Back</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Forward</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Forward</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Home</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Home</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Previous Topic</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Previous Topic</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Next Topic</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Next Topic</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">Online Help</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">Online Help</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Search for the keyword:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Search for the keyword:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">View</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">View</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Search help for:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Search help for:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Search</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Search</variable>
 
-  <variable id="Online Help Search Method Field">Search method</variable>
-  <variable id="Online Help Search Method Or">or</variable>
-  <variable id="Online Help Search Method And">and</variable>
-  <variable id="Search Highlight Switch">Highlight text in search results</variable>
-  <variable id="Search index next button title">Show Next</variable>
-  <variable id="Search Whole Words Switch">Find whole words only</variable>
-  <variable id="Search Case Sensitive Switch">Match case</variable>
-  <variable id="Search Stopped Message">The search was stopped after 50 hits.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field">Search method</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or">or</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And">and</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch">Highlight text in search results</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title">Show Next</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch">Find whole words only</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch">Match case</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message">The search was stopped after 50 hits.</variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message">"The following words were excluded from the search: "+<param ref-name="stop-words-list"/></variable>
-  <variable id="Search Search in Progress Message">Search in progress...</variable>
-  <variable id="Search Search Give No Results Message">No matches were found.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message">"The following words were excluded from the search: "+<param ref-name="stop-words-list"/></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message">Search in progress...</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message">No matches were found.</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -170,14 +170,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Referencia cruzada a: </variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Referencia de contenido a: </variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Sección sin título.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Sección sin título.</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -195,7 +195,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Buscar título</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Buscar título</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
@@ -258,43 +258,43 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Contenido</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Contenido</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">Índice</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">Índice</variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Búsqueda</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Búsqueda</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Detrás</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Detrás</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Adelante</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Adelante</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Página Principal</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Página Principal</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Página Anterior</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Página Anterior</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Página Siguiente</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Página Siguiente</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">Ayuda En línea</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">Ayuda En línea</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Búsqueda para la palabra clave:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Búsqueda para la palabra clave:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">Visión</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">Visión</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Ayuda de la búsqueda para:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Ayuda de la búsqueda para:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Búsqueda</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Búsqueda</variable>
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Peatükk <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Mittenõutav:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -51,7 +51,7 @@
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -79,7 +79,7 @@
 
   <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>
   
-  <variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Valinnainen:</variable>
   <variable id="Required Step">Pakollinen:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -170,14 +170,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Référence croisée vers :</variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Référence de contenu vers :</variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Section sans titre.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Section sans titre.</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -195,7 +195,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Titre de recherche</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Titre de recherche</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Chapitre <param ref-name="number"/></variable>
@@ -258,43 +258,43 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Sommaire</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Sommaire</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">Index</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">Index</variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Recherche</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Recherche</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Retournez</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Retournez</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Allez En avant</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Allez En avant</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Page Principale</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Page Principale</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Page Précédente</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Page Précédente</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Prochaine Page</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Prochaine Page</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">Aide En ligne</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">Aide En ligne</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Recherche du mot-clé :</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Recherche du mot-clé :</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">Regardez</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">Regardez</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Aide de recherche pour :</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Aide de recherche pour :</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Recherche</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Recherche</variable>
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Facultatif :</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -51,7 +51,7 @@
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -79,7 +79,7 @@
 
   <variable id="Related references">תיעוד קשור</variable>
   
-  <variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">אופציונלי:</variable>
   <variable id="Required Step">דרוש:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">अध्याय <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!--    Label for a step with importance="optional"-->
     <variable id="Optional Step">वैकल्पिक:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcijsko:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number"><param ref-name="number"/>. fejezet</variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Választható:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opsional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number"><param ref-name="number"/>. kafli</variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Valfrjáls:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -170,14 +170,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Riferimento incrociato a: </variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Riferimento di contenuto a: </variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Sezione senza titolo.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Sezione senza titolo.</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -195,7 +195,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Titolo di ricerca</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Titolo di ricerca</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Capitolo <param ref-name="number"/></variable>
@@ -258,43 +258,43 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Sommario</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Sommario</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">Indice</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">Indice</variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Ricerca</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Ricerca</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Indietro</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Indietro</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Avanti</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Avanti</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Pagina Principale</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Pagina Principale</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Pagina Precedente</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Pagina Precedente</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Pagina Seguente</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Pagina Seguente</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">Aiuto In linea</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">Aiuto In linea</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Ricerca della parola chiave:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Ricerca della parola chiave:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">Osservi</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">Osservi</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Aiuto di ricerca per:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Aiuto di ricerca per:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Ricerca</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Ricerca</variable>
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opzionale:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -177,14 +177,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">相互参照 : </variable>
 
-    <!-- Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">コンテンツ参照 : </variable>
 
     <!-- Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">無題のセクション</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">無題のセクション</variable>
 
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -202,7 +202,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">検索タイトル</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">検索タイトル</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
@@ -271,60 +271,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">目次</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">目次</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">索引</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">索引</variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">、 </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">、 </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">検索</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">検索</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">戻る</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">戻る</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">進む</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">進む</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">ホーム</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">ホーム</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">前のトピック</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">前のトピック</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">次のトピック</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">次のトピック</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">オンライン ヘルプ</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">オンライン ヘルプ</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">次のキーワードを検索します:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">次のキーワードを検索します:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">表示</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">表示</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">ヘルプで次の文字列を検索します:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">ヘルプで次の文字列を検索します:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">検索</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">検索</variable>
 
-  <variable id="Online Help Search Method Field">検索方法</variable>
-  <variable id="Online Help Search Method Or">または</variable>
-  <variable id="Online Help Search Method And">および</variable>
-  <variable id="Search Highlight Switch">検索結果でテキストを強調表示する</variable>
-  <variable id="Search index next button title">次を表示</variable>
-  <variable id="Search Whole Words Switch">単語単位で探す</variable>
-  <variable id="Search Case Sensitive Switch">大文字と小文字を区別する</variable>
-  <variable id="Search Stopped Message">50 件ヒットしたので、検索は停止しました。</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field">検索方法</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or">または</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And">および</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch">検索結果でテキストを強調表示する</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title">次を表示</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch">単語単位で探す</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch">大文字と小文字を区別する</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message">50 件ヒットしたので、検索は停止しました。</variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message">"次の単語は検索から除外されました: "+<param ref-name="stop-words-list"/></variable>
-  <variable id="Search Search in Progress Message">検索中...</variable>
-  <variable id="Search Search Give No Results Message">一致は見つかりませんでした。</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message">"次の単語は検索から除外されました: "+<param ref-name="stop-words-list"/></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message">検索中...</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message">一致は見つかりませんでした。</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">オプション:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Бөлім <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Қосымша:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">제 <param ref-name="number"/> 장 </variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">옵션:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Skyrius <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Nebūtina:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Nodaļa <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Neobligāts:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Поглавје <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Изборен:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opsyenal:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -50,11 +50,11 @@
   <variable id="Related Links">Verwante onderwerpen</variable>
   <variable id="Cross-Reference">Verwijzing naar:</variable>
   <variable id="Content-Reference">Verwijzing naar:</variable>
-  <variable id="Untitled section">Naamloze sectie.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section">Naamloze sectie.</variable>
   <variable id="List item">Lijst onderdeel.</variable>
   <variable id="Foot note">Voetnoot.</variable>
   <variable id="Navigation title">Navigatietitel</variable>
-  <variable id="Search title">Zoektitel</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search title">Zoektitel</variable>
   <variable id="Chapter with number">Hoofdstuk <param ref-name="number"/></variable>
   <variable id="Appendix with number">Appendix <param ref-name="number"/></variable>
   <variable id="Part with number">Deel <param ref-name="number"/></variable>
@@ -79,31 +79,31 @@
 
   <variable id="Related references">Verwante verwijzingen</variable>
   
-  <variable id="Contents button title">Inhoud</variable>
-  <variable id="Index button title">Index</variable>
-  <variable id="Index multiple entries separator">, </variable>
-  <variable id="Search button title">Zoek</variable>
-  <variable id="Back button title">Terug</variable>
-  <variable id="Forward button title">Vooruit</variable>
-  <variable id="Main page button title">Hoofdpagina</variable>
-  <variable id="Previous page button title">Vorig onderwerp</variable>
-  <variable id="Next page button title">Volgend onderwerp</variable>
-  <variable id="Online help prefix">Online Help</variable>
-  <variable id="Search index field title">Zoek op het trefwoord:</variable>
-  <variable id="Search index button title">Zie</variable>
-  <variable id="Search text field title">Zoek help voor:</variable>
-  <variable id="Search text button title">Zoek</variable>
-  <variable id="Online Help Search Method Field">Zoek methode</variable>
-  <variable id="Online Help Search Method Or">of</variable>
-  <variable id="Online Help Search Method And">en</variable>
-  <variable id="Search Highlight Switch">Markeer tekst in zoekresultaten</variable>
-  <variable id="Search index next button title">Toon volgende</variable>
-  <variable id="Search Whole Words Switch">Zoek alleen hele woorden</variable>
-  <variable id="Search Case Sensitive Switch">Hoofdlettergevoelig</variable>
-  <variable id="Search Stopped Message">De zoekactie is gestopt na 50 treffers.</variable>
-  <variable id="Search Excluded Stop Words Message">"De volgende woorden worden uitgesloten van de zoekactie: "+<param ref-name="stop-words-list"/></variable>
-  <variable id="Search Search in Progress Message">De zoekactie loopt...</variable>
-  <variable id="Search Search Give No Results Message">Geen treffers gevonden.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Contents button title">Inhoud</variable>
+  <!-- Deprecated since 2.3 --><variable id="Index button title">Index</variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Search button title">Zoek</variable>
+  <!-- Deprecated since 2.3 --><variable id="Back button title">Terug</variable>
+  <!-- Deprecated since 2.3 --><variable id="Forward button title">Vooruit</variable>
+  <!-- Deprecated since 2.3 --><variable id="Main page button title">Hoofdpagina</variable>
+  <!-- Deprecated since 2.3 --><variable id="Previous page button title">Vorig onderwerp</variable>
+  <!-- Deprecated since 2.3 --><variable id="Next page button title">Volgend onderwerp</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online help prefix">Online Help</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index field title">Zoek op het trefwoord:</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index button title">Zie</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search text field title">Zoek help voor:</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search text button title">Zoek</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field">Zoek methode</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or">of</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And">en</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch">Markeer tekst in zoekresultaten</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title">Toon volgende</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch">Zoek alleen hele woorden</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch">Hoofdlettergevoelig</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message">De zoekactie is gestopt na 50 treffers.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message">"De volgende woorden worden uitgesloten van de zoekactie: "+<param ref-name="stop-words-list"/></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message">De zoekactie loopt...</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message">Geen treffers gevonden.</variable>
   <variable id="Optional Step">Optioneel:</variable>
   <variable id="Required Step">Vereist:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Kapittel <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Valgfritt:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Rozdział <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcjonalne:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -51,7 +51,7 @@
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -79,7 +79,7 @@
 
   <variable id="Related references">Referinţe înrudite</variable>
   
-  <variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Opţional:</variable>
   <variable id="Required Step">Necesar:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -51,7 +51,7 @@
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -79,7 +79,7 @@
 
   <variable id="Related references">Ссылки, связанные с данной</variable>
   
-  <variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Необязательно:</variable>
   <variable id="Required Step">Обязательно:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Voliteľný:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -51,11 +51,11 @@ See the accompanying license.txt file for applicable licenses.
   <variable id="Related Links">Sorodne povezave</variable>
   <variable id="Cross-Reference">Križni sklic na:</variable>
   <variable id="Content-Reference">Navzkrižni sklic na:</variable>
-  <variable id="Untitled section">Neimenovan odsek.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section">Neimenovan odsek.</variable>
   <variable id="List item">Točka seznama.</variable>
   <variable id="Foot note">Opomba v nogi.</variable>
   <variable id="Navigation title">Poimenovanje krmarjenja</variable>
-  <variable id="Search title">Poimenovanje iskanja</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search title">Poimenovanje iskanja</variable>
   <variable id="Chapter with number">Poglavje <param ref-name="number"/></variable>
   <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
   <variable id="Part with number">Del <param ref-name="number"/></variable>
@@ -80,31 +80,31 @@ See the accompanying license.txt file for applicable licenses.
 
   <variable id="Related references">Sorodne reference</variable>
   
-  <variable id="Contents button title">Vsebine</variable>
-  <variable id="Index button title">Kazalo</variable>
-  <variable id="Index multiple entries separator">, </variable>
-  <variable id="Search button title">Iskanje</variable>
-  <variable id="Back button title">Nazaj</variable>
-  <variable id="Forward button title">Naprej</variable>
-  <variable id="Main page button title">Domov</variable>
-  <variable id="Previous page button title">Predhodnji</variable>
-  <variable id="Next page button title">Naslednji</variable>
-  <variable id="Online help prefix">Sprotna pomoč</variable>
-  <variable id="Search index field title">Išči ključno besedo:</variable>
-  <variable id="Search index button title">Poglej</variable>
-  <variable id="Search text field title">Iskanje pomoči za:</variable>
-  <variable id="Search text button title">Išči</variable>
-  <variable id="Online Help Search Method Field">Način iskanja</variable>
-  <variable id="Online Help Search Method Or">ali</variable>
-  <variable id="Online Help Search Method And">in</variable>
-  <variable id="Search Highlight Switch">Poudari besedilo v rezultatih iskanja</variable>
-  <variable id="Search index next button title">Prikaži naslednjo</variable>
-  <variable id="Search Whole Words Switch">Najdi samo cele besede</variable>
-  <variable id="Search Case Sensitive Switch">Ujemanje velikosti</variable>
-  <variable id="Search Stopped Message">Iskanje je bilo ustavljeno po 50 zadetkih.</variable>
-  <variable id="Search Excluded Stop Words Message">"Naslednje besede so izključene iz iskanja: "+<param ref-name="stop-words-list"/></variable>
-  <variable id="Search Search in Progress Message">Iskanje v teku...</variable>
-  <variable id="Search Search Give No Results Message">Ni ujemanj.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Contents button title">Vsebine</variable>
+  <!-- Deprecated since 2.3 --><variable id="Index button title">Kazalo</variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Search button title">Iskanje</variable>
+  <!-- Deprecated since 2.3 --><variable id="Back button title">Nazaj</variable>
+  <!-- Deprecated since 2.3 --><variable id="Forward button title">Naprej</variable>
+  <!-- Deprecated since 2.3 --><variable id="Main page button title">Domov</variable>
+  <!-- Deprecated since 2.3 --><variable id="Previous page button title">Predhodnji</variable>
+  <!-- Deprecated since 2.3 --><variable id="Next page button title">Naslednji</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online help prefix">Sprotna pomoč</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index field title">Išči ključno besedo:</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index button title">Poglej</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search text field title">Iskanje pomoči za:</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search text button title">Išči</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field">Način iskanja</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or">ali</variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And">in</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch">Poudari besedilo v rezultatih iskanja</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title">Prikaži naslednjo</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch">Najdi samo cele besede</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch">Ujemanje velikosti</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message">Iskanje je bilo ustavljeno po 50 zadetkih.</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message">"Naslednje besede so izključene iz iskanja: "+<param ref-name="stop-words-list"/></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message">Iskanje v teku...</variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message">Ni ujemanj.</variable>
   <variable id="Optional Step">Izbiren:</variable>
   <variable id="Required Step">Zahtevano:</variable>
   <!-- Prereq was "Predzahteva", changing to common string, currently "Preden začnete" -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcionalno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Neobavezno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Поглавље <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Необавезно:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -51,7 +51,7 @@
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
+  <!-- Deprecated since 2.3 --><variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -79,7 +79,7 @@
 
   <variable id="Related references">Närliggande referens</variable>
   
-  <variable id="Index multiple entries separator">, </variable>
+  <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Valfritt:</variable>
   <variable id="Required Step">Krävs:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">บทที่ <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">ทางเลือก:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Bölüm <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">İsteğe bağlı:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Розділ <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">За бажанням:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">باب <param ref-name="number"/></variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">اختیاری:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -153,14 +153,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -178,7 +178,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">Chương <param ref-name="number"/></variable>
@@ -247,60 +247,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Tùy chọn:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -173,14 +173,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -198,7 +198,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
@@ -261,43 +261,43 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title">Contents</variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title">Contents</variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title">索引</variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title">索引</variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title">Search</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title">Search</variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title">Back</variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title">Back</variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title">Forward</variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title">Forward</variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title">Main Page</variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title">Main Page</variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title">Previous Page</variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title">Previous Page</variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title">Next Page</variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title">Next Page</variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix">Online Help</variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix">Online Help</variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title">Search for the keyword:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title">Search for the keyword:</variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title">View</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title">View</variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title">Search help for:</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title">Search help for:</variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title">Search</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title">Search</variable>
     
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">可选：</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
@@ -154,14 +154,14 @@ See the accompanying license.txt file for applicable licenses.
          text in case it's not specified in source. -->
     <variable id="Cross-Reference">Cross-Reference to:</variable>
 
-    <!-- UNUSED: Default content-reference text prefix. Used to generate reference 
+    <!-- Prefix for unresolved content reference. Used to generate reference 
          text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Content-Reference to:</variable>
+    <variable id="Content-Reference">Unresolved content reference to:</variable>
 
     <!-- UNUSED: Default title text for referenced section title. Used to generate 
          reference text in case reference has no explicit content and
          referenced section has no title. -->
-    <variable id="Untitled section">Untitled section.</variable>
+    <!-- Deprecated since 2.3 --><variable id="Untitled section">Untitled section.</variable>
 
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
@@ -179,7 +179,7 @@ See the accompanying license.txt file for applicable licenses.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
+    <!-- Deprecated since 2.3 --><variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
     <variable id="Chapter with number">第 <param ref-name="number"/> 章 </variable>
@@ -248,60 +248,60 @@ See the accompanying license.txt file for applicable licenses.
     -->
 
     <!-- The title of the "contents" button in online-help output -->
-    <variable id="Contents button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Contents button title"></variable>
 
     <!-- The title of the "index" button in online-help output -->
-    <variable id="Index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Index button title"></variable>
 
     <!-- The separator of multiple index entries in online-help output -->
-    <variable id="Index multiple entries separator">, </variable>
+    <!-- Deprecated since 2.3 --><variable id="Index multiple entries separator">, </variable>
 
     <!-- The title of the "search" button in online-help output -->
-    <variable id="Search button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search button title"></variable>
 
     <!-- The title of the "back" button in online-help output -->
-    <variable id="Back button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Back button title"></variable>
 
     <!-- The title of the "forward" button in online-help output -->
-    <variable id="Forward button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Forward button title"></variable>
 
     <!-- The title of the "main page" button in online-help output -->
-    <variable id="Main page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Main page button title"></variable>
 
     <!-- The title of the "previous page" button in online-help output -->
-    <variable id="Previous page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Previous page button title"></variable>
 
     <!-- The title of the "next page" button in online-help output -->
-    <variable id="Next page button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Next page button title"></variable>
 
     <!-- The "online help" document title prefix in online-help output -->
-    <variable id="Online help prefix"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Online help prefix"></variable>
 
     <!-- The search by index field title in online-help output -->
-    <variable id="Search index field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index field title"></variable>
 
     <!-- The search by index button title in online-help output -->
-    <variable id="Search index button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search index button title"></variable>
 
     <!-- The search by text field title in online-help output -->
-    <variable id="Search text field title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text field title"></variable>
 
     <!-- The search by text button title in online-help output -->
-    <variable id="Search text button title"></variable>
+    <!-- Deprecated since 2.3 --><variable id="Search text button title"></variable>
 
-  <variable id="Online Help Search Method Field"></variable>
-  <variable id="Online Help Search Method Or"></variable>
-  <variable id="Online Help Search Method And"></variable>
-  <variable id="Search Highlight Switch"></variable>
-  <variable id="Search index next button title"></variable>
-  <variable id="Search Whole Words Switch"></variable>
-  <variable id="Search Case Sensitive Switch"></variable>
-  <variable id="Search Stopped Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Field"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method Or"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Online Help Search Method And"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Highlight Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search index next button title"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Whole Words Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Case Sensitive Switch"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Stopped Message"></variable>
   <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
   and quotes to the string expressions.-->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <variable id="Search Search in Progress Message"></variable>
-  <variable id="Search Search Give No Results Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Excluded Stop Words Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search in Progress Message"></variable>
+  <!-- Deprecated since 2.3 --><variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">選擇性的:</variable>


### PR DESCRIPTION
This pull request covers related updates to the PDF variable files:

- [x] Update the "Content-reference" variable. I thought this was unused (and marked it as unused in new variable files). In fact, it is used when `@conref` did not resolve. I tweaked the comment to clarify the purpose, and changed the text from "Content-reference to" to the more accurate "Unresolved content reference to"
- [x] Mark the "Untitled section" variable as deprecated. This is not used in our code, is untranslated for almost every language, and I cannot see a case where we generate that in a default process.
- [x] Mark all of the online help variables as deprecated. I'm guessing (but cannot verify) that these were used by Suite-sol code unrelated to PDF, and that they stored them with PDF strings for convenience. As with the previous, these are untranslated for almost every language and never used by any DITA-OT code.

For the deprecated strings, my goal is to mark them deprecated in 2.3 so that we can easily remove them in 3.0.