### PR TITLE
Support override of args.filter

### DIFF
--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -110,12 +110,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- begin to init required parameters -->
     
-    <condition property="skip.ditaval.preprocess" value="true">
-      <not>
-          <isset property="args.filter"/>
-      </not>
-    </condition>
-    
     <condition property="filter-stage" value="early">
       <not>
         <isset property="filter-stage"/>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -6,7 +6,7 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<project xmlns:dita="http://dita-ot.sourceforge.net" name="ditaot-preprocess">
+<project xmlns:dita="http://dita-ot.sourceforge.net" name="ditaot-preprocess" xmlns:if="ant:if">
 
   <!-- Set to "true" if you get out-of-memory errors during preprocess
        while processing very large (thousands of files) document sets. -->
@@ -69,13 +69,13 @@ See the accompanying LICENSE file for applicable license.
     </delete>
   </target>
   
-  <target name="ditaval-merge" unless="skip.ditaval.preprocess"
+  <target name="ditaval-merge"
     dita:depends="{depend.preprocess.ditaval-merge.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     description="Merge DITAVAL files into temporary file">
-    <pipeline message="Preprocess and merge ditavals" taskname="ditaval-merge">
+    <pipeline message="Preprocess and merge ditavals" taskname="ditaval-merge" if:set="args.filter">
       <module class="org.dita.dost.module.MergeDitavalModule">
-        <param name="ditaval" location="${args.filter}" if="args.filter"/>
+        <param name="ditaval" value="${args.filter}"/>
       </module>
     </pipeline>
   </target>


### PR DESCRIPTION
This request builds on #2637 to make the `args.filter` processing just a bit more flexible.

Currently (in 2.4 and with the update in #2637) the `build-init` task checks to see if a build defines the `args.filter` parameter. If not, it sets up a property that will skip all future ditaval processing. The problem here is that there is no way for a plugin to insert processing for default transforms before the `build-init` task; you either need a new transform with your own init step, or you can plug in before the bigger `preprocess`.

This request moves the check for `args.filter` into `preprocess` so that we do not set `skip.ditaval.preprocess` until it's needed. I see three benefits for this:

1. A plugin can supply one or more common ditaval files. By inserting a target before preprocess, it can set `args.filter` to use those common properties for any or all existing transform types.
1. A plugin can use its own property with a custom platform-independent separator, and then convert that property to an `args.filter` value that is appropriate for the system running the build. This is probably how I will handle the platform questions that came up after #2637 was merged -- use a property like `custom.args.filter` that always uses a comma or semi-colon, and then converts that separator to `;` or `:` in `args.filter`.
1. Even if those use cases are not broadly applicable, it's just a better design to avoid setting `skip.ditaval.preprocess` until we actually need it.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>