### PR TITLE
Update html/image copy, avoid copy outside outdir #2550 #1964

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -586,7 +586,7 @@ See the accompanying LICENSE file for applicable license.
     dita:depends="{depend.preprocess.copy-image.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction" 
     description="Copy image files">
-    <condition property="copy-image.todir" value="${dita.output.dir}/${uplevels}" else="${dita.output.dir}">
+    <condition property="copy-image.todir" value="${_dita.map.output.dir}/${uplevels}" else="${dita.output.dir}">
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
     <copy todir="${copy-image.todir}" failonerror="false">
@@ -599,7 +599,10 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.copy-html.skip"
     description="Copy html files">
-    <copy todir="${dita.output.dir}" failonerror="false">
+    <condition property="copy-html.todir" value="${_dita.map.output.dir}/${uplevels}" else="${dita.output.dir}">
+      <equals arg1="${generate.copy.outer}" arg2="1"/>      
+    </condition>
+    <copy todir="${copy-html.todir}" failonerror="false">
       <dita-fileset format="html" />
     </copy>
   </target>


### PR DESCRIPTION
The "uplevels" construct used when copying images currently uses the wrong value. By using the specified output directory, followed by "uplevels", we actually allow the "uplevels" to leave the output directory and place images somewhere else. By using the correct parameter (the map based directory) followed by uplevels, we stay within the context of the output directory, and place images in the correct location.

Because this task is adjacent to `copy-html`, and they perform basically the same task, I've made the logic consistent between both. This also covers the update requested in #1964.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>