### PR TITLE
Support DITA composite docs in topicmerge #1077

### DIFF
--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -211,8 +211,10 @@ public final class MergeMapParser extends XMLFilterImpl {
                         if (f.exists()) {
                             topicParser.parse(toFile(p).getPath(), dirPath);
                             final String fileId = topicParser.getFirstTopicId();
-                            util.addId(absTarget, fileId);
-                            if (attValue.getFragment() != null) {
+                            if (util.getIdValue(absTarget) == null) {
+                                util.addId(absTarget, fileId);
+                            }
+                            if (attValue.getFragment() != null && util.getIdValue(stripFragment(absTarget)) == null) {
                                 util.addId(stripFragment(absTarget), fileId);
                             }
                             final URI firstTopicId = toURI(SHARP + fileId);

--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -45,6 +45,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
     private final MergeUtils util;
     private DITAOTLogger logger;
     private File output;
+    private final String GENERATED_DITA_ELEMENT_ID = "GENERATED-DITA-ID";
     
     /**
      * Default Constructor.
@@ -93,10 +94,6 @@ public final class MergeTopicParser extends XMLFilterImpl {
 
     @Override
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-        // Skip redundant <dita> tags.
-        if (ELEMENT_NAME_DITA.equals(qName)) {
-            return;
-        }
         getContentHandler().endElement(uri, localName, qName);
     }
 
@@ -202,15 +199,16 @@ public final class MergeTopicParser extends XMLFilterImpl {
     @Override
     public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
             throws SAXException {
-        // Skip redundant <dita> tags.
-        if (ELEMENT_NAME_DITA.equals(qName)) {
-            rootLang = attributes.getValue(XML_NS_URI, "lang");
-            return;
-        }
         final AttributesImpl atts = new AttributesImpl(attributes);
         final String classValue = atts.getValue(ATTRIBUTE_NAME_CLASS);
 
-        if (TOPIC_TOPIC.matches(classValue)) {
+        if (ELEMENT_NAME_DITA.equals(qName)) {
+            rootLang = attributes.getValue(XML_NS_URI, "lang");
+            if (atts.getValue(ATTRIBUTE_NAME_ID) == null) {
+            	XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_ID, GENERATED_DITA_ELEMENT_ID);
+            }
+        }
+        if (TOPIC_TOPIC.matches(classValue) || ELEMENT_NAME_DITA.equals(qName)) {
             handleID(atts);
             if (firstTopicId == null) {
                 firstTopicId = atts.getValue(ATTRIBUTE_NAME_ID);

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -47,9 +47,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:variable name="msgprefix" select="'PDFX'"/>
   <xsl:variable name="separator" select="'_Connect_42_'"/>
     
-    <xsl:variable name="originalMap" as="element()">
-        <xsl:sequence select="/dita-merge/*[contains(@class,' map/map ')][1]"/>
-    </xsl:variable>
+  <xsl:variable name="originalMap" as="element()"
+    select="/dita-merge/*[contains(@class,' map/map ')][1]"/>
 
     <xsl:output indent="no"/>
 
@@ -57,25 +56,24 @@ See the accompanying LICENSE file for applicable license.
     <xsl:key name="topicref" match="//*[contains(@class,' map/topicref ')]" use="generate-id()"/>
 
   <xsl:template match="/">
-      <xsl:variable name="updatedMap"  as="document-node()">
-          <xsl:document>
-          <xsl:choose>
-              <xsl:when test="/dita-merge/dita">
-                  <xsl:apply-templates select="/dita-merge" mode="resolve-root-dita">
-                      <xsl:with-param name="ditaDocs" as="element()">
-                          <root>
-                              <xsl:sequence select="/dita-merge/dita"/>
-                          </root>
-                      </xsl:with-param>
-                  </xsl:apply-templates>
-              </xsl:when>
-              <xsl:otherwise>
-                  <xsl:sequence select="/*"/>
-              </xsl:otherwise>
-          </xsl:choose>
-          </xsl:document>
-      </xsl:variable>
-      <xsl:apply-templates select="$updatedMap/*"/>
+    <xsl:variable name="updatedMap"  as="document-node()">
+      <xsl:document>
+        <xsl:choose>
+          <xsl:when test="/dita-merge/dita">
+            <xsl:apply-templates select="/dita-merge" mode="resolve-root-dita">
+              <xsl:with-param name="ditaDocs" as="element()">
+                <root><xsl:sequence select="/dita-merge/dita"/>
+                </root>
+              </xsl:with-param>
+            </xsl:apply-templates>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="/*"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:document>
+    </xsl:variable>
+    <xsl:apply-templates select="$updatedMap/*"/>
   </xsl:template>
 
 
@@ -88,63 +86,63 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     
     <xsl:template match="*[contains(@class,' map/topicref ')][@first_topic_id]" mode="resolve-root-dita">
-        <xsl:param name="ditaDocs" as="element()+"/>
-        <xsl:variable name="topicId" select="substring-after(@first_topic_id,'#')"/>
-        <xsl:choose>
-            <xsl:when test="$ditaDocs/*[@id=$topicId]">
-                <xsl:variable name="topicref" select="." as="element()"/>
-                <xsl:for-each select="$ditaDocs/*[@id=$topicId]/*[contains(@class,' topic/topic ')]">
-                    <xsl:variable name="updateTopicTarget" select="concat('#',@id)" as="xs:string"/>
-                    <xsl:variable name="lastTopic" select="if (position()=last()) then true() else false()" as="xs:boolean"/>
-                    <xsl:for-each select="$topicref">
-                        <xsl:copy>
-                            <xsl:copy-of select="@*[not(name()='href' or name()='first_topic_id')]"/>
-                            <xsl:attribute name="first_topic_id" select="$updateTopicTarget"/>
-                            <xsl:attribute name="href"><xsl:value-of select="$updateTopicTarget"/></xsl:attribute>
-                            <xsl:choose>
-                                <xsl:when test="$lastTopic">
-                                    <xsl:apply-templates select="*|comment()|processing-instruction()" mode="resolve-root-dita">
-                                        <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
-                                    </xsl:apply-templates>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:sequence select="*[contains(@class,' map/topicmeta ')]"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:copy>
-                    </xsl:for-each>
-                </xsl:for-each>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:copy>
-                    <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
-                        <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+      <xsl:param name="ditaDocs" as="element()+"/>
+      <xsl:variable name="topicId" select="substring-after(@first_topic_id,'#')"/>
+      <xsl:choose>
+        <xsl:when test="$ditaDocs/*[@id=$topicId]">
+          <xsl:variable name="topicref" select="." as="element()"/>
+          <xsl:for-each select="$ditaDocs/*[@id=$topicId]/*[contains(@class,' topic/topic ')]">
+            <xsl:variable name="updateTopicTarget" select="concat('#',@id)" as="xs:string"/>
+            <xsl:variable name="lastTopic" select="position() eq last()" as="xs:boolean"/>
+            <xsl:for-each select="$topicref">
+              <xsl:copy>
+                <xsl:copy-of select="@* except (@href, @first_topic_id)"/>
+                <xsl:attribute name="first_topic_id" select="$updateTopicTarget"/>
+                <xsl:attribute name="href" select="$updateTopicTarget"/>
+                <xsl:choose>
+                  <xsl:when test="$lastTopic">
+                    <xsl:apply-templates select="*|comment()|processing-instruction()" mode="resolve-root-dita">
+                      <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
                     </xsl:apply-templates>
-                </xsl:copy>
-            </xsl:otherwise>
-        </xsl:choose>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:sequence select="*[contains(@class,' map/topicmeta ')]"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:copy>
+            </xsl:for-each>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy>
+            <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+              <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+            </xsl:apply-templates>
+          </xsl:copy>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:template>
     
     <xsl:template match="@href[starts-with(.,'#')]" mode="resolve-root-dita">
-        <xsl:param name="ditaDocs" as="element()+"/>
-        <xsl:variable name="topicId" select="substring-after(.,'#')"/>
-        <xsl:choose>
-            <xsl:when test="$ditaDocs/*[@id=$topicId]">
-                <xsl:attribute name="href" select="concat('#',$ditaDocs/*[@id=$topicId]/*[1]/@id)"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="."/>
-            </xsl:otherwise>
-        </xsl:choose>
+      <xsl:param name="ditaDocs" as="element()+"/>
+      <xsl:variable name="topicId" select="substring-after(.,'#')"/>
+      <xsl:choose>
+        <xsl:when test="$ditaDocs/*[@id=$topicId]">
+          <xsl:attribute name="href" select="concat('#',$ditaDocs/*[@id=$topicId]/*[1]/@id)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:sequence select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:template>
     
     <xsl:template match="@*|node()" mode="resolve-root-dita">
-        <xsl:param name="ditaDocs" as="element()+"/>
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
-                <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
-            </xsl:apply-templates>
-        </xsl:copy>
+      <xsl:param name="ditaDocs" as="element()+"/>
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+          <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+        </xsl:apply-templates>
+      </xsl:copy>
     </xsl:template>
 
     <xsl:template match="dita-merge/*[contains(@class,' map/map ')]" mode="build-tree">

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -46,25 +46,105 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 2.3 -->
   <xsl:variable name="msgprefix" select="'PDFX'"/>
   <xsl:variable name="separator" select="'_Connect_42_'"/>
+    
+    <xsl:variable name="originalMap" as="element()">
+        <xsl:sequence select="/dita-merge/*[contains(@class,' map/map ')][1]"/>
+    </xsl:variable>
 
     <xsl:output indent="no"/>
 
-    <xsl:key name="topic" match="dita-merge/*[contains(@class,' topic/topic ')]" use="concat('#',@id)"/>
-    <xsl:key name="topic" match="dita-merge/dita" use="concat('#',*[contains(@class, ' topic/topic ')][1]/@id)"/>
+    <xsl:key name="topic" match="dita-merge/*[contains(@class,' topic/topic ')]|dita-merge/dita/*" use="concat('#',@id)"/>
     <xsl:key name="topicref" match="//*[contains(@class,' map/topicref ')]" use="generate-id()"/>
 
-<!--
   <xsl:template match="/">
-    <xsl:copy-of select="."/>
+      <xsl:variable name="updatedMap"  as="document-node()">
+          <xsl:document>
+          <xsl:choose>
+              <xsl:when test="/dita-merge/dita">
+                  <xsl:apply-templates select="/dita-merge" mode="resolve-root-dita">
+                      <xsl:with-param name="ditaDocs" as="element()">
+                          <root>
+                              <xsl:sequence select="/dita-merge/dita"/>
+                          </root>
+                      </xsl:with-param>
+                  </xsl:apply-templates>
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:sequence select="/*"/>
+              </xsl:otherwise>
+          </xsl:choose>
+          </xsl:document>
+      </xsl:variable>
+      <xsl:apply-templates select="$updatedMap/*"/>
   </xsl:template>
--->
 
-  <xsl:template match="dita-merge">
+
+    <xsl:template match="dita-merge">
         <xsl:variable name="map" select="(*[contains(@class,' map/map ')])[1]"/>
         <xsl:element name="{name($map)}">
           <xsl:copy-of select="$map/@*"/>
           <xsl:apply-templates select="$map" mode="build-tree"/>
         </xsl:element>
+    </xsl:template>
+    
+    <xsl:template match="*[contains(@class,' map/topicref ')][@first_topic_id]" mode="resolve-root-dita">
+        <xsl:param name="ditaDocs" as="element()+"/>
+        <xsl:variable name="topicId" select="substring-after(@first_topic_id,'#')"/>
+        <xsl:choose>
+            <xsl:when test="$ditaDocs/*[@id=$topicId]">
+                <xsl:variable name="topicref" select="." as="element()"/>
+                <xsl:for-each select="$ditaDocs/*[@id=$topicId]/*[contains(@class,' topic/topic ')]">
+                    <xsl:variable name="updateTopicTarget" select="concat('#',@id)" as="xs:string"/>
+                    <xsl:variable name="lastTopic" select="if (position()=last()) then true() else false()" as="xs:boolean"/>
+                    <xsl:for-each select="$topicref">
+                        <xsl:copy>
+                            <xsl:copy-of select="@*[not(name()='href' or name()='first_topic_id')]"/>
+                            <xsl:attribute name="first_topic_id" select="$updateTopicTarget"/>
+                            <xsl:attribute name="href"><xsl:value-of select="$updateTopicTarget"/></xsl:attribute>
+                            <xsl:choose>
+                                <xsl:when test="$lastTopic">
+                                    <xsl:apply-templates select="*|comment()|processing-instruction()" mode="resolve-root-dita">
+                                        <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+                                    </xsl:apply-templates>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:sequence select="*[contains(@class,' map/topicmeta ')]"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:copy>
+                    </xsl:for-each>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+                        <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+                    </xsl:apply-templates>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="@href[starts-with(.,'#')]" mode="resolve-root-dita">
+        <xsl:param name="ditaDocs" as="element()+"/>
+        <xsl:variable name="topicId" select="substring-after(.,'#')"/>
+        <xsl:choose>
+            <xsl:when test="$ditaDocs/*[@id=$topicId]">
+                <xsl:attribute name="href" select="concat('#',$ditaDocs/*[@id=$topicId]/*[1]/@id)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="@*|node()" mode="resolve-root-dita">
+        <xsl:param name="ditaDocs" as="element()+"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+                <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+            </xsl:apply-templates>
+        </xsl:copy>
     </xsl:template>
 
     <xsl:template match="dita-merge/*[contains(@class,' map/map ')]" mode="build-tree">
@@ -158,7 +238,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' map/topicref ') and @print='no']" priority="6"/>
-    <xsl:template match="*[contains(@class,' topic/topic ')] | dita-merge/dita">
+    <xsl:template match="*[contains(@class,' topic/topic ')]">
 
         <xsl:param name="parentId"/>
       <xsl:variable name="idcount">

--- a/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
@@ -15,6 +15,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
 import org.xml.sax.SAXException;
 import org.xml.sax.InputSource;
 import org.dita.dost.TestUtils;
@@ -26,6 +28,11 @@ public class MergeMapParserTest {
     final File resourceDir = TestUtils.getResourceDir(MergeMapParserTest.class);
     private final File srcDir = new File(resourceDir, "src");
     private final File expDir = new File(resourceDir, "exp");
+
+    @Before
+    public void setUp() {
+        XMLUnit.setIgnoreWhitespace(true);
+    }
 
     @Test
     public void testReadStringString() throws SAXException, IOException {
@@ -52,6 +59,36 @@ public class MergeMapParserTest {
         parser.read(new File(srcDir, "space in map name.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(UTF8));
         assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
+                new InputSource(new ByteArrayInputStream(output.toByteArray())));
+    }
+
+    @Test
+    public void testComposite() throws SAXException, IOException {
+        final MergeMapParser parser = new MergeMapParser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(srcDir));
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write("<wrapper>".getBytes(UTF8));
+        parser.setOutputStream(output);
+        parser.read(new File(srcDir, "testcomposite.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
+        output.write("</wrapper>".getBytes(UTF8));
+
+        assertXMLEqual(new InputSource(new File(expDir, "mergedwithditasub.xml").toURI().toString()),
+                new InputSource(new ByteArrayInputStream(output.toByteArray())));
+    }
+
+    @Test
+    public void testSubtopic() throws SAXException, IOException {
+        final MergeMapParser parser = new MergeMapParser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(srcDir));
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write("<wrapper>".getBytes(UTF8));
+        parser.setOutputStream(output);
+        parser.read(new File(srcDir, "testsubtopic.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
+        output.write("</wrapper>".getBytes(UTF8));
+
+        assertXMLEqual(new InputSource(new File(expDir, "mergedsub.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
     

--- a/src/test/resources/MergeMapParserTest/exp/merged.xml
+++ b/src/test/resources/MergeMapParserTest/exp/merged.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <wrapper><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
   domains="(topic delay-d) (map mapgroup-d) (topic indexing-d) (map glossref-d)"
-  ditaarch:DITAArchVersion="1.2">
+  ditaarch:DITAArchVersion="1.3">
   <topicref class="- map/topicref " ohref="test.xml" href="#unique_1" first_topic_id="#unique_1"/>
   <topicref class="- map/topicref " ohref="test2.xml" href="#unique_3" first_topic_id="#unique_3"/>
   <topicref class="- map/topicref " ohref="test.xml" href="#unique_1"/>
 </map><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "
   domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  oid="topic" id="unique_1" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  oid="topic" id="unique_1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
   <title class="- topic/title ">Concept</title>
   <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
     class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    oid="concept" id="unique_2" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+    oid="concept" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
     <title class="- topic/title ">Concept 2</title>
   </concept>
 </concept><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "
   domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  oid="topic" id="unique_3" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  oid="topic" id="unique_3" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
   <title class="- topic/title ">Concept</title>
   <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
     class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    oid="concept" id="unique_4" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+    oid="concept" id="unique_4" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
     <title class="- topic/title ">Concept 2</title>
   </concept>
 </concept></wrapper>

--- a/src/test/resources/MergeMapParserTest/exp/mergedsub.xml
+++ b/src/test/resources/MergeMapParserTest/exp/mergedsub.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+<wrapper><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)"
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " ohref="test.xml#concept" href="#unique_2" first_topic_id="#unique_1"/>
+</map><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "
   domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  id="topic" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  oid="topic" id="unique_1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
   <title class="- topic/title ">Concept</title>
   <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
     class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    id="concept" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+    oid="concept" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
     <title class="- topic/title ">Concept 2</title>
   </concept>
-</concept>
+</concept></wrapper>

--- a/src/test/resources/MergeMapParserTest/exp/mergedsub.xml
+++ b/src/test/resources/MergeMapParserTest/exp/mergedsub.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wrapper><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
-  domains="(map mapgroup-d)"
-  ditaarch:DITAArchVersion="1.3">
-  <topicref class="- map/topicref " ohref="test.xml#concept" href="#unique_2" first_topic_id="#unique_1"/>
-</map><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-  class="- topic/topic concept/concept "
-  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  oid="topic" id="unique_1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Concept</title>
+<wrapper>
+  <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+       domains="(map mapgroup-d)"
+       ditaarch:DITAArchVersion="1.3">
+    <topicref class="- map/topicref " ohref="test.xml#concept" href="#unique_2" first_topic_id="#unique_1"/>
+  </map>
   <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-    class="- topic/topic concept/concept "
-    domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    oid="concept" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-    <title class="- topic/title ">Concept 2</title>
+           class="- topic/topic concept/concept "
+           domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+           oid="topic" id="unique_1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+    <title class="- topic/title ">Concept</title>
+    <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+             class="- topic/topic concept/concept "
+             domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+             oid="concept" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+      <title class="- topic/title ">Concept 2</title>
+    </concept>
   </concept>
-</concept></wrapper>
+</wrapper>

--- a/src/test/resources/MergeMapParserTest/exp/mergedwithditasub.xml
+++ b/src/test/resources/MergeMapParserTest/exp/mergedwithditasub.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wrapper><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)"
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " ohref="testdita1.xml" href="#unique_1" first_topic_id="#unique_1"/>
+  <topicref class="- map/topicref " ohref="testdita2.xml#second" href="#unique_6" first_topic_id="#unique_4"/>
+</map><dita id="unique_1" oid="GENERATED-DITA-ID"><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic concept/concept "
+  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  oid="topic1" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Concept</title>
+</concept><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+class="- topic/topic concept/concept "
+domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+oid="topic2" id="unique_3" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+<title class="- topic/title ">Concept 2</title>
+</concept></dita><dita id="unique_4" oid="GENERATED-DITA-ID"><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+class="- topic/topic concept/concept "
+domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+oid="first" id="unique_5" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+<title class="- topic/title ">Concept</title>
+</concept><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+class="- topic/topic concept/concept "
+domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+oid="second" id="unique_6" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+<title class="- topic/title ">Concept 2</title>
+</concept></dita></wrapper>

--- a/src/test/resources/MergeMapParserTest/exp/mergedwithditasub.xml
+++ b/src/test/resources/MergeMapParserTest/exp/mergedwithditasub.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wrapper><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
-  domains="(map mapgroup-d)"
-  ditaarch:DITAArchVersion="1.3">
-  <topicref class="- map/topicref " ohref="testdita1.xml" href="#unique_1" first_topic_id="#unique_1"/>
-  <topicref class="- map/topicref " ohref="testdita2.xml#second" href="#unique_6" first_topic_id="#unique_4"/>
-</map><dita id="unique_1" oid="GENERATED-DITA-ID"><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-  class="- topic/topic concept/concept "
-  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  oid="topic1" id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Concept</title>
-</concept><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-class="- topic/topic concept/concept "
-domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-oid="topic2" id="unique_3" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-<title class="- topic/title ">Concept 2</title>
-</concept></dita><dita id="unique_4" oid="GENERATED-DITA-ID"><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-class="- topic/topic concept/concept "
-domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-oid="first" id="unique_5" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-<title class="- topic/title ">Concept</title>
-</concept><concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-class="- topic/topic concept/concept "
-domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-oid="second" id="unique_6" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-<title class="- topic/title ">Concept 2</title>
-</concept></dita></wrapper>
+<wrapper>
+  <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)"
+       ditaarch:DITAArchVersion="1.3">
+    <topicref class="- map/topicref " href="#unique_1" ohref="testdita1.xml" first_topic_id="#unique_1"/>
+    <topicref class="- map/topicref " href="#unique_6" ohref="testdita2.xml#second" first_topic_id="#unique_4"/>
+  </map>
+  <dita id="unique_1" oid="GENERATED-DITA-ID">
+    <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic concept/concept "
+             domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+             id="unique_2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us" oid="topic1">
+      <title class="- topic/title ">Concept</title>
+    </concept>
+    <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic concept/concept "
+             domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+             id="unique_3" ditaarch:DITAArchVersion="1.3" xml:lang="en-us" oid="topic2">
+      <title class="- topic/title ">Concept 2</title>
+    </concept>
+  </dita>
+  <dita id="unique_4" oid="GENERATED-DITA-ID">
+    <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic concept/concept "
+             domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+             id="unique_5" ditaarch:DITAArchVersion="1.3" xml:lang="en-us" oid="first">
+      <title class="- topic/title ">Concept</title>
+    </concept>
+    <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic concept/concept "
+             domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+             id="unique_6" ditaarch:DITAArchVersion="1.3" xml:lang="en-us" oid="second">
+      <title class="- topic/title ">Concept 2</title>
+    </concept>
+  </dita>
+</wrapper>

--- a/src/test/resources/MergeMapParserTest/src/space in map name.ditamap
+++ b/src/test/resources/MergeMapParserTest/src/space in map name.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
   domains="(topic delay-d) (map mapgroup-d) (topic indexing-d) (map glossref-d)"
-  ditaarch:DITAArchVersion="1.2">
+  ditaarch:DITAArchVersion="1.3">
   <topicref class="- map/topicref " href="test.xml"/>
   <topicref class="- map/topicref " href="test2.xml"/>
   <topicref class="- map/topicref " href="test.xml"/>

--- a/src/test/resources/MergeMapParserTest/src/test.ditamap
+++ b/src/test/resources/MergeMapParserTest/src/test.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
   domains="(topic delay-d) (map mapgroup-d) (topic indexing-d) (map glossref-d)"
-  ditaarch:DITAArchVersion="1.2">
+  ditaarch:DITAArchVersion="1.3">
   <topicref class="- map/topicref " href="test.xml"/>
   <topicref class="- map/topicref " href="test2.xml"/>
   <topicref class="- map/topicref " href="test.xml"/>

--- a/src/test/resources/MergeMapParserTest/src/test2.xml
+++ b/src/test/resources/MergeMapParserTest/src/test2.xml
@@ -2,12 +2,12 @@
 <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "
   domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  id="topic" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  id="topic" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
   <title class="- topic/title ">Concept</title>
   <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
     class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    id="concept" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+    id="concept" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
     <title class="- topic/title ">Concept 2</title>
   </concept>
 </concept>

--- a/src/test/resources/MergeMapParserTest/src/testcomposite.ditamap
+++ b/src/test/resources/MergeMapParserTest/src/testcomposite.ditamap
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)"
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="testdita1.xml"/>
+  <topicref class="- map/topicref " href="testdita2.xml#second"/>
+</map>

--- a/src/test/resources/MergeMapParserTest/src/testdita1.xml
+++ b/src/test/resources/MergeMapParserTest/src/testdita1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dita>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic concept/concept "
+  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Concept</title>
+</concept>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+class="- topic/topic concept/concept "
+domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+id="topic2" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+<title class="- topic/title ">Concept 2</title>
+</concept>
+</dita>

--- a/src/test/resources/MergeMapParserTest/src/testdita2.xml
+++ b/src/test/resources/MergeMapParserTest/src/testdita2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dita>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic concept/concept "
+  domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  id="first" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Concept</title>
+</concept>
+<concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+class="- topic/topic concept/concept "
+domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+id="second" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+<title class="- topic/title ">Concept 2</title>
+</concept>
+</dita>

--- a/src/test/resources/MergeMapParserTest/src/testsubtopic.ditamap
+++ b/src/test/resources/MergeMapParserTest/src/testsubtopic.ditamap
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)"
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="test.xml#concept"/>
+</map>

--- a/src/test/resources/MergeTopicParserTest/exp/test.xml
+++ b/src/test/resources/MergeTopicParserTest/exp/test.xml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
+<dita id="unique_1" oid="GENERATED-DITA-ID">
 <?foo?><?foo bar?><?foo <&?>
 <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "
   domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-  id="unique_1" oid="topic" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+  id="unique_2" oid="topic" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
   <title class="- topic/title ">Test</title>
   <conbody class="- topic/body  concept/conbody ">
     <p class="- topic/p ">&lt;&amp;</p>
@@ -11,21 +12,21 @@
     <p class="- topic/p " id="a">A</p>
     <p class="- topic/p " id="b">B</p>
     <p class="- topic/p " id="a">A2</p>
-    <xref class="- topic/xref " href="#unique_2/a" ohref="test.xml#topic2/a"/>
+    <xref class="- topic/xref " href="#unique_3/a" ohref="test.xml#topic2/a"/>
     <xref class="- topic/xref " href="http://example.com/test.xml"/>
     <xref class="- topic/xref " href="#topic2/a" scope="peer"/>
     <xref class="- topic/xref " href="#topic2/a" format="html"/>
-    <xref class="- topic/xref " ohref="test2.xml" href="#unique_3"/>
-    <xref class="- topic/xref " ohref="test2.xml#concept" href="#unique_4"/>
-    <xref class="- topic/xref " ohref="test.xml#åäö" href="#unique_5"/>
-    <xref class="- topic/xref " ohref="test.xml#åäö" href="#unique_5"/>
+    <xref class="- topic/xref " ohref="test2.xml" href="#unique_4"/>
+    <xref class="- topic/xref " ohref="test2.xml#concept" href="#unique_5"/>
+    <xref class="- topic/xref " ohref="test.xml#åäö" href="#unique_6"/>
+    <xref class="- topic/xref " ohref="test.xml#åäö" href="#unique_6"/>
     <foreign class="- topic/foreign ">
       <foo xmlns="http://example.com/foo" xmlns:bar="http://example.com/bar" bar:foo="baz"/>
     </foreign>
   </conbody>
   <concept class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    id="unique_2" oid="topic2" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+    id="unique_3" oid="topic2" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
     <title class="- topic/title ">Test 2</title>
     <conbody class="- topic/body  concept/conbody ">
       <p class="- topic/p " id="a">A</p>
@@ -33,22 +34,23 @@
   </concept>
   <concept class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    id="unique_2" oid="topic2" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
+    id="unique_3" oid="topic2" ditaarch:DITAArchVersion="1.2" xml:lang="en-us">
     <title class="- topic/title ">Test 2</title>
   </concept>
   <concept class="- topic/topic concept/concept "
     domains="(topic concept) (topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
-    id="unique_5" oid="åäö" ditaarch:DITAArchVersion="1.2" xml:lang="en-us"><!-- non-ASCII ID -->
+    id="unique_6" oid="åäö" ditaarch:DITAArchVersion="1.2" xml:lang="en-us"><!-- non-ASCII ID -->
     <title class="- topic/title ">Unicode</title>
   </concept>
   <related-links class="- topic/related-link ">
-    <link class="- topic/link " href="#unique_2/a" ohref="test.xml#topic2/a"/>
+    <link class="- topic/link " href="#unique_3/a" ohref="test.xml#topic2/a"/>
     <link class="- topic/link " href="#topic2/a" scope="peer"/>
     <link class="- topic/link " href="#topic2/a" format="html"/>
-    <link class="- topic/link " ohref="test.xml#åäö/a" href="#unique_5/a"/>
-    <link class="- topic/link " ohref="test.xml#åäö" href="#unique_5"/>
+    <link class="- topic/link " ohref="test.xml#åäö/a" href="#unique_6/a"/>
+    <link class="- topic/link " ohref="test.xml#åäö" href="#unique_6"/>
     <link class="- topic/link " href="#åäö" scope="peer"/>
     <link class="- topic/link " href="#åäö" format="html"/>
     
   </related-links>
 </concept>
+</dita>

--- a/src/test/resources/MergeTopicParserTest/src/test.xml
+++ b/src/test/resources/MergeTopicParserTest/src/test.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<dita><!-- remove dita elements -->
+<!-- 2.5: do not remove dita elements -->
+<dita>
 <?foo?><?foo bar?><?foo <&?>
 <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   class="- topic/topic concept/concept "


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This fix addresses #1077 as well as an unreported issue I found with a test case for #1077.

Background: if you have a DITA document that uses the `<dita>` root element, the topicmerge process will only ever preserve the first `<topic>` in that document. This is true whether you reference the document (`href="composite.dita"`), the first topic (`href="composite.dita#first"`), another child of the root element (`href="composite.dita#thirdChildOfRootDita"`), or a sub-topic anywhere in the document (`href="composite.dita#subTopicSomewhere"`). This is clearly wrong; no matter what topic you reference, you get the first (and only the first) topic with its children, which may not even include the one you referenced.

Additional background: with a "normal" DITA document that has a root `topic`: regardless of how a map references the document (just the file, root topic, or sub-topic), you get the whole document in the PDF.

I think there's an argument to be made that if a map references the Nth child of `<dita>` you should only get the Nth child. But I've based this fix around the current processing for "normal" DITA topics. So: if a map references a topic that starts with `<dita>`, you get the whole file (this is the normal scenario). If a map references a sub-topic, you still get the whole file (I haven't actually seen this happen but it matches "normal" topics). This is the behavior we've supported internally for 13+ years, and it's the one that's made the most sense for our users.

To make this fix: `topicmerge` preserves the `<dita>` element and adds an ID so that maps can reference it. In the XSL post-process, if I reference a `<dita>` element, I split the reference up - preserving metadata for each reference, but only putting child topics in the end. [I had hoped to mostly handle this in the actual PDF2 code. But it's so heavily based on topic-id keys that any fix would have to add "If parent is `<dita>` then X else Y" around 20 or 100 times, and would effectively 1) make this a backwards incompatible change and 2) mean nobody with a customization gets the fix.

*Unreported issue that's fixed*

I realized that if I have a "normal" DITA document with a root topic, but only have the map reference a sub-topic, all links are broken. Basically, the map merge process (lines [214](https://github.com/dita-ot/dita-ot/pull/2679/files#diff-e43908434e07462fa522d4e253d607dbR214) and [215](https://github.com/dita-ot/dita-ot/pull/2679/files#diff-e43908434e07462fa522d4e253d607dbR215) ) assume that if you reference a topic ID in the map, that can only be the root topic; so they re-write any references to be to the first topic. That is: if my map has `topics.dita#subtopic`, lines [214](https://github.com/dita-ot/dita-ot/pull/2679/files#diff-e43908434e07462fa522d4e253d607dbR214) and [215](https://github.com/dita-ot/dita-ot/pull/2679/files#diff-e43908434e07462fa522d4e253d607dbR215) ensure that any references to `#subtopic` are rewritten to go to `firstTopicId`. This is also the reason that even if a map references the 3rd child of `<dita>`, you only get the first child of `<dita>` in your PDF.