### PR TITLE
Feature/remove keep with next from list label

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
@@ -61,7 +61,6 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="ul.li__label">
         <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
-        <xsl:attribute name="keep-with-next.within-line">always</xsl:attribute>
         <xsl:attribute name="end-indent">label-end()</xsl:attribute>
     </xsl:attribute-set>
 
@@ -91,7 +90,6 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="ol.li__label">
         <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
-        <xsl:attribute name="keep-with-next.within-line">always</xsl:attribute>
         <xsl:attribute name="end-indent">label-end()</xsl:attribute>
     </xsl:attribute-set>
 
@@ -120,7 +118,6 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="sl.sli__label">
         <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
-        <xsl:attribute name="keep-with-next.within-line">always</xsl:attribute>
         <xsl:attribute name="end-indent">label-end()</xsl:attribute>
     </xsl:attribute-set>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
@@ -149,7 +149,6 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="__toc__mini__label">
         <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
-        <xsl:attribute name="keep-with-next.within-line">always</xsl:attribute>
         <xsl:attribute name="end-indent">label-end()</xsl:attribute>
     </xsl:attribute-set>
 


### PR DESCRIPTION
The attribute keep-with-next.* is not allowed on list-item-label. 

https://www.w3.org/TR/xsl/#fo_list-item-label