### PR TITLE
Add support to define XML reader features in plugin configuration

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -260,6 +260,10 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         }
         ditavalFile = toFile(input.getAttribute(ANT_INVOKER_PARAM_DITAVAL));
         validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
+        if (!validate) {
+            final String msg = MessageUtils.getInstance().getMessage("DOTJ037W").toString();
+            logger.warn(msg);
+        }
         transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
         gramcache = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAM_GRAMCACHE));
         setSystemid = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID));

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.module;
 
+import static java.util.Collections.EMPTY_MAP;
 import static org.dita.dost.reader.GenListModuleReader.*;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.Configuration.*;
@@ -59,6 +60,7 @@ import org.dita.dost.writer.ExportAnchorsFilter.ExportAnchor;
 import org.dita.dost.writer.ProfilingFilter;
 import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.helpers.XMLReaderFactory;
 
 /**
  * This class extends AbstractPipelineModule, used to generate map and topic
@@ -68,7 +70,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * 
  * @author Wu, Zhi Qiang
  */
-public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
+public final class GenMapAndTopicListModule extends SourceReaderModule {
 
     public static final String ELEMENT_STUB = "stub";
     /** Generate {@code xtrf} and {@code xtrc} attributes */
@@ -137,8 +139,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
     /** Absolute basedir for processing */
     private URI baseInputDir;
 
-    /** Absolute ditadir for processing */
-    private File ditaDir;
     /** Profiling is enabled. */
     private boolean profilingEnabled;
     /** Absolute path for filter file. */
@@ -146,12 +146,9 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
     /** Number of directory levels base directory is adjusted. */
     private int uplevels = 0;
 
-    /** XMLReader instance for parsing dita file */
-    private XMLReader reader;
     private GenListModuleReader listFilter;
     private KeydefFilter keydefFilter;
     private ExportAnchorsFilter exportAnchorsFilter;
-    private boolean xmlValidate = true;
     private ContentHandler nullHandler;
     private FilterUtils filterUtils;
     private TempFileNameScheme tempFileNameScheme;
@@ -168,9 +165,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
     private final Map<URI, Set<URI>> schemeDictionary;
     private final Map<URI, URI> copyTo = new HashMap<>();
     private String transtype;
-
-    /** use grammar pool cache */
-    private boolean gramcache = true;
 
     private boolean setSystemid = true;
 
@@ -218,7 +212,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
             parseInputParameters(input);
 
             initFilters();
-            initXMLReader(ditaDir, xmlValidate);
+            initXmlReader();
             
             addToWaitList(new Reference(rootFile));
             processWaitList();
@@ -258,43 +252,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         
         nullHandler = new DefaultHandler();
     }
-
-    /**
-     * Init xml reader used for pipeline parsing.
-     * 
-     * @param ditaDir absolute path to DITA-OT directory
-     * @param validate whether validate input file
-     * @throws SAXException parsing exception
-     */
-    private void initXMLReader(final File ditaDir, final boolean validate) throws SAXException {
-        reader = XMLUtils.getXMLReader();
-        // to check whether the current parsing file's href value is out of inputmap.dir
-        reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
-        if (validate) {
-            reader.setFeature(FEATURE_VALIDATION, true);
-            try {
-                reader.setFeature(FEATURE_VALIDATION_SCHEMA, true);
-            } catch (final SAXNotRecognizedException e) {
-                // Not Xerces, ignore exception
-            }
-        } else {
-            final String msg = MessageUtils.getInstance().getMessage("DOTJ037W").toString();
-            logger.warn(msg);
-        }
-        if (gramcache) {
-            final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
-            try {
-                reader.setProperty("http://apache.org/xml/properties/internal/grammar-pool", grammarPool);
-                logger.info("Using Xerces grammar pool for DTD and schema caching.");
-            } catch (final NoClassDefFoundError e) {
-                logger.debug("Xerces not available, not using grammar caching");
-            } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
-                logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
-            }
-        }
-        CatalogUtils.setDitaDir(ditaDir);
-        reader.setEntityResolver(CatalogUtils.getCatalogResolver());
-    }
     
     private void parseInputParameters(final AbstractPipelineInput input) {
         ditaDir = toFile(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
@@ -302,7 +259,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
             throw new IllegalArgumentException("DITA-OT installation directory " + ditaDir + " must be absolute");
         }
         ditavalFile = toFile(input.getAttribute(ANT_INVOKER_PARAM_DITAVAL));
-        xmlValidate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
+        validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
         gramcache = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAM_GRAMCACHE));
         setSystemid = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID));
