### PR TITLE
Suggested approach for #2691

### DIFF
--- a/src/test/java/org/dita/dost/writer/TopicFragmentFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/TopicFragmentFilterTest.java
@@ -42,7 +42,7 @@ public class TopicFragmentFilterTest {
     
     @Before
     public void setUp() throws Exception {
-        tempDir = TestUtils.createTempDir(KeyrefPaserTest.class);
+        tempDir = TestUtils.createTempDir(TopicFragmentFilterTest.class);
         TestUtils.resetXMLUnit();
         XMLUnit.setIgnoreWhitespace(true);
         XMLUnit.setIgnoreComments(true);


### PR DESCRIPTION
It is likely to fix keyrefs to `nested-topic-id/element-id`.

Also it makes possible to reference a topic by the keyref of `a/b` form where `a` points to file and `b` points to topic id. For now this is not supported.  It seems that this change should not affect the current behavior, but rather expands it.