### PR TITLE
Drop empty fo:inline elements

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -104,7 +104,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
         </fo:block>
     </xsl:template>
-
+ 
     <xsl:template name="startPageNumbering" as="attribute()*">
         <!--BS: uncomment if you need reset page numbering at first chapter-->
 <!--

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -247,9 +247,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/xref ')]" name="topic.xref">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
 
     <xsl:variable name="destination" select="opentopic-func:getDestinationId(@href)"/>
     <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]"/>
@@ -264,6 +261,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
 
     <fo:basic-link xsl:use-attribute-sets="xref">
+      <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="buildBasicLinkDestination">
         <xsl:with-param name="scope" select="@scope"/>
         <xsl:with-param name="format" select="@format"/>
@@ -309,7 +307,7 @@ See the accompanying LICENSE file for applicable license.
                       <xsl:with-param name="element" select="$element"/>
                   </xsl:call-template>
             </xsl:if>
-    </xsl:if>
+      </xsl:if>
 
     </xsl:template>
 
@@ -405,11 +403,9 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ul">
         <xsl:for-each select="$children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])]">
           <fo:list-item xsl:use-attribute-sets="related-links.ul.li">
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="related-links.ul.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ul.li__label__content">
-                <fo:inline>
-                  <xsl:call-template name="commonattributes"/>
-                </fo:inline>
                 <xsl:call-template name="getVariable">
                   <xsl:with-param name="id" select="'Unordered List bullet'"/>
                 </xsl:call-template>
@@ -436,11 +432,9 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ol">
         <xsl:for-each select="($children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])])">
           <fo:list-item xsl:use-attribute-sets="related-links.ol.li">
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="related-links.ol.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ol.li__label__content">
-                <fo:inline>
-                  <xsl:call-template name="commonattributes"/>
-                </fo:inline>
                 <xsl:call-template name="getVariable">
                   <xsl:with-param name="id" select="'Ordered List Number'"/>
                   <xsl:with-param name="params">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -64,12 +64,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ul ')]/*[contains(@class, ' topic/li ')]">
         <xsl:variable name="depth" select="count(ancestor::*[contains(@class, ' topic/ul ')])"/>
         <fo:list-item xsl:use-attribute-sets="ul.li">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ul.li__label">
                 <fo:block xsl:use-attribute-sets="ul.li__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="concat('Unordered List bullet ', $depth)"/>
                     </xsl:call-template>
@@ -91,12 +88,9 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="ol.li">
-          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="concat('Ordered List Number ', $depth)"/>
                         <xsl:with-param name="params" as="element()*">
@@ -135,12 +129,9 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/sl ')]/*[contains(@class, ' topic/sli ')]">
         <fo:list-item xsl:use-attribute-sets="sl.sli">
-          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="sl.sli__label">
                 <fo:block xsl:use-attribute-sets="sl.sli__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                 </fo:block>
             </fo:list-item-label>
             <fo:list-item-body xsl:use-attribute-sets="sl.sli__body">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -348,67 +348,12 @@ See the accompanying LICENSE file for applicable license.
         </fo:block>
     </xsl:template>
 
