### PR TITLE
Fix #2573 by removing duplicated templates from topic.xsl

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2633,44 +2633,6 @@ See the accompanying LICENSE file for applicable license.
     <meta charset="UTF-8"/>
   </xsl:template>  
   
-  <xsl:template match="*[contains(@class,' topic/copyright ')]" mode="gen-metadata">
-    <meta name="rights">
-      <xsl:attribute name="content">
-        <xsl:text>&#xA9; </xsl:text>
-        <xsl:apply-templates select="*[contains(@class,' topic/copyryear ')][1]" mode="gen-metadata"/>
-        <xsl:text> </xsl:text>
-        <xsl:if test="*[contains(@class,' topic/copyrholder ')]">
-          <xsl:value-of select="*[contains(@class,' topic/copyrholder ')]"/>
-        </xsl:if>                
-      </xsl:attribute>
-    </meta>
-  </xsl:template>
-  <xsl:template match="*[contains(@class,' topic/copyryear ')]" mode="gen-metadata">
-    <xsl:param name="previous" select="/.."/>
-    <xsl:param name="open-sequence" select="false()"/>
-    <xsl:variable name="next" select="following-sibling::*[contains(@class,' topic/copyryear ')][1]"/>
-    <xsl:variable name="begin-sequence" select="@year + 1 = number($next/@year)"/>
-    <xsl:choose>
-      <xsl:when test="$begin-sequence">
-        <xsl:if test="not($open-sequence)">
-          <xsl:value-of select="@year"/>
-          <xsl:text>&#x2013;</xsl:text>
-        </xsl:if>
-      </xsl:when>
-      <xsl:when test="$next">
-        <xsl:value-of select="@year"/>
-        <xsl:text>, </xsl:text>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="@year"/>
-      </xsl:otherwise>
-    </xsl:choose>
-    <xsl:apply-templates select="$next" mode="gen-metadata">
-      <xsl:with-param name="previous" select="."/>
-      <xsl:with-param name="open-sequence" select="$begin-sequence"/>
-    </xsl:apply-templates>
-  </xsl:template>
-  
   <xsl:template match="*[contains(@class,' topic/title ')]" mode="gen-metadata"/>
   <xsl:template match="*[contains(@class,' topic/shortdesc ')]" mode="gen-metadata">
     <xsl:variable name="shortmeta">


### PR DESCRIPTION
This change removes the conflict and allows processing copyright metadata using the templates in get-meta.xsl.

Signed-off-by: Shane Taylor <shane@taylortext.com>