### PR TITLE
PDF: Remove background color from table heads

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -135,7 +135,6 @@ See the accompanying license.txt file for applicable licenses.
 
   <xsl:attribute-set name="thead.row.entry">
     <!--head cell-->
-    <xsl:attribute name="background-color">antiquewhite</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="thead.row.entry__content" use-attribute-sets="common.table.body.entry common.table.head.entry">


### PR DESCRIPTION
Sync default presentation with HTML-based output and `<simpletable>` per comments in #2384.

Closes #2384.