-    <xsl:template match="*[contains(@class,' pr-d/groupcomp ')]/*[contains(@class,' pr-d/groupcomp ')]">
-        <fo:inline>
-          <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupchoice ')]/*[contains(@class,' pr-d/groupchoice ')]">
+    <xsl:template match="*[contains(@class,' pr-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' pr-d/groupseq ')]/
+        *[contains(@class,' pr-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' pr-d/groupseq ')]">
         <fo:inline>
             <xsl:call-template name="commonattributes"/>
+            <xsl:call-template name="makeGroup"/>
         </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupseq ')]/*[contains(@class,' pr-d/groupseq ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupchoice ')]/*[contains(@class,' pr-d/groupcomp ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupchoice ')]/*[contains(@class,' pr-d/groupseq ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupcomp ')]/*[contains(@class,' pr-d/groupchoice ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupcomp ')]/*[contains(@class,' pr-d/groupseq ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupseq ')]/*[contains(@class,' pr-d/groupchoice ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
-    </xsl:template>
-
-    <xsl:template match="*[contains(@class,' pr-d/groupseq ')]/*[contains(@class,' pr-d/groupcomp ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
-        <xsl:call-template name="makeGroup"/>
     </xsl:template>
 
     <xsl:template name="makeGroup">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -253,12 +253,9 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="steps.step">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps.step__label">
                 <fo:block xsl:use-attribute-sets="steps.step__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:if test="preceding-sibling::*[contains(@class, ' task/step ')] | following-sibling::*[contains(@class, ' task/step ')]">
                         <xsl:call-template name="getVariable">
                             <xsl:with-param name="id" select="'Step Number'"/>
@@ -283,12 +280,9 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/steps-unordered ')]/*[contains(@class, ' task/step ')]">
         <fo:list-item xsl:use-attribute-sets="steps-unordered.step">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps-unordered.step__label">
                 <fo:block xsl:use-attribute-sets="steps-unordered.step__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="'Unordered List bullet'"/>
                     </xsl:call-template>
@@ -306,6 +300,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/step ')]" mode="onestep">
     <fo:block xsl:use-attribute-sets="steps.step__content--onestep">
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
@@ -313,12 +308,9 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepsection ')]">
         <fo:list-item xsl:use-attribute-sets="stepsection">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="stepsection__label">
               <fo:block xsl:use-attribute-sets="stepsection__label__content">
-                  <fo:inline>
-                      <xsl:call-template name="commonattributes"/>
-                  </fo:inline>
               </fo:block>
             </fo:list-item-label>
 
@@ -346,12 +338,9 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="substeps.substep">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="substeps.substep__label">
                 <fo:block xsl:use-attribute-sets="substeps.substep__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:call-template name="getVariable">
                       <xsl:with-param name="id" select="'Substep Number'"/>
                       <xsl:with-param name="params" as="element()*">
@@ -380,12 +369,9 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/choice ')]">
         <fo:list-item xsl:use-attribute-sets="choices.choice">
-            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="choices.choice__label">
                 <fo:block xsl:use-attribute-sets="choices.choice__label__content">
-                    <fo:inline>
-                        <xsl:call-template name="commonattributes"/>
-                    </fo:inline>
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="'Unordered List bullet'"/>
                     </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -1342,9 +1342,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:function>
 
     <xsl:template match="*[contains(@class,' topic/fn ')]">
-        <!--<fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>-->
       <xsl:variable name="id" select="dita-ot:getFootnoteInternalID(.)" as="xs:string"/>
       <xsl:variable name="callout" as="xs:string">
         <xsl:apply-templates select="." mode="callout"/>
@@ -1397,9 +1394,6 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/indexterm ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
         <xsl:apply-templates/>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
@@ -11,9 +11,10 @@ See the accompanying LICENSE file for applicable license.
     version="2.0">
 
     <xsl:template match="*[contains(@class,' ut-d/imagemap ')]">
-        <fo:inline>
-            <xsl:call-template name="commonattributes"/>
-        </fo:inline>
+        <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable>
+        <xsl:if test="exists($attributes)">
+            <fo:inline><xsl:sequence select="$attributes"/></fo:inline>
+        </xsl:if>
         <xsl:apply-templates select="*[contains(@class,' topic/image ')]"/>
         <fo:list-block xsl:use-attribute-sets="ol">
             <xsl:apply-templates select="*[contains(@class,' ut-d/area ')]"/>


### PR DESCRIPTION
There are quite a few instances of this in the PDF code:

``` xml
<fo:inline>
  <xsl:call-template name="commonattributes"/>
</fo:inline>
```

These are mostly added as a way to preserve `@id` anchors, but could potentially add other attributes.

When working on a document with a lot of `<xref>` elements, I noticed this resulted in `<fo:inline/>` for every link or cross reference. With an overly-linked document like the DITA specification, this results in over 100,000 unnecessary `<fo:inline/>` elements.

With a bit of searching I noticed there were 20+ instances of this same construct, so I've created a single mode template to handle each of them. It processes the `commonattributes` template as above. If any attributes are returned, it creates the `<fo:inline>` element with those attributes. Otherwise, it skips generating the empty element.
