### PR TITLE
PDF: Change table head background to neutral gray

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -135,7 +135,7 @@ See the accompanying license.txt file for applicable licenses.
 
   <xsl:attribute-set name="thead.row.entry">
     <!--head cell-->
-    <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
+    <xsl:attribute name="background-color">#f0f0f0</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="thead.row.entry__content" use-attribute-sets="common.table.body.entry common.table.head.entry">


### PR DESCRIPTION
This replaces the last vestige of "antiquewhite" with the 6% gray shade "#f0f0f0" that is used for codeblock & screen backgrounds.

See #2382.