### PR TITLE
Consistent CLI argument format and validation

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -138,16 +138,26 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private static final Map<String, Argument> ARGUMENTS = new HashMap<>();
     static {
         ARGUMENTS.put("-f", new StringArgument("transtype"));
-        ARGUMENTS.put("-format", new StringArgument("transtype"));
-        ARGUMENTS.put("-transtype", new StringArgument("transtype"));
+        ARGUMENTS.put("--format", new StringArgument("transtype"));
+        ARGUMENTS.put("--transtype", new StringArgument("transtype"));
         ARGUMENTS.put("-i", new FileOrUriArgument("args.input"));
-        ARGUMENTS.put("-input", new FileOrUriArgument("args.input"));
+        ARGUMENTS.put("--input", new FileOrUriArgument("args.input"));
         ARGUMENTS.put("-o", new FileArgument("output.dir"));
-        ARGUMENTS.put("-output", new FileArgument("output.dir"));
-        ARGUMENTS.put("-filter", new FileArgument("args.filter"));
+        ARGUMENTS.put("--output", new FileArgument("output.dir"));
+        ARGUMENTS.put("--filter", new FileArgument("args.filter"));
         ARGUMENTS.put("-t", new FileArgument(ANT_TEMP_DIR));
-        ARGUMENTS.put("-temp", new FileArgument(ANT_TEMP_DIR));
+        ARGUMENTS.put("--temp", new FileArgument(ANT_TEMP_DIR));
+        addSingleHyphenOptions(ARGUMENTS);
     }
+
+    private static void addSingleHyphenOptions(final Map<String, Argument> args) {
+        for (final Map.Entry<String, Argument> e : new HashMap<>(args).entrySet()) {
+            if (e.getKey().startsWith("--")) {
+                args.put(e.getKey().substring(1), e.getValue());
+            }
+        }
+    }
+
     private static final Map<String, String> RESERVED_PROPERTIES = new HashMap<>();
     static {
         for (final Map.Entry<String, Argument> a: ARGUMENTS.entrySet()) {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -130,7 +130,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         LAUNCH_COMMANDS.add("-lib");
         LAUNCH_COMMANDS.add("-cp");
         LAUNCH_COMMANDS.add("-noclasspath");
-        LAUNCH_COMMANDS.add("--noclasspath");
+        LAUNCH_COMMANDS.add("-noclasspath");
         LAUNCH_COMMANDS.add("-nouserlib");
         LAUNCH_COMMANDS.add("-main");
     }
@@ -341,6 +341,11 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
 
         try {
             processArgs(args);
+        } catch (final RuntimeException e) {
+            handleLogfile();
+            e.printStackTrace();
+            exit(1);
+            return;
         } catch (final Throwable exc) {
             handleLogfile();
             printMessage(exc);
@@ -1354,7 +1359,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      *            <code>null</code>, in which case no descriptions are
      *            displayed. If non-<code>null</code>, this should have as many
      *            elements as <code>names</code>.
-     * @param topDependencies The list of dependencies for each target. The
+     * @param dependencies The list of dependencies for each target. The
      *            dependencies are listed as a non null enumeration of String.
      * @param heading The heading to display. Should not be <code>null</code>.
      * @param maxlen The maximum length of the names of the targets. If

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -532,6 +532,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 throw new BuildException(msg);
             } else if (arg.equals("-autoproxy")) {
                 proxy = true;
+            } else if (arg.startsWith("--")) {
+                i = handleArgDefine(args, i);
             } else if (arg.startsWith("-") || arg.startsWith("/")) {
                 // we don't have any more args to recognize!
                 final String msg = "Error: Unknown argument: " + arg;

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -1281,8 +1281,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // msg.append("  -buildfile <file>      use given buildfile" + lSep);
         // msg.append("    -file    <file>              ''" + lSep);
         // msg.append("    -f       <file>              ''" + lSep);
-        msg.append("  -D<property>=<value>,      use value for given property\n");
-        msg.append("  --<property>=<value>\n");
+        msg.append("  --<property>=<value>        use value for given property\n");
         // msg.append("  -keep-going, -k        execute all targets that do not depend"
         // + lSep);
         // msg.append("                         on failed target(s)" + lSep);

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -964,6 +964,8 @@ public final class Constants {
     public static final String CONF_PRINT_TRANSTYPES = "print_transtypes";
     /** Property name for template files. */
     public static final String CONF_TEMPLATES = "templates";
+    /** Plugin configuration file name. */
+    public static final String PLUGIN_CONF = "plugins.xml";
 
     /** Project reference name for job configuration object. */
     public static final String ANT_REFERENCE_JOB = "job";

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -49,6 +49,15 @@ public final class XMLUtils {
     /** Private constructor to make class uninstantiable. */
     private XMLUtils() {}
 
+    /** Convert DOM NodeList to List. */
+    public static <T> List<T> toList(final NodeList nodes) {
+        final List<T> res = new ArrayList<>(nodes.getLength());
+        for (int i = 0; i < nodes.getLength(); i++) {
+            res.add((T) nodes.item(i));
+        }
+        return res;
+    }
+
     /**
      * List descendant elements by DITA class.
      *


### PR DESCRIPTION
Adds support for

* setting long form options using double hyphen
* defining properties with double hyphen addition to `-D`
* validate properties based on plugin configuration