### PR TITLE
Navref and anchor elements lost when resolving submap

### DIFF
--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -134,7 +134,7 @@ See the accompanying LICENSE file for applicable license.
                   <xsl:sequence select="$file//*[contains(@class,' map/topicref ')][@id = $element-id]"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:sequence select="$file/*/*[contains(@class,' map/topicref ')] |
+                  <xsl:sequence select="$file/*/*[contains(@class,' map/topicref ') or contains(@class,' map/navref ') or contains(@class,' map/anchor ')] |
                                         $file/*/processing-instruction()"/>
                 </xsl:otherwise>
               </xsl:choose>


### PR DESCRIPTION
The `<navref>` and `<anchor>` elements make up part of a map's navigation structure. Their intent is to provide dynamic resolution at a later point. (The `<navref>` will pull something in when available; `<anchor>` provides an anchor that other bits of navigation can make use of, typically to insert more navigation.) I know some people generally don't like these elements, but we use `<navref>` very widely and ran into this today.

* When those elements appear in a root map, they survive to the end of processing as expected.
* When those elements appear inside of a branch from a submap, they survive to the end of processing
* When those elements are the direct child of `<map>`, they are lost when resolving a submap, because in the navigation context `maprefImpl.xsl` explicitly grabs only `<topicref>` elements

We should be preserving both of these elements as-is when resolving nested maps.

The only other child element that's perhaps questionable here is `<data>` -- I'm not sure if it makes sense to pull those in, or to drop them as we do with the map's `<title>` and `<topicmeta>`. Relationship tables are handled elsewhere, because (for the resolved map to be valid) they must be located at the end of the resolved map.