### PR TITLE
Fix error msg for odd lang condition

### DIFF
--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -84,6 +84,7 @@
     <xsl:param name="params" as="node()*"/>
     <xsl:param name="ancestorlang" as="xs:string*"/>
     <xsl:param name="defaultlang" as="xs:string*"/>
+    <xsl:param name="originallang" as="xs:string*" select="$ancestorlang[1]"/>
 
     <xsl:variable name="l" select="($ancestorlang, $defaultlang)[1]" as="xs:string?"/>
     <xsl:choose>
@@ -102,7 +103,7 @@
             <xsl:if test="empty($ancestorlang)">
               <xsl:call-template name="output-message">
                 <xsl:with-param name="id" select="'DOTX001W'"/>
-                <xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/>;%2=<xsl:call-template name="getLowerCaseLang"/>;%3=<xsl:value-of select="$DEFAULTLANG"/></xsl:with-param>
+                <xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/>;%2=<xsl:value-of select="$originallang"/>;%3=<xsl:value-of select="$DEFAULTLANG"/></xsl:with-param>
               </xsl:call-template>
             </xsl:if>
           </xsl:when>
@@ -112,6 +113,7 @@
               <xsl:with-param name="params" select="$params"/>
               <xsl:with-param name="ancestorlang" select="$ancestorlang[position() gt 1]"/>
               <xsl:with-param name="defaultlang" select="if (exists($ancestorlang)) then $defaultlang else $defaultlang[position() gt 1]"/>
+              <xsl:with-param name="originallang" select="$originallang"/>
             </xsl:call-template>
           </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
I've got a test bookmap with Albanian topics (`xml:lang="sq-al"`). This language is not supported by the toolkit or my extensions.

As expected, this generates `DOTX001W` about an unsupported string falling back to the default. However, the line setting the fallback uses these parameters:
`<xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/>;%2=<xsl:call-template name="getLowerCaseLang"/>;%3=<xsl:value-of select="$DEFAULTLANG"/></xsl:with-param>`

Parameter `%2` is supposed to provide the language that we were unable to look up. However, there are a couple of problems:
* By default, `getLowerCaseLang` just gives a lower case version of `$locale`. Thus with our Albanian topic the message ends up saying it can't find the language `en_us` so will use the default `en`. In general the logic here is also just a bit off - if we can't find `$ancestorlang`, we issue a message based on `getLowerCaseLang`, and there is not necessarily a connection between the two.
* For other reasons, we've overridden `getLowerCaseLang` so that it always gets the closest language from `ancestor-or-self` (the falling back to the default). The problem here is that `findString` is called from a function, thus has no context. Result: 1) we can't find strings for `sq-al`; 2) code generates `DOTX001W`; 3) when it calls in `getLowerCaseLang`, there is no context, so our check for `ancestor-or-self` results in an XSLT crash.

This pull request stores the original, most complete value of the ancestor language (`sq-al` versus `sq` or the fallback `en`); if we cannot locate the string for a language, that original value is used in the message.