### PR TITLE
2448 Don't generate a random value for the @headers attribute

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -83,14 +83,9 @@
       <xsl:variable name="keycolhead">
         <xsl:if test="$keycol and $thiscolnum != number($keycol)">
           <xsl:variable name="col" select="../*[number($keycol)]"/>
-          <xsl:choose>
-            <xsl:when test="$col/@id">
-              <xsl:value-of select="$col/@id"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="generate-id($col)"/>
-            </xsl:otherwise>
-          </xsl:choose>
+          <xsl:if test="$col/@id">
+            <xsl:value-of select="$col/@id"/>
+          </xsl:if>
         </xsl:if>
       </xsl:variable>
       


### PR DESCRIPTION
If no header `@id` is found, generating a new value in `@headers` doesn't do anything for accessibility; instead, it merely adds noise to the change history of the generated HTML.
