### PR TITLE
Fix numbering for unknown front matter topics

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -705,16 +705,17 @@ See the accompanying license.txt file for applicable licenses.
   <xsl:attribute-set name="page-sequence.cover" use-attribute-sets="__force__page__count">
   </xsl:attribute-set>
 
-  <xsl:attribute-set name="page-sequence.notice" use-attribute-sets="__force__page__count">
+  <xsl:attribute-set name="page-sequence.frontmatter">
     <xsl:attribute name="format">i</xsl:attribute>
   </xsl:attribute-set>
   
-  <xsl:attribute-set name="page-sequence.preface" use-attribute-sets="__force__page__count">
-    <xsl:attribute name="format">i</xsl:attribute>  
+  <xsl:attribute-set name="page-sequence.notice" use-attribute-sets="__force__page__count page-sequence.frontmatter">
   </xsl:attribute-set>
   
-  <xsl:attribute-set name="page-sequence.toc" use-attribute-sets="__force__page__count">
-    <xsl:attribute name="format">i</xsl:attribute>
+  <xsl:attribute-set name="page-sequence.preface" use-attribute-sets="__force__page__count page-sequence.frontmatter">
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="page-sequence.toc" use-attribute-sets="__force__page__count page-sequence.frontmatter">
   </xsl:attribute-set>
 
   <xsl:attribute-set name="page-sequence.lot" use-attribute-sets="page-sequence.toc">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -176,6 +176,9 @@ See the accompanying license.txt file for applicable licenses.
             <xsl:when test="$topicType = 'topicIndexList'">
               <xsl:call-template name="processIndexList"/>
             </xsl:when>
+            <xsl:when test="$topicType = 'topicFrontMatter'">
+              <xsl:call-template name="processFrontMatterTopic"/>
+            </xsl:when>
             <xsl:when test="$topicType = 'topicSimple'">
               <xsl:call-template name="processTopicSimple"/>
             </xsl:when>
@@ -502,6 +505,36 @@ See the accompanying license.txt file for applicable licenses.
         </fo:page-sequence>
    </xsl:template>
 
+
+    <xsl:template name="processFrontMatterTopic">
+        <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.frontmatter">
+             <!-- Ideally would use existing template "insertFrontMatterStaticContents". Using "insertBodyStaticContents"
+                  for compatibility with 2.3 and earlier; front matter version drops headers, page numbers. -->
+             <xsl:call-template name="insertBodyStaticContents"/>
+             <fo:flow flow-name="xsl-region-body">
+                 <fo:block xsl:use-attribute-sets="topic">
+                     <xsl:call-template name="commonattributes"/>
+                     <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
+                         <fo:marker marker-class-name="current-topic-number">
+                             <xsl:number format="1"/>
+                         </fo:marker>
+                         <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+                     </xsl:if>
+                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+                     <fo:block xsl:use-attribute-sets="topic.title">
+                         <xsl:attribute name="id">
+                             <xsl:call-template name="generate-toc-id"/>
+                         </xsl:attribute>
+                         <xsl:call-template name="pullPrologIndexTerms"/>
+                         <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
+                             <xsl:apply-templates select="." mode="getTitle"/>
+                         </xsl:for-each>
+                     </fo:block>
+                     <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
+                 </fo:block>
+             </fo:flow>
+         </fo:page-sequence>
+   </xsl:template>
 
     <xsl:template name="insertChapterFirstpageStaticContent">
         <xsl:param name="type" as="xs:string"/>
@@ -2176,6 +2209,14 @@ See the accompanying license.txt file for applicable licenses.
     </xsl:template>
     <xsl:template match="*[contains(@class, ' bookmap/notices ')]" mode="determineTopicType">
         <xsl:text>topicNotices</xsl:text>
+    </xsl:template>
+    <xsl:template match="*[contains(@class,' bookmap/frontmatter ')]/* |
+                         *[contains(@class,' bookmap/booklists ')]/*" mode="determineTopicType" priority="10">
+      <!-- Catch topics in front matter that do not have another match.
+           Changing priorities for the default rule or (e.g) preface can break customizations;
+           the high priority + variable fallback will support old and new without breaking customizations. --> 
+      <xsl:variable name="fallback" as="xs:string"><xsl:next-match/></xsl:variable>
+      <xsl:value-of select="if ($fallback = 'topicSimple') then 'topicFrontMatter' else $fallback"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/data ')]"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -27,7 +27,7 @@ These terms and conditions supersede the terms and conditions in any
 licensing agreement to the extent that such terms and conditions conflict
 with those set forth herein.
 
-This file is part of the DITA Open Toolkit project hosted on Sourceforge.net. 
+This file is part of the DITA Open Toolkit. 
 See the accompanying license.txt file for applicable licenses.
 -->
 
@@ -265,9 +265,21 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:apply-templates select="*" mode="generatePageSequences"/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="generatePageSequences" priority="0">
-    <xsl:for-each select="key('topic-id', @id)">
-      <xsl:call-template name="processTopicSimple"/>
-    </xsl:for-each>
+    <xsl:choose>
+      <xsl:when test="ancestor::*[contains(@class,' bookmap/frontmatter ')]">
+        <!-- TODO: To fit the pattern, this should be in its own match template. But a general match for frontmatter/*
+             conflicts with priority of existing rules (e.g., preface); changing priorities would
+             break customizations. --> 
+        <xsl:for-each select="key('topic-id', @id)">
+          <xsl:call-template name="processFrontMatterTopic"/>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="key('topic-id', @id)">
+          <xsl:call-template name="processTopicSimple"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/frontmatter ') or
                          contains(@class, ' bookmap/backmatter ') or


### PR DESCRIPTION
Bookmap defines a lot of sections that can appear in the front matter, such as `<toc>`, `<preface>`, and `<draftintro>`. Our code has special handling for many of them which results in roman numerals as the default style for page numbering. Many of the sections do not have special handling, which means they are treated as unknown generic topics, and use Arabic numerals. The result is default front matter processing that in my test switches from Roman (TOC, figlist, tablelist), to Arabic (generic booklist), to Roman (Preface), to Arabic (abstract, dedication, draft-intro), to Roman (Notices), to Arabic (generic topicref in the front matter).

This pull request makes the default page numbering consistent (Roman numerals) across the front matter.

My front matter is:
```xml
<frontmatter id="frontm">
  <booklists>
    <toc/>
    <figurelist/>
    <tablelist/>
    <booklist href="frontmatterlist.dita"/>
  </booklists>
  <preface href="preface.dita">
    <topicref href="generic.dita" copy-to="subpreface.dita"/>
  </preface>
  <bookabstract href="abstract.dita"/>
  <dedication href="dedication.dita"/>
  <draftintro href="draftintro.dita">
    <topicref href="generic.dita" copy-to="subdraftintro.dita"/>
  </draftintro>
  <notices href="notices.dita">
    <topicref href="generic.dita" copy-to="subnotices.dita"/>
  </notices>
  <topicref href="frontmtopic.dita">
    <topicref href="generic.dita" copy-to="subfrontmtopic.dita"/>
  </topicref>
</frontmatter>
```

Full samples at https://github.com/robander/metadita/tree/master/sampledocs/bookmap or in the attached zip (`bookmap.ditamap`).
[bookmap.zip](https://github.com/dita-ot/dita-ot/files/300881/bookmap.zip)
