### PR TITLE
Support alternate rendering directory with internal property

### DIFF
--- a/src/main/plugins/com.sophos.tocjs/integrator.xml
+++ b/src/main/plugins/com.sophos.tocjs/integrator.xml
@@ -29,7 +29,7 @@ See the accompanying LICENSE file for applicable license.
             <isset property="output.file" />
         </not>
     </condition>
-    <property name="output.file" value="${output.dir}${file.separator}toctree.js"/>
+    <property name="output.file" value="${dita.output.dir}${file.separator}toctree.js"/>
     <property name="out.ext" value=".html"/>
   </target>
 
@@ -61,7 +61,7 @@ See the accompanying LICENSE file for applicable license.
       <antcall target="tocjsDefaultXhtmlOutput"/>
       <antcall target="tocjsDefaultFrameset"/>
       <!-- Copy default JS and related files -->
-      <copy todir="${output.dir}"><fileset
+    <copy todir="${dita.output.dir}"><fileset
           dir="${dita.plugin.com.sophos.tocjs.dir}${file.separator}basefiles"><include name="**/*"/></fileset></copy>
   </target>
 
@@ -77,7 +77,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Create the default frameset itself -->
       <xslt
 		basedir="${dita.temp.dir}"
-		destdir="${output.dir}"
+		destdir="${dita.output.dir}"
         includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
         extension="${out.ext}"
 		style="${dita.plugin.com.sophos.tocjs.dir}${file.separator}xsl${file.separator}frameset.xsl">

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -85,6 +85,9 @@ See the accompanying LICENSE file for applicable license.
       </condition>
     </fail>
     <property name="output.dir" location="${basedir}/out" />
+    <condition property="dita.output.dir" value="${dita.temp.dir}${file.separator}${temp.output.dir.name}" else="${output.dir}">
+      <isset property="temp.output.dir.name"/>
+    </condition>
     <property environment="env" />
   </target>
 

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -103,7 +103,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="generatecopyouter" value="${generate.copy.outer}"/>
         <param name="outercontrol" value="${outer.control}"/>
         <param name="onlytopicinmap" value="${onlytopic.in.map}"/>
-        <param name="outputdir" location="${output.dir}"/>
+        <param name="outputdir" location="${dita.output.dir}"/>
         <param name="transtype" value="${transtype}"/>
         <param name="gramcache" value="${args.grammar.cache}"/>
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
@@ -239,7 +239,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="generatecopyouter" value="${generate.copy.outer}"/>
         <param name="outercontrol" value="${outer.control}"/>
         <param name="onlytopicinmap" value="${onlytmopic.in.map}"/>
-        <param name="outputdir" location="${output.dir}"/>
+        <param name="outputdir" location="${dita.output.dir}"/>
         <param name="transtype" value="${transtype}"/>
         <param name="gramcache" value="${args.grammar.cache}"/>
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
@@ -436,7 +436,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="FILTERFILEURL" expression="${dita.input.filterfile.url}"/>
         <param name="DRAFT" expression="${args.draft}" if="args.draft"/>
         <param name="BASEDIR" expression="${basedir}"/>
-        <param name="OUTPUTDIR" expression="${output.dir}"/>
+        <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <dita:extension id="dita.preprocess.flag-module.param" behavior="org.dita.dost.platform.InsertAction"/>
         <xmlcatalog refid="dita.catalog"/>
@@ -476,7 +476,7 @@ See the accompanying LICENSE file for applicable license.
           dita:depends="{depend.preprocess.copy-image.pre}"
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
           description="Copy image files">
-    <copy todir="${output.dir}" failonerror="false">
+    <copy todir="${dita.output.dir}" failonerror="false">
       <dita-fileset format="image" />
     </copy>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -96,7 +96,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="generatecopyouter" value="${generate.copy.outer}"/>
         <param name="outercontrol" value="${outer.control}"/>
         <param name="onlytopicinmap" value="${onlytopic.in.map}"/>
-        <param name="outputdir" location="${output.dir}"/>
+        <param name="outputdir" location="${dita.output.dir}"/>
         <param name="transtype" value="${transtype}"/>
         <param name="gramcache" value="${args.grammar.cache}"/>
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
@@ -167,7 +167,7 @@ See the accompanying LICENSE file for applicable license.
     <property name="copytosourcefile" value="copytosource.list"/>
     <property name="subtargetsfile" value="subtargets.list"/>
     <property name="resourceonlyfile" value="resourceonly.list"/>
