### PR TITLE
Fix missing "Continued" variable marked as TODO

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -29,7 +29,7 @@
   <variable id="Unordered List bullet">•</variable>
   <variable id="Table of Contents">Sisällys</variable>
   
-  <variable id="Index Continued String"><!--TODO:continued--></variable>
+  <variable id="Index Continued String">jatkoa</variable>
   <variable id="Index See String">, Katso </variable>
   <variable id="Index See Also String">Katso myös </variable>
   <variable id="Table of Contents Chapter">Luku <param ref-name="number"/>. </variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -29,13 +29,13 @@
   <variable id="Unordered List bullet">•</variable>
   <variable id="Table of Contents">Cuprins</variable>
   
-  <variable id="Index Continued String"><!--TODO:continued--></variable>
+  <variable id="Index Continued String">continuare</variable>
   <variable id="Index See String">, Vezi </variable>
   <variable id="Index See Also String">Vezi și </variable>
   <variable id="Table of Contents Chapter">Cap. <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Appendix">Anexa <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Parte <param ref-name="number"/>. </variable>
-  <variable id="Table of Contents Preface"><!--TODO:Preface: --></variable>
+  <variable id="Table of Contents Preface">Prefață: </variable>
   <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Prefață</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -29,13 +29,13 @@
   <variable id="Unordered List bullet">•</variable>
   <variable id="Table of Contents">Содержание</variable>
   
-  <variable id="Index Continued String"><!--TODO:continued--></variable>
+  <variable id="Index Continued String">продолжение</variable>
   <variable id="Index See String">, См. </variable>
   <variable id="Index See Also String">См. также </variable>
   <variable id="Table of Contents Chapter">Глава <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Appendix">Приложение <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Часть <param ref-name="number"/>. </variable>
-  <variable id="Table of Contents Preface"><!--TODO:Preface: --></variable>
+  <variable id="Table of Contents Preface">Предисловие: </variable>
   <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Предисловие</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -29,7 +29,7 @@
   <variable id="Unordered List bullet">•</variable>
   <variable id="Table of Contents">Innehållsförteckning</variable>
   
-  <variable id="Index Continued String"><!--TODO:continued--></variable>
+  <variable id="Index Continued String">forts</variable>
   <variable id="Index See String">, Se </variable>
   <variable id="Index See Also String">Se Även </variable>
   <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>. </variable>


### PR DESCRIPTION
While working on support for tables and index terms continued across pages, we noticed that 4 of the original PDF2 languages contained a "TODO" comment for the Index Continued variable (FI, RO, RU, and SV). I've put in a translation based on variable files we've used internally for many years.

While working on those, I noticed that both Russian and Romanian had a TODO comment for "Table of Contents Preface", even though both already contain a translation of Preface. I replaced that TODO with the existing translation and a colon. This uses the same pattern as existing languages that correctly set both variables.