### PR TITLE
Preserve atts from <dita> when merging topics #1298

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -136,6 +136,15 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:template>
     
+    <xsl:template match="dita/*[contains(@class,' topic/topic ')]" mode="resolve-root-dita">
+      <xsl:param name="ditaDocs" as="element()+"/>
+      <xsl:copy>
+        <xsl:apply-templates select="parent::dita/@*,@*|node()" mode="resolve-root-dita">
+          <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
+        </xsl:apply-templates>
+      </xsl:copy>
+    </xsl:template>
+    
     <xsl:template match="@*|node()" mode="resolve-root-dita">
       <xsl:param name="ditaDocs" as="element()+"/>
       <xsl:copy>


### PR DESCRIPTION
Addresses the issue in #1298 -- attributes on `<dita>` (from the source or from preprocessing) are lost during the topic merge step. This update copies those attributes onto child topics, with matching attributes from `topic` taking precedence.

Signed-off-by: Robert D Anderson <robander@us.ibm.com>