### PR TITLE
Allow getVariable from string context #2512

### DIFF
--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -80,7 +80,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template name="getVariable">
     <xsl:param name="id" as="xs:string"/>
     <xsl:param name="params" as="node()*"/>
-    <xsl:sequence select="dita-ot:get-variable(., $id, $params)"/>
+    <xsl:param name="ctx" as="node()" select="."/>
+    <xsl:sequence select="dita-ot:get-variable($ctx, $id, $params)"/>
   </xsl:template>
 
   <xsl:template name="findString">


### PR DESCRIPTION
getVariable is currently designed to work from the context of an XML node. This enhancement allows getVariable to be called from any context; it also allows somebody to override the context, which could be used to override the language (if that's ever needed).