### PR TITLE
Add support for configuring tm scope in PDF #1245

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -96,9 +96,7 @@ See the accompanying license.txt file for applicable licenses.
         <xsl:attribute name="baseline-shift">20%</xsl:attribute>
     </xsl:attribute-set>
 
-    <xsl:attribute-set name="tm__content__service">
-        <xsl:attribute name="font-size">40%</xsl:attribute>
-        <xsl:attribute name="baseline-shift">50%</xsl:attribute>
+    <xsl:attribute-set name="tm__content__service" use-attribute-sets="tm__content">
     </xsl:attribute-set>
 
     <xsl:attribute-set name="author">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -819,9 +819,6 @@ See the accompanying license.txt file for applicable licenses.
                 <xsl:when test="@tmtype='reg'">
                     <fo:inline xsl:use-attribute-sets="tm__content">&#174;</fo:inline>
                 </xsl:when>
-                <xsl:otherwise>
-                    <fo:inline xsl:use-attribute-sets="tm__content"><xsl:text>Error in tm type.</xsl:text></fo:inline>
-                </xsl:otherwise>
             </xsl:choose>
         </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -803,11 +803,15 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tm ')]">
+      <xsl:variable name="generate-symbol" as="xs:boolean">
+        <xsl:apply-templates select="." mode="tm-scope"/>
+      </xsl:variable>
         <fo:inline xsl:use-attribute-sets="tm">
             <xsl:apply-templates/>
             <xsl:choose>
+              <xsl:when test="not($generate-symbol)"/>
                 <xsl:when test="@tmtype='service'">
-                    <fo:inline xsl:use-attribute-sets="tm__content__service">SM</fo:inline>
+                  <fo:inline xsl:use-attribute-sets="tm__content__service">&#8480;</fo:inline>
                 </xsl:when>
                 <xsl:when test="@tmtype='tm'">
                     <fo:inline xsl:use-attribute-sets="tm__content">&#8482;</fo:inline>
@@ -822,6 +826,10 @@ See the accompanying license.txt file for applicable licenses.
         </fo:inline>
     </xsl:template>
 
+  <xsl:template match="node() | @*" mode="tm-scope" as="xs:boolean" priority="-10">
+    <xsl:sequence select="true()"/>
+  </xsl:template>  
+  
   <xsl:template match="*[contains(@class,' topic/term ')]" name="topic.term">
     <xsl:param name="keys" select="@keyref" as="attribute()?"/>
     <xsl:param name="contents" as="node()*">


### PR DESCRIPTION
Add mode to control whether trademark symbol is created.

Uses "℠" Unicode character instead of "SM".