### PR TITLE
Fix build failures from bad simpletable markup

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -27,9 +27,16 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="dita2html:get-max-entry-count"/>
     </xsl:variable>
     <xsl:variable name="col-widths" as="xs:double*">
-      <xsl:variable name="widths" select="tokenize(normalize-space(@relcolwidth), '\s+')" as="xs:string*"/>
+      <xsl:variable name="widths" select="tokenize(normalize-space(translate(@relcolwidth, '*', '')), '\s+')" as="xs:string*"/>
       <xsl:for-each select="$widths">
-        <xsl:sequence select="xs:double(substring(., 1, string-length(.) - 1))"/>
+        <xsl:choose>
+          <xsl:when test=". castable as xs:double">
+            <xsl:sequence select="xs:double(.)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="xs:double(1)"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
       <xsl:for-each select="1 to ($col-count - count($widths))">
         <xsl:sequence select="xs:double(1)"/>
@@ -104,7 +111,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- If there is a header, get the ID from the head cell in this column.
              Go up to simpletable, into the row, to the entry at column $thiscolnum -->
       <xsl:variable name="header">
-        <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/sthead ')]">
+        <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')][number($thiscolnum)]">
           <xsl:value-of select="dita-ot:generate-html-id(parent::*/parent::*/*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')][number($thiscolnum)])"/>
         </xsl:if>
       </xsl:variable>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -721,9 +721,16 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="dita2html:get-max-entry-count"/>
     </xsl:variable>
     <xsl:variable name="col-widths" as="xs:double*">
-      <xsl:variable name="widths" select="tokenize(normalize-space(@relcolwidth), '\s+')" as="xs:string*"/>
+      <xsl:variable name="widths" select="tokenize(normalize-space(translate(@relcolwidth, '*', '')), '\s+')" as="xs:string*"/>
       <xsl:for-each select="$widths">
-        <xsl:sequence select="xs:double(substring(., 1, string-length(.) - 1))"/>
+        <xsl:choose>
+          <xsl:when test=". castable as xs:double">
+            <xsl:sequence select="xs:double(.)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="xs:double(1)"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
       <xsl:for-each select="1 to ($col-count - count($widths))">
         <xsl:sequence select="xs:double(1)"/>
@@ -829,7 +836,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- If there is a header, get the ID from the head cell in this column.
            Go up to simpletable, into the row, to the entry at column $thiscolnum -->
       <xsl:variable name="header">
-          <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/sthead ')]">
+          <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')][number($thiscolnum)]">
             <xsl:value-of select="dita-ot:generate-html-id(parent::*/parent::*/*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')][number($thiscolnum)])"/>
           </xsl:if>
       </xsl:variable>


### PR DESCRIPTION
A very large document from one of my users went into a new DITA-OT build today for the first time, and failed due to two markup issues:

- Some tables had an invalid `@relcolwidth` attribute of `relcolwidth="*4"`. (No idea how that ended up in the doc.) In XHTML output this kills the build with an XSLT failure; in HTML5 the build continues but it still results in a long series of XSLT errors on the console.
- Another table had a header with only one `<stentry/>` while the table itself had two columns. HTML5 doesn't have a problem with this but an XHTML build fails when adding accessibility tagging, it assumes that if you have a header, there will be one `<stentry>` in the header for each column.

The fix ignores any individual values in `relcolwidth` that can't be interpreted as numbers. (It makes use of a tip I saw on stackoverflow -- `number($x) = number($x)` fails when the input is not a number, because `NaN != NaN`.) The header issue was simpler, we already test "is there a header", I updated that test to say "is there a header with enough columns".

Signed-off-by: Robert D Anderson <robander@us.ibm.com>