@@ -486,7 +443,7 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         }
 
         if (!listFilter.isValidInput() && currentFile.equals(rootFile)) {
-            if (xmlValidate) {
+            if (validate) {
                 // stop the build if all content in the input file was filtered out.
                 throw new DITAOTException(MessageUtils.getInstance().getMessage("DOTJ022F", params).toString());
             } else {
@@ -499,19 +456,6 @@ public final class GenMapAndTopicListModule extends AbstractPipelineModuleImpl {
         listFilter.reset();
         keydefFilter.reset();
 
-    }
-
-    private XMLReader getXmlReader(final String format) throws SAXException {
-        for (final Map.Entry<String, String> e: parserMap.entrySet()) {
-            if (format != null && format.equals(e.getKey())) {
-                try {
-                    return (XMLReader) this.getClass().forName(e.getValue()).newInstance();
-                } catch (final InstantiationException | ClassNotFoundException | IllegalAccessException ex) {
-                    throw new SAXException(ex);
-                }
-            }
-        }
-        return reader;
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2017 Jarno Elovirta
+ *
+ *  See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.module;
+
+import org.apache.xerces.xni.grammars.XMLGrammarPool;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.reader.GrammarPoolManager;
+import org.dita.dost.util.CatalogUtils;
+import org.dita.dost.util.XMLUtils;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import java.io.File;
+import java.util.Map;
+
+import static java.util.Collections.EMPTY_MAP;
+import static org.dita.dost.util.Configuration.parserFeatures;
+import static org.dita.dost.util.Configuration.parserMap;
+import static org.dita.dost.util.Constants.*;
+
+
+/**
+ * Common functionality for modules that read source documents.
+ */
+abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
+
+    private static final String FEATURE_GRAMMAR_POOL = "http://apache.org/xml/properties/internal/grammar-pool";
+
+    /**
+     * XMLReader instance for parsing dita file
+     */
+    XMLReader reader;
+    /**
+     * Validate source documents
+     */
+    boolean validate;
+    /**
+     * Use grammar pool cache
+     */
+    boolean gramcache = true;
+    /**
+     * Absolute DITA-OT base path.
+     */
+    File ditaDir;
+
+    /**
+     * Get reader for input format
+     * @param format input document format
+     * @return reader for given format
+     * @throws SAXException if creating reader failed
+     */
+    XMLReader getXmlReader(final String format) throws SAXException {
+        if (format == null || format.equals(ATTR_FORMAT_VALUE_DITA)) {
+            return reader;
+        }
+        for (final Map.Entry<String, String> e : parserMap.entrySet()) {
+            if (format.equals(e.getKey())) {
+                try {
+                    // XMLReaderFactory.createXMLReader cannot be used
+                    final XMLReader r = (XMLReader) this.getClass().forName(e.getValue()).newInstance();
+                    final Map<String, Boolean> features = parserFeatures.getOrDefault(e.getKey(), EMPTY_MAP);
+                    for (final Map.Entry<String, Boolean> feature : features.entrySet()) {
+                        try {
+                            r.setFeature(feature.getKey(), feature.getValue());
+                        } catch (final SAXNotRecognizedException ex) {
+                            // Not Xerces, ignore exception
+                        }
+                    }
+                    return r;
+                } catch (final InstantiationException | ClassNotFoundException | IllegalAccessException ex) {
+                    throw new SAXException(ex);
+                }
+            }
+        }
+        return reader;
+    }
+
+    /**
+     * XML reader used for pipeline parsing DITA documents.
+     *
+     * @throws SAXException if parser configuration failed
+     */
+    void initXmlReader() throws SAXException {
+        if (parserMap.containsKey(ATTR_FORMAT_VALUE_DITA)) {
+            reader = XMLReaderFactory.createXMLReader(parserMap.get(ATTR_FORMAT_VALUE_DITA));
+            final Map<String, Boolean> features = parserFeatures.getOrDefault(ATTR_FORMAT_VALUE_DITA, EMPTY_MAP);
+            for (final Map.Entry<String, Boolean> feature : features.entrySet()) {
+                try {
+                    reader.setFeature(feature.getKey(), feature.getValue());
+                } catch (final SAXNotRecognizedException e) {
+                    // Not Xerces, ignore exception
+                }
+            }
+        } else {
+            reader = XMLUtils.getXMLReader();
+        }
+
+        reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
+        if (validate) {
+            reader.setFeature(FEATURE_VALIDATION, true);
+            try {
+                reader.setFeature(FEATURE_VALIDATION_SCHEMA, true);
+            } catch (final SAXNotRecognizedException e) {
+                // Not Xerces, ignore exception
+            }
+        } else {
+            final String msg = MessageUtils.getInstance().getMessage("DOTJ037W").toString();
+            logger.warn(msg);
+        }
+        if (gramcache) {
+            final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
+            try {
+                reader.setProperty(FEATURE_GRAMMAR_POOL, grammarPool);
+                logger.info("Using Xerces grammar pool for DTD and schema caching.");
+            } catch (final NoClassDefFoundError e) {
+                logger.debug("Xerces not available, not using grammar caching");
+            } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
+                logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
+            }
+        }
+
+        CatalogUtils.setDitaDir(ditaDir);
+        reader.setEntityResolver(CatalogUtils.getCatalogResolver());
+    }
+
+}

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -111,9 +111,6 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
             } catch (final SAXNotRecognizedException e) {
                 // Not Xerces, ignore exception
             }
-        } else {
-            final String msg = MessageUtils.getInstance().getMessage("DOTJ037W").toString();
-            logger.warn(msg);
         }
         if (gramcache) {
             final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -7,6 +7,7 @@
  */
 package org.dita.dost.util;
 
+import static org.dita.dost.platform.Integrator.CONF_PARSER_FORMAT;
 import static org.dita.dost.util.Constants.*;
 
 import java.io.BufferedInputStream;
@@ -145,15 +146,30 @@ public final class Configuration {
     }
     
     public static final Map<String, String> parserMap;
+    public static final Map<String, Map<String, Boolean>> parserFeatures;
     static {
         final Map<String, String> m = new HashMap<>();
+        final Map<String, Map<String, Boolean>> f = new HashMap<>();
         for (final Map.Entry<String, String> e: configuration.entrySet()) {
             final String key = e.getKey();
-            if (key.startsWith("parser.")) {
-                m.put(key.substring(7), e.getValue());
+            if (key.startsWith(CONF_PARSER_FORMAT) && key.indexOf('.', CONF_PARSER_FORMAT.length()) == -1) {
+                final String format = key.substring(CONF_PARSER_FORMAT.length());
+                final String cls = e.getValue();
+                m.put(format, cls);
+
+                final String fs = configuration.get(CONF_PARSER_FORMAT + format + ".features");
+                if (fs != null) {
+                    for (final String pairs : fs.split(";")) {
+                        final String[] tokens = pairs.split("=");
+                        Map<String, Boolean> fm = f.getOrDefault(format, new HashMap<>());
+                        fm.put(tokens[0], Boolean.parseBoolean(tokens[1]));
+                        f.put(format, fm);
+                    }
+                }
             }
         }
         parserMap = Collections.unmodifiableMap(m);
+        parserFeatures = Collections.unmodifiableMap(f);
     }
 
     public static final Set<String> ditaFormat;
@@ -161,8 +177,8 @@ public final class Configuration {
         final Set<String> s = new HashSet<>();
         for (final Map.Entry<String, String> e: configuration.entrySet()) {
             final String key = e.getKey();
-            if (key.startsWith("parser.")) {
-                s.add(key.substring(7));
+            if (key.startsWith(CONF_PARSER_FORMAT) && key.indexOf('.', CONF_PARSER_FORMAT.length()) == -1) {
+                s.add(key.substring(CONF_PARSER_FORMAT.length()));
             }
         }
         ditaFormat = Collections.unmodifiableSet(s);


### PR DESCRIPTION
Extend plugin configuration for source parsers so that parser features can be configured. This will allow e.g. toggling XInclude processing or changing error recovery options.