### PR TITLE
Output error messages in red colour in Terminal

### DIFF
--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -45,6 +45,17 @@ import org.apache.tools.ant.util.FileUtils;
  * 
  */
 class DefaultLogger implements BuildLogger {
+
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_BLACK = "\u001B[30m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_GREEN = "\u001B[32m";
+    public static final String ANSI_YELLOW = "\u001B[33m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+    public static final String ANSI_PURPLE = "\u001B[35m";
+    public static final String ANSI_CYAN = "\u001B[36m";
+    public static final String ANSI_WHITE = "\u001B[37m";
+
     /**
      * Size of left-hand column for right-justified task name.
      * 
@@ -346,7 +357,13 @@ class DefaultLogger implements BuildLogger {
      *            implementation.)
      */
     private void printMessage(final String message, final PrintStream stream, final int priority) {
-        stream.println(message);
+        if (priority == Project.MSG_ERR) {
+            stream.print(ANSI_RED);
+            stream.print(message);
+            stream.println(ANSI_RESET);
+        } else {
+            stream.println(message);
+        }
     }
 
     /**

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -83,6 +83,7 @@ class DefaultLogger implements BuildLogger {
 
     /** Whether or not to use emacs-style output */
     private boolean emacsMode = false;
+    private boolean useColor = false;
 
     // CheckStyle:VisibilityModifier ON
 
@@ -143,6 +144,10 @@ class DefaultLogger implements BuildLogger {
     @Override
     public void setEmacsMode(final boolean emacsMode) {
         this.emacsMode = emacsMode;
+    }
+
+    public void useColor(final boolean useColor) {
+        this.useColor = useColor;
     }
 
     /**
@@ -357,7 +362,7 @@ class DefaultLogger implements BuildLogger {
      *            implementation.)
      */
     private void printMessage(final String message, final PrintStream stream, final int priority) {
-        if (priority == Project.MSG_ERR) {
+        if (useColor && priority == Project.MSG_ERR) {
             stream.print(ANSI_RED);
             stream.print(message);
             stream.println(ANSI_RESET);

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -549,7 +549,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         boolean justPrintUsage = false;
         boolean justPrintVersion = false;
         boolean justPrintDiagnostics = false;
-        useColor = Boolean.parseBoolean(Configuration.configuration.getOrDefault("cli.color", "true"));
+        useColor = getUseColor();
 
         final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
         while (!args.isEmpty()) {
@@ -751,6 +751,14 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             System.setErr(err);
         }
         readyToRun = true;
+    }
+
+    private boolean getUseColor() {
+        final String os = System.getProperty("os.name");
+        if (os != null && os.startsWith("Windows")) {
+            return false;
+        }
+        return Boolean.parseBoolean(Configuration.configuration.getOrDefault("cli.color", "true"));
     }
 
     private PrintStream handleArgLogFile(Deque<String> args) {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -391,8 +391,14 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private static void printMessage(final Throwable t) {
         final String message = t.getMessage();
         if (message != null && !message.trim().isEmpty()) {
-            System.err.println("Error: " + message);
+            printErrorMessage("Error: " + message);
         }
+    }
+
+    private static void printErrorMessage(final String msg) {
+        System.err.print(DefaultLogger.ANSI_RED);
+        System.err.print("Error: " + msg);
+        System.err.println(DefaultLogger.ANSI_RESET);
     }
 
     /**
@@ -608,7 +614,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             } else if (arg.startsWith("-") || arg.startsWith("/")) {
                 // we don't have any more args to recognize!
                 final String msg = "Error: Unknown argument: " + arg;
-                System.err.println(msg);
+                printErrorMessage(msg);
                 printUsage();
                 throw new BuildException("");
             } else {
@@ -650,13 +656,13 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             }
         } else {
             if (!definedProps.containsKey("transtype")) {
-                System.err.println("Error: Transformation type not defined");
+                printErrorMessage("Error: Transformation type not defined");
                 printUsage();
                 throw new BuildException("");
                 //justPrintUsage = true;
             }
             if (!definedProps.containsKey("args.input")) {
-                System.err.println("Error: Input file not defined");
+                printErrorMessage("Error: Input file not defined");
                 printUsage();
                 throw new BuildException("");
                 //justPrintUsage = true;
@@ -1145,10 +1151,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 } catch (final Throwable t) {
                     // yes, I know it is bad style to catch Throwable,
                     // but if we don't, we lose valuable information
-                    System.err.println("Caught an exception while logging the" + " end of the build.  Exception was:");
+                    printErrorMessage("Caught an exception while logging the" + " end of the build.  Exception was:");
                     t.printStackTrace();
                     if (error != null) {
-                        System.err.println("There has been an error prior to" + " that:");
+                        printErrorMessage("There has been an error prior to" + " that:");
                         error.printStackTrace();
                     }
                     throw new BuildException(t);
@@ -1219,7 +1225,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 logger = (BuildLogger) ClasspathUtils.newInstance(loggerClassname, Main.class.getClassLoader(),
                         BuildLogger.class);
             } catch (final BuildException e) {
-                System.err.println("The specified logger class " + loggerClassname + " could not be used because "
+                printErrorMessage("The specified logger class " + loggerClassname + " could not be used because "
                         + e.getMessage());
                 throw new RuntimeException();
             }

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -74,6 +74,8 @@ import static org.dita.dost.util.XMLUtils.toList;
  */
 public class Main extends org.apache.tools.ant.Main implements AntMain {
 
+    private boolean useColor;
+
     private static abstract class Argument {
         final String property;
 
@@ -388,17 +390,21 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      * @param t Throwable to print the message of. Must not be <code>null</code>
      *            .
      */
-    private static void printMessage(final Throwable t) {
+    private void printMessage(final Throwable t) {
         final String message = t.getMessage();
         if (message != null && !message.trim().isEmpty()) {
             printErrorMessage("Error: " + message);
         }
     }
 
-    private static void printErrorMessage(final String msg) {
-        System.err.print(DefaultLogger.ANSI_RED);
-        System.err.print("Error: " + msg);
-        System.err.println(DefaultLogger.ANSI_RESET);
+    private void printErrorMessage(final String msg) {
+        if (useColor) {
+            System.err.print(DefaultLogger.ANSI_RED);
+            System.err.print("Error: " + msg);
+            System.err.println(DefaultLogger.ANSI_RESET);
+        } else {
+            System.err.println("Error: " + msg);
+        }
     }
 
     /**
@@ -543,6 +549,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         boolean justPrintUsage = false;
         boolean justPrintVersion = false;
         boolean justPrintDiagnostics = false;
+        useColor = Boolean.parseBoolean(Configuration.configuration.getOrDefault("cli.color", "true"));
 
         final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
         while (!args.isEmpty()) {
@@ -753,6 +760,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             final File logFile = new File(value);
             logTo = new PrintStream(new FileOutputStream(logFile));
             isLogFileUsed = true;
+            useColor = false;
         } catch (final IOException ioe) {
             final String msg = "Cannot write on the specified log file. "
                     + "Make sure the path exists and you have write " + "permissions.";
@@ -1231,6 +1239,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             }
         } else {
             logger = new DefaultLogger();
+            ((DefaultLogger) logger).useColor(useColor);
         }
 
         logger.setMessageOutputLevel(msgOutputLevel);

--- a/src/main/lib/configuration.properties
+++ b/src/main/lib/configuration.properties
@@ -11,6 +11,7 @@ generate-debug-attributes = true
 processing-mode = lax
 default.cascade = merge
 temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$DefaultTempFileScheme
+cli.color = true
 
 # Integration
 plugindirs = plugins;demo


### PR DESCRIPTION
Use [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) to colour error messages in `dita` command output. When log is written to a file, colour output is disabled. Colour output can be toggled using `cli.color=true|false` configuration option.