-    <dirname property="_dita.map.output.dir" file="${output.dir}/${user.input.file}" />
+    <dirname property="_dita.map.output.dir" file="${dita.output.dir}/${user.input.file}" />
     <dirname property="_dita.map.temp.dir" file="${dita.temp.dir}/${user.input.file}" />
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
     <condition property="noMap">
@@ -190,7 +190,7 @@ See the accompanying LICENSE file for applicable license.
         <!--param name="ditadir" location="${dita.dir}"/-->
         <param name="ditaval" location="${dita.input.valfile}" if="dita.input.valfile"/>
         <!--param name="inputdir" location="${args.input.dir}" if="args.input.dir"/-->
-        <!--param name="outputdir" location="${output.dir}"/-->
+        <!--param name="outputdir" location="${dita.output.dir}"/-->
         <!--param name="setsystemid" value="${args.xml.systemid.set}"/-->
         <param name="transtype" value="${transtype}"/>
       </module>
@@ -500,7 +500,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="FILTERFILEURL" expression="${dita.input.filterfile.url}"/>
         <param name="DRAFT" expression="${args.draft}" if="args.draft"/>
         <param name="BASEDIR" expression="${basedir}"/>
-        <param name="OUTPUTDIR" expression="${output.dir}"/>
+        <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <!-- Deprecated since 2.4 -->
         <param name="DBG" expression="${args.debug}" if="args.debug"/>
         <param name="defaultLanguage" expression="${default.language}"/>
@@ -586,7 +586,7 @@ See the accompanying LICENSE file for applicable license.
     dita:depends="{depend.preprocess.copy-image.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction" 
     description="Copy image files">
-    <condition property="copy-image.todir" value="${output.dir}/${uplevels}" else="${output.dir}">
+    <condition property="copy-image.todir" value="${dita.output.dir}/${uplevels}" else="${dita.output.dir}">
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
     <copy todir="${copy-image.todir}" failonerror="false">
@@ -599,7 +599,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.copy-html.skip"
     description="Copy html files">
-    <copy todir="${output.dir}" failonerror="false">
+    <copy todir="${dita.output.dir}" failonerror="false">
       <dita-fileset format="html" />
     </copy>
   </target>
@@ -611,7 +611,7 @@ See the accompanying LICENSE file for applicable license.
     description="Copy flag files">
     <property name="flagimagefile" value="flagimage.list"/>
     <job-helper file="flagimage.list" property="flagimagelist"/>
-    <dita-ot-copy todir="${output.dir}" includesfile="${dita.temp.dir}/${flagimagefile}" relativepaths="${relflagimagelist}" />
+    <dita-ot-copy todir="${dita.output.dir}" includesfile="${dita.temp.dir}/${flagimagefile}" relativepaths="${relflagimagelist}" />
   </target>
   
   <target name="copy-flag-check">

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -99,7 +99,7 @@ See the accompanying LICENSE file for applicable license.
             description="Build EclipseHelp TOC file">
         <xslt
               basedir="${dita.temp.dir}"
-              destdir="${output.dir}"
+              destdir="${dita.output.dir}"
               includesfile="${dita.temp.dir}/${fullditamapfile}"
               extension=".xml"
               classpathref="dost.class.path"
@@ -117,7 +117,7 @@ See the accompanying LICENSE file for applicable license.
         description="Build EclipseHelp TOC file">
         <xslt
             basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
+            destdir="${dita.output.dir}"
             includesfile="${dita.temp.dir}/${fullditamapfile}"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
@@ -141,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
             tempdir="${dita.temp.dir}"
             inputmap="${user.input.file}">
     	    <module class="org.dita.dost.module.IndexTermExtractModule">
-            <param name="output" location="${output.dir}/${user.input.file}"/>
+            <param name="output" location="${dita.output.dir}/${user.input.file}"/>
             <param name="targetext" value="${out.ext}"/>
             <param name="indextype" value="eclipsehelp"/>
             <param name="indexclass" value="${dita.eclipsehelp.index.class}"/>
