### PR TITLE
Use Sass `// comment` syntax for partials copyrights

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_display-attr.scss
+++ b/src/main/plugins/org.dita.html5/sass/_display-attr.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // @frame
 
 .frame-top {

--- a/src/main/plugins/org.dita.html5/sass/_domains.scss
+++ b/src/main/plugins/org.dita.html5/sass/_domains.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 @import 'domains/abbreviated-form';
 @import 'domains/bookmap';
 @import 'domains/classification';

--- a/src/main/plugins/org.dita.html5/sass/_figures.scss
+++ b/src/main/plugins/org.dita.html5/sass/_figures.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for figure & image styles
 
 .fig {

--- a/src/main/plugins/org.dita.html5/sass/_headings.scss
+++ b/src/main/plugins/org.dita.html5/sass/_headings.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for heading (title) styles
 
 /* Set heading sizes, getting smaller for deeper nesting */

--- a/src/main/plugins/org.dita.html5/sass/_links.scss
+++ b/src/main/plugins/org.dita.html5/sass/_links.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for link group styles
 
 /* Most link groups are created with <div>. Ensure they have space before and after. */

--- a/src/main/plugins/org.dita.html5/sass/_lists.scss
+++ b/src/main/plugins/org.dita.html5/sass/_lists.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for list styles
 
 /* Simple lists do not get a bullet */

--- a/src/main/plugins/org.dita.html5/sass/_notes.scss
+++ b/src/main/plugins/org.dita.html5/sass/_notes.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for note styles
 
 /* All note formats have the same default presentation */

--- a/src/main/plugins/org.dita.html5/sass/_phrases.scss
+++ b/src/main/plugins/org.dita.html5/sass/_phrases.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for phrase styles
 
 /* Various basic phrase styles */

--- a/src/main/plugins/org.dita.html5/sass/_tables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_tables.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for table styles
 
 table {

--- a/src/main/plugins/org.dita.html5/sass/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/_topic.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2005 IBM Corporation
+//
+// See the accompanying LICENSE file for applicable license.
+
 /* Add space for top level topics */
 .nested0 {
   margin-top: 1em;

--- a/src/main/plugins/org.dita.html5/sass/_variables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_variables.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Roger Sheen
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
 //
 // Variables (based on Bootstrap Sass defaults)
 // --------------------------------------------------

--- a/src/main/plugins/org.dita.html5/sass/commonltr.scss
+++ b/src/main/plugins/org.dita.html5/sass/commonltr.scss
@@ -1,11 +1,12 @@
 /*!
- * This file is part of the DITA Open Toolkit project. See the accompanying LICENSE file for applicable license.
- */
-/*
- | (c) Copyright 2004, 2005 IBM Corporation
+ * This file is part of the DITA Open Toolkit project. 
+ *
+ * Copyright 2004, 2005 IBM Corporation
+ *
+ * See the accompanying LICENSE file for applicable license.
  */
 
- // Import variables first to ensure they are available to subsequent partials
+// Import variables first to ensure they are available to subsequent partials
 @import 'variables';
 
 @import 'domains';

--- a/src/main/plugins/org.dita.html5/sass/commonrtl.scss
+++ b/src/main/plugins/org.dita.html5/sass/commonrtl.scss
@@ -1,11 +1,15 @@
-/*
+/*!
  * This file is part of the DITA Open Toolkit project.
  *
  * Copyright 2015 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
+
+// Import common left-to-right rules first
 @import 'commonltr';
+
+// Overrides for right-to-left languages
 
 .linklist {
   margin-bottom: 1em;

--- a/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // inline 
 .abbreviated-form {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .abbrevlist {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .subjectCell {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .conbody {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .equation-block {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .glossAbbreviation {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .glossgroup {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .glossref {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .consequence {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // inline 
 .b {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .index-see {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .lcAnswerContent {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .lcLom {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningAssessment {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .lcAudience {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningContent {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningOverview {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .lcAge {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningSummary {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningContentRef {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .learningGroupMap {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_map.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_map.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .linktext {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .anchorref {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // inline 
 .markupname {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_mathml-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_mathml-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 .mathml {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .codeblock {
   font-family: monospace;

--- a/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .propdesc {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_relmgmt-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_relmgmt-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 .change-historylist {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .defaultSubject {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_svg-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_svg-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 .svg-container {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .msgblock {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_task.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_task.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 div.tasklabel {
   margin-top: 1em;
   margin-bottom: 1em;

--- a/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .closereqs {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .abstract {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .cause {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2015 Jarno Elovirta
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2015 Jarno Elovirta
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .screen {
   padding: 5px 5px 5px 5px;

--- a/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .area {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // Sass partial for DITA 1.3 XML mention domain
 
 $code-fonts: Menlo, Monaco, Consolas, "Courier New", monospace;

--- a/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
@@ -1,10 +1,9 @@
-/*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2016 Eero Helenius
- *
- * See the accompanying LICENSE file for applicable license.
- */
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2016 Eero Helenius
+//
+// See the accompanying LICENSE file for applicable license.
+
 // block 
 .addressdetails {
 }


### PR DESCRIPTION
While testing the Sass changes in #2499, I noticed an unintended side-effect of the copyright statement revisions from #2467, which results in  multiple redundant copyright comments in the generated CSS files for HTML5.

This PR replaces the C-style (multi-line) `/* comment */` syntax used in the copyright statements of the referenced Sass partials, as these comments are all passed through to the output.

Switching these to Sass C++-style (single-line) `// comment` syntax reduces noise in the CSS output, like in #2369.

The copyright statements in the master Sass files `commonltr.scss` & `commonrtl.scss` are left in C-style syntax to ensure they are propagated to the generated CSS.

The resulting generated CSS files are functionally equivalent to those shipped with DITA-OT 2.3.3.

Signed-off-by: Roger Sheen <roger@infotexture.net>