### PR TITLE
Added missing dependencies for dost.jar in build.xml

### DIFF
--- a/src/main/build_template.xml
+++ b/src/main/build_template.xml
@@ -25,6 +25,8 @@ See the accompanying LICENSE file for applicable license.
     
   <path id="dost.class.path">
     <dita:extension id="dita.conductor.lib.import" behavior="org.dita.dost.platform.ImportAntLibAction"/>
+    <pathelement location="${dita.dir}/lib/commons-io-2.5.jar"/>
+    <pathelement location="${dita.dir}/lib/commons-codec-1.10.jar"/>
     <pathelement location="${dita.dir}/lib/dost.jar"/>
     <pathelement location="${dita.dir}/lib/dost-configuration.jar"/>
   </path>


### PR DESCRIPTION
The dita:extesion is not including the two dependencies for dost.jar, which renders build.xml useless.
Probably the way it is done in this PR is not state-of-art, but at least it raises a flag.