@@ -162,7 +162,7 @@ See the accompanying LICENSE file for applicable license.
             tempdir="${dita.temp.dir}"
             inputmap="${user.input.file}">
           <module class="org.dita.dost.module.IndexTermExtractModule">
-            <param name="output" location="${output.dir}/index.xml"/>
+            <param name="output" location="${dita.output.dir}/index.xml"/>
             <param name="targetext" value="${out.ext}"/>
             <param name="indextype" value="eclipsehelp"/>
             <param name="indexclass" value="${dita.eclipsehelp.index.class}"/>
@@ -205,7 +205,7 @@ See the accompanying LICENSE file for applicable license.
         description="Build Eclipsehelp plugin file">
         <xslt
             in="${dita.temp.dir}/${user.input.file}"
-            out="${output.dir}/plugin.xml"
+            out="${dita.output.dir}/plugin.xml"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
             <param name="TOCROOT" expression="${dita.map.filename.root}" />
@@ -302,7 +302,7 @@ See the accompanying LICENSE file for applicable license.
     description="Create eclipse plugin.properties file">
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
-      out="${output.dir}/plugin.properties"
+      out="${dita.output.dir}/plugin.properties"
       classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <outputproperty value="text" name="method"/>
@@ -324,7 +324,7 @@ See the accompanying LICENSE file for applicable license.
     description="Create eclipse plugin.properties file">
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
-      out="${output.dir}/plugin.properties"
+      out="${dita.output.dir}/plugin.properties"
       classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <outputproperty value="text" name="method"/>
@@ -364,8 +364,8 @@ See the accompanying LICENSE file for applicable license.
     if="old.transform">
     <defaultexcludes add="**/META-INF/**"/>
     <defaultexcludes add="**/nl/**"/>
-  	<delete file="${output.dir}/plugin.xml"/>
-  	<delete file="${output.dir}/plugincustomization.ini"/>
+  	<delete file="${dita.output.dir}/plugin.xml"/>
+  	<delete file="${dita.output.dir}/plugincustomization.ini"/>
     <move todir="${dita.map.output.dir}/${fragment.dirname}" includeemptydirs="yes">
       <fileset dir="${dita.map.output.dir}" defaultexcludes="yes">
         <exclude name="helpData.xml"/>
@@ -379,7 +379,7 @@ See the accompanying LICENSE file for applicable license.
       	<exclude name="plugincustomization.ini"/>
       </fileset>
     </move>
-  	<move file="${output.dir}/plugin.properties" tofile="${output.dir}/plugin_${fragment.property.name}.properties" failonerror="no"/>
+  	<move file="${dita.output.dir}/plugin.properties" tofile="${dita.output.dir}/plugin_${fragment.property.name}.properties" failonerror="no"/>
 
   	
   </target>
@@ -388,10 +388,10 @@ See the accompanying LICENSE file for applicable license.
     if="inner.transform">
     <defaultexcludes add="**/META-INF/**"/>
     <defaultexcludes add="**/nl/**"/>
-  	<delete file="${output.dir}/plugin.xml"/>
-  	<delete file="${output.dir}/plugincustomization.ini"/>
-    <move todir="${output.dir}/${fragment.dirname}" includeemptydirs="yes">
-      <fileset dir="${output.dir}" defaultexcludes="yes">
+  	<delete file="${dita.output.dir}/plugin.xml"/>
+  	<delete file="${dita.output.dir}/plugincustomization.ini"/>
+    <move todir="${dita.output.dir}/${fragment.dirname}" includeemptydirs="yes">
+      <fileset dir="${dita.output.dir}" defaultexcludes="yes">
         <exclude name="helpData.xml"/>
       	<exclude name="plugin.properties"/>
       	<exclude name="plugin_${fragment.property.name}.properties"/>
@@ -403,7 +403,7 @@ See the accompanying LICENSE file for applicable license.
       	<exclude name="plugincustomization.ini"/>
       </fileset>
     </move>
-  	<move file="${output.dir}/plugin.properties" tofile="${output.dir}/plugin_${fragment.property.name}.properties" failonerror="no"/>
+  	<move file="${dita.output.dir}/plugin.properties" tofile="${dita.output.dir}/plugin_${fragment.property.name}.properties" failonerror="no"/>
   </target>
   
   <!--<target name="dita.map.eclipse"
