### PR TITLE
Fixes for two distinct PDF flagging issues in #2459

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -127,6 +127,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:for-each>
         </fo:marker>
       </xsl:if>
+      <fo:block>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/prolog ')]"/>
         <xsl:apply-templates select="*[not(contains(@class, ' topic/title ')) and
@@ -135,6 +137,7 @@ See the accompanying LICENSE file for applicable license.
         <!--xsl:apply-templates select="." mode="buildRelationships"/-->
         <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
         <xsl:apply-templates select="." mode="topicEpilog"/>
+      </fo:block>
     </xsl:template>
 
     <!-- Hook that allows common end-of-topic processing (after nested topics). -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -15,14 +15,14 @@ See the accompanying LICENSE file for applicable license.
   <!-- For reference, flagging info as it appears in the topics: -->
   <!--<ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop ">
     <prop action="flag" att="audience" val="p">
-      <startflag imageref="yukface.jpg"><alt-text>Start P</alt-text></startflag>
+      <startflag imageref="yukface.jpg" dita-ot:original-imageref="yukface.jpg"><alt-text>Start P</alt-text></startflag>
     </prop>
     <prop action="flag" att="audience" backcolor="aqua" color="blue" style="italics" val="meep"/>
     <revprop action="flag" backcolor="maroon" changebar="|" color="olive" style="underline" val="testrev"/>
   </ditaval-startprop>
   <ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop ">
     <prop action="flag" att="audience" val="p">
-      <endflag imageref="smileface.jpg"><alt-text>End P</alt-text></endflag>
+      <endflag imageref="smileface.jpg" dita-ot:original-imageref="smileface.jpg"><alt-text>End P</alt-text></endflag>
     </prop>
   </ditaval-endprop>
   -->
@@ -164,6 +164,11 @@ See the accompanying LICENSE file for applicable license.
         <xsl:variable name="flags" as="element()*">
           <xsl:for-each select=".//startflag|.//endflag">
             <xsl:choose>
+              <xsl:when test="@dita-ot:original-imageref">
+                <image class="+ topic/image ditaot-d/flagimage " href="{@dita-ot:original-imageref}" placement="inline">
+                  <alt class="- topic/alt "><xsl:value-of select="alt-text"/></alt>
+                </image>
+              </xsl:when>
               <xsl:when test="@imageref">
                 <image class="+ topic/image ditaot-d/flagimage " href="{@imageref}" placement="inline">
                   <alt class="- topic/alt "><xsl:value-of select="alt-text"/></alt>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -253,6 +253,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="steps.step">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps.step__label">
                 <fo:block xsl:use-attribute-sets="steps.step__label__content">
                     <fo:inline>
@@ -282,6 +283,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/steps-unordered ')]/*[contains(@class, ' task/step ')]">
         <fo:list-item xsl:use-attribute-sets="steps-unordered.step">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps-unordered.step__label">
                 <fo:block xsl:use-attribute-sets="steps-unordered.step__label__content">
                     <fo:inline>
@@ -311,6 +313,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepsection ')]">
         <fo:list-item xsl:use-attribute-sets="stepsection">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="stepsection__label">
               <fo:block xsl:use-attribute-sets="stepsection__label__content">
                   <fo:inline>
@@ -343,6 +346,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="substeps.substep">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="substeps.substep__label">
                 <fo:block xsl:use-attribute-sets="substeps.substep__label__content">
                     <fo:inline>
@@ -376,6 +380,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/choice ')]">
         <fo:list-item xsl:use-attribute-sets="choices.choice">
+            <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
             <fo:list-item-label xsl:use-attribute-sets="choices.choice__label">
                 <fo:block xsl:use-attribute-sets="choices.choice__label__content">
                     <fo:inline>

--- a/src/main/xsl/preprocess/flagImpl.xsl
+++ b/src/main/xsl/preprocess/flagImpl.xsl
@@ -27,7 +27,8 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   version="2.0"  
   xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-  exclude-result-prefixes="xs ditamsg">
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  exclude-result-prefixes="xs ditamsg dita-ot">
 
  <!-- ========== Flagging with flags & revisions ========== -->
 
@@ -153,6 +154,7 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
         <startflag>
           <xsl:copy-of select="startflag/@*"/>
           <xsl:apply-templates select="startflag/@imageref" mode="adjust-imageref"/>
+          <xsl:apply-templates select="startflag/@imageref" mode="original-imageref"/>
           <xsl:copy-of select="startflag/*"/>
         </startflag>
       </xsl:if>
@@ -174,6 +176,7 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
         <endflag>
           <xsl:copy-of select="endflag/@*"/>
           <xsl:apply-templates select="endflag/@imageref" mode="adjust-imageref"/>
+          <xsl:apply-templates select="endflag/@imageref" mode="original-imageref"/>
           <xsl:copy-of select="endflag/*"/>
         </endflag>
       </xsl:if>
@@ -219,6 +222,7 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
          <startflag>
            <xsl:copy-of select="startflag/@*"/>
            <xsl:apply-templates select="startflag/@imageref" mode="adjust-imageref"/>
+           <xsl:apply-templates select="startflag/@imageref" mode="original-imageref"/>
            <xsl:copy-of select="startflag/*"/>
          </startflag>
        </xsl:when>
@@ -249,6 +253,7 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
           <endflag>
             <xsl:copy-of select="endflag/@*"/>
             <xsl:apply-templates select="endflag/@imageref" mode="adjust-imageref"/>
+            <xsl:apply-templates select="endflag/@imageref" mode="original-imageref"/>
             <xsl:copy-of select="endflag/*"/>
           </endflag>
         </xsl:when>
@@ -318,6 +323,12 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
         <xsl:value-of select="."/>
       </xsl:attribute>
     </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="@imageref" mode="original-imageref">
+    <xsl:attribute name="dita-ot:original-imageref">
+        <xsl:value-of select="."/>
+    </xsl:attribute>
   </xsl:template>
 
 


### PR DESCRIPTION
Issue #2459 includes three distinct PDF flagging issues, each of which are resolved by this pull request.

1. Problem 1 / first commit: several task elements do not support text decorations based on DITAVAL (color, bold, underline, etc).
1. Problem 2 / second commit: topics that are not in the map's directory do not pick up flag images based on the DITAVAL
1. Problem 3 / third commit: topics do not support flagging with text decorations when the flagging is set at the root topic element