### PR TITLE
Support processing DITA elements within foreign / unknown

### DIFF
--- a/src/main/java/org/dita/dost/util/DitaClass.java
+++ b/src/main/java/org/dita/dost/util/DitaClass.java
@@ -29,6 +29,8 @@ public final class DitaClass {
     // Variables
 
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern VALID_DITA_CLASS = Pattern.compile("(\\+|-)\\s+(topic|map)/\\S+\\s+" +
+                                                         "([\\S[^/]]+/\\S+\\s+)*");
 
     /** Module/type pair for the most specialized type, with a single preceding and following space character. */
     public final String matcher;
@@ -36,6 +38,8 @@ public final class DitaClass {
     public final String localName;
     /** Normalized specialization hierarchy string. */
     private final String stringValue;
+    /** Does this class value use valid DITA class syntax */
+    private boolean validDitaClass = false;
 
     // Constructors
 
@@ -54,6 +58,7 @@ public final class DitaClass {
             sb.append(s).append(' ');
         }
         stringValue = sb.toString();
+        validDitaClass = VALID_DITA_CLASS.matcher(stringValue).matches();
     }
 
     /**
@@ -172,6 +177,15 @@ public final class DitaClass {
             return matches(((Element) node).getAttribute(ATTRIBUTE_NAME_CLASS));
         }
         return false;
+    }
+    
+    /**
+     * Test if the current DitaClass is a valid DITA class value
+     * 
+     * @return {@code true} if uses valid DITA class syntax, otherwise {@code false} 
+     */
+    public boolean isValid () {
+    	return validDitaClass;
     }
 
 }

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -117,6 +117,27 @@ public final class XMLUtils {
         }
         return res;
     }