@@ -450,7 +450,7 @@ See the accompanying LICENSE file for applicable license.
 	
 	<target name="copy-plugin-files">
 	  	<!-- Look for files that override behavior in Eclipse plugins -->
-	  	<copy todir="${output.dir}">
+	  	<copy todir="${dita.output.dir}">
 	  	      <fileset dir="${user.input.dir}">
 	  	      	<include name="disabled_book.css"/>
 	  	        <include name="narrow_book.css"/>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -134,7 +134,7 @@ See the accompanying LICENSE file for applicable license.
           unless="html5.image-metadata.skip" description="Read image metadata">
     <pipeline message="Read image metadata." taskname="image-metadata" tempdir="${dita.temp.dir}">
       <module class="org.dita.dost.module.ImageMetadataModule">
-        <param name="outputdir" location="${output.dir}"/>
+        <param name="outputdir" location="${dita.output.dir}"/>
       </module>
     </pipeline>
   </target>
@@ -181,7 +181,7 @@ See the accompanying LICENSE file for applicable license.
     <sequential>
       <pipeline message="Convert DITA topic to HTML5" taskname="xslt">
       <xslt basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
+            destdir="${dita.output.dir}"
             reloadstylesheet="${dita.html5.reloadstylesheet}"
             classpathref="dost.class.path"
             extension="${out.ext}"
@@ -205,7 +205,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta"/>
         <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
         <param name="BASEDIR" expression="${basedir}"/>
-        <param name="OUTPUTDIR" expression="${output.dir}"/>
+        <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <params/>
         <xmlcatalog refid="dita.catalog"/>
@@ -218,7 +218,7 @@ See the accompanying LICENSE file for applicable license.
     <element name="params" optional="true" implicit="true"/>
     <sequential>
       <local name="html5.toc.output.dir"/>
-      <condition property="html5.toc.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+      <condition property="html5.toc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
         <isset property="inner.transform"/>
       </condition>
       <pipeline message="Convert DITA map to HTML5" taskname="xslt">
@@ -248,7 +248,7 @@ See the accompanying LICENSE file for applicable license.
         <isset property="args.css.present"/>
       </and>
     </condition>
-    <property name="user.csspath.real" location="${output.dir}/${user.csspath}"/>
+    <property name="user.csspath.real" location="${dita.output.dir}/${user.csspath}"/>
     <mkdir dir="${user.csspath.real}"/>
     <!-- Always copy system default css files -->
     <copy todir="${user.csspath.real}">

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp.xml
@@ -59,7 +59,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="dita.map.htmlhelp.hhp" depends="dita.map.htmlhelp.init"
           description="Build HTMLHelp HHP file">
     <local name="htmlhelp.hhp.output.dir"/>
-    <condition property="htmlhelp.hhp.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+    <condition property="htmlhelp.hhp.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
     <xslt basedir="${dita.temp.dir}"
@@ -82,7 +82,7 @@ See the accompanying LICENSE file for applicable license.
           description="Build HTMLHelp HHP file">
     <dita-ot-echo id="DOTX070W"><param name="1" value="dita.out.map.htmlhelp.hhp"/></dita-ot-echo>
     <xslt basedir="${dita.temp.dir}"
-          destdir="${output.dir}"
+          destdir="${dita.output.dir}"
           includesfile="${dita.temp.dir}/${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhp.xsl">
@@ -98,7 +98,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="dita.map.htmlhelp.hhc" depends="dita.map.htmlhelp.init"
           description="Build HTMLHelp HHC file">
     <local name="htmlhelp.hhc.output.dir"/>
-    <condition property="htmlhelp.hhc.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+    <condition property="htmlhelp.hhc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
     <xslt basedir="${dita.temp.dir}"
@@ -119,7 +119,7 @@ See the accompanying LICENSE file for applicable license.
           description="Build HTMLHelp HHC file">
     <dita-ot-echo id="DOTX070W"><param name="1" value="dita.out.map.htmlhelp.hhc"/></dita-ot-echo>
     <xslt basedir="${dita.temp.dir}"
-          destdir="${output.dir}"
+          destdir="${dita.output.dir}"
           includesfile="${dita.temp.dir}/${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhc.xsl">
