### PR TITLE
Disable preprocessing topicpull in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -51,6 +51,7 @@ with those set forth herein.
       <param name="1" location="${args.xsl.pdf}"/>
     </dita-ot-fail>
     
+    <property name="preprocess.topicpull.skip" value="true"/>
     <property name="preprocess.copy-image.skip" value="true"/>
     
     <condition property="args.rellinks" value="nofamily">


### PR DESCRIPTION
PDF will construct link text and preprocessed link texts are not needed.

Implements PDF part of  #2380.

Signed-off-by: Jarno Elovirta jarno@elovirta.com
