### PR TITLE
Fix empty link citation in FOP index #2584

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -66,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
               select="key('refid-by-value', @value)
                       [empty(ancestor-or-self::opentopic-index:index.entry[@end-range])]
                       [empty(ancestor::opentopic-index:index.groups)]
-                      [empty(ancestor::*[@no-page eq 'true'])]"/>
+                      [empty(ancestor::*[@no-page eq 'true'])]
+                      [ancestor::*[contains(@class,' topic/topic ')]]"/>
           </xsl:for-each>
         </xsl:variable>
 


### PR DESCRIPTION
This drops FOP index links to map entries, which currently do not generate anchors in the content anyway. This results in two problems:
* If anchors existed, we'd get duplicate page citations (one for the entry in the map, another for the entry after it is pushed into the topic)
* Because the anchor does not exist, we get an empty citation followed by a comma