### PR TITLE
Replace named template with mode for easy override of static content

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -246,9 +246,9 @@ See the accompanying license.txt file for applicable licenses.
 
                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:call-template name="insertChapterFirstpageStaticContent">
+                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                         <xsl:with-param name="type" select="'chapter'"/>
-                    </xsl:call-template>
+                    </xsl:apply-templates>
 
                     <fo:block xsl:use-attribute-sets="topic.title">
                         <xsl:call-template name="pullPrologIndexTerms"/>
@@ -298,9 +298,9 @@ See the accompanying license.txt file for applicable licenses.
 
                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:call-template name="insertChapterFirstpageStaticContent">
+                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                         <xsl:with-param name="type" select="'appendix'"/>
-                    </xsl:call-template>
+                    </xsl:apply-templates>
 
                     <fo:block xsl:use-attribute-sets="topic.title">
                         <xsl:call-template name="pullPrologIndexTerms"/>
@@ -347,9 +347,9 @@ See the accompanying license.txt file for applicable licenses.
           
           <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
           
-          <xsl:call-template name="insertChapterFirstpageStaticContent">
+          <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
             <xsl:with-param name="type" select="'appendices'"/>
-          </xsl:call-template>
+          </xsl:apply-templates>
           
           <fo:block xsl:use-attribute-sets="topic.title">
             <xsl:call-template name="pullPrologIndexTerms"/>
@@ -411,9 +411,9 @@ See the accompanying license.txt file for applicable licenses.
 
                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:call-template name="insertChapterFirstpageStaticContent">
+                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                         <xsl:with-param name="type" select="'part'"/>
-                    </xsl:call-template>
+                    </xsl:apply-templates>
 
                     <fo:block xsl:use-attribute-sets="topic.title">
                         <xsl:call-template name="pullPrologIndexTerms"/>
@@ -473,9 +473,9 @@ See the accompanying license.txt file for applicable licenses.
 
                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:call-template name="insertChapterFirstpageStaticContent">
+                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                         <xsl:with-param name="type" select="'notices'"/>
-                    </xsl:call-template>
+                    </xsl:apply-templates>
 
                     <fo:block xsl:use-attribute-sets="topic.title">
                         <xsl:call-template name="pullPrologIndexTerms"/>
@@ -503,7 +503,15 @@ See the accompanying license.txt file for applicable licenses.
    </xsl:template>
 
 
+    <!-- Deprecated in 3.0: use mode="insertChapterFirstpageStaticContent" -->
     <xsl:template name="insertChapterFirstpageStaticContent">
+      <xsl:param name="type" as="xs:string"/>
+      <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+        <xsl:with-param name="type" select="$type" as="xs:string"/>
+      </xsl:apply-templates>
+    </xsl:template>
+
+   <xsl:template match="*" mode="insertChapterFirstpageStaticContent">
         <xsl:param name="type" as="xs:string"/>
         <fo:block>
             <xsl:attribute name="id">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -27,7 +27,7 @@ These terms and conditions supersede the terms and conditions in any
 licensing agreement to the extent that such terms and conditions conflict
 with those set forth herein.
 
-This file is part of the DITA Open Toolkit project hosted on Sourceforge.net. 
+This file is part of the DITA Open Toolkit project. 
 See the accompanying license.txt file for applicable licenses.
 -->
 
@@ -50,9 +50,9 @@ See the accompanying license.txt file for applicable licenses.
                          <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
                      </xsl:if>
                      <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
-                     <xsl:call-template name="insertChapterFirstpageStaticContent">
+                     <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                          <xsl:with-param name="type" select="'preface'"/>
-                     </xsl:call-template>
+                     </xsl:apply-templates>
                      <fo:block xsl:use-attribute-sets="topic.title">
                          <xsl:call-template name="pullPrologIndexTerms"/>
                          <xsl:for-each select="child::*[contains(@class,' topic/title ')]">


### PR DESCRIPTION
I have a need to override static content generation for some types of topics - specifically, if referencing "Notices" or a "Preface" topic, when the referenced topic has its own title, I want to skip generating any default title. 

Currently, I have to override the entire `insertChapterFirstpageStaticContent` template, which contains a lot of processing for different conditions:
```xml
<xsl:template name="insertChapterFirstpageStaticContent">
  <fo:block>
    ...generate ID...
    if type=chapter, do a lot
    else if type=appendix, do a lot
    else if type=appendices, do a lot
    else if type=part, do a lot
    else if type=preface, create a title
    else if type=notices, create a title
  </fo:block>
</xsl:template>
```

Converting this to a mode template allows me to override the template, change the 2 simple conditions, and use `<xsl:next-match/>` to keep default processing for chapters / parts / appendices. In pseudocode:
```xml
<xsl:template match="*" mode="insertChapterFirstpageStaticContent">
  if (type="notices" or type="preface") and empty title, then
    just generate TOC id
  otherwise
    <xsl:next-match/>
</xsl:template>
```

After I typed this all out, I realized - an alternate way to do this would be to make each of the "if/then/else" templates into a new call to a mode template, allowing control of any individual `type` without affecting the others. I could add that as well, but I think either way it makes sense to convert this one to a mode.