+    
+    /**
+     * Checks if the closest DITA ancestor <foreign> or <unknown>
+     * 
+     * @param classes stack of class attributes for open elements
+     * @return true if closest DITA ancestor is <foreign> or <unknown>, otherwise false
+     */
+    public static boolean nonDitaContext(final Deque<DitaClass> classes) {
+    	final Iterator<DitaClass> it = classes.iterator();
+    	it.next(); // Skip first, because we're checking if current element is inside non-DITA context
+    	while (it.hasNext()) {
+    		final DitaClass cls = it.next();
+    		if (cls != null && cls.isValid() && 
+    				(TOPIC_FOREIGN.matches(cls) || TOPIC_UNKNOWN.matches(cls))) {
+    			return true;
+    		} else if (cls != null && cls.isValid()) {
+    			return false;
+    		}
+    	}
+    	return false;
+    }
 
     /**
      * Get specific element node from child nodes.

--- a/src/main/resources/messages_template.xml
+++ b/src/main/resources/messages_template.xml
@@ -132,7 +132,7 @@ See the accompanying LICENSE file for applicable license.
   
   <message id="DOTJ030I" type="INFO">
     <reason>No 'class' attribute for was found for element '&lt;%1&gt;'.</reason>
-    <response>This generally indicates that your DTD or Schema was not developed properly according to the DITA specification.</response>
+    <response>The element will be processed as an unknown or non-DITA element.</response>
   </message> 
   
   <message id="DOTJ031I" type="INFO">
@@ -331,6 +331,11 @@ See the accompanying LICENSE file for applicable license.
   <message id="DOTJ069E" type="ERROR">
     <reason>Circular key definition %1.</reason>
     <response></response>
+  </message>
+
+  <message id="DOTJ070I" type="INFO">
+    <reason>Invalid 'class' attribute '%1' for was found for element '&lt;%2&gt;'.</reason>
+    <response>The element will be processed as an unknown or non-DITA element.</response>
   </message>
 
   <!-- End of Java Messages -->

--- a/src/test/java/org/dita/dost/util/DitaClassTest.java
+++ b/src/test/java/org/dita/dost/util/DitaClassTest.java
@@ -91,5 +91,18 @@ public class DitaClassTest {
         assertTrue(new DitaClass("- foo/bar baz/qux ").matches(elem));
         assertFalse(new DitaClass("- bar/baz ").matches(elem));
     }
+    
+    @Test
+    public void testValidDitaClass() {
+        assertTrue(new DitaClass("- topic/p ").isValid());
+        assertTrue(new DitaClass("+ topic/p topic-d/domain_element ").isValid());
+        assertTrue(new DitaClass("+ topic/p topic-d/domain_element   ex+d/x ").isValid());
+        assertTrue(new DitaClass("- map/topicref ").isValid());
+        assertTrue(new DitaClass("+ map/topicref map-d/domain_element ").isValid());
+        assertFalse(new DitaClass("").isValid());
+        assertFalse(new DitaClass("invalid syntax").isValid());
+        assertFalse(new DitaClass("- close/but/invalid ").isValid());
+        assertFalse(new DitaClass("- also\\invalid ").isValid());
+    }
 
 }

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -10,6 +10,8 @@ package org.dita.dost.util;
 import static javax.xml.XMLConstants.*;
 import static org.junit.Assert.*;
 
+import java.util.Deque;
+import java.util.LinkedList;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Element;
@@ -161,6 +163,48 @@ public class XMLUtilsTest {
         final String expected = "&lt;this is test of char update for xml href=&quot; see link: http://www.ibm.com/download.php?abc=123&amp;def=456&quot;&gt;&apos;test&apos; &lt;/test&gt;";
         result = XMLUtils.escapeXML(input, 0, input.length);
         assertEquals(expected, result);
+    }
+    
+    @Test
+    public void testNonDitaContext() {
+    	/* Queue assumes the following values:
+    	 * <topic class="- topic/topic ">...
+    	 *  <body class="- topic/body ">
+    	 *   <foreign class="- topic/foreign ">
+    	 *    <NONDITA class="nondita">
+    	 *      <moreNonDita/>
+    	 *    </NONDITA>
+    	 *    <ditaInForeign class="- topic/xref foreign-d/ditaInForeign ">
+    	 *      <ph class="- topic/ph "/>
+    	 *    <unknown class="- topic/unknown ">
+    	 *     <moreNonDita><more/></moreNonDita>
+    	 *    </unknown></ditaInForeign></foreign></body></topic>
+    	 */
+    	Deque<DitaClass> classes = new LinkedList<>();
+    	classes.addFirst(new DitaClass("- topic/topic "));
+    	assertFalse(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(new DitaClass("- topic/body "));
+    	assertFalse(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(new DitaClass("- topic/foreign "));
+    	assertFalse(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(new DitaClass("nondita"));
+    	assertTrue(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(new DitaClass(""));
+    	assertTrue(XMLUtils.nonDitaContext(classes));
+    	classes.pop();
+    	classes.pop();
+    	classes.addFirst(new DitaClass("+ topic/xref foreign-d/ditaInForeign "));
+    	assertTrue(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(new DitaClass("+ topic/ph "));
+    	assertFalse(XMLUtils.nonDitaContext(classes));
+    	classes.pop();
+    	classes.pop();
+    	classes.addFirst(new DitaClass("- topic/unknown "));
+    	assertTrue(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(null);
+    	assertTrue(XMLUtils.nonDitaContext(classes));
+    	classes.addFirst(null);
+    	assertTrue(XMLUtils.nonDitaContext(classes));
     }
 
 }

--- a/src/test/resources/ProfilingFilterTest/exp/topic.dita
+++ b/src/test/resources/ProfilingFilterTest/exp/topic.dita
@@ -11,6 +11,8 @@
     <p class="- topic/p " platform="osx">OS X platform</p>
     <p class="- topic/p " platform="windows osx">Windows and OS X platform</p>
     <foreign class="- topic/foreign ">
+      <para platform="windows">non-DITA para, should not filter</para>
+      <para class="notdita" platform="windows">another non-DITA para, should not filter</para>
       <p class="- topic/p " platform="windows">Foreign Windows</p>
     </foreign>
     <p hardware-platform="" class="- topic/p ">Empty hardware-platform</p>

--- a/src/test/resources/ProfilingFilterTest/exp/topic1.dita
+++ b/src/test/resources/ProfilingFilterTest/exp/topic1.dita
@@ -11,7 +11,9 @@
     <p class="- topic/p " platform="osx">OS X platform</p>
     <p class="- topic/p " platform="windows osx">Windows and OS X platform</p>
     <foreign class="- topic/foreign ">
-      <p platform="windows" class="- topic/p ">Foreign Windows</p>
+      <para platform="windows">non-DITA para, should not filter</para>
+      <para class="notdita" platform="windows">another non-DITA para, should not filter</para>
+      <!--<p platform="windows" class="- topic/p ">Foreign Windows</p>-->
     </foreign>
     <p hardware-platform="" class="- topic/p ">Empty hardware-platform</p>
     <!--p hardware-platform="arm" class="- topic/p ">ARM hardware-platform</p-->

--- a/src/test/resources/ProfilingFilterTest/src/topic.dita
+++ b/src/test/resources/ProfilingFilterTest/src/topic.dita
@@ -11,6 +11,8 @@
     <p class="- topic/p " platform="osx">OS X platform</p>
     <p class="- topic/p " platform="windows osx">Windows and OS X platform</p>
     <foreign class="- topic/foreign ">
+      <para platform="windows">non-DITA para, should not filter</para>
+      <para class="notdita" platform="windows">another non-DITA para, should not filter</para>
       <p class="- topic/p " platform="windows">Foreign Windows</p>
     </foreign>
     <p hardware-platform="" class="- topic/p ">Empty hardware-platform</p>


### PR DESCRIPTION
This is coming out of discussion in #2561 but distinct from that issue.

The `foreign` and `unknown` elements are outlets for non-DITA content. As such, DITA-OT more or less ignores all content during preprocessing. However, they will often contain DITA elements, possibly as a way to provide alternate versions for processors that cannot recognize or work with the actual foreign / unknown material. (In the math context, the standard uses an `xref` specialization for other reasons.) DITA-OT preprocess should recognize DITA elements -- those with valid DITA `@class` attributes -- and handle them as it would handle those same elements outside of a foreign context.

This is not intended to cover rendering the elements, which will always vary based on transform type and based on what else is part of the `foreign` or `unknown` elements.