### PR TITLE
Use job mapper when transforming topics to final output

### DIFF
--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -123,9 +123,7 @@
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
             <param name="defaultLanguage" expression="${default.language}"/>
             <dita:extension behavior="org.dita.dost.platform.InsertAction" id="dita.conductor.eclipse.toc.param"/>
-            <mapper type="regexp"
-                from="^(${tempdirToinputmapdir.relative.value})(.*?)(\.ditamap)$$" 
-                to="\2\.xml"/>
+            <mapper classname="org.dita.dost.util.JobMapper" to=".xml"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
     </target>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -137,16 +137,14 @@
   <target name="html5.topics.common" unless="noTopic" if="old.transform">
     <html5.topics>
       <dita:extension id="dita.conductor.html5.param" behavior="org.dita.dost.platform.InsertAction"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
     </html5.topics>
   </target>
 
   <target name="html5.topics.common.inner" unless="noTopic" if="inner.transform">
     <html5.topics>
       <dita:extension id="dita.conductor.html5.param" behavior="org.dita.dost.platform.InsertAction"/>
-      <!--New,To generate&copy all dita files in the inputmap.dir,not all files in dita.temp.dir -->
-      <mapper type="regexp"
-              from="^(${tempdirToinputmapdir.relative.value})(.*?)(\.(\w+))$$"
-              to="\2${out.ext}"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
     </html5.topics>
   </target>
 

--- a/src/main/plugins/org.dita.troff/build_dita2troff.xml
+++ b/src/main/plugins/org.dita.troff/build_dita2troff.xml
@@ -44,6 +44,7 @@
     	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
       <param name="OUTFORMAT" expression="${troff.outformat}" if="troff.outformat"/>
       <param name="defaultLanguage" expression="${default.language}"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>
@@ -59,9 +60,7 @@
       style="${troff.step2.xsl}">
     	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
       <param name="OUTFORMAT" expression="${troff.outformat}" if="troff.outformat"/>
-      <mapper type="regexp" 
-        from="^(${tempdirToinputmapdir.relative.value})(.*?)(\.(xml|dita))$$" 
-        to="\2${out.ext}"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
   </target>

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -177,6 +177,7 @@
     <topics.html>
       <dita:extension id="dita.conductor.xhtml.param" behavior="org.dita.dost.platform.InsertAction"/>
       <dita:extension id="dita.conductor.html.param" behavior="org.dita.dost.platform.InsertAction"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
     </topics.html>
   </target>
   
@@ -187,10 +188,7 @@
     <topics.html>
       <dita:extension id="dita.conductor.xhtml.param" behavior="org.dita.dost.platform.InsertAction"/>
       <dita:extension id="dita.conductor.html.param" behavior="org.dita.dost.platform.InsertAction"/>
-      <!--New,To generate&copy all dita files in the inputmap.dir,not all files in dita.temp.dir -->
-      <mapper type="regexp"
-        from="^(${tempdirToinputmapdir.relative.value})(.*?)(\.(\w+))$$" 
-        to="\2${out.ext}"/>
+      <mapper classname="org.dita.dost.util.JobMapper" to="${out.ext}"/>
     </topics.html>
   </target>
   


### PR DESCRIPTION
This Ant mapper implementation uses Job configuration to map temporary files to result files. The same mapper can be used to process content in `generate.copy.outer` modes `1` and `3`.