### PR TITLE
Fix: args.outext not working for HTML5

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -102,7 +102,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- end to check and init css relevant parameters -->
     <condition property="out.ext" value=".html">
       <not>
-        <isset property="out.ext"/>
+        <isset property="args.outext"/>
       </not>
     </condition>
     <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>


### PR DESCRIPTION
Signed-off-by: Shane Taylor <shane@taylortext.com>