@@ -133,7 +133,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="dita.map.htmlhelp.hhk" depends="dita.map.htmlhelp.init"
           description="Build HTMLHelp HHK file">
     <local name="htmlhelp.hhk.output.dir"/>
-    <condition property="htmlhelp.hhk.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+    <condition property="htmlhelp.hhk.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
     <pipeline message="Extract index term." tempdir="${dita.temp.dir}" inputmap="${user.input.file}">
@@ -153,7 +153,7 @@ See the accompanying LICENSE file for applicable license.
     <dita-ot-echo id="DOTX070W"><param name="1" value="dita.out.map.htmlhelp.hhk"/></dita-ot-echo>
     <pipeline message="Extract index term." tempdir="${dita.temp.dir}" inputmap="${user.input.file}">
       <module class="org.dita.dost.module.IndexTermExtractModule">
-        <param name="output" location="${output.dir}/${dita.map.filename.root}.hhk"/>
+        <param name="output" location="${dita.output.dir}/${dita.map.filename.root}.hhk"/>
         <param name="targetext" value="${out.ext}"/>
         <param name="indextype" value="htmlhelp"/>
         <param name="encoding" value="${args.dita.locale}" if="args.dita.locale"/>
@@ -172,15 +172,15 @@ See the accompanying LICENSE file for applicable license.
                 basedir="${basedir}"
                 tempdir="${dita.temp.dir}"
                 inputmap="${user.input.file}"
-                outputdir="${output.dir}"/>
+                outputdir="${dita.output.dir}"/>
     <convert-lang message="Convert Language"
                   basedir="${basedir}"
-                  outputdir="${output.dir}"
+                  outputdir="${dita.output.dir}"
                   langcode="${htmlhelp.locale}"/>
   </target>
 
   <target name="compile.HTML.Help" if="HTMLHelpCompiler" description="Compile HTMLHelp output">
-    <condition property="compile.dir" value="${output.dir}">
+    <condition property="compile.dir" value="${dita.output.dir}">
       <isset property="inner.transform"/>
     </condition>
     <condition property="compile.dir" value="${dita.map.output.dir}">

--- a/src/main/plugins/org.dita.javahelp/build_dita2javahelp.xml
+++ b/src/main/plugins/org.dita.javahelp/build_dita2javahelp.xml
@@ -51,7 +51,7 @@ See the accompanying LICENSE file for applicable license.
             depends="dita.map.javahelp.init"
             description="Build JavaHelp TOC file">
         <local name="javahelp.toc.output.dir"/>
-        <condition property="javahelp.toc.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+        <condition property="javahelp.toc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
           <isset property="inner.transform"/>
         </condition>
         <xslt
@@ -73,7 +73,7 @@ See the accompanying LICENSE file for applicable license.
         description="Build JavaHelp TOC file">
         <xslt
             basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
+            destdir="${dita.output.dir}"
             includesfile="${dita.temp.dir}/${user.input.file.listfile}"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.javahelp.dir}/xsl/map2javahelptoc.xsl">
@@ -90,7 +90,7 @@ See the accompanying LICENSE file for applicable license.
             depends="dita.map.javahelp.init"
             description="Build JavaHelp Map file">
         <local name="javahelp.map.output.dir"/>
-        <condition property="javahelp.map.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+        <condition property="javahelp.map.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
           <isset property="inner.transform"/>
         </condition>
         <xslt
@@ -112,7 +112,7 @@ See the accompanying LICENSE file for applicable license.
         description="Build JavaHelp Map file">
         <xslt
             basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
+            destdir="${dita.output.dir}"
             includesfile="${dita.temp.dir}/${user.input.file.listfile}"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.javahelp.dir}/xsl/map2javahelpmap.xsl">
@@ -129,7 +129,7 @@ See the accompanying LICENSE file for applicable license.
             depends="dita.map.javahelp.init, dita.map.javahelp.map"
             description="Build JavaHelp Set file">
         <local name="javahelp.set.output.dir"/>
-        <condition property="javahelp.set.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+        <condition property="javahelp.set.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
           <isset property="inner.transform"/>
         </condition>
         <xslt
