### PR TITLE
Log XSLT messages to logger instead of standard out

### DIFF
--- a/src/main/java/org/dita/dost/log/LoggingErrorListener.java
+++ b/src/main/java/org/dita/dost/log/LoggingErrorListener.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2017 Jarno Elovirta
+ *
+ *  See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.log;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.TransformerException;
+
+public class LoggingErrorListener implements ErrorListener {
+
+    private final DITAOTLogger logger;
+
+    public LoggingErrorListener(final DITAOTLogger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void warning(TransformerException exception) throws TransformerException {
+        logger.warn(exception.getMessage());
+    }
+
+    @Override
+    public void error(TransformerException exception) throws TransformerException {
+        logger.error(exception.getMessage());
+    }
+
+    @Override
+    public void fatalError(TransformerException exception) throws TransformerException {
+        throw exception;
+    }
+}

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -60,6 +60,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
     private static final String SKIP_FILTER = "skip-filter";
     private static final String BRANCH_COPY_TO = "filter-copy-to";
 
+    private final XMLUtils xmlUtils;
     private final DocumentBuilder builder;
     private final DitaValReader ditaValReader;
     private TempFileNameScheme tempFileNameScheme;
@@ -73,12 +74,14 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         builder = XMLUtils.getDocumentBuilder();
         ditaValReader = new DitaValReader();
         ditaValReader.initXMLReader(true);
+        xmlUtils = new XMLUtils();
     }
     
     @Override
     public void setLogger(final DITAOTLogger logger) {
         super.setLogger(logger);
         ditaValReader.setLogger(logger);
+        xmlUtils.setLogger(logger);
     }
 
     @Override
