### PR TITLE
Fix rellink path resolution #2017

### DIFF
--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -87,11 +87,11 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             linkInserter.setLogger(logger);
             linkInserter.setJob(job);
             for (final Map.Entry<File, Map<String, Element>> entry: mapSet.entrySet()) {
-                final File f = new File(job.tempDir, entry.getKey().getPath());
-                logger.info("Processing " + f);
+                final URI uri = inputFile.toURI().resolve(entry.getKey().getPath());
+                logger.info("Processing " + uri);
                 linkInserter.setLinks(entry.getValue());
                 try {
-                    linkInserter.write(f);
+                    linkInserter.write(new File(uri));
                 } catch (final DITAOTException e) {
                     logger.error("Failed to insert links: " + e.getMessage(), e);
                 }

--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -109,7 +109,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
         String idValue = atts.getValue(ATTRIBUTE_NAME_ID);
         if (idValue != null) {
             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OID, idValue);
-            final URI value = setFragment(toURI(filePath), idValue);
+            final URI value = setFragment(dirPath.toURI().resolve(filePath), idValue);
             if (util.findId(value)) {
                 idValue = util.getIdValue(value);
             } else {
@@ -140,27 +140,29 @@ public final class MergeTopicParser extends XMLFilterImpl {
             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OHREF,
                     URLUtils.clean(pathFromMap + attValue.substring(sharpIndex), false));
             final URI topicId = toURI(pathFromMap + getElementID(SHARP + getFragment(attValue)));
+            URI absolutePath = dirPath.toURI().resolve(topicId);
             final int index = attValue.indexOf(SLASH, sharpIndex);
             final String elementId = index != -1 ? attValue.substring(index) : "";
-            if (util.findId(topicId)) {// topicId found
-                retAttValue = SHARP + util.getIdValue(topicId) + elementId;
+            if (util.findId(absolutePath)) {// topicId found
+                retAttValue = SHARP + util.getIdValue(absolutePath) + elementId;
             } else {// topicId not found
-                retAttValue = SHARP + util.addId(topicId) + elementId;
+                retAttValue = SHARP + util.addId(absolutePath) + elementId;
             }
         } else { // href value refer to a topic
             pathFromMap = toURI(resolveTopic(new File(filePath).getParent(), attValue));
+            URI absolutePath = dirPath.toURI().resolve(pathFromMap);
             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OHREF, pathFromMap.toString());
-            if (util.findId(pathFromMap)) {
-                retAttValue = SHARP + util.getIdValue(pathFromMap);
+            if (util.findId(absolutePath)) {
+                retAttValue = SHARP + util.getIdValue(absolutePath);
             } else {
-                final String fileId = MergeUtils.getFirstTopicId(pathFromMap, dirPath, false);
-                final URI key = setFragment(pathFromMap, fileId);
+                final String fileId = MergeUtils.getFirstTopicId(absolutePath, dirPath, false);
+                final URI key = setFragment(absolutePath, fileId);
                 if (util.findId(key)) {
-                    util.addId(pathFromMap, util.getIdValue(key));
+                    util.addId(absolutePath, util.getIdValue(key));
                     retAttValue = SHARP + util.getIdValue(key);
                 } else {
-                    retAttValue = SHARP + util.addId(pathFromMap);
-                    util.addId(key, util.getIdValue(pathFromMap));
+                    retAttValue = SHARP + util.addId(absolutePath);
+                    util.addId(key, util.getIdValue(absolutePath));
                 }
 
             }

--- a/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
@@ -51,22 +51,31 @@ public class MergeTopicParserTest {
     @Test
     public void testParse() throws Exception {
         final MergeTopicParser parser = new MergeTopicParser(new MergeUtils());
+        parse(parser, "test.xml");
+
+        final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalHref", URI.class);
+        method.setAccessible(true);
+        assertEquals(new URI("images/test.jpg"), method.invoke(parser, new URI("images/test.jpg")));
+    }
+
+    @Test
+    public void testParseSubdir() throws Exception {
+        parse(new MergeTopicParser(new MergeUtils()), "subdir/test3.xml");
+    }
+
+    public void parse(MergeTopicParser parser, String file) throws Exception {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         final TransformerHandler s = stf.newTransformerHandler();
         s.getTransformer().setOutputProperty(OMIT_XML_DECLARATION , "yes");
         s.setResult(new StreamResult(output));
         parser.setContentHandler(s);
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setOutput(new File(srcDir, "test.xml"));
+        parser.setOutput(new File(srcDir, file));
         s.startDocument();
-        parser.parse("test.xml", srcDir.getAbsoluteFile());
+        parser.parse(file, srcDir.getAbsoluteFile());
         s.endDocument();
-        assertXMLEqual(new InputSource(new File(expDir, "test.xml").toURI().toString()),
+        assertXMLEqual(new InputSource(new File(expDir, file).toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
-
-        final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalHref", URI.class);
-        method.setAccessible(true);
-        assertEquals(new URI("images/test.jpg"), method.invoke(parser, new URI("images/test.jpg")));
     }
 
     @Test

--- a/src/test/resources/MergeTopicParserTest/exp/subdir/test3.xml
+++ b/src/test/resources/MergeTopicParserTest/exp/subdir/test3.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic concept/concept "
+  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  id="unique_1" oid="topic" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  <title class="- topic/title ">Concept</title>
+  <related-links class="- topic/related-link ">
+    <link class="- topic/link " href="#unique_2" ohref="test2.xml#topic"/>
+    <link class="- topic/link " href="#unique_2" ohref="../src/test2.xml#topic"/>
+  </related-links>
+</concept>

--- a/src/test/resources/MergeTopicParserTest/src/subdir/test3.xml
+++ b/src/test/resources/MergeTopicParserTest/src/subdir/test3.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic concept/concept "
+  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  id="topic" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  <title class="- topic/title ">Concept</title>
+  <related-links class="- topic/related-link ">
+    <link class="- topic/link " href="../test2.xml#topic"/>
+    <link class="- topic/link " href="../../src/test2.xml#topic"/>
+  </related-links>
+</concept>


### PR DESCRIPTION
The change in `MoveLinksModule` should be relatively straightforward: resolve the file URI against the input DITA map file instead of the root of the temp directory.

When `MergeTopicParser` creates a map from topic URLs to `unique_n` IDs, it uses relative URIs as map keys, which doesn't always yield the correct result. Using the absolute URI of the topic instead makes things more stable.

The code in the `MergeTopicParser` class isn't very easy to understand (at least for me), so a review wouldn't hurt.