### PR TITLE
Let's keep the map valid after the branch filtering

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -478,7 +478,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
             for (int i = 0; i < branches.size(); i++) {
                 final Element branch = branches.get(i);
                 final Element ditavalref = ditavalRefs.get(i);
-                branch.insertBefore(ditavalref, branch.getFirstChild());
+                branch.appendChild(ditavalref);
                 final Branch currentFilter = filter.merge(ditavalref);
                 processAttributes(branch, currentFilter);
                 final Branch childFilter = new Branch(currentFilter.resourcePrefix, currentFilter.resourceSuffix, Optional.empty(), Optional.empty());

--- a/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/input.ditamap
@@ -3,7 +3,6 @@
   ditaarch:DITAArchVersion="1.3">
   <title class="- topic/title ">DITA Topic Map</title>
   <topicref class="- map/topicref " href="install.dita" keyscope="install">
-    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
     <topicref class="- map/topicref " href="perform-install.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="perform-install.dita" copy-to="installation-procedure.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="configure-novice.dita" keyscope="novice-configure">
@@ -23,14 +22,9 @@
       </ditavalref>
     </topicref>
     <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="linux.ditaval" processing-role="resource-only"/>
   </topicref>
   <topicref class="- map/topicref " href="install-mac.dita" keyscope="mac-install">
-    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
-      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
-        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
-        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
-      </ditavalmeta>
-    </ditavalref>
     <topicref class="- map/topicref " href="perform-install-mac.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="installation-procedure-mac.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="configure-novice-mac.dita" keyscope="novice-configure">
@@ -50,14 +44,14 @@
       </ditavalref>
     </topicref>
     <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
-  </topicref>
-  <topicref class="- map/topicref " href="install-win.dita" keyscope="win-install">
-    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
       <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
-        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-win</dvrResourceSuffix>
-        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">win-</dvrKeyscopePrefix>
+          <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
+          <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
       </ditavalmeta>
     </ditavalref>
+  </topicref>
+  <topicref class="- map/topicref " href="install-win.dita" keyscope="win-install">
     <topicref class="- map/topicref " href="perform-install-win.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="installation-procedure-win.dita" keyscope="perform-install"/>
     <topicref class="- map/topicref " href="configure-novice-win.dita" keyscope="novice-configure">
@@ -77,6 +71,12 @@
       </ditavalref>
     </topicref>
     <topicref class="- map/topicref " href="http://example.com/install.dita" scope="external"/>
+      <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="win.ditaval" processing-role="resource-only">
+          <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+              <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-win</dvrResourceSuffix>
+              <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">win-</dvrKeyscopePrefix>
+          </ditavalmeta>
+      </ditavalref>
   </topicref>
   <topicref class="- map/topicref " href="install-linux.dita" keyscope="linux-">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">


### PR DESCRIPTION
According to the schema ([map](http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/contentmodels/cmltd.html#cmltd__ditavalref), [topicref](http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part3-all-inclusive/contentmodels/cmltt.html#cmltt__topicref), ...) the ditavalref element should be placed after topicmeta. But the [BranchFilterModule doesn't keep it in mind](https://github.com/dita-ot/dita-ot/blob/develop/src/main/java/org/dita/dost/module/BranchFilterModule.java#L481).

This microscopic fix [moves ditavalref to the bottom](https://github.com/mironovalexey/dita-ot/blob/fix/ditavalref-branchfilter-validmap/src/main/java/org/dita/dost/module/BranchFilterModule.java#L481) of the filtering branch (instead of its top). It restores the validation and should not break the filtering. Then the preprocessed ditamap can be processed again. E.g. this is very useful when the document is preprocessed for translation purposes.

The  [expected transformation result](https://github.com/mironovalexey/dita-ot/blob/fix/ditavalref-branchfilter-validmap/src/test/resources/BranchFilterModuleTest/exp/input.ditamap) of the [corresponding test](https://github.com/dita-ot/dita-ot/blob/develop/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java#L107) is also to be changed.

[test.tar.gz](https://github.com/dita-ot/dita-ot/files/972629/test.tar.gz)