### PR TITLE
Add support for table @orient attribute #1777

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -72,6 +72,10 @@ See the accompanying license.txt file for applicable licenses.
   <xsl:attribute-set name="__tableframe__right" use-attribute-sets="common.border__right">
   </xsl:attribute-set>
 
+  <xsl:attribute-set name="table__container">
+    <xsl:attribute name="reference-orientation" select="if (@orient eq 'land') then 90 else 0"/>
+  </xsl:attribute-set>
+
   <xsl:attribute-set name="table" use-attribute-sets="base-font">
     <!--It is a table container -->
     <xsl:attribute name="space-after">10pt</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -249,20 +249,22 @@
             <xsl:call-template name="getTableScale"/>
         </xsl:variable>
 
-        <fo:block xsl:use-attribute-sets="table">
-            <xsl:call-template name="commonattributes"/>
-            <xsl:if test="not(@id)">
-              <xsl:attribute name="id">
-                <xsl:call-template name="get-id"/>
-              </xsl:attribute>
-            </xsl:if>
-            <xsl:if test="exists($scale)">
-                <xsl:attribute name="font-size" select="concat($scale, '%')"/>
-            </xsl:if>
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
-            <xsl:apply-templates/>
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
-        </fo:block>
+        <fo:block-container xsl:use-attribute-sets="table__container">
+            <fo:block xsl:use-attribute-sets="table">
+                <xsl:call-template name="commonattributes"/>
+                <xsl:if test="not(@id)">
+                  <xsl:attribute name="id">
+                    <xsl:call-template name="get-id"/>
+                  </xsl:attribute>
+                </xsl:if>
+                <xsl:if test="exists($scale)">
+                    <xsl:attribute name="font-size" select="concat($scale, '%')"/>
+                </xsl:if>
+                <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+                <xsl:apply-templates/>
+                <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+            </fo:block>
+        </fo:block-container>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]">


### PR DESCRIPTION
[Test files](https://github.com/eerohele/dita-ot-issues/tree/master/fixtures/1777).

Sample output:

- [Antenna House](https://github.com/dita-ot/dita-ot/files/279806/root_ah.pdf)
- [FOP](https://github.com/dita-ot/dita-ot/files/279807/root_fop.pdf)

This is the smallest change that implements support for `@orient` per spec, so far as I can tell. Anything missing?

(Note to any potential users of this feature: Antenna House supports multi-page landscape tables — FOP doesn't.)