@@ -345,7 +348,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
                     logger.error("Failed to create directory " + dstDirUri);
                 }
                 try {
-                    XMLUtils.transform(srcAbsUri,
+                    xmlUtils.transform(srcAbsUri,
                                        dstAbsUri,
                                        pipe);
                 } catch (final DITAOTException e) {
@@ -387,7 +390,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
             final URI srcAbsUri = job.tempDirURI.resolve(map.resolve(href));
             logger.info("Filtering " + srcAbsUri);
             try {
-                XMLUtils.transform(toFile(srcAbsUri),
+                xmlUtils.transform(toFile(srcAbsUri),
                         pipe);
             } catch (final DITAOTException e) {
                 logger.error("Failed to filter " + srcAbsUri + ": " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -10,6 +10,7 @@ package org.dita.dost.module;
 
 import org.apache.commons.io.FileUtils;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
 import static org.dita.dost.util.XMLUtils.addOrSetAttribute;
-import static org.dita.dost.util.XMLUtils.transform;
+import org.dita.dost.util.XMLUtils;
 
 /**
  * Move temporary files not based on output URI to match output URI structure.
@@ -41,6 +42,13 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
     private final LinkFilter filter = new LinkFilter();
     private final MapCleanFilter mapFilter = new MapCleanFilter();
+    private final XMLUtils xmlUtils = new XMLUtils();
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
+    }
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
@@ -65,7 +73,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
                         final List<XMLFilter> processingPipe = getProcessingPipe(fi, srcFile, destFile);
                         if (!processingPipe.isEmpty()) {
                             logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
-                            transform(srcFile.toURI(), destFile.toURI(), processingPipe);
+                            xmlUtils.transform(srcFile.toURI(), destFile.toURI(), processingPipe);
                             if (!srcFile.equals(destFile)) {
                                 logger.debug("Deleting " + srcFile.toURI());
                                 FileUtils.deleteQuietly(srcFile);

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -8,6 +8,7 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.GenMapAndTopicListModule.TempFileNameScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -42,6 +43,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
     private boolean forceUnique;
     private ForceUniqueFilter forceUniqueFilter;
     private final CopyToReader reader = new CopyToReader();
+    private final XMLUtils xmlUtils = new XMLUtils();
 
     @Override
     public void setJob(final Job job) {
@@ -52,6 +54,12 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             throw new RuntimeException(e);
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
+    }
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
     }
 
     @Override
@@ -88,7 +96,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
 
         final List<XMLFilter> pipe = getProcessingPipe(in);
 
-        XMLUtils.transform(in, pipe);
+        xmlUtils.transform(in, pipe);
     }
 
     /**
@@ -199,7 +207,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
 
         logger.info("Processing " + src + " to " + target);
         try {
-            XMLUtils.transform(src, target, Collections.singletonList(filter));
+            xmlUtils.transform(src, target, Collections.singletonList(filter));
         } catch (final DITAOTException e) {
             logger.error("Failed to write copy-to file: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -22,6 +22,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.GenMapAndTopicListModule.TempFileNameScheme;
 import org.dita.dost.util.*;
 import org.dita.dost.writer.TopicFragmentFilter;
@@ -56,6 +57,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     final Set<URI> normalProcessingRole = new HashSet<>();
     final Map<URI, Integer> usage = new HashMap<>();
     private TopicFragmentFilter topicFragmentFilter;
+    private XMLUtils xmlUtils = new XMLUtils();
 
     @Override
     public void setJob(final Job job) {
@@ -66,6 +68,12 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             throw new RuntimeException(e);
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
+    }
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
     }
 
     /**
@@ -355,12 +363,12 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             if (r.out != null) {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri) +
                         " to " + job.tempDirURI.resolve(r.out.uri));
-                XMLUtils.transform(new File(job.tempDir, r.in.file.getPath()),
+                xmlUtils.transform(new File(job.tempDir, r.in.file.getPath()),
                                    new File(job.tempDir, r.out.file.getPath()),
                                    filters);
             } else {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri));
-                XMLUtils.transform(new File(job.tempDir, r.in.file.getPath()), filters);
+                xmlUtils.transform(new File(job.tempDir, r.in.file.getPath()), filters);
             }
             // validate resource-only list
             normalProcessingRole.addAll(parser.getNormalProcessingRoleTargets());

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -20,7 +20,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -33,6 +32,7 @@ import java.util.Map;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.withLogger;
 
 /**
  * MoveLinksModule implements move links step in preprocess. It reads the map links
@@ -62,7 +62,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             doc = XMLUtils.getDocumentBuilder().newDocument();
             final TransformerFactory transformerFactory = TransformerFactory.newInstance();
             transformerFactory.setURIResolver(CatalogUtils.getCatalogResolver());
-            final Transformer transformer = transformerFactory.newTransformer(new StreamSource(styleFile));
+            final Transformer transformer = withLogger(transformerFactory.newTransformer(new StreamSource(styleFile)), logger);
             transformer.setURIResolver(CatalogUtils.getCatalogResolver());
             if (input.getAttribute("include.rellinks") != null) {
                 transformer.setParameter("include.rellinks", input.getAttribute("include.rellinks"));

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -10,6 +10,7 @@ package org.dita.dost.module;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.withLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -95,7 +96,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final TransformerFactory tf = TransformerFactory.newInstance();
                 final CatalogResolver xmlCatalog = CatalogUtils.getCatalogResolver();
                 tf.setURIResolver(xmlCatalog);
-                final Transformer t = tf.newTransformer(new StreamSource(styleFile));
+                final Transformer t = withLogger(tf.newTransformer(new StreamSource(styleFile)), logger);
                 final URIResolver resolver;
                 if (Configuration.DEBUG) {
                     resolver = new DebugURIResolver(xmlCatalog);

--- a/src/main/java/org/dita/dost/module/TopicFragmentModule.java
+++ b/src/main/java/org/dita/dost/module/TopicFragmentModule.java
@@ -8,6 +8,7 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Configuration;
@@ -36,6 +37,13 @@ final class TopicFragmentModule extends AbstractPipelineModuleImpl {
 
     private Configuration.Mode processingMode;
     private boolean resolveCoderef;
+    private final XMLUtils xmlUtils = new XMLUtils();
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
+    }
 
     /**
      * Process topic files for same topic fragments identifiers.
@@ -60,7 +68,7 @@ final class TopicFragmentModule extends AbstractPipelineModuleImpl {
             final URI file = job.tempDirURI.resolve(f.uri);
             logger.info("Processing " + file);
             try {
-                XMLUtils.transform(file, getProcessingPipe(file));
+                xmlUtils.transform(file, getProcessingPipe(file));
             } catch (final DITAOTException e) {
                 logger.error("Failed to process same topic fragment identifiers: " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -9,6 +9,7 @@
 package org.dita.dost.module;
 
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.withLogger;
 import static org.dita.dost.writer.ImageMetadataFilter.*;
 import static javax.xml.XMLConstants.*;
 
@@ -97,7 +98,7 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
                 final TransformerFactory factory = TransformerFactory.newInstance();
                 factory.setURIResolver(CatalogUtils.getCatalogResolver());
                 final StreamSource styleSource = new StreamSource(style);
-                final Transformer transformer = factory.newTransformer(styleSource);
+                final Transformer transformer = withLogger(factory.newTransformer(styleSource), logger);
                 final StreamSource source = new StreamSource(new ByteArrayInputStream(midBuffer.toByteArray()));
                 final StreamResult result = new StreamResult(output);
                 transformer.transform(source, result);

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -8,6 +8,7 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
@@ -27,7 +28,14 @@ import java.util.List;
  */
 public final class XmlFilterModule extends AbstractPipelineModuleImpl {
 
+    private final XMLUtils xmlUtils = new XMLUtils();
     private List<FilterPair> pipe;
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
+    }
 
     /**
      * Filter files through XML filters.
@@ -43,7 +51,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
             final URI file = job.tempDirURI.resolve(f.uri);
             logger.info("Processing " + file);
             try {
-                XMLUtils.transform(file, getProcessingPipe(f));
+                xmlUtils.transform(file, getProcessingPipe(f));
             } catch (final DITAOTException e) {
                 logger.error("Failed to process XML filter: " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.dita.dost.util.XMLUtils.withLogger;
+
 /**
  * XSLT processing module.
  * 
@@ -92,7 +94,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
             if (reloadstylesheet || t == null) {
                 logger.info("Loading stylesheet " + style.getAbsolutePath());
                 try {
-                    t = templates.newTransformer();
+                    t = withLogger(templates.newTransformer(), logger);
                     if (Configuration.DEBUG) {
                         t.setURIResolver(new XMLUtils.DebugURIResolver(xmlcatalog));
                     }
@@ -204,5 +206,5 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
     public void setMapper(final FileNameMapper mapper) {
         this.mapper = mapper;
     }
-    
+
 }

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -58,6 +58,7 @@ public final class TopicBranchFilterModule extends AbstractPipelineModuleImpl {
     private static final String SKIP_FILTER = "skip-filter";
     private static final String BRANCH_COPY_TO = "filter-copy-to";
 
+    private final XMLUtils xmlUtils = new XMLUtils();
     private final DocumentBuilder builder;
     private final DitaValReader ditaValReader;
 //    private final TempFileNameScheme tempFileNameScheme;
@@ -82,6 +83,7 @@ public final class TopicBranchFilterModule extends AbstractPipelineModuleImpl {
     public void setLogger(final DITAOTLogger logger) {
         super.setLogger(logger);
         ditaValReader.setLogger(logger);
+        xmlUtils.setLogger(logger);
     }
 
 //    @Override
@@ -193,7 +195,7 @@ public final class TopicBranchFilterModule extends AbstractPipelineModuleImpl {
                     logger.error("Failed to create directory " + dstDirUri);
                 }
                 try {
-                    XMLUtils.transform(srcAbsUri,
+                    xmlUtils.transform(srcAbsUri,
                                        dstAbsUri,
                                        pipe);
                 } catch (final DITAOTException e) {
@@ -235,7 +237,7 @@ public final class TopicBranchFilterModule extends AbstractPipelineModuleImpl {
             final URI srcAbsUri = job.tempDirURI.resolve(map.resolve(href));
             logger.info("Filtering " + srcAbsUri);
             try {
-                XMLUtils.transform(toFile(srcAbsUri),
+                xmlUtils.transform(toFile(srcAbsUri),
                         pipe);
             } catch (final DITAOTException e) {
                 logger.error("Failed to filter " + srcAbsUri + ": " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -9,6 +9,7 @@
 package org.dita.dost.util;
 
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.withLogger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -244,7 +245,7 @@ public final class DelayConrefUtils {
         final TransformerFactory tf = TransformerFactory.newInstance();
         Transformer t = null;
         try {
-            t = tf.newTransformer();
+            t = withLogger(tf.newTransformer(), logger);
             t.setOutputProperty(OutputKeys.INDENT, "yes");
             t.setOutputProperty(OutputKeys.METHOD, "xml");
             t.setOutputProperty(OutputKeys.ENCODING, "UTF-8");

--- a/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
@@ -31,6 +31,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
 public abstract class AbstractXMLFilter extends XMLFilterImpl implements AbstractWriter {
 
     protected DITAOTLogger logger;
+    protected final XMLUtils xmlUtils = new XMLUtils();
     Job job;
     /** Absolute temporary directory URI to file being processed */
     protected URI currentFile;
@@ -39,12 +40,13 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
     @Override
     public void write(final File filename) throws DITAOTException {
         assert filename.isAbsolute();
-        XMLUtils.transform(filename, Collections.singletonList((XMLFilter) this));
+        xmlUtils.transform(filename, Collections.singletonList((XMLFilter) this));
     }
 
     @Override
     public final void setLogger(final DITAOTLogger logger) {
         this.logger = logger;
+        xmlUtils.setLogger(logger);
     }
 
     @Override


### PR DESCRIPTION
Use Saxon specific functionality to output `xsl:message` output to JAXP error listener. This allows us to log to `DITAOTLogger` instead of standard out and have a consistent approach to log handling.