### PR TITLE
Update build_axf.xml for additional AXF Windows install path

### DIFF
--- a/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
@@ -145,11 +145,19 @@
           <fileset dir="/Applications" includes="AntennaHouse/run.sh" erroronmissingdir="false"/>
           <fileset dir="/usr" includes="AHFormatterV*/run.sh" erroronmissingdir="false"/>
           <fileset dir="/usr" includes="XSLFormatterV*/run.sh" erroronmissingdir="false"/>
+          <fileset dir="C:\Program Files\Antenna House" erroronmissingdir="false">
+            <include name="AHFormatterV*\AHFCmd.exe"/>
+            <include name="XSLFormatterV*\XSLCmd.exe"/>
+          </fileset>
           <fileset dir="C:\Program Files\AntennaHouse" erroronmissingdir="false">
             <include name="AHFormatterV*\AHFCmd.exe"/>
             <include name="XSLFormatterV*\XSLCmd.exe"/>
           </fileset>
           <fileset dir="C:\Program Files\Antenna" erroronmissingdir="false">
+            <include name="AHFormatterV*\AHFCmd.exe"/>
+            <include name="XSLFormatterV*\XSLCmd.exe"/>
+          </fileset>
+          <fileset dir="C:\Program Files (x86)\Antenna House" erroronmissingdir="false">
             <include name="AHFormatterV*\AHFCmd.exe"/>
             <include name="XSLFormatterV*\XSLCmd.exe"/>
           </fileset>


### PR DESCRIPTION
Recent versions of Antenna House for Windows install into 
`C:\Program Files\Antenna House`
Current code only checks for "AntennaHouse" (no space) - this updates the AXF script so that we find it in either location.