@@ -142,7 +142,7 @@ See the accompanying LICENSE file for applicable license.
             <param name="javahelpmap" expression="${args.javahelp.map}" />
             <param name="javahelptoc" expression="${args.javahelp.toc}" />
         	<param name="basedir" expression="${basedir}"/>
-        	<param name="outputdir" expression="${output.dir}"/>
+        	<param name="outputdir" expression="${dita.output.dir}"/>
             <mergemapper to="${dita.map.filename.root}_helpset.hs"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
@@ -154,7 +154,7 @@ See the accompanying LICENSE file for applicable license.
         description="Build JavaHelp Set file">
         <xslt
             basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
+            destdir="${dita.output.dir}"
             includesfile="${dita.temp.dir}/${user.input.file.listfile}"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.javahelp.dir}/xsl/map2javahelpset.xsl">
@@ -162,7 +162,7 @@ See the accompanying LICENSE file for applicable license.
             <param name="javahelpmap" expression="${args.javahelp.map}" />
             <param name="javahelptoc" expression="${args.javahelp.toc}" />
         	<param name="basedir" expression="${basedir}"/>
-        	<param name="outputdir" expression="${output.dir}"/>
+        	<param name="outputdir" expression="${dita.output.dir}"/>
             <mapper type="glob"
                 from="${user.input.file}"
                 to="${dita.map.filename.root}_helpset.hs" />
@@ -173,7 +173,7 @@ See the accompanying LICENSE file for applicable license.
     <target name="dita.map.javahelp.index"
             description="Build JavaHelp Index file">
         <local name="javahelp.index.output.dir"/>
-        <condition property="javahelp.index.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+        <condition property="javahelp.index.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
           <isset property="inner.transform"/>
         </condition>
         <pipeline message="Extract index term."
@@ -195,7 +195,7 @@ See the accompanying LICENSE file for applicable license.
             tempdir="${dita.temp.dir}"
             inputmap="${user.input.file}">
           <module class="org.dita.dost.module.IndexTermExtractModule">
-            <param name="output" location="${output.dir}/${dita.map.filename.root}.xml"/>
+            <param name="output" location="${dita.output.dir}/${dita.map.filename.root}.xml"/>
             <param name="targetext" value=".html"/>
             <param name="indextype" value="javahelp"/>
             <param name="encoding" value="${args.dita.locale}" if="args.dita.locale"/>
@@ -210,7 +210,7 @@ See the accompanying LICENSE file for applicable license.
         <condition property="compile.dir" value="${dita.map.output.dir}">
             <isset property="old.transform"/>
         </condition>
-        <condition property="compile.dir" value="${output.dir}">
+        <condition property="compile.dir" value="${dita.output.dir}">
             <isset property="inner.transform"/>
         </condition>
         <delete dir="${compile.dir}/JavaHelpSearch" />

--- a/src/main/plugins/org.dita.troff/build_dita2troff.xml
+++ b/src/main/plugins/org.dita.troff/build_dita2troff.xml
@@ -40,7 +40,7 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="dita.topic.troff" unless="noTopic" if="old.transform"
     description="Build troff output from dita inner and outer topics,which will adjust the directory.">
-    <xslt basedir="${dita.temp.dir}" destdir="${output.dir}"
+    <xslt basedir="${dita.temp.dir}" destdir="${dita.output.dir}"
       includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}" extension="${out.ext}"
       classpathref="dost.class.path"
       style="${troff.step2.xsl}">
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
     description="Build troff output from inner dita topics">
 	<echo level="info">the ditmapoutputdir is ${dita.map.output.dir}</echo>
     <!-- step 2 -->
-    <xslt basedir="${dita.temp.dir}" destdir="${output.dir}"
+    <xslt basedir="${dita.temp.dir}" destdir="${dita.output.dir}"
       includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}" extension="${out.ext}"
       classpathref="dost.class.path"
       style="${troff.step2.xsl}">

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -51,7 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <element name="params" optional="true" implicit="true"/>
     <sequential>
       <local name="xhtml.toc.output.dir"/>
-      <condition property="xhtml.toc.output.dir" value="${output.dir}" else="${_dita.map.output.dir}">
+      <condition property="xhtml.toc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
        <isset property="inner.transform"/>
       </condition>      
       <xslt
