### PR TITLE
Add simple API to invoke DITA-OT from Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,11 @@ dependencies {
     compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.9.7'
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.23'
-    runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.9.7'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.1'
+    runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.9.7'
     testCompile group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'xmlunit', name: 'xmlunit', version:'1.6'
-    testCompile group: 'org.slf4j', name: 'slf4j-simple', version:'1.7.23'
 }
 
 jar.archiveName = "${project.name}.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,12 @@ dependencies {
     compile group: 'org.apache.ant', name: 'ant', version:'1.9.7'
     compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.9.7'
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.23'
     runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.9.7'
     testCompile group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'xmlunit', name: 'xmlunit', version:'1.6'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version:'1.7.23'
 }
 
 jar.archiveName = "${project.name}.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.23'
     runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.9.7'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.1'
     testCompile group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'xmlunit', name: 'xmlunit', version:'1.6'

--- a/src/main/java/org/dita/dost/Processor.java
+++ b/src/main/java/org/dita/dost/Processor.java
@@ -3,6 +3,7 @@ package org.dita.dost;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.ProjectHelper;
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.LoggerListener;
 import org.slf4j.Logger;
 
@@ -125,9 +126,9 @@ public final class Processor {
     /**
      * Run process
      *
-     * @throws BuildException if processing failed
+     * @throws DITAOTException if processing failed
      */
-    public void run() {
+    public void run() throws DITAOTException {
         if (!args.containsKey("args.input")) {
             throw new IllegalStateException();
         }
@@ -152,7 +153,7 @@ public final class Processor {
             targets.addElement(project.getDefaultTarget());
             project.executeTargets(targets);
         } catch (final BuildException e) {
-            throw e;
+            throw new DITAOTException(e);
         } finally {
             System.setOut(savedOut);
             System.setErr(savedErr);

--- a/src/main/java/org/dita/dost/Processor.java
+++ b/src/main/java/org/dita/dost/Processor.java
@@ -1,0 +1,162 @@
+package org.dita.dost;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.ProjectHelper;
+import org.dita.dost.log.LoggerListener;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * DITA-OT processer. Not thread-safe, but can be reused.
+ */
+public final class Processor {
+
+    private File ditaDir;
+    private Map<String, String> args;
+    private Logger logger;
+
+    Processor(final File ditaDir, final String transtype, final Map<String, String> args) {
+        this.ditaDir = ditaDir;
+        this.args = new HashMap<>(args);
+        this.args.put("dita.dir", ditaDir.getAbsolutePath());
+        this.args.put("transtype", transtype);
+    }
+
+    /**
+     * Set input document.
+     *
+     * @param input input document file
+     * @return this Process object
+     */
+    public Processor setInput(final File input) {
+        if (!input.isAbsolute()) {
+            throw new IllegalArgumentException("Input file path must be absolute");
+        }
+        setInput(input.toURI());
+        return this;
+    }
+
+    /**
+     * Set input document.
+     *
+     * @param input absolute input document URI
+     * @return this Process object
+     */
+    public Processor setInput(final URI input) {
+        if (!input.isAbsolute()) {
+            throw new IllegalArgumentException("Input file URI must be absolute");
+        }
+        args.put("args.input", input.toString());
+        return this;
+    }
+
+    /**
+     * Set output directory.
+     *
+     * @param output absolute output directory
+     * @return this Process object
+     */
+    public Processor setOutput(final File output) {
+        if (!output.isAbsolute()) {
+            throw new IllegalArgumentException("Output directory path must be absolute");
+        }
+        args.put("output.dir", output.getAbsolutePath());
+        return this;
+    }
+
+    /**
+     * Set output directory.
+     *
+     * @param output absolute output directory URI
+     * @return this Process object
+     */
+    public Processor setOutput(final URI output) {
+        if (!output.isAbsolute()) {
+            throw new IllegalArgumentException("Output directory URI must be absolute");
+        }
+        if (!output.getScheme().equals("file")) {
+            throw new IllegalArgumentException("Only file scheme allowed as output directory URI");
+        }
+        args.put("output.dir", output.toString());
+        return this;
+    }
+
+    /**
+     * Set property. Existing property mapping will be overridden.
+     *
+     * @param name property name
+     * @param value property value
+     * @return this Process object
+     */
+    public Processor setProperty(final String name, final String value) {
+        args.put(name, value);
+        return this;
+    }
+
+    /**
+     * Set properties. Existing property mapping will be overridden.
+     *
+     * @param value property mappings
+     * @return this Process object
+     */
+    public Processor setProperties(final Map<String, String> value) {
+        args.putAll(value);
+        return this;
+    }
+
+    /**
+     * Set process logger
+     *
+     * @param logger process logger
+     * @return this Process object
+     */
+    public Processor setLogger(final Logger logger) {
+        this.logger = logger;
+        return this;
+    }
+
+    /**
+     * Run process
+     *
+     * @throws BuildException if processing failed
+     */
+    public void run() {
+        if (!args.containsKey("args.input")) {
+            throw new IllegalStateException();
+        }
+        final PrintStream savedErr = System.err;
+        final PrintStream savedOut = System.out;
+        try {
+            final File buildFile = new File(ditaDir, "build.xml");
+            final Project project = new Project();
+            project.setCoreLoader(this.getClass().getClassLoader());
+            if (logger != null) {
+                project.addBuildListener(new LoggerListener(logger));
+            }
+            project.fireBuildStarted();
+            project.init();
+            project.setBaseDir(ditaDir);
+            project.setKeepGoingMode(false);
+            for (final Map.Entry<String, String> arg : args.entrySet()) {
+                project.setUserProperty(arg.getKey(), arg.getValue());
+            }
+            ProjectHelper.configureProject(project, buildFile);
+            final Vector<String> targets = new Vector<>();
+            targets.addElement(project.getDefaultTarget());
+            project.executeTargets(targets);
+        } catch (final BuildException e) {
+            throw e;
+        } finally {
+            System.setOut(savedOut);
+            System.setErr(savedErr);
+        }
+    }
+
+}

--- a/src/main/java/org/dita/dost/ProcessorFactory.java
+++ b/src/main/java/org/dita/dost/ProcessorFactory.java
@@ -1,5 +1,7 @@
 package org.dita.dost;
 
+import org.dita.dost.util.Configuration;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +53,9 @@ public final class ProcessorFactory {
     public Processor newProcessor(final String transtype) {
         if (ditaDir == null) {
             throw new IllegalStateException();
+        }
+        if (!Configuration.transtypes.contains(transtype)) {
+            throw new IllegalArgumentException("Transtype " + transtype + " not supported");
         }
         return new Processor(ditaDir, transtype, Collections.unmodifiableMap(args));
     }

--- a/src/main/java/org/dita/dost/ProcessorFactory.java
+++ b/src/main/java/org/dita/dost/ProcessorFactory.java
@@ -37,7 +37,7 @@ public final class ProcessorFactory {
      *
      * @param tmp absolute directory for temporary directories
      */
-    public void setTempDir(final File tmp) {
+    public void setBaseTempDir(final File tmp) {
         if (!tmp.isAbsolute()) {
             throw new IllegalArgumentException("Temporary directory must be absolute");
         }

--- a/src/main/java/org/dita/dost/ProcessorFactory.java
+++ b/src/main/java/org/dita/dost/ProcessorFactory.java
@@ -1,0 +1,58 @@
+package org.dita.dost;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * DITA-OT processer factory. Not thread-safe, but can be reused.
+ */
+public final class ProcessorFactory {
+
+    private final File ditaDir;
+    private final Map<String, String> args = new HashMap<>();
+
+    private ProcessorFactory(final File ditaDir) {
+        this.ditaDir = ditaDir;
+    }
+
+    /**
+     * Obtain a new instance of a ProcessorFactory.
+     *
+     * @param ditaDir absolute directory to DITA-OT installation
+     * @return new ProcessorFactory instance
+     */
+    public static ProcessorFactory newInstance(final File ditaDir) {
+        if (!ditaDir.isAbsolute()) {
+            throw new IllegalArgumentException("DITA-OT directory must be absolute");
+        }
+        return new ProcessorFactory(ditaDir);
+    }
+
+    /**
+     * Set base directory for temporary directories.
+     *
+     * @param tmp absolute directory for temporary directories
+     */
+    public void setTempDir(final File tmp) {
+        if (!tmp.isAbsolute()) {
+            throw new IllegalArgumentException("Temporary directory must be absolute");
+        }
+        args.put("base.temp.dir", tmp.getAbsolutePath());
+    }
+
+    /**
+     * Create new Processor to run DITA-OT
+     *
+     * @param transtype transtype for the processor
+     * @return new Processor instance
+     */
+    public Processor newProcessor(final String transtype) {
+        if (ditaDir == null) {
+            throw new IllegalStateException();
+        }
+        return new Processor(ditaDir, transtype, Collections.unmodifiableMap(args));
+    }
+
+}

--- a/src/main/java/org/dita/dost/log/LoggerListener.java
+++ b/src/main/java/org/dita/dost/log/LoggerListener.java
@@ -1,0 +1,91 @@
+package org.dita.dost.log;
+
+import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.BuildListener;
+import org.apache.tools.ant.Project;
+import org.slf4j.Logger;
+
+import java.util.regex.Pattern;
+
+/**
+ * Logger adapter from Ant logger to SLF4J logger.
+ */
+public final class LoggerListener implements BuildListener {
+
+    private static final Pattern FATAL_PATTERN = Pattern.compile("\\[\\w+F\\]\\[FATAL\\]");
+    private static final Pattern ERROR_PATTERN = Pattern.compile("\\[\\w+E\\]\\[ERROR\\]");
+    private static final Pattern WARN_PATTERN = Pattern.compile("\\[\\w+W\\]\\[WARN\\]");
+    private static final Pattern INFO_PATTERN = Pattern.compile("\\[\\w+I\\]\\[INFO\\]");
+    private static final Pattern DEBUG_PATTERN = Pattern.compile("\\[\\w+D\\]\\[DEBUG\\]");
+
+    private final Logger logger;
+
+    public LoggerListener(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void buildStarted(BuildEvent event) {
+        //System.out.println("build started: " + event.getMessage());
+    }
+
+    @Override
+    public void buildFinished(BuildEvent event) {
+        //System.out.println("build finished: " + event.getMessage());
+    }
+
+    @Override
+    public void targetStarted(BuildEvent event) {
+        //System.out.println(event.getTarget().getName() + ":");
+    }
+
+    @Override
+    public void targetFinished(BuildEvent event) {
+        //System.out.println("target finished: " + event.getTarget().getName());
+    }
+
+    @Override
+    public void taskStarted(BuildEvent event) {
+        //System.out.println("task started: " + event.getTask().getTaskName());
+    }
+
+    @Override
+    public void taskFinished(BuildEvent event) {
+        //System.out.println("task finished: " + event.getTask().getTaskName());
+    }
+
+    @Override
+    public void messageLogged(BuildEvent event) {
+        final String message = event.getMessage();
+        int level;
+        if (FATAL_PATTERN.matcher(message).find()) {
+            level = Project.MSG_ERR;
+        } else if (ERROR_PATTERN.matcher(message).find()) {
+            level = Project.MSG_ERR;
+        } else if (WARN_PATTERN.matcher(message).find()) {
+            level = Project.MSG_WARN;
+        } else if (INFO_PATTERN.matcher(message).find()) {
+            level = Project.MSG_INFO;
+        } else if (DEBUG_PATTERN.matcher(message).find()) {
+            level = Project.MSG_DEBUG;
+        } else {
+            level = event.getPriority();
+        }
+        switch (level) {
+            case Project.MSG_DEBUG:
+                logger.trace(message);
+                break;
+            case Project.MSG_VERBOSE:
+                logger.debug(message);
+                break;
+            case Project.MSG_INFO:
+                logger.info(message);
+                break;
+            case Project.MSG_WARN:
+                logger.warn(message);
+                break;
+            default:
+                logger.error(message);
+        }
+    }
+}

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -70,6 +70,7 @@ public final class Integrator {
     private static final String FEAT_RESOURCE_EXTENSIONS = "dita.resource.extensions";
     /** Feature name for print transformation types. */
     private static final String FEAT_PRINT_TRANSTYPES = "dita.transtype.print";
+    private static final String FEAT_TRANSTYPES = "dita.conductor.transtype.check";
     private static final String FEAT_LIB_EXTENSIONS = "dita.conductor.lib.import";
     private static final String ELEM_PLUGINS = "plugins";
 
@@ -259,6 +260,14 @@ public final class Integrator {
         // extensions
         configuration.put(CONF_SUPPORTED_HTML_EXTENSIONS, readExtensions(FEAT_HTML_EXTENSIONS));
         configuration.put(CONF_SUPPORTED_RESOURCE_EXTENSIONS, readExtensions(FEAT_RESOURCE_EXTENSIONS));
+
+        // transtypes
+        final String transtypes = featureTable.entrySet().stream()
+                .filter(e -> e.getKey().equals(FEAT_TRANSTYPES))
+                .flatMap(e -> e.getValue().stream())
+                .distinct()
+                .collect(Collectors.joining(CONF_LIST_SEPARATOR));
+        configuration.put(CONF_TRANSTYPES, transtypes);
 
         // print transtypes
         final Set<String> printTranstypes = new HashSet<>();

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -132,6 +132,23 @@ public final class Configuration {
         printTranstype = Collections.unmodifiableList(types);
     }
 
+    /** List of transtypes. */
+    public static final List<String> transtypes;
+    static {
+        final List<String> types = new ArrayList<>();
+        final String printTranstypes = Configuration.configuration.get(CONF_TRANSTYPES);
+        if (printTranstypes != null) {
+            if (printTranstypes.trim().length() > 0) {
+                for (final String transtype: printTranstypes.split(CONF_LIST_SEPARATOR)) {
+                    types.add(transtype.trim());
+                }
+            }
+        } else {
+            logger.error("Failed to read transtypes from configuration, using empty list.");
+        }
+        transtypes = Collections.unmodifiableList(types);
+    }
+
     /** Map of plug-in resource directories. */
     public static final Map<String, File> pluginResourceDirs;
     static {

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -107,7 +107,12 @@ public final class Configuration {
 
     /** Processing mode */
     public enum Mode {
-        STRICT, SKIP, LAX
+        /** Processing fails on error. */
+        STRICT,
+        /** Processing continues after error and will not attempt error recovery */
+        SKIP,
+        /** Processing continues after error with error recovery */
+        LAX
     }
     
     /** Private constructor to disallow instance creation. */

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -962,6 +962,7 @@ public final class Constants {
     public static final String CONF_SUPPORTED_RESOURCE_EXTENSIONS = "supported_resource_extensions";
     /** Property name for print transtypes. */
     public static final String CONF_PRINT_TRANSTYPES = "print_transtypes";
+    public static final String CONF_TRANSTYPES = "transtypes";
     /** Property name for template files. */
     public static final String CONF_TEMPLATES = "templates";
     /** Plugin configuration file name. */

--- a/src/test/java/org/dita/dost/ProcessorFactoryTest.java
+++ b/src/test/java/org/dita/dost/ProcessorFactoryTest.java
@@ -29,4 +29,14 @@ public class ProcessorFactoryTest {
         assertNotNull(pf.newProcessor("html5"));
     }
 
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void testUnsupportedTranstype() {
+        String ditaDir = System.getProperty("dita.dir");
+        if (ditaDir == null) {
+            ditaDir = new File("src" + File.separator + "main").getAbsolutePath();
+        }
+        final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
+        pf.newProcessor("xxx");
+    }
+
 }

--- a/src/test/java/org/dita/dost/ProcessorFactoryTest.java
+++ b/src/test/java/org/dita/dost/ProcessorFactoryTest.java
@@ -1,0 +1,32 @@
+package org.dita.dost;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.dita.dost.ProcessorFactory;
+import org.junit.Test;
+
+import java.io.File;
+
+public class ProcessorFactoryTest {
+
+    @Test
+    public void testNewInstance() {
+        String ditaDir = System.getProperty("dita.dir");
+        if (ditaDir == null) {
+            ditaDir = new File("src" + File.separator + "main").getAbsolutePath();
+        }
+        assertNotNull(ProcessorFactory.newInstance(new File(ditaDir)));
+    }
+
+    @Test
+    public void testNewProcessor() {
+        String ditaDir = System.getProperty("dita.dir");
+        if (ditaDir == null) {
+            ditaDir = new File("src" + File.separator + "main").getAbsolutePath();
+        }
+        final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
+        assertNotNull(pf.newProcessor("html5"));
+    }
+
+}

--- a/src/test/java/org/dita/dost/ProcessorFactoryTest.java
+++ b/src/test/java/org/dita/dost/ProcessorFactoryTest.java
@@ -1,12 +1,10 @@
 package org.dita.dost;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
-import org.dita.dost.ProcessorFactory;
 import org.junit.Test;
 
 import java.io.File;
+
+import static org.junit.Assert.assertNotNull;
 
 public class ProcessorFactoryTest {
 

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -1,5 +1,6 @@
 package org.dita.dost;
 
+import org.dita.dost.exception.DITAOTException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -7,6 +8,8 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.helpers.NOPLogger;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import static org.junit.Assert.fail;
 
@@ -38,10 +41,17 @@ public class ProcessorTest {
     }
 
     @Test
-    public void testRun() throws Exception {
-        final File mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/test.ditamap").toURI());
+    public void testRun() throws DITAOTException {
+        final File mapFile;
+        final File out;
+        try {
+            mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/test.ditamap").toURI());
+            out = tmpDir.newFolder("out");
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
         p.setInput(mapFile)
-                .setOutput(tmpDir.newFolder("out"))
+                .setOutput(out)
                 .setLogger(NOPLogger.NOP_LOGGER)
                 .run();
     }

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -11,8 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -33,7 +31,7 @@ public class ProcessorTest {
         final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
 
         tempDir = tempDirGenerator.newFolder("tmp");
-        pf.setTempDir(tempDir);
+        pf.setBaseTempDir(tempDir);
         p = pf.newProcessor("html5");
     }
 
@@ -59,6 +57,8 @@ public class ProcessorTest {
         p.setInput(mapFile)
                 .setOutputDir(out)
                 .run();
+
+        assertEquals(1, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
     }
 
 
@@ -75,9 +75,11 @@ public class ProcessorTest {
         try {
             p.setInput(mapFile)
                     .setOutputDir(out)
+                    .createDebugLog(false)
                     .run();
         } catch (Exception e) {
-            assertTrue(tempDir.exists());
+            assertEquals(0, tempDir.listFiles(f -> f.isDirectory()).length);
+            assertEquals(0, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
             throw e;
         }
     }
@@ -98,7 +100,9 @@ public class ProcessorTest {
                     .cleanOnFailure(false)
                     .run();
         } catch (BuildException e) {
-            assertFalse(tempDir.exists());
+            assertEquals(1, tempDir.listFiles(f -> f.isDirectory()).length);
+            assertEquals(1, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
+
             throw e;
         }
     }

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -57,7 +57,7 @@ public class ProcessorTest {
             throw new RuntimeException(e);
         }
         p.setInput(mapFile)
-                .setOutput(out)
+                .setOutputDir(out)
                 .run();
     }
 
@@ -74,7 +74,7 @@ public class ProcessorTest {
         }
         try {
             p.setInput(mapFile)
-                    .setOutput(out)
+                    .setOutputDir(out)
                     .run();
         } catch (Exception e) {
             assertTrue(tempDir.exists());
@@ -94,7 +94,7 @@ public class ProcessorTest {
         }
         try {
             p.setInput(mapFile)
-                    .setOutput(out)
+                    .setOutputDir(out)
                     .cleanOnFailure(false)
                     .run();
         } catch (BuildException e) {

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -56,4 +56,21 @@ public class ProcessorTest {
                 .run();
     }
 
+
+    @Test(expected = org.dita.dost.exception.DITAOTException.class)
+    public void testBroken() throws DITAOTException {
+        final File mapFile;
+        final File out;
+        try {
+            mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/broken.dita").toURI());
+            out = tmpDir.newFolder("out");
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException(e);
+        }
+        p.setInput(mapFile)
+                .setOutput(out)
+                .setLogger(NOPLogger.NOP_LOGGER)
+                .run();
+    }
+
 }

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -1,0 +1,49 @@
+package org.dita.dost;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.helpers.NOPLogger;
+
+import java.io.File;
+
+import static org.junit.Assert.fail;
+
+public class ProcessorTest {
+
+    @Rule
+    public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private Processor p;
+
+    @Before
+    public void setUp() throws Exception {
+        String ditaDir = System.getProperty("dita.dir");
+        if (ditaDir == null) {
+            ditaDir = new File("src" + File.separator + "main").getAbsolutePath();
+        }
+        final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
+        pf.setTempDir(tmpDir.newFolder("tmp"));
+        p = pf.newProcessor("html5");
+    }
+
+    @Test
+    public void testRunWithoutArgs() throws Exception {
+        try {
+            p.run();
+            fail();
+        } catch (final IllegalStateException e) {
+        }
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        final File mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/test.ditamap").toURI());
+        p.setInput(mapFile)
+                .setOutput(tmpDir.newFolder("out"))
+                .setLogger(NOPLogger.NOP_LOGGER)
+                .run();
+    }
+
+}

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -27,7 +27,8 @@ public class ProcessorTest {
             ditaDir = new File("src" + File.separator + "main").getAbsolutePath();
         }
         final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
-        pf.setTempDir(tmpDir.newFolder("tmp"));
+//        pf.setTempDir(tmpDir.newFolder("tmp"));
+        pf.setTempDir(new File("/Volumes/tmp/test/temp"));
         p = pf.newProcessor("html5");
     }
 

--- a/src/test/resources/IntegratorTest/exp/lib/org.dita.dost.platform/plugin.properties
+++ b/src/test/resources/IntegratorTest/exp/lib/org.dita.dost.platform/plugin.properties
@@ -3,4 +3,5 @@
 supported_image_extensions=.bmp;.svg;.png;.tif;.jpg;.gif;.jpeg;.tiff;.eps
 supported_resource_extensions=
 supported_html_extensions=
+transtypes=
 print_transtypes=

--- a/src/test/resources/ProcessorTest/broken.dita
+++ b/src/test/resources/ProcessorTest/broken.dita
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_obl_ck4_kp">
+  <body>
+    <p>paragraph.</p>
+  </body>
+</topic>

--- a/src/test/resources/ProcessorTest/test.dita
+++ b/src/test/resources/ProcessorTest/test.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_obl_ck4_kp">
+  <title>test</title>
+  <body>
+    <p>paragraph.</p>
+  </body>
+</topic>

--- a/src/test/resources/ProcessorTest/test.ditamap
+++ b/src/test/resources/ProcessorTest/test.ditamap
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+ <title>DITA Topic Map</title>
+</map>

--- a/src/test/resources/org.dita.dost.platform/plugin.properties
+++ b/src/test/resources/org.dita.dost.platform/plugin.properties
@@ -2,7 +2,7 @@ supported_resource_extensions=.pdf;.swf
 print_transtypes=pdf2;pdf;legacypdf;odt
 supported_image_extensions=.bmp;.svg;.png;.tif;.jpg;.gif;.jpeg;.tiff;.eps
 supported_html_extensions=.htm;.html
-
+transtypes=pdf;pdf2;tocjs;xhtml;eclipsehelp;html5;htmlhelp;javahelp;troff
 plugin.com.sophos.tocjs.dir=plugins/com.sophos.tocjs
 plugin.org.dita.specialization.dita132.dir=plugins/org.dita.specialization.dita132
 plugin.org.dita.odt.dir=plugins/org.dita.odt


### PR DESCRIPTION
A Java API can be use invoke DITA-OT from Java code without needing to have knowledge about the internals of DITA-OT, like Ant.

# Usage

```java
final ProcessorFactory pf = ProcessorFactory.newInstance(ditaDir);
pf.setTempDir(absoluteBaseTempDir);
final Processor p = pf.newProcessor("html5");
try {
  p.setInput(absoluteInputmapFile)
   .setOutputDir(absoluteOutputDir)
   .cleanOnFailure(false)
   .setMode(Mode.LAX)
   .setProperty("brand", "acme")
   .setLogger(logger)
   .run();
} catch (DITAOTException e) {
  logger.error("Failed to process: " + e.getMessage());
}
```

The `Processor` object is reusable but not thread-safe.