### PR TITLE
Support creating Eclipse Help output as JAR file

### DIFF
--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -6,7 +6,7 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<project xmlns:dita="http://dita-ot.sourceforge.net" name="dita2eclipsehelp">
+<project xmlns:dita="http://dita-ot.sourceforge.net" name="dita2eclipsehelp" xmlns:if="ant:if">
 	
   <target name="dita.eclipsehelp.init">
     <property name="html-version" value="xhtml"/>
@@ -14,6 +14,9 @@ See the accompanying LICENSE file for applicable license.
       <not>
         <isset property="args.xsl" />
       </not>
+    </condition>
+    <condition property="temp.output.dir.name" value="temp_jar_dir">
+      <isset property="args.eclipsehelp.jar.name"/>
     </condition>
   </target>
 	
@@ -26,15 +29,19 @@ See the accompanying LICENSE file for applicable license.
 	
     <target name="dita2eclipsehelp"
             unless="noMap"
-        depends="build-init, dita.eclipsehelp.init, preprocess, 
+        depends="dita.eclipsehelp.init, build-init, preprocess, 
                  xhtml.topics,
-                 copy-css">
-      <antcall target="dita.map.eclipse"></antcall>
+                 copy-css,
+                 dita.map.eclipse,
+                 build.eclipse.jar">
     </target>
 
   <target name="dita.map.eclipse"
-    depends=" dita.map.eclipse.init, copy-plugin-files, dita.map.eclipse.fragment.language.init, dita.map.eclipse.fragment.language.country.init, dita.map.eclipse.fragment.error">
-    
+    depends="dita.map.eclipse.init, 
+    copy-plugin-files, 
+    dita.map.eclipse.fragment.language.init, 
+    dita.map.eclipse.fragment.language.country.init, 
+    dita.map.eclipse.fragment.error">
   </target>
 	
 	<target name="dita.map.eclipse.init" if="eclipse.plugin"
@@ -462,5 +469,11 @@ See the accompanying LICENSE file for applicable license.
 	  		  
 	  	</copy>
 	</target>
-
+  
+  <target name="build.eclipse.jar">
+    <jar destfile="${output.dir}/${args.eclipsehelp.jar.name}" basedir="${dita.output.dir}" if:set="args.eclipsehelp.jar.name">
+      <include name="**/*"/>
+    </jar>
+  </target>
+  
 </project>

--- a/src/main/plugins/org.dita.eclipsehelp/plugin.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/plugin.xml
@@ -14,6 +14,7 @@ See the accompanying LICENSE file for applicable license.
   <extension-point id="dita.conductor.eclipse.toc.param" name="Eclipse Help TOC XSLT parameter"/>
   <!-- extensions -->
   <transtype name="eclipsehelp" extends="base-html" desc="Eclipse Help">
+    <param name="args.eclipsehelp.jar.name" desc="Specifies that the output should be zipped and returned using this name." type="string"/>
     <param name="args.eclipsehelp.country" desc="Specifies the region for the language that is specified by the args." type="string"/> 
     <param name="args.eclipsehelp.language" desc="Specifies the base language for translated content, such as en for English." type="string"/> 
     <param name="args.eclipse.provider" desc="Specifies the name of the person or organization that provides the Eclipse help." type="string">


### PR DESCRIPTION
In 15 years of supporting people using Eclipse, _nearly_ every user has wanted me to return the output as a single JAR rather than as many separate files. I've always managed this with complicated overrides + post-processing, but the new feature #2670 makes it simple.

I realized when I saw #2261 that this was probably common to every Eclipse Help user - the preferred output is a JAR file - so this pull request adds a parameter to make this automatic. When the new parameter specifies a JAR file name, the results will all be placed in that JAR file, and only that file is placed in the output directory.

If I was starting from scratch, returning a JAR would be the default behavior, and the default JAR name would be based on the map. At this point though it's likely many others have post-processing like mine, so we shouldn't change the default behavior.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>