### PR TITLE
Use context variable for localclass in messages stylesheet #2526

### DIFF
--- a/src/main/xsl/common/output-message.xsl
+++ b/src/main/xsl/common/output-message.xsl
@@ -60,7 +60,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="localclass" select="@class"/>
+    <xsl:variable name="localclass" select="$ctx/@class" as="attribute(class)?"/>
     <xsl:variable name="xtrf" select="$ctx/@xtrf" as="attribute(xtrf)?"/>
     <xsl:variable name="xtrc" select="$ctx/@xtrc" as="attribute(xtrc)?"/>
     <xsl:variable name="debugloc">


### PR DESCRIPTION
See https://github.com/dita-ot/dita-ot/issues/2526
Harmonized $localclass with $xtrf and $xtrc syntax