### PR TITLE
Fix empty nav ToC in topic with to-content chunk #2577

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -238,6 +238,9 @@ See the accompanying LICENSE file for applicable license.
                         (not(@format) or @format = 'dita' or @format = 'ditamap') ">
           <xsl:value-of select="@copy-to"/>
         </xsl:when>
+        <xsl:when test="contains(@chunk, 'to-content')">
+          <xsl:value-of select="substring-before(@href,'#')"/>
+        </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="@href"/>
         </xsl:otherwise>


### PR DESCRIPTION
When a topic is chunked to-content a #id is added at the end of the file name in the @href.

When creating the `current-topicref variable` :

```
<xsl:variable name="current-topicrefs" input.map//*[contains(@class, ' map/topicref ')][dita-ot:get-path($PATH2PROJ, .) = $current-file]"/> 
```
The result of dita-ot:get-path contains the #id therefore the condition is never met.