### PR TITLE
Exclude additional namespace prefixes

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
                 version="2.0"
-                exclude-result-prefixes="xs dita2html dita-ot table simpletable">
+                exclude-result-prefixes="xs dita2html ditamsg dita-ot table simpletable">
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-summary-attribute">
     <!-- Override this to use a local convention for setting table's @summary attribute,

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 version="2.0"
-                exclude-result-prefixes="xs dita-ot">
+                exclude-result-prefixes="xs dita-ot related-links dita2html ditamsg ">
   
   <!-- Determines whether to generate titles for task sections. Values are YES and NO. -->
   <xsl:param name="GENERATE-TASK-LABELS" select="'NO'"/>


### PR DESCRIPTION
Building `dev` docs output w/ 2.4.1 reveals additional spurious namespace attributes in HTML5 output that are not present in output generated with 2.3.3 (see dita-ot/dita-ot.github.io@cbbcea5).

The issue was partially addressed (for tables) in 2.4.1 with commit d59e3a8.

This PR applies the same exclusions to additional cases (task bodies & simpletables).

Signed-off-by: Roger Sheen <roger@infotexture.net>