### PR TITLE
Move XHTML parameters & remove `common-html` transtype

### DIFF
--- a/src/main/plugins/org.dita.xhtml/plugin.xml
+++ b/src/main/plugins/org.dita.xhtml/plugin.xml
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="args.xsl" desc="Specifies a custom XSL file to be used instead of the default XSL transformation." type="file"/>
   </transtype>
-  <transtype name="common-html" extends="base-html" desc="HTML5 and XHTML">
+  <transtype name="xhtml" extends="base-html" desc="XHTML">
     <param name="args.xhtml.contenttarget" desc="Specifies the value of the @target attribute on the &lt;base&gt; element in the TOC file." type="string">
       <val default="true">contentwin</val>
     </param>
@@ -67,7 +67,6 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.xhtml.toc.class" desc="Specifies the value of the @class attribute on the &lt;body&gt; element in the TOC file." type="string"/>
     <param name="args.xhtml.toc.xsl" desc="Specifies a custom XSL file to be used for TOC generation." type="file"/>
   </transtype>
-  <transtype name="xhtml" extends="common-html" desc="XHTML"/>
   <feature extension="dita.conductor.target.relative" file="conductor.xml"/>
   <feature extension="dita.xsl.messages" file="resource/messages.xml"/>
   <template file="build_general_template.xml"/>


### PR DESCRIPTION
XHTML parameters are no longer shared after HTML5 split from XHTML for dita-ot/dita-ot#2405.

This PR ensures that the generated docs topics list these parameters as specific to XHTML rather than as shared [HTML5 and XHTML parameters](http://www.dita-ot.org/2.3/parameters/parameters-common-html.html).

Signed-off-by: Roger Sheen <roger@infotexture.net>