### PR TITLE
Change HTML5 to use libsass instead of Compass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ task copyInstall(type: Copy) {
     }
     destinationDir = file("src/main/lib")
 }
-task buildLocal(type: JavaExec, dependsOn: [copyInstall, ":fo:copyInstall", ":axf:copyInstall", ":xep:copyInstall", ":html5:compassCompile"]) {
+task buildLocal(type: JavaExec, dependsOn: [copyInstall, ":fo:copyInstall", ":axf:copyInstall", ":xep:copyInstall", ":html5:compileSass"]) {
     description "Build archives and install all plugins with dependencies"
     main = "org.apache.tools.ant.launch.Launcher"
     classpath = sourceSets.main.runtimeClasspath + files("${projectDir}/src/main", "${projectDir}/src/main/lib", "${projectDir}/src/main/resources")

--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -1,27 +1,26 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2015 Jarno Elovirta
+ * Copyright 2016 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
-buildscript {
-    dependencies {
-        classpath "com.github.jruby-gradle:jruby-gradle-plugin:0.1.12"
-    }
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+dependencies {
+    compile group: 'com.cathive.sass', name: 'sass-java', version: '4.0.0'
 }
 
-plugins {
-  id "com.github.robfletcher.compass" version "2.0.6"
+ant.taskdef(name: 'sass', classname: 'com.cathive.sass.SassTask', classpath: configurations.runtime.asPath)
+
+task deleteCss(type: Delete) {
+    delete file('css')
 }
 
-configurations.all {
-    resolutionStrategy.force 'rubygems:rb-inotify:0.9.5'
-}
-
-compass {
-  cssDir = file("css")
-  sassDir = file("sass")
-  environment = "production"
-  outputStyle = "expanded"
+task compileSass(dependsOn: [deleteCss] ) << {
+    ant.sass(in: file('sass/commonltr.scss'), outdir: file('css'), outputstyle: 1)
+    ant.sass(in: file('sass/commonrtl.scss'), outdir: file('css'), outputstyle: 1)
 }

--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -5,22 +5,59 @@
  *
  * See the accompanying LICENSE file for applicable license.
  */
+buildscript {
+    dependencies {
+        classpath 'com.cathive.sass:sass-java:4.0.0'
+    }
+
+    repositories {
+        mavenCentral()
+    }
+}
+
 apply plugin: 'java'
 
-repositories {
-    mavenCentral()
-}
-dependencies {
-    compile group: 'com.cathive.sass', name: 'sass-java', version: '4.0.0'
-}
-
-ant.taskdef(name: 'sass', classname: 'com.cathive.sass.SassTask', classpath: configurations.runtime.asPath)
+File cssDir = file('css')
+File sassDir = file('sass')
 
 task deleteCss(type: Delete) {
-    delete file('css')
+    delete cssDir
 }
 
-task compileSass(dependsOn: [deleteCss] ) << {
-    ant.sass(in: file('sass/commonltr.scss'), outdir: file('css'), outputstyle: 1)
-    ant.sass(in: file('sass/commonrtl.scss'), outdir: file('css'), outputstyle: 1)
+import com.cathive.sass.SassCompilationException
+import com.cathive.sass.SassFileContext
+import com.cathive.sass.SassOutputStyle
+
+import java.io.IOException
+import java.io.FileOutputStream
+
+def sass(FileCollection files, File outputDir) {
+    outputDir.mkdir()
+
+    files.each {
+        def ctx = SassFileContext.create(it.toPath())
+        def options = ctx.getOptions()
+        options.setOutputStyle(SassOutputStyle.EXPANDED)
+
+        try {
+            def basename = it.getName().substring(0, it.getName().lastIndexOf('.'))
+            ctx.compile(new FileOutputStream(new File(outputDir, basename + '.css')))
+        } catch (SassCompilationException e) {
+            System.err.println(e.getMessage())
+        } catch (IOException e) {
+            System.err.println(String.format("Compilation failed: %s", e.getMessage()))
+        }
+    }
+}
+
+task compileSass {
+    inputs.dir sassDir
+    outputs.dir cssDir
+
+    doLast {
+        sass(
+            fileTree(dir: 'sass', includes: ['commonltr.scss', 'commonrtl.scss']),
+            cssDir
+        )
+    }
 }

--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -20,15 +20,15 @@ apply plugin: 'java'
 File cssDir = file('css')
 File sassDir = file('sass')
 
+
 import com.cathive.sass.SassCompilationException
 import com.cathive.sass.SassFileContext
 import com.cathive.sass.SassOutputStyle
 
-import java.io.IOException
-import java.io.FileOutputStream
-
 def sass(FileCollection files, File outputDir) {
-    outputDir.mkdir()
+    if (!outputDir.exists() && !outputDir.mkdir()) {
+        throw new IOException("Failed to create ${outputDir}")
+    }
 
     files.each {
         def ctx = SassFileContext.create(it.toPath())
@@ -37,11 +37,12 @@ def sass(FileCollection files, File outputDir) {
 
         try {
             def basename = it.getName().substring(0, it.getName().lastIndexOf('.'))
+            logger.info("Compiling ${it}")
             ctx.compile(new FileOutputStream(new File(outputDir, basename + '.css')))
         } catch (SassCompilationException e) {
-            System.err.println(e.getMessage())
+            logger.error(e.getMessage())
         } catch (IOException e) {
-            System.err.println(String.format("Compilation failed: %s", e.getMessage()))
+            logger.error("Compilation failed: ${e.getMessage()}")
         }
     }
 }
@@ -52,8 +53,8 @@ task compileSass {
 
     doLast {
         sass(
-            fileTree(dir: 'sass', includes: ['commonltr.scss', 'commonrtl.scss']),
-            cssDir
+                fileTree(dir: 'sass', includes: ['commonltr.scss', 'commonrtl.scss']),
+                cssDir
         )
     }
 }

--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -20,10 +20,6 @@ apply plugin: 'java'
 File cssDir = file('css')
 File sassDir = file('sass')
 
-task deleteCss(type: Delete) {
-    delete cssDir
-}
-
 import com.cathive.sass.SassCompilationException
 import com.cathive.sass.SassFileContext
 import com.cathive.sass.SassOutputStyle


### PR DESCRIPTION
Change HTML5 to use libsass instead of Compass. This will not use JRuby and is a lot faster as a result.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>