### PR TITLE
Add range by ID extension to coderef

### DIFF
--- a/src/main/java/org/dita/dost/writer/CoderefResolver.java
+++ b/src/main/java/org/dita/dost/writer/CoderefResolver.java
@@ -11,11 +11,7 @@ package org.dita.dost.writer;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
@@ -23,10 +19,10 @@ import java.util.regex.Pattern;
 
 import org.dita.dost.util.Job;
 import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.FileUtils;
 
 /**
  * Coderef element resolver filter.
@@ -44,6 +40,12 @@ import org.dita.dost.util.FileUtils;
  * <pre>uri ("#line-range(" start ("," end)? ")" )?</pre>
  * 
  * <p>Start and end line numbers start from 1 and are inclusive. If end range
+ * is omitted, range ends in last line.</p>
+ * <p>Optional id range is defined using:</p>
+ *
+ * <pre>uri ("#id-range(" start ("," end)? ")" )?</pre>
+ *
+ * <p>Lines idenfified using start and end IDs are exclusive. If end range
  * is omitted, range ends in last line.</p>
  */
 public final class CoderefResolver extends AbstractXMLFilter {
@@ -99,9 +101,10 @@ public final class CoderefResolver extends AbstractXMLFilter {
                     if (codeFile.exists()){
                         logger.debug("Resolve coderef " + codeFile);
                         final Charset charset = getCharset(atts.getValue(ATTRIBUTE_NAME_FORMAT));
+                        final Range range = getRange(hrefValue);
                         try (BufferedReader codeReader = new BufferedReader(
                                 new InputStreamReader(new FileInputStream(codeFile), charset))) {
-                            copyLines(codeReader, new Range(hrefValue));
+                            range.copyLines(codeReader);
                         } catch (final Exception e) {
                             logger.error("Failed to process code reference " + codeFile, e);
                         }
@@ -133,72 +136,157 @@ public final class CoderefResolver extends AbstractXMLFilter {
     // Private methods ---------------------------------------------------------
 
     /**
-     * Copy lines from reader to output
-     * 
-     * @param codeReader line reader
-     * @param range range of lines to copy
+     * Factory method for Range implementation
      */
-    private void copyLines(final BufferedReader codeReader, final Range range) throws IOException, SAXException {
-        boolean first = true;
-        String line = codeReader.readLine();
-        for (int i = 0; line != null; i++) {
-            if (i >= range.start && i <= range.end) {
+    private Range getRange(final URI uri) {
+        int start = 0;
+        int end = Integer.MAX_VALUE;
+        String startId = null;
+        String endId = null;
+
+        final String fragment = uri.getFragment();
+        if (fragment != null) {
+            // RFC 5147
+            final Matcher m = Pattern.compile("^line=(?:(\\d+)|(\\d+)?,(\\d+)?)$").matcher(fragment);
+            if (m.matches()) {
+                if (m.group(1) != null) {
+                    start = Integer.parseInt(m.group(1));
+                    end = start;
+                } else {
+                    if (m.group(2) != null) {
+                        start = Integer.parseInt(m.group(2));
+                    }
+                    if (m.group(3) != null) {
+                        end = Integer.parseInt(m.group(3)) - 1;
+                    }
+                }
+                return new LineNumberRange(start, end).handler(this);
+            } else {
+                final Matcher mc = Pattern.compile("^line-range\\((\\d+)(?:,\\s*(\\d+))?\\)$").matcher(fragment);
+                if (mc.matches()) {
+                    start = Integer.parseInt(mc.group(1)) - 1;
+                    if (mc.group(2) != null) {
+                        end = Integer.parseInt(mc.group(2)) - 1;
+                    }
+                    return new LineNumberRange(start, end).handler(this);
+                } else {
+                    final Matcher mi = Pattern.compile("^line-id\\(([^,\\s)]+)(?:,\\s*([^,\\s)]+))?\\)$").matcher(fragment);
+                    if (mi.matches()) {
+                        startId = mi.group(1);
+                        if (mi.group(2) != null) {
+                            endId = mi.group(2);
+                        }
+                        return new AnchorRange(startId, endId).handler(this);
+                    }
+                }
+            }
+        }
+
+        return new AllRange().handler(this);
+    }
+
+    private interface Range {
+        /**
+         * Copy lines from reader to target handler
+         *
+         * @param codeReader line reader
+         */
+        void copyLines(final BufferedReader codeReader) throws IOException, SAXException;
+        /**
+         * Set target handler
+         */
+        Range handler(final ContentHandler contentHandler);
+    }
+
+    private static class LineNumberRange extends AllRange implements Range {
+
+        private final int start;
+        private final int end;
+
+        LineNumberRange(final int start, final int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public void copyLines(final BufferedReader codeReader) throws IOException, SAXException {
+            boolean first = true;
+            String line = codeReader.readLine();
+            for (int i = 0; line != null; i++) {
+                if (i >= start && i <= end) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        handler.characters(XML_NEWLINE, 0, XML_NEWLINE.length);
+                    }
+                    final char[] ch = line.toCharArray();
+                    handler.characters(ch, 0, ch.length);
+                }
+                line = codeReader.readLine();
+            }
+        }
+    }
+
+    private static class AnchorRange extends AllRange implements Range {
+
+        private final String start;
+        private final String end;
+        private int include;
+
+        AnchorRange(final String start, final String end) {
+            this.start = start;
+            this.end = end;
+            include = -1;
+        }
+
+        @Override
+        public void copyLines(final BufferedReader codeReader) throws IOException, SAXException {
+            boolean first = true;
+            String line;
+            while ((line = codeReader.readLine()) != null) {
+                if (include == -1) {
+                    include = line.contains(start) ? 0 : -1;
+                } else if (include > -1 && end != null) {
+                    include = line.contains(end) ? -1 : include;
+                }
+                if (include > 0) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        handler.characters(XML_NEWLINE, 0, XML_NEWLINE.length);
+                    }
+                    final char[] ch = line.toCharArray();
+                    handler.characters(ch, 0, ch.length);
+                }
+                if (include >= 0) {
+                    include++;
+                }
+            }
+        }
+    }
+
+    private static class AllRange implements Range {
+
+        ContentHandler handler;
+
+        @Override
+        public Range handler(final ContentHandler handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        @Override
+        public void copyLines(BufferedReader codeReader) throws IOException, SAXException {
+            boolean first = true;
+            String line;
+            while ((line = codeReader.readLine()) != null) {
                 if (first) {
                     first = false;
                 } else {
-                    super.characters(XML_NEWLINE, 0, XML_NEWLINE.length);
+                    handler.characters(XML_NEWLINE, 0, XML_NEWLINE.length);
                 }
                 final char[] ch = line.toCharArray();
-                super.characters(ch, 0, ch.length);
-            }
-            line = codeReader.readLine();
-        }
-    }
-    
-    /**
-     * Line range tuple
-     */
-    private static class Range {
-        final int start;
-        final int end;
-        Range(final URI uri) {
-            final String fragment = uri.getFragment();
-            if (fragment == null) {
-                this.start = 0;
-                this.end = Integer.MAX_VALUE;
-            } else {
-                // RFC 5147
-                final Matcher m = Pattern.compile("^line=(?:(\\d+)|(\\d+)?,(\\d+)?)$").matcher(fragment);
-                if (m.matches()) {
-                    if (m.group(1) != null) {
-                        this.start = Integer.parseInt(m.group(1));
-                        this.end = this.start;
-                    } else {
-                        if (m.group(2) != null) {
-                            this.start = Integer.parseInt(m.group(2));
-                        } else {
-                            this.start = 0;
-                        }
-                        if (m.group(3) != null) {
-                            this.end = Integer.parseInt(m.group(3)) - 1;
-                        } else {
-                            this.end = Integer.MAX_VALUE;
-                        }
-                    }
-                } else {
-                    final Matcher mc = Pattern.compile("^line-range\\((\\d+)(?:,\\s*(\\d+))?\\)$").matcher(fragment);
-                    if (mc.matches()) {
-                        this.start = Integer.parseInt(mc.group(1)) - 1;
-                        if (mc.group(2) != null) {
-                            this.end = Integer.parseInt(mc.group(2)) - 1;
-                        } else {
-                            this.end = Integer.MAX_VALUE;
-                        }
-                    } else {
-                        this.start = 0;
-                        this.end = Integer.MAX_VALUE;
-                    }
-                }
+                handler.characters(ch, 0, ch.length);
             }
         }
     }

--- a/src/test/java/org/dita/dost/writer/CoderefResolverTest.java
+++ b/src/test/java/org/dita/dost/writer/CoderefResolverTest.java
@@ -40,6 +40,7 @@ public class CoderefResolverTest {
         copyFile(new File(srcDir, "code.xml"), new File(tempDir, "code.xml"));
         copyFile(new File(srcDir, "utf-8.xml"), new File(tempDir, "utf-8.xml"));
         copyFile(new File(srcDir, "plain.txt"), new File(tempDir, "plain.txt"));
+        copyFile(new File(srcDir, "range.txt"), new File(tempDir, "range.txt"));
 
         final CoderefResolver filter = new CoderefResolver();
         filter.setLogger(new TestUtils.TestLogger());

--- a/src/test/resources/CoderefResolverTest/exp/test.dita
+++ b/src/test/resources/CoderefResolverTest/exp/test.dita
@@ -30,5 +30,15 @@ fifth</codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">second
 third</codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">second</codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">second
+third
+fourth</codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">second
+third
+fourth
+# END-A
+fifth</codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">fifth</codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"></codeblock>
   </body>
 </topic>

--- a/src/test/resources/CoderefResolverTest/exp/test.dita
+++ b/src/test/resources/CoderefResolverTest/exp/test.dita
@@ -40,5 +40,12 @@ fourth
 fifth</codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">fifth</codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"># START-B
+# END-B
+first
+# START-A
+second
+third
+fourth</codeblock>
   </body>
 </topic>

--- a/src/test/resources/CoderefResolverTest/src/range.txt
+++ b/src/test/resources/CoderefResolverTest/src/range.txt
@@ -1,0 +1,9 @@
+# START-B
+# END-B
+first
+# START-A
+second
+third
+fourth
+# END-A
+fifth

--- a/src/test/resources/CoderefResolverTest/src/test.dita
+++ b/src/test/resources/CoderefResolverTest/src/test.dita
@@ -12,9 +12,10 @@
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=2,"/></codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=1,3"/></codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=1"/></codeblock>
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-A,END-A)"/></codeblock>
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-A)"/></codeblock>
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(END-A, START-A)"/></codeblock>
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-B, END-B)"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#token=START-A,END-A"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#token=START-A"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#token=END-A,START-A"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#token=START-B,END-B"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#token=,END-A"/></codeblock>
   </body>
 </topic>

--- a/src/test/resources/CoderefResolverTest/src/test.dita
+++ b/src/test/resources/CoderefResolverTest/src/test.dita
@@ -12,5 +12,9 @@
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=2,"/></codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=1,3"/></codeblock>
     <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="plain.txt#line=1"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-A,END-A)"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-A)"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(END-A, START-A)"/></codeblock>
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve"><coderef class="+ topic/xref pr-d/coderef " href="range.txt#line-id(START-B, END-B)"/></codeblock>
   </body>
 </topic>


### PR DESCRIPTION
Add an extension to `<coderef>` processing to allow selecting ranges by ID.

Optional ID range is defined using:

```
uri ("#token=" start? ("," end)? )?
```
Lines identified using start and end IDs are exclusive. If the start ID is omitted, range starts from the first line; if end ID is omitted, range ends in last line.

Example
--------

With source `fact.hs`

```
-- START-FACT
fact :: Int -> Int
fact 0 = 1
fact n = n * fact (n-1)
-- END-FACT
main = print $ fact 7
```
and it's used with

```xml
<codeblock><coderef href="fact.hs#token=START-FACT,END-FACT"/></codeblock>
```

The result will equivalent to

```xml
<codeblock>fact :: Int -> Int
fact 0 = 1
fact n = n * fact (n-1)</codeblock>
```

