### PR TITLE
Stop generating extra linked or conref'ed files #2077

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -460,7 +460,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     }
 
     /**
-     * Process results from parsing a single topic
+     * Process results from parsing a single topic or map
      *
      * @param currentFile absolute URI processes files
      */
@@ -684,6 +684,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
         // Remove pure conref targets from fullTopicSet
         fullTopicSet.removeAll(pureConrefTargets);
+        // Treat pure conref targets same as resource-only
+        resourceOnlySet.addAll(pureConrefTargets);
     }
 
     /**
@@ -718,6 +720,10 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         job.setProperty("uplevels", getLevelsPath(rootTemp));
 
         resourceOnlySet.addAll(listFilter.getResourceOnlySet());
+        
+        if (job.getOnlyTopicInMap()) {
+            resourceOnlySet.addAll(listFilter.getNonTopicrefReferenceSet());
+        }
 
         for (final URI file: outDitaFilesSet) {
             getOrCreateFileInfo(fileinfos, file).isOutDita = true;

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -274,21 +274,21 @@ public class TestGenMapAndTopicListModule {
         final Job job = generate(inputDirParallel, inputMapParallel, outDirParallel, tempDir);
 
         assertEquals(new HashSet(Arrays.asList(
+                "link-from-normal-ALSORESOURCEONLY.dita",
                 "conref-from-resource-only-ALSORESOURCEONLY.dita",
                 "resourceonly.dita",
+                "conref-from-normal.dita",
+                "conref-from-resource-only.dita",
+                "link-from-resource-only-ALSORESOURCEONLY.dita",
                 "conref-from-normal-ALSORESOURCEONLY.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> f.isResourceOnly)
                         .map(fi -> fi.uri.toString())
                         .collect(Collectors.toSet()));
         assertEquals(new HashSet(Arrays.asList(
-                "link-from-normal-ALSORESOURCEONLY.dita",
                 "main.ditamap",
                 "link-from-normal.dita",
                 "link-from-resource-only.dita",
-                "conref-from-normal.dita",
-                "conref-from-resource-only.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
                 "normal.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> !f.isResourceOnly)
@@ -306,6 +306,8 @@ public class TestGenMapAndTopicListModule {
         assertEquals(new HashSet(Arrays.asList(
                 "conref-from-resource-only-ALSORESOURCEONLY.dita",
                 "resourceonly.dita",
+                "conref-from-normal.dita",
+                "conref-from-resource-only.dita",
                 "conref-from-normal-ALSORESOURCEONLY.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> f.isResourceOnly)
@@ -316,8 +318,6 @@ public class TestGenMapAndTopicListModule {
                 "link.ditamap",
                 "link-from-normal.dita",
                 "link-from-resource-only.dita",
-                "conref-from-normal.dita",
-                "conref-from-resource-only.dita",
                 "link-from-resource-only-ALSORESOURCEONLY.dita",
                 "normal.dita")),
                 job.getFileInfo().stream()

--- a/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
+++ b/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptySet;
 import static org.dita.dost.util.Constants.FEATURE_VALIDATION;
 import static org.dita.dost.util.Constants.FEATURE_VALIDATION_SCHEMA;
 import static org.junit.Assert.*;
@@ -93,6 +94,9 @@ public class TestGenListModuleReader {
                 srcDirUri.resolve("topics/target-topic-a.xml"))),
                 reader.getOutFilesSet());
 
+        assertEquals(emptySet(),
+                reader.getNonTopicrefReferenceSet());
+
         assertTrue(reader.getResourceOnlySet().isEmpty());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
@@ -132,6 +136,9 @@ public class TestGenListModuleReader {
         assertTrue(reader.getResourceOnlySet().isEmpty());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
+
+        assertEquals(emptySet(),
+                reader.getNonTopicrefReferenceSet());
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());
@@ -184,10 +191,10 @@ public class TestGenListModuleReader {
                         .collect(Collectors.toSet()),
                 reader.getNonCopytoResult());
 
-        assertEquals(Collections.emptySet(),
+        assertEquals(emptySet(),
                 reader.getOutDitaFilesSet());
 
-        assertEquals(Collections.emptySet(),
+        assertEquals(emptySet(),
                 reader.getOutFilesSet());
 
         assertEquals(Stream.of(
@@ -201,6 +208,9 @@ public class TestGenListModuleReader {
                 reader.getResourceOnlySet());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
+
+        assertEquals(emptySet(),
+                reader.getNonTopicrefReferenceSet());
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());


### PR DESCRIPTION
There are several problems with current processing of `resource-only` topics, and (related) problems with the `onlytopic.in.map` parameter.  In each case addressed here, the problem is that we generate output files for topics that should not be generated (in X/HTML or other formats that generate output by topic). This is because some topics marked `resource-only` are treated as normal, and topics not referenced by the map are (by default) always treated as normal.

In all of these cases, I recognize that switching to keys might resolve some issues. But, it remains legal to use this markup without keys; I've got millions of legacy topics without keys, many of which demonstrate these problems.

This request solves several issues in current `develop` level code. I think some are clearly bugs and the fix is appropriate:

1. I have `topicA.dita` marked `resource-only` in the map. In turn, `topicA.dita` has a `conref` reference to `topicZ.dita` which is not in the map. The resource only `topicA` does not generate output, but `topicZ` does. Instead, `topicZ` should default to `resource-only` as well, and should not generate output unless listed as normal in the map.
1. Similar: I have `topicB.dita` marked as `resource-only`. In turn, `topicB.dita` links to `topicZZ.dita` that does not appear in the map. The `topicZZ` target should also default to `resource-only`; currently it will generate output, *even if listed as `resource-only` in the map*.
1. When `onlytopic.in.map` is true: we should only generate output for topics referenced as `normal` in the map. We currently generate all local conref targets not listed in the map, whether the target is in normal or `resource-only` topics.
1. When `onlytopic.in.map` is true, we also generate output for any link targets that are only listed in the map as `resource-only`. 

I think these are also good corrections to current behavior but there _might_ be an argument for the current results:

1. I have a normal topic in my map. It has a `conref` reference to some other file not listed in the map. In my view - that `conref` target should _not_ generate output -- it should default to `resource-only` because it is only being used as a resource. If output is required, it should be listed in the map as a normal topic.
1. I have `topic.dita` in my map but only marked as `resource-only`. There are links to `topic.dita` from other normal topics. Currently this will generate output - and there is no way *not* to generate output, because links inside the topic cannot be marked `resource-only`. This pull request will not generate output for `topic.dita` unless a) the `resource-only` value is removed, b) it is added somewhere in the map as a "normal" topic, or c) it is removed from the map entirely. [Note: changes when using `onlytopic.in.map` are clearer and addressed above.]
1. Almost the same as previous: I have a normal `topic.dita` with link to `rOnly.dita`. The topic `rOnly.dita` appears in the map as `resource-only`. I think we should interpret this to mean the topic is `resource-only`, for the reasons above, and not generate output. Today, we will generate `rOnly.html`.

Remaining issue not resolved by this fix: If I have a `resource-only` topic, AND that topic has an `@href` reference to `edge.dita` (not `@conref`) to another topic, AND that other topic doesn't appear in the map, AND `onlytopic.in.map` is false or unspecified, we still generate `edge.html`. Ideally this link inside a `resource-only` topic would be defaulting to `resource-only` as well.

The overall code changes to do this are relatively small:
* Currently all references are added to a "normal" or "resourceOnly" set. This adds a third set for anything referenced by non-topicref elements (which _cannot_ specify an explicit role).
* When all references are scanned, if `onlytopic.in.map` is specified, anything that only appears in the non-topicref set (that is, anything never referenced by `topicref`) is added to the resourceOnly set. Otherwise, they remain as normal references (will generate output).
* When all references are scanned, any "pure Conref target" topics are also added to the resourceOnly set, regardless of `onlytopic.in.map`

Signed-off-by: Robert D Anderson <robander@us.ibm.com>