### PR TITLE
Use arabic numbering for notices in back matter

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -459,6 +459,9 @@ See the accompanying license.txt file for applicable licenses.
 
     <xsl:template name="processTopicNotices">
         <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.notice">
+            <xsl:if test="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)/ancestor::*[contains(@class,' bookmap/backmatter ')]">
+              <xsl:attribute name="format">1</xsl:attribute>
+            </xsl:if>
             <xsl:call-template name="startPageNumbering"/>
             <xsl:call-template name="insertPrefaceStaticContents"/>
             <fo:flow flow-name="xsl-region-body">


### PR DESCRIPTION
We noticed that if a book map has `<notices>` in the back matter, the page numbering switches to roman numerals (under the assumption that this is the Notices section in the front matter). This is normally the correct default for any topic under `<notices>`, which is most commonly located in the front matter, and thus the page number format is picked up from the attribute set `page-sequence.notice`.

By default the body and back matter use arabic numerals; this fix checks to see if the notices is inside `<backmatter>`, and if so, switches format back to arabic.

Feel free to suggest a better way to do this; the current fix uses the same key from later in the template to pick up `<notices>` and check ancestry, which seems straightforward but looks cumbersome somehow.