### PR TITLE
Map temporary files to source/result files using job configuration

### DIFF
--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -142,7 +142,8 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
             for (final FileInfo f : job.getFileInfo()) {
                 if (ATTR_FORMAT_VALUE_DITA.equals(f.format) || ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
                     topicRefWriter.setFixpath(relativePath2fix.get(f.uri));
-                    topicRefWriter.write(new File(job.tempDir, f.file.getPath()));
+                    final File tmp = new File(job.tempDirURI.resolve(f.uri));
+                    topicRefWriter.write(tmp);
                 }
             }
         } catch (final DITAOTException ex) {
@@ -189,6 +190,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
             }
         }
 
+        // relative temporary files
         final Set<URI> topicList = new LinkedHashSet<>(128);
         final Set<URI> oldTopicList = new HashSet<>();
         for (final FileInfo f : job.getFileInfo()) {

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2016 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.module;
+
+import org.apache.commons.io.FileUtils;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.URLUtils;
+import org.dita.dost.writer.AbstractXMLFilter;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.addOrSetAttribute;
+import static org.dita.dost.util.XMLUtils.transform;
+
+/**
+ * Move temporary files not based on output URI to match output URI structure.
+ *
+ * @since 2.4
+ */
+public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
+
+    @Override
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
+        final URI base = job.getInputDir();
+
+        final Collection<FileInfo> fis = job.getFileInfo().stream()
+                .collect(Collectors.toList());
+
+        final LinkFilter filter = new LinkFilter();
+        filter.setJob(job);
+        filter.setLogger(logger);
+        final Collection<FileInfo> res = new ArrayList<>(fis.size());
+        for (final FileInfo fi : fis) {
+            try {
+                final FileInfo.Builder builder = new FileInfo.Builder(fi);
+                final File srcFile = new File(job.tempDirURI.resolve(fi.uri)).getCanonicalFile();
+                if (srcFile.exists()) {
+                    final URI rel = base.relativize(fi.result);
+                    final File destFile = new File(job.tempDirURI.resolve(rel)).getCanonicalFile();
+                    if (fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA) || fi.format.equals(ATTR_FORMAT_VALUE_DITAMAP)) {
+                        logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
+                        filter.setCurrentFile(srcFile.toURI());
+                        filter.setDestFile(destFile.toURI());
+                        transform(srcFile.toURI(), destFile.toURI(), Collections.singletonList(filter));
+                        if (!srcFile.equals(destFile)) {
+                            logger.debug("Deleting " + srcFile.toURI());
+                            FileUtils.deleteQuietly(srcFile);
+                        }
+                    } else if (fi.format.equals("coderef")) {
+                        // SKIP
+                    } else if (!srcFile.equals(destFile)) {
+                        logger.info("Copying " + srcFile.toURI() + " to " + destFile.toURI());
+                        FileUtils.moveFile(srcFile, destFile);
+                    }
+                    builder.uri(rel);
+
+                    // start map
+                    if (fi.src.equals(job.getInputFile())) {
+                        job.setProperty(INPUT_DITAMAP_URI, rel.toString());
+                        job.setProperty(INPUT_DITAMAP, toFile(rel).getPath());
+                    }
+                }
+                res.add(builder.build());
+            } catch (final IOException e) {
+                logger.error("Failed to clean " + job.tempDirURI.resolve(fi.uri) + ": " + e.getMessage(), e);
+            }
+        }
+
+        fis.stream().forEach(fi -> job.remove(fi));
+        res.stream().forEach(fi -> job.add(fi));
+
+        try {
+            job.write();
+        } catch (IOException e) {
+            throw new DITAOTException();
+        }
+
+        return null;
+    }
+
+    private class LinkFilter extends AbstractXMLFilter {
+
+        private URI destFile;
+        private URI base;
+
+        @Override
+        public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+                throws SAXException {
+            Attributes res = atts;
+
+            if (hasLocalDitaLink(atts)) {
+                final AttributesImpl resAtts = new AttributesImpl(atts);
+                final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
+                final URI resHref = getHref(href);
+                addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, resHref.toString());
+                res = resAtts;
+            }
+
+            getContentHandler().startElement(uri, localName, qName, res);
+        }
+
+        private boolean hasLocalDitaLink(final Attributes atts) {
+            final boolean hasHref = atts.getIndex(ATTRIBUTE_NAME_HREF) != -1;
+            final boolean notExternal = !ATTR_SCOPE_VALUE_EXTERNAL.equals(atts.getValue(ATTRIBUTE_NAME_SCOPE));
+            if (hasHref && notExternal) {
+                return true;
+            }
+            final URI data = toURI(atts.getValue(ATTRIBUTE_NAME_DATA));
+            if (data != null && !data.isAbsolute()) {
+                return true;
+            }
+            return false;
+        }
+
+        private URI getHref(final URI href) {
+            final URI targetAbs = stripFragment(currentFile.resolve(href));
+            final FileInfo targetFileInfo = job.getFileInfo(targetAbs);
+            final URI rel = base.relativize(targetFileInfo.result);
+            final URI targetDestFile = job.tempDirURI.resolve(rel);
+            final URI relTarget = URLUtils.getRelativePath(destFile, targetDestFile);
+            return setFragment(relTarget, href.getFragment());
+        }
+
+        public void setDestFile(final URI destFile) {
+            this.destFile = destFile;
+        }
+
+        @Override
+        public void setJob(final Job job) {
+            super.setJob(job);
+            base = job.getInputDir();
+        }
+    }
+
+}

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -140,13 +140,13 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                         }
                     } else {
                         // use randomly generated file name
-                        outputFileName = currentFile.resolve(generateFilename());
+                        outputFileName = generateOutputFile(currentFile);
                     }
 
                     // Check if there is any conflict
                     if (new File(outputFileName).exists() && !MAP_MAP.matches(classValue)) {
                         final URI t = outputFileName;
-                        outputFileName = currentFile.resolve(generateFilename());
+                        outputFileName = generateOutputFile(currentFile);
                         conflictTable.put(outputFileName, t);
                     }
                     // add newly generated file to changTable

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -12,6 +12,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.reader.SvgMetadataReader;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -110,9 +111,9 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
             final Attributes atts) throws SAXException {
         if (TOPIC_IMAGE.matches(atts)) {
             final XMLUtils.AttributesBuilder a = new XMLUtils.AttributesBuilder(atts);
-            final String href = atts.getValue(ATTRIBUTE_NAME_HREF);
+            final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
             if (href != null) {
-                final URI imgInput = getImageFile(toURI(href));
+                final URI imgInput = getImageFile(href);
                 if (imgInput != null) {
                     Attributes m = cache.get(imgInput);
                     if (m == null) {
@@ -277,12 +278,15 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
         }
     }
 
+    // TODO create a list of files and list of directories, then check permutations for hits
     private URI getImageFile(final URI href) {
-        URI fileDir = tempDir.toURI().relativize(currentFile.resolve("."));
-        if (job.getGeneratecopyouter() != Job.Generate.OLDSOLUTION) {
-            fileDir = fileDir.resolve(uplevels.replace(File.separator, URI_SEPARATOR));
+        final URI fileName;
+        final FileInfo fi = job.getFileInfo(currentFile.resolve(href));
+        if (fi != null) {
+            fileName = job.getInputDir().relativize(fi.src);
+        } else {
+            fileName = href;
         }
-        final URI fileName = fileDir.resolve(href);
 
         final URI outputURI = outputDir.toURI().resolve(fileName);
         if (exists(outputURI)) {
@@ -290,10 +294,18 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
             return outputURI;
         }
 
-        final URI tempURI = outputDir.toURI().resolve(fileName);
+        final URI tempURI = job.tempDirURI.resolve(fileName);
         if (exists(tempURI)) {
             logger.debug("Found " + tempURI);
             return tempURI;
+        }
+
+        if (fi != null) {
+            final URI srcTempURI = job.tempDirURI.resolve(fi.uri);
+            if (exists(srcTempURI)) {
+                logger.debug("Found " + srcTempURI);
+                return srcTempURI;
+            }
         }
 
         final URI srcURI = job.getInputDir().resolve(fileName);

--- a/src/main/lib/configuration.properties
+++ b/src/main/lib/configuration.properties
@@ -10,6 +10,7 @@ default.language = en
 generate-debug-attributes = true
 processing-mode = lax
 default.cascade = merge
+temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$HashTempFileScheme
 
 # Integration
 plugindirs = plugins;demo

--- a/src/main/lib/configuration.properties
+++ b/src/main/lib/configuration.properties
@@ -10,7 +10,7 @@ default.language = en
 generate-debug-attributes = true
 processing-mode = lax
 default.cascade = merge
-temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$HashTempFileScheme
+temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$DefaultTempFileScheme
 
 # Integration
 plugindirs = plugins;demo

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -37,6 +37,7 @@ See the accompanying LICENSE file for applicable license.
                   topicpull,
                   flag-module,
                   clean-map,
+                  clean-preprocess,
                   {depend.preprocess.post}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     description="Preprocessing ended" />
@@ -529,6 +530,36 @@ See the accompanying LICENSE file for applicable license.
     <condition property="preprocess.clean-map-check.skip">
       <isset property="noMap"/>
     </condition>
+  </target>
+
+  <!-- Clean tempory files at the end of preprocess -->
+  <target name="clean-preprocess"
+          unless="preprocess.clean-preprocess.skip"
+          description="Clean preprocess">
+    <pipeline message="Clean preprocess" taskname="clean-preprocess">
+      <module class="org.dita.dost.module.CleanPreprocessModule"/>
+    </pipeline>
+    <job-helper file="canditopics.list" property="canditopicslist"/>
+    <job-helper file="conref.list" property="conreflist"/>
+    <job-helper file="conreftargets.list" property="conreftargetslist"/>
+    <job-helper file="copytosource.list" property="copytosourcelist"/>
+    <job-helper file="flagimage.list" property="flagimagelist"/>
+    <job-helper file="fullditamap.list" property="fullditamaplist"/>
+    <job-helper file="fullditamapandtopic.list" property="fullditamapandtopiclist"/>
+    <job-helper file="fullditatopic.list" property="fullditatopiclist"/>
+    <job-helper file="hrefditatopic.list" property="hrefditatopiclist"/>
+    <job-helper file="hreftargets.list" property="hreftargetslist"/>
+    <!-- Deprecated since 2.1 -->
+    <job-helper file="html.list" property="htmllist"/>
+    <!-- Deprecated since 2.1 -->
+    <job-helper file="image.list" property="imagelist"/>
+    <job-helper file="outditafiles.list" property="outditafileslist"/>
+    <job-helper file="resourceonly.list" property="resourceonlylist"/>
+    <job-helper file="resourceonly.list" property="resourceonlylist"/>    
+    <job-helper file="subjectscheme.list" property="subjectschemelist"/>
+    <job-helper file="subtargets.list" property="subtargetslist"/>
+    <job-helper file="user.input.file.list" property="user.input.file"/>
+    <job-helper file="usr.input.file.list" property="user.input.file"/>
   </target>
   
   <!-- copy-files

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -55,14 +55,17 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         XMLUnit.setIgnoreComments(true);
 
         job = new Job(tempDir);
+        job.setProperty(INPUT_DIR_URI, tempDir.toURI().toString());
         job.add(new Job.FileInfo.Builder()
                 .src(new File(tempDir, "input.ditamap").toURI())
+                .result(new File(tempDir, "input.ditamap").toURI())
                 .uri(new URI("input.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
         for (final String uri: Arrays.asList("linux.ditaval", "novice.ditaval", "advanced.ditaval", "mac.ditaval", "win.ditaval")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
+                    .result(new File(tempDir, uri).toURI())
                     .uri(new URI(uri))
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
@@ -70,8 +73,15 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
+                    .result(new File(tempDir, uri).toURI())
                     .uri(new URI(uri))
                     .format(ATTR_FORMAT_VALUE_DITA)
+                    .build());
+        }
+        for (final String uri: Arrays.asList("installation-procedure.dita", "getting-started.dita")) {
+            job.add(new Job.FileInfo.Builder()
+                    .result(new File(tempDir, uri).toURI())
+                    .uri(new URI(uri))
                     .build());
         }
     }
@@ -105,8 +115,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 new InputSource(new File(tempDir, "input.ditamap").toURI().toString()));
 
         final List<String> exp = Arrays.asList(
-                //"installation-procedure.dita",
-                //"getting-started.dita",
+                "installation-procedure.dita", "getting-started.dita",
                 //"http://example.com/install.dita",
                 "configure.dita",
                 "input.ditamap", "install.dita", "linux.ditaval", "perform-install.dita",

--- a/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
@@ -54,11 +54,17 @@ public class ChunkMapReaderTest {
         mapReader.setJob(job);
 
         TestUtils.copy(new File(srcDir, "gen.ditamap"), new File(tempDir, "maps" + File.separator + "gen.ditamap"));
-        job.add(new Job.FileInfo.Builder().uri(toURI("maps/gen.ditamap")).build());
+        job.add(new Job.FileInfo.Builder()
+                .src(new File(srcDir, "maps" + File.separator + "gen.ditamap").toURI())
+                .uri(toURI("maps/gen.ditamap"))
+                .build());
         for (final String srcFile : getSrcFiles()) {
             final URI dst = tempDir.toURI().resolve(srcFile);
             TestUtils.copy(new File(srcDir, "topic.dita"), new File(dst));
-            job.add(new Job.FileInfo.Builder().uri(toURI(srcFile)).build());
+            job.add(new Job.FileInfo.Builder()
+                    .src(new File(srcDir, srcFile).toURI())
+                    .uri(toURI(srcFile))
+                    .build());
         }
 
         mapReader.read(new File(tempDir, "maps" + File.separator + "gen.ditamap"));

--- a/src/test/resources/1.5.2_M4_BUG3056939/exp/xhtml/langref/conreffing-target.html
+++ b/src/test/resources/1.5.2_M4_BUG3056939/exp/xhtml/langref/conreffing-target.html
@@ -20,9 +20,9 @@
   <div class="body">
     <p class="p">This topic conrefs from a topic in a different directory structure that has an xref in it.</p>
 
-    <p class="p">This is a direct xref to the target "XRef target topic": <a class="xref" href="../common/../langref/xref-target-topic.html#topic-1">XRef Target Topic</a>.</p>
+    <p class="p">This is a direct xref to the target "XRef target topic": <a class="xref" href="xref-target-topic.html#topic-1">XRef Target Topic</a>.</p>
 
-    <p class="p">This is a keyref xref to the target "XRef target topic": <a class="xref" href="../common/../langref/xref-target-topic.html">keyref xref to xref-target-topic</a></p>
+    <p class="p">This is a keyref xref to the target "XRef target topic": <a class="xref" href="xref-target-topic.html">keyref xref to xref-target-topic</a></p>
 
   </div>
 

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -6,6 +6,7 @@ generate-debug-attributes = true
 processing-mode = lax
 chunk.id-generation-scheme = counter
 default.cascade = nomerge
+temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$DefaultTempFileScheme
 
 # Integration
 plugindirs = plugins;demo


### PR DESCRIPTION
Use job configuration to track temporary files and their source/result URI. This allows using e.g. hashed temporary file names, or temporary paths that contain the absolute path to source file. Using a hashed/full path for temporary files makes uplevels processing redundant and allows constructing full temporary file structure before reading all input files.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>