@@ -81,7 +81,7 @@ See the accompanying LICENSE file for applicable license.
         <dita-ot-echo id="DOTX070W"><param name="1" value="dita.out.map.xhtml.toc"/></dita-ot-echo>
         <xslt
               basedir="${dita.temp.dir}"
-              destdir="${output.dir}"
+              destdir="${dita.output.dir}"
               includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
               classpathref="dost.class.path"
               style="${args.xhtml.toc.xsl}">
@@ -112,7 +112,7 @@ See the accompanying LICENSE file for applicable license.
         <isset property="args.css.present"/>
       </and>
     </condition>
-    <property name="user.csspath.real" location="${output.dir}/${user.csspath}"/>
+    <property name="user.csspath.real" location="${dita.output.dir}/${user.csspath}"/>
     <mkdir dir="${user.csspath.real}"/>
     <!-- Always copy system default css files -->
     <copy todir="${user.csspath.real}">

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -123,7 +123,7 @@ See the accompanying LICENSE file for applicable license.
           description="Read image metadata">
     <pipeline message="Read image metadata." taskname="image-metadata" tempdir="${dita.temp.dir}">
       <module class="org.dita.dost.module.ImageMetadataModule">
-        <param name="outputdir" location="${output.dir}"/>
+        <param name="outputdir" location="${dita.output.dir}"/>
       </module>
     </pipeline>
   </target>
@@ -140,7 +140,7 @@ See the accompanying LICENSE file for applicable license.
     <sequential>
       <pipeline>
       <xslt basedir="${dita.temp.dir}"
-        destdir="${output.dir}"
+        destdir="${dita.output.dir}"
         reloadstylesheet="${dita.xhtml.reloadstylesheet}"
         classpathref="dost.class.path"
         extension="${out.ext}" style="${args.xsl}"
@@ -167,7 +167,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta" />
         <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
         <param name="BASEDIR" expression="${basedir}"/>
-        <param name="OUTPUTDIR" expression="${output.dir}"/>
+        <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <param name="DBG" expression="${args.debug}" if="args.debug"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <params/>


### PR DESCRIPTION
I have several custom transform types that override the `html5`, `xhtml`, and `eclipsehelp` transform types. In each case, my custom transform type is _almost_ the same as the default, but I need to return a zip of the result to the output directory.

Currently, this is very difficult (particularly with `eclipsehelp`). The default `output.dir` property is used in many targets that either copy or render files. My custom transform type - which again is _almost_ exactly the same as `html5` - has to override all of preprocess so that I can redirect targets that copy images. It has to override the main HTML5 steps for the same reason.

This pull request allows custom transform types to use an `init` style parameter that specifies a relative path within the temporary directory. When specified, all steps that render or copy files (apart from the log) will be placed in that directory within temp. This allows a final custom target to zip the files or do any other custom post-processing before they are returned. For example, an ebook transform type could use this to render all HTML5 / CSS / images in a temporary directory, add a step to generate the TOC and manifest, and return a complete zipped EPUB.

The new internal property is (for now) named `ditaot.render.dir`, and defaults to the output directory. This is fully backwards compatible; any custom transform type that uses `output.dir` will still work, and any value specified for `output.dir` will still work. This will only change processing for transform types that choose to override the render directory before running `build-init`.

For myself - this property is most important for `html5`, `xhtml`, and `eclipsehelp` (I override all of these to create a zip). It's less urgent for other transform types, but potentially useful for the same reasons, so this pull request supports the new property for all default transform types. For that same reason, I've added a new parameter `dita.map.render.dir` that could deprecate the existing `dita.map.output.dir`. This wasn't 100% necessary, but particularly with Eclipse Help, it felt wrong to have all the topics go to a `render` directory while map based files all went to a `output` directory.

The property used to do this is currently `temp.render.dir.name`. (I tried a lot of different property names and wasn't 100% happy with any of them.) It must be a relative path that will be created within the temporary directory. For example, if the value is `zip_dir`, all output files will be placed inside `temp/zip_dir`.

Whether or not that is the final parameter name, I'd like to create some initial doc for the parameter, but would like input from @infotexture on where that should go. (It's not really something that should be set on the command line, rather it's there for anybody doing custom transform types. If you set it on the command line with a default transform type, you won't get any output.)