### PR TITLE
Clean PDF2 styling and move legacy styling plugin

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -85,7 +85,6 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:attribute-set name="common.link">
     <xsl:attribute name="color">blue</xsl:attribute>
-    <xsl:attribute name="font-style">italic</xsl:attribute>
   </xsl:attribute-set>
 
     <xsl:attribute-set name="__unresolved__conref">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
@@ -36,6 +36,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute-set name="linklist">
     </xsl:attribute-set>
 
+  <xsl:attribute-set name="linklist.title" use-attribute-sets="common.title">
+    <xsl:attribute name="font-weight">bold</xsl:attribute>
+  </xsl:attribute-set>
+
     <xsl:attribute-set name="linkpool">
     </xsl:attribute-set>
 
@@ -88,6 +92,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:attribute-set name="related-links.ol.li__content" use-attribute-sets="ol.li__content">
   </xsl:attribute-set>
 
+  <!-- FIXME: is this obsolete? -->
     <xsl:attribute-set name="related-links.title">
     <xsl:attribute name="font-weight">bold</xsl:attribute>
   </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
@@ -35,11 +35,6 @@ See the accompanying LICENSE file for applicable license.
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     version="2.0">
 
-    <xsl:attribute-set name="linklist.title">
-        <xsl:attribute name="font-weight">bold</xsl:attribute>
-        <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
-    </xsl:attribute-set>
-
     <!--Common-->
     <xsl:attribute-set name="li.itemgroup">
         <xsl:attribute name="space-after">3pt</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -74,11 +74,13 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:attribute-set name="table__container">
     <xsl:attribute name="reference-orientation" select="if (@orient eq 'land') then 90 else 0"/>
+    <xsl:attribute name="start-indent">from-parent(start-indent)</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="table" use-attribute-sets="base-font">
     <!--It is a table container -->
     <xsl:attribute name="space-after">10pt</xsl:attribute>
+    <xsl:attribute name="start-indent">0pt</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="table.tgroup">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
@@ -123,6 +123,9 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="steps.step__content" use-attribute-sets="ol.li__content">
     </xsl:attribute-set>
+  
+  <xsl:attribute-set name="steps.step__content--onestep" use-attribute-sets="common.block">
+  </xsl:attribute-set>
 
     <!-- Stepsection (new in DITA 1.2) -->
     <xsl:attribute-set name="stepsection" use-attribute-sets="ul.li">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -192,19 +192,14 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute-set name="topic__shortdesc" use-attribute-sets="body">
     </xsl:attribute-set>
 
-    <xsl:attribute-set name="section" use-attribute-sets="base-font">
-        <xsl:attribute name="line-height"><xsl:value-of select="$default-line-height"/></xsl:attribute>
+    <xsl:attribute-set name="section">
         <xsl:attribute name="space-before">0.6em</xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="section__content">
     </xsl:attribute-set>
 
-    <xsl:attribute-set name="example" use-attribute-sets="base-font common.border">
-        <xsl:attribute name="line-height"><xsl:value-of select="$default-line-height"/></xsl:attribute>
+    <xsl:attribute-set name="example">
         <xsl:attribute name="space-before">0.6em</xsl:attribute>
-        <xsl:attribute name="start-indent">36pt + from-parent(start-indent)</xsl:attribute>
-        <xsl:attribute name="end-indent">36pt</xsl:attribute>
-        <xsl:attribute name="padding">5pt</xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="example__content">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -206,64 +206,45 @@ See the accompanying LICENSE file for applicable license.
         </fo:block>
     </xsl:template>
 
-    <!--Steps-->
-    <xsl:template match="*[contains(@class, ' task/steps ')]">
-        <xsl:choose>
-            <xsl:when test="$GENERATE-TASK-LABELS='YES'">
-              <fo:block>
-                  <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
-                      <xsl:with-param name="use-label">
-                        <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
-                          <xsl:with-param name="pdf2-string">Task Steps</xsl:with-param>
-                          <xsl:with-param name="common-string">task_procedure</xsl:with-param>
-                        </xsl:apply-templates>
-                      </xsl:with-param>
-                  </xsl:apply-templates>
-                  <fo:list-block xsl:use-attribute-sets="steps">
-                      <xsl:call-template name="commonattributes"/>
-                      <xsl:apply-templates/>
-                  </fo:list-block>
-              </fo:block>
-            </xsl:when>
-            <xsl:otherwise>
-                <fo:list-block xsl:use-attribute-sets="steps">
-                    <xsl:call-template name="commonattributes"/>
-                    <xsl:apply-templates/>
-                </fo:list-block>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-  <xsl:template match="*[contains(@class, ' task/steps-unordered ')]">
-    <xsl:choose>
-      <xsl:when test="$GENERATE-TASK-LABELS='YES'">
-        <fo:block>
-          <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
-            <xsl:with-param name="use-label">
-              <!--<xsl:call-template name="getVariable">
-                <xsl:with-param name="id" select="'#steps-unordered-label'"/>
-              </xsl:call-template>-->
-              <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
-                <xsl:with-param name="pdf2-string">#steps-unordered-label</xsl:with-param>
-                <xsl:with-param name="common-string">task_procedure_unordered</xsl:with-param>
-              </xsl:apply-templates>
-            </xsl:with-param>
-          </xsl:apply-templates>
-          <fo:list-block xsl:use-attribute-sets="steps-unordered">
+    <xsl:template match="*[contains(@class, ' task/steps ')]" name="steps">
+      <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
+          <xsl:with-param name="use-label">
+            <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+              <xsl:with-param name="pdf2-string">Task Steps</xsl:with-param>
+              <xsl:with-param name="common-string">task_procedure</xsl:with-param>
+            </xsl:apply-templates>
+          </xsl:with-param>
+      </xsl:apply-templates>
+      <xsl:choose>
+        <xsl:when test="count(*[contains(@class, ' task/step ')]) eq 1">
+          <fo:block>
+            <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates mode="onestep"/>
+          </fo:block>
+        </xsl:when>
+        <xsl:otherwise>
+          <fo:list-block xsl:use-attribute-sets="steps">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
           </fo:list-block>
-        </fo:block>
-      </xsl:when>
-      <xsl:otherwise>
-        <fo:list-block xsl:use-attribute-sets="steps-unordered">
-          <xsl:call-template name="commonattributes"/>
-          <xsl:apply-templates/>
-        </fo:list-block>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:template>
 
+  <xsl:template match="*[contains(@class, ' task/steps-unordered ')]" name="steps-unordered">
+    <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
+      <xsl:with-param name="use-label">
+        <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
+          <xsl:with-param name="pdf2-string">#steps-unordered-label</xsl:with-param>
+          <xsl:with-param name="common-string">task_procedure_unordered</xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:with-param>
+    </xsl:apply-templates>
+    <fo:list-block xsl:use-attribute-sets="steps-unordered">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates/>
+    </fo:list-block>
+  </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/steps ')]/*[contains(@class, ' task/step ')]">
         <!-- Switch to variable for the count rather than xsl:number, so that step specializations are also counted -->
@@ -317,6 +298,13 @@ See the accompanying LICENSE file for applicable license.
 
         </fo:list-item>
     </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' task/step ')]" mode="onestep">
+    <fo:block xsl:use-attribute-sets="steps.step__content--onestep">
+      <xsl:apply-templates/>
+    </fo:block>
+  </xsl:template>
+  <xsl:template match="node()" mode="onestep" priority="-10"/>
 
     <xsl:template match="*[contains(@class, ' task/stepsection ')]">
         <fo:list-item xsl:use-attribute-sets="stepsection">


### PR DESCRIPTION
Clean PDF2 to remove styling that is almost always overridden or are ugly, and move legacy styling to a separate plugin to reproduce them.

* [Legacy plugin repository][1]

[1]: https://github.com/dita-ot/org.dita.pdf2.legacy