### PR TITLE
Support root level grouping topicrefs #2092 #2648 #2614

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -223,9 +223,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:call-template name="insertBodyStaticContents"/>
           <fo:flow flow-name="xsl-region-body">
             <xsl:for-each select="opentopic:map/*[contains(@class, ' map/topicref ')]">
-              <xsl:for-each select="key('topic-id', @id)">
-                <xsl:apply-templates select="." mode="processTopic"/>
-              </xsl:for-each>
+              <xsl:apply-templates select="." mode="generatePageSequenceFromTopicref"/>
             </xsl:for-each>
           </fo:flow>
         </fo:page-sequence>
@@ -238,6 +236,20 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
     <xsl:call-template name="createBackCover"/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' map/topicref ')]" mode="generatePageSequenceFromTopicref">
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
+    <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="generatePageSequenceFromTopicref"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="$referencedTopic">
+          <xsl:apply-templates select="." mode="processTopic"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' bookmap/bookmap ')]" mode="generatePageSequences" priority="10">
@@ -265,17 +277,21 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*" mode="generatePageSequences"/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="generatePageSequences" priority="0">
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+      </xsl:when>
       <xsl:when test="ancestor::*[contains(@class,' bookmap/frontmatter ')]">
         <!-- TODO: To fit the pattern, this should be in its own match template. But a general match for frontmatter/*
              conflicts with priority of existing rules (e.g., preface); changing priorities would
              break customizations. --> 
-        <xsl:for-each select="key('topic-id', @id)">
+        <xsl:for-each select="$referencedTopic">
           <xsl:call-template name="processFrontMatterTopic"/>
         </xsl:for-each>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:for-each select="key('topic-id', @id)">
+        <xsl:for-each select="$referencedTopic">
           <xsl:call-template name="processTopicSimple"/>
         </xsl:for-each>
       </xsl:otherwise>
@@ -287,26 +303,59 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*" mode="generatePageSequences"/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/chapter ')]" mode="generatePageSequences">
-    <xsl:for-each select="key('topic-id', @id)">
-      <xsl:call-template name="processTopicChapter"/>
-    </xsl:for-each>
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
+    <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="$referencedTopic">
+          <xsl:call-template name="processTopicChapter"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/appendix ')]" mode="generatePageSequences">
-    <xsl:for-each select="key('topic-id', @id)">
-      <xsl:call-template name="processTopicAppendix"/>
-    </xsl:for-each>
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
+    <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="$referencedTopic">
+          <xsl:call-template name="processTopicAppendix"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/preface ')]" mode="generatePageSequences">
-    <xsl:for-each select="key('topic-id', @id)">
-      <xsl:call-template name="processTopicPreface"/>
-    </xsl:for-each>
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
+    <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="$referencedTopic">
+            <xsl:call-template name="processTopicPreface"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/appendices ')]" mode="generatePageSequences">
-    <xsl:for-each select="key('topic-id', @id)">
-      <xsl:call-template name="processTopicAppendices"/>
-    </xsl:for-each>
+    <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
+    <xsl:choose>
+      <xsl:when test="empty($referencedTopic)">
+        <xsl:apply-templates select="*[contains(@class, ' bookmap/appendix ')]" mode="generatePageSequences"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:for-each select="$referencedTopic">
+            <xsl:call-template name="processTopicAppendices"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/part ')]" mode="generatePageSequences">
+    <!-- Merge process generates placeholder for <part> with no title, no topic -->
     <xsl:for-each select="key('topic-id', @id)">
       <xsl:call-template name="processTopicPart"/>
     </xsl:for-each>


### PR DESCRIPTION
The current PDF2 process assumes that if a root branch of a map has any real content, the root `topicref` of the branch will have either a title or reference a topic (or both). When that is not the case, the PDF is broken. If there is only the one root branch, FOP will crash (as reported in #2648). If there are "valid" root branches, the branch with a root grouping element will appear in the TOC + contents but not in the actual content.

Related, the much older issue #2092 has the same root cause -- it assumes that in a bookmap, any `chapter`, `appendix`, `appendices`, `preface`, or `topicref` (as child of front/back matter container) will either have a title or reference a topic. When that is not the case, results are the same as above.

In all of these cases, the code assumes that the container elements will reference a topic, and try to process the topic with `<xsl:for-each select="key('topic-id', @id)">` (note that when there is only a title in the `topicref` / `chapter` / etc, the merge process generates a topic with that title, so the key-lookup still works). When the `topic-id` lookup fails, no page sequence is generated, and children are not processed.

The fix here checks to see if the `topic-id` returns anything. If the result is empty, it continues to any `topicref` children with the same mode. Additional grouping `topicref` elements do the same. If a topic is eventually found, a valid page sequence is generated, and normal processing continues at that point.

Just realized that this also addresses #2614.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>