### PR TITLE
Fix error when <linktext> contains <tm> #2303

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -179,7 +179,9 @@
                                               [generate-id(.) = generate-id(key('hideduplicates', related-links:hideduplicates(.))[1])]"/>
        </xsl:apply-templates>
       </xsl:variable>
-      <xsl:apply-templates select="$unordered-links"/>
+      <xsl:apply-templates select="$unordered-links">
+        <xsl:with-param name="root" select="root()" as="document-node()" tunnel="yes"/>
+      </xsl:apply-templates>
       <!--linklists - last but not least, create all the linklists and their links, with no sorting or re-ordering-->
       <xsl:apply-templates select="*[contains(@class, ' topic/linklist ')]"/>
     </nav>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -898,6 +898,7 @@
   <!-- process the TM tag -->
   <!-- removed priority 1 : should not be needed -->
   <xsl:template match="*[contains(@class, ' topic/tm ')]" name="topic.tm">
+    <xsl:param name="root" select="root()" as="document-node()" tunnel="yes"/>
   
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:apply-templates/> <!-- output the TM content -->
@@ -917,7 +918,7 @@
           <xsl:if test="ancestor::*[contains(@class, ' topic/title ')]/parent::*[contains(@class, ' topic/topic ')]">
             <xsl:choose>
               <!-- Not the first one in a title -->
-              <xsl:when test="generate-id(.) != generate-id(key('tm', .)[1])">skip</xsl:when>
+              <xsl:when test="generate-id(.) != generate-id($root/key('tm', .)[1])">skip</xsl:when>
               <!-- First one in the topic, BUT it appears in a shortdesc or body -->
               <xsl:when test="//*[contains(@class, ' topic/shortdesc ') or contains(@class, ' topic/body ')]//*[contains(@class, ' topic/tm ')][@trademark = $tmvalue]">skip</xsl:when>
               <xsl:otherwise>use</xsl:otherwise>
@@ -932,7 +933,7 @@
             <!-- If in a title or prolog, skip -->
             <xsl:when test="ancestor::*[contains(@class, ' topic/title ') or contains(@class, ' topic/prolog ')]/parent::*[contains(@class, ' topic/topic ')]">skip</xsl:when>
             <!-- If first in the document, use it -->
-            <xsl:when test="generate-id(.) = generate-id(key('tm', .)[1])">use</xsl:when>
+            <xsl:when test="generate-id(.) = generate-id($root/key('tm', .)[1])">use</xsl:when>
             <!-- If there is another before this that is in the body or shortdesc, skip -->
             <xsl:when test="preceding::*[contains(@class, ' topic/tm ')][@trademark = $tmvalue][ancestor::*[contains(@class, ' topic/body ') or contains(@class, ' topic/shortdesc ')]]">skip</xsl:when>
             <!-- Otherwise, any before this must be in a title or ignored section -->


### PR DESCRIPTION
Regression introduced in ad0e1d8. An intermediate tree is assigned to the `$unordered-links` variable, which is then applied. The root node of an intermediate tree is not a document node, which causes any calls to the `key()` function to fail.

The solution is to pass the original root node as a tunnel parameter and use that as the context node for any calls to `key()`.