### PR TITLE
Enable PDF product name overrides for #2293

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -64,8 +64,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="productName">
         <xsl:variable name="mapProdname" select="(/*/opentopic:map//*[contains(@class, ' topic/prodname ')])[1]" as="element()?"/>
         <xsl:choose>
-            <xsl:when test="$mapProdname">
-                <xsl:value-of select="$mapProdname"/>
+            <xsl:when test="exists($mapProdname)">
+                <xsl:apply-templates select="$mapProdname" mode="set-product-name"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="getVariable">
@@ -85,7 +85,11 @@ See the accompanying LICENSE file for applicable license.
         </xsl:for-each>
     </xsl:variable>
 
-  <xsl:variable name="relatedTopicrefs" select="//*[contains(@class, ' map/reltable ')]//*[contains(@class, ' map/topicref ')]" as="element()*"/>
+    <xsl:variable name="relatedTopicrefs" select="//*[contains(@class, ' map/reltable ')]//*[contains(@class, ' map/topicref ')]" as="element()*"/>
+
+    <xsl:template match="*[contains(@class, ' topic/prodname ')]" mode="set-product-name">
+      <xsl:apply-templates select="." mode="dita-ot:text-only"/>
+    </xsl:template>
 
     <xsl:template name="validateTopicRefs">
         <xsl:apply-templates select="//opentopic:map" mode="topicref-validation"/>


### PR DESCRIPTION
The `$productName` variable is set globally in the PDF code, and then used in many places (headers, footers, etc).

If product name metadata is specified in the map, that name is used to set the variable with `xsl:value-of`. If you want to modify the product name in any way (typically by supporting keywords that should generate extra text, as with the ™ character in #2293), there is no way to do so without overriding every use of `$productName` (default code today uses it in 17 named templates).

This pull request uses the existing `text-only` mode to ensure elements that add text are supported. This doesn't directly address ™, but it does pick up changes from similar elements and means that a simple override can add ™ into those 17 contexts.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>