### PR TITLE
Clean up log when conref is to missing file

### DIFF
--- a/src/main/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/xsl/preprocess/conrefImpl.xsl
@@ -177,8 +177,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <!-- get domains attribute in the target file -->
-    <xsl:variable name="domains" select="(document($file, /)/*/@domains | document($file, /)/dita/*[@domains][1]/@domains)[1]" as="xs:string"/>
-    <!--the file name is useful to href when resolveing conref -->
+    <xsl:variable name="domains" select="(document($file, /)/*/@domains | document($file, /)/dita/*[@domains][1]/@domains)[1]" as="xs:string?"/>
+    <!--the file name is useful to href when resolving conref -->
     <xsl:variable name="conref-filename" as="xs:string">
       <xsl:call-template name="replace-blank">
         <xsl:with-param name="file-origin" select="substring-after(substring-after($file-origin, $file-prefix), $add-relative-path)"/>
@@ -697,7 +697,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:function name="conref:isValid" as="xs:boolean">
-    <xsl:param name="domains" as="xs:string"/>
+    <xsl:param name="domains" as="xs:string?"/>
     <xsl:call-template name="checkValid">
       <xsl:with-param name="sourceDomains" select="normalize-space($ORIGINAL-DOMAINS)"/>
       <xsl:with-param name="targetDomains" select="normalize-space(concat('(topic) ', $domains))"/>


### PR DESCRIPTION
I have a conref to a file that doesn't exist. I already get errors about this. It's been showing up lately in one particular reuse scenario -- [several files] have conref to `reuse_library.dita`, using only sections of that file; _other_ sections of that file then conref elsewhere. So we don't actually _need_ to evaluate the other conref, but we do, because we don't know it's unnecessary.

When the extra conref is evaluated, we set up a `$domains` variable by reading from the target file. This variable is typed as `xs:string` -- later code assumes it's a string. When the target file doesn't exist, the variable ends up empty, and the conref code fails:
```
   [conref] Recoverable error on line 175 of conrefImpl.xsl:
   [conref]   FODC0002: java.io.FileNotFoundException:
   [conref]   C:\Users\IBM_AD~1\AppData\Local\Temp\temp20170310160053330\secondary_conref.dita
   [conref]   (The system cannot find the file specified.)
   [conref] Error on line 272 of conrefImpl.xsl:
   [conref]   XTTE0570: An empty sequence is not allowed as the value of variable $domains
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]/taskbody[1]/steps[1]/step[1]/cmd[1]/image[1]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]/taskbody[1]/steps[1]/step[1]/cmd[1]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]/taskbody[1]/steps[1]/step[1]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]/taskbody[1]/steps[1]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]/taskbody[1]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]/task[2]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]/task[2]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#799)
   [conref]      processing /task/task[3]
   [conref]   at xsl:apply-templates (file:/C:/DCS/2.3.1/xsl/preprocess/conrefImpl.xsl#29)
   [conref]      processing /task
   [conref] Failed to transform document: An empty sequence is not allowed as the value of variable $domains
```

If we just cast that variable as a string, we don't get these ugly errors (though as expected, we still get the missing file errors). Casting the null value as a string also means later usage like `conref:isValid($domains)` can continue to treat it as `xs:string`.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>