### PR TITLE
Avoid using topic title when @href is missing

### DIFF
--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -413,19 +413,6 @@
   </xsl:template>  
   
   <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="grab-group-title" as="xs:string?">
-    <xsl:variable name="file-origin">
-      <xsl:call-template name="get-file-uri">
-        <xsl:with-param name="href" select="@href"/>
-        <xsl:with-param name="file-prefix" select="$file-prefix"/>
-      </xsl:call-template>
-    </xsl:variable>
-    <xsl:variable name="file">
-      <xsl:call-template name="replace-blank">
-        <xsl:with-param name="file-origin">
-          <xsl:value-of select="$file-origin"/>
-        </xsl:with-param>
-      </xsl:call-template>
-    </xsl:variable>
     <xsl:choose>
       <xsl:when test="parent::*[contains(@class, ' map/relcolspec ')]/*[contains(@class, ' topic/title ')][not(title = '')]">
         <xsl:value-of select="parent::*[contains(@class, ' map/relcolspec ')]/*[contains(@class, ' topic/title ')]"/>
@@ -436,10 +423,25 @@
       <xsl:when test="@navtitle and not(@navtitle = '')">
         <xsl:value-of select="@navtitle"/>
       </xsl:when>
-      <xsl:when test="document($file,/)//*[contains(@class, ' topic/title ')]">
-        <xsl:value-of select="document($file,/)//*[contains(@class, ' topic/title ')][1]"/>
+      <xsl:when test="@href">
+        <xsl:variable name="file-origin">
+          <xsl:call-template name="get-file-uri">
+            <xsl:with-param name="href" select="@href"/>
+            <xsl:with-param name="file-prefix" select="$file-prefix"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="file">
+          <xsl:call-template name="replace-blank">
+            <xsl:with-param name="file-origin">
+              <xsl:value-of select="$file-origin"/>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="document($file,/)//*[contains(@class, ' topic/title ')]">
+          <xsl:value-of select="document($file,/)//*[contains(@class, ' topic/title ')][1]"/>
+        </xsl:if>
       </xsl:when>
-    </xsl:choose>
+     </xsl:choose>
   </xsl:template>
   
   <!-- Override this moded template to add your own kinds of links. -->


### PR DESCRIPTION
Avoid computing topic title when we have topichead inside reltable section.
Possible fix for: https://github.com/dita-ot/dita-ot/issues/2432
