### PR TITLE
Combine string variables for quotation marks

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">الأشكال</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Малюнкі</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
@@ -385,6 +385,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Фигури</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figures</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Obrázky</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -383,6 +383,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figurer</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -356,6 +356,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">Tabellenverzeichnis</variable>
     <variable id="List of Figures">Abbildungsverzeichnis</variable>
 
-  <variable id="#quote-start">„</variable>
-  <variable id="#quote-end">“</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Σχήματα</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -406,6 +406,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">List of Figures</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -347,6 +347,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">Lista de tablas</variable>
     <variable id="List of Figures">Lista de figuras</variable>
 
-  <variable id="#quote-start">«</variable>
-  <variable id="#quote-end">»</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Joonised</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -119,6 +119,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">Luettelo tauluista</variable>
   <variable id="List of Figures">Luettelo kuvista</variable>
 
-  <variable id="#quote-start">”</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -347,6 +347,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">Liste des tableaux</variable>
     <variable id="List of Figures">Liste des illustrations</variable>
 
-  <variable id="#quote-start">« </variable>
-  <variable id="#quote-end"> »</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -119,6 +119,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">רשימת טבלאות</variable>
   <variable id="List of Figures">רשימת איורים</variable>
 
-  <variable id="#quote-start">„</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">आंकड़े</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Ábrák</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Gambar</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Myndir</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -347,6 +347,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">Lista delle tabelle</variable>
     <variable id="List of Figures">Lista delle figure</variable>
 
-  <variable id="#quote-start">«</variable>
-  <variable id="#quote-end">»</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -390,6 +390,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">表の一覧</variable>
     <variable id="List of Figures">図の一覧</variable>
 
-  <variable id="#quote-start">「</variable>
-  <variable id="#quote-end">」</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Суреттер</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">그림</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Piešiniai</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Attēli</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Слики</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Rajah</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -177,6 +177,6 @@ See the accompanying LICENSE file for applicable license.
   <!-- The heading string to put at the top of the List of Figures -->
   <variable id="List of Figures">Figuren</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figurer</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Rysunki</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figuras</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figuras</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -119,6 +119,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">Listă de tabele</variable>
   <variable id="List of Figures">Listă de figuri</variable>
 
-  <variable id="#quote-start">„</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -119,6 +119,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">Список таблиц</variable>
   <variable id="List of Figures">Список иллюстраций</variable>
 
-  <variable id="#quote-start">«</variable>
-  <variable id="#quote-end">»</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Obrázky</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -172,6 +172,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">Seznam tabel</variable>
   <variable id="List of Figures">Seznam slik</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Ilustracije</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -371,6 +371,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Илустрације</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -119,6 +119,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List of Tables">Tabellförteckning</variable>
   <variable id="List of Figures">Figurförteckning</variable>
 
-  <variable id="#quote-start">”</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">รูป</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Şekiller</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Мал.</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">اعداد</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -383,6 +383,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Hình</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -351,6 +351,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="List of Tables">表格清单</variable>
     <variable id="List of Figures">插图清单</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
@@ -384,6 +384,6 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">圖</variable>
 
-  <variable id="#quote-start">“</variable>
-  <variable id="#quote-end">”</variable>
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/xsl/common/strings-ar-eg.xml
+++ b/src/main/xsl/common/strings-ar-eg.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">حقوق النشر لشركة</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-be-by.xml
+++ b/src/main/xsl/common/strings-be-by.xml
@@ -67,8 +67,8 @@ See the accompanying LICENSE file for applicable license.
 
   <str name="Copyright">Copyright</str> 
   <!-- Symbols --> 
-  <str name="OpenQuote">"</str> 
-  <str name="CloseQuote">"</str> 
+  <str name="OpenQuote">“</str> 
+  <str name="CloseQuote">”</str> 
   <str name="ColonSymbol">:</str> 
   <str name="#menucascade-separator"> &gt; </str> 
   <str name="a11y.and-then"></str> 

--- a/src/main/xsl/common/strings-bg-bg.xml
+++ b/src/main/xsl/common/strings-bg-bg.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Авторско право</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-bs-ba.xml
+++ b/src/main/xsl/common/strings-bs-ba.xml
@@ -74,8 +74,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ca-es.xml
+++ b/src/main/xsl/common/strings-ca-es.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-cs-cz.xml
+++ b/src/main/xsl/common/strings-cs-cz.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-da-dk.xml
+++ b/src/main/xsl/common/strings-da-dk.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-de-ch.xml
+++ b/src/main/xsl/common/strings-de-ch.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">„</str>
+<str name="CloseQuote">“</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-de-de.xml
+++ b/src/main/xsl/common/strings-de-de.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">„</str>
+<str name="CloseQuote">“</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-el-gr.xml
+++ b/src/main/xsl/common/strings-el-gr.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-en-ca.xml
+++ b/src/main/xsl/common/strings-en-ca.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-en-gb.xml
+++ b/src/main/xsl/common/strings-en-gb.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-en-us.xml
+++ b/src/main/xsl/common/strings-en-us.xml
@@ -74,8 +74,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then">and then</str>

--- a/src/main/xsl/common/strings-es-es.xml
+++ b/src/main/xsl/common/strings-es-es.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">«</str>
+<str name="CloseQuote">»</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-et-ee.xml
+++ b/src/main/xsl/common/strings-et-ee.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Autoriõigus</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-fi-fi.xml
+++ b/src/main/xsl/common/strings-fi-fi.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">”</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-fr-be.xml
+++ b/src/main/xsl/common/strings-fr-be.xml
@@ -70,8 +70,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">« </str>
+   <str name="CloseQuote"> »</str>
    <str name="ColonSymbol"> :</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-fr-ca.xml
+++ b/src/main/xsl/common/strings-fr-ca.xml
@@ -70,8 +70,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">« </str>
+   <str name="CloseQuote"> »</str>
    <str name="ColonSymbol">:</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-fr-ch.xml
+++ b/src/main/xsl/common/strings-fr-ch.xml
@@ -70,8 +70,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">« </str>
+   <str name="CloseQuote"> »</str>
    <str name="ColonSymbol"> :</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-fr-fr.xml
+++ b/src/main/xsl/common/strings-fr-fr.xml
@@ -71,8 +71,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">« </str>
+   <str name="CloseQuote"> »</str>
    <str name="ColonSymbol"> :</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-he-il.xml
+++ b/src/main/xsl/common/strings-he-il.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">„</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-hi-in.xml
+++ b/src/main/xsl/common/strings-hi-in.xml
@@ -72,8 +72,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">कॉपीराइट</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-hr-hr.xml
+++ b/src/main/xsl/common/strings-hr-hr.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Autorska prava</str>
 
    <!--Symbols-->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">“</str>
+   <str name="CloseQuote">”</str>
    <str name="ColonSymbol">:</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-hu-hu.xml
+++ b/src/main/xsl/common/strings-hu-hu.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-id-id.xml
+++ b/src/main/xsl/common/strings-id-id.xml
@@ -65,8 +65,8 @@
 <str name="Copyright">Hak cipta</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-is-is.xml
+++ b/src/main/xsl/common/strings-is-is.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-it-ch.xml
+++ b/src/main/xsl/common/strings-it-ch.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">«</str>
+<str name="CloseQuote">»</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-it-it.xml
+++ b/src/main/xsl/common/strings-it-it.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">«</str>
+<str name="CloseQuote">»</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ja-jp.xml
+++ b/src/main/xsl/common/strings-ja-jp.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">「</str>
+<str name="CloseQuote">」</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-kk-kz.xml
+++ b/src/main/xsl/common/strings-kk-kz.xml
@@ -65,8 +65,8 @@
 <str name="Copyright">авторлық құқықтары</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ko-kr.xml
+++ b/src/main/xsl/common/strings-ko-kr.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-lt-lt.xml
+++ b/src/main/xsl/common/strings-lt-lt.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-lv-lv.xml
+++ b/src/main/xsl/common/strings-lv-lv.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-mk-mk.xml
+++ b/src/main/xsl/common/strings-mk-mk.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Авторски права</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ms-my.xml
+++ b/src/main/xsl/common/strings-ms-my.xml
@@ -65,8 +65,8 @@
 <str name="Copyright">Hak Cipta</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-nl-be.xml
+++ b/src/main/xsl/common/strings-nl-be.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-nl-nl.xml
+++ b/src/main/xsl/common/strings-nl-nl.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-no-no.xml
+++ b/src/main/xsl/common/strings-no-no.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-pl-pl.xml
+++ b/src/main/xsl/common/strings-pl-pl.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-pt-br.xml
+++ b/src/main/xsl/common/strings-pt-br.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-pt-pt.xml
+++ b/src/main/xsl/common/strings-pt-pt.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ro-ro.xml
+++ b/src/main/xsl/common/strings-ro-ro.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">„</str>
+   <str name="CloseQuote">”</str>
    <str name="ColonSymbol">:</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ru-ru.xml
+++ b/src/main/xsl/common/strings-ru-ru.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">«</str>
+<str name="CloseQuote">»</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sk-sk.xml
+++ b/src/main/xsl/common/strings-sk-sk.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">“</str>
+   <str name="CloseQuote">”</str>
    <str name="ColonSymbol">:</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sl-si.xml
+++ b/src/main/xsl/common/strings-sl-si.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
    <str name="Copyright">Copyright</str>
 
    <!-- Symbols -->
-   <str name="OpenQuote">"</str>
-   <str name="CloseQuote">"</str>
+   <str name="OpenQuote">“</str>
+   <str name="CloseQuote">”</str>
    <str name="ColonSymbol">:</str>
    <str name="#menucascade-separator"> &gt; </str>
    <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sr-latn-me.xml
+++ b/src/main/xsl/common/strings-sr-latn-me.xml
@@ -74,8 +74,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sr-latn-rs.xml
+++ b/src/main/xsl/common/strings-sr-latn-rs.xml
@@ -72,8 +72,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sr-sp.xml
+++ b/src/main/xsl/common/strings-sr-sp.xml
@@ -75,8 +75,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-sv-se.xml
+++ b/src/main/xsl/common/strings-sv-se.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">”</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-th-th.xml
+++ b/src/main/xsl/common/strings-th-th.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">ลิขสิทธิ์ของ</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-tr-tr.xml
+++ b/src/main/xsl/common/strings-tr-tr.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-uk-ua.xml
+++ b/src/main/xsl/common/strings-uk-ua.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-ur-pk.xml
+++ b/src/main/xsl/common/strings-ur-pk.xml
@@ -72,8 +72,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">حقوق</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-vi-vn.xml
+++ b/src/main/xsl/common/strings-vi-vn.xml
@@ -74,8 +74,8 @@ This file is part of the DITA Open Toolkit project.
 <str name="Copyright">Bản quyền</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/main/xsl/common/strings-zh-cn.xml
+++ b/src/main/xsl/common/strings-zh-cn.xml
@@ -76,5 +76,7 @@ See the accompanying LICENSE file for applicable license.
 <str name="OpenQuote">“</str>
 <str name="CloseQuote">”</str>
 <str name="ColonSymbol">：</str>
+<str name="#menucascade-separator"> &gt; </str>
+<str name="a11y.and-then"></str>
 
 </strings>

--- a/src/main/xsl/common/strings-zh-tw.xml
+++ b/src/main/xsl/common/strings-zh-tw.xml
@@ -73,8 +73,8 @@ See the accompanying LICENSE file for applicable license.
 <str name="Copyright">Copyright</str>
 
 <!-- Symbols -->
-<str name="OpenQuote">"</str>
-<str name="CloseQuote">"</str>
+<str name="OpenQuote">“</str>
+<str name="CloseQuote">”</str>
 <str name="ColonSymbol">:</str>
 <str name="#menucascade-separator"> &gt; </str>
 <str name="a11y.and-then"></str>

--- a/src/test/resources/1.5.3_M2_BUG3164866/exp/xhtml/testpng.html
+++ b/src/test/resources/1.5.3_M2_BUG3164866/exp/xhtml/testpng.html
@@ -18,11 +18,11 @@
   <h1 class="title topictitle1" id="ariaid-title1">Test upper case PNG</h1>
 
   <div class="body conbody">
-    <p class="p">This is lower case <span class="q">".png"</span> <img class="image" src="images/lowercase.png" /></p>
+    <p class="p">This is lower case <span class="q">“.png”</span> <img class="image" src="images/lowercase.png" /></p>
 
     
     
-    <p class="p">This is upper case <span class="q">".PNG"</span> <img class="image" src="images/uppercase.PNG" /> </p>
+    <p class="p">This is upper case <span class="q">“.PNG”</span> <img class="image" src="images/uppercase.PNG" /> </p>
 
   </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-areg.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">شكل 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>المعلومات المتعلقة</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml/lang-beby.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Малюнак 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Адпаведная інфармацыя</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-bgbg.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Фигура 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Свързана информация</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml/lang-caes.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informació relacionada</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-concept.html
+++ b/src/test/resources/lang/exp/xhtml/lang-concept.html
@@ -26,7 +26,7 @@
 <p class="p">stuff</p>
 
 <div class="fig fignone" id="lang-concept__fig"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml/lang-cscz.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Obrázek 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Související informace</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dadk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Beslægtede oplysninger</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Abbildung 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">„quote“</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Abbildung 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">„quote“</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-elgr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Σχήμα 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Συναφείς πληροφορίες</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enca.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml/lang-engb.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enus.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml/lang-eses.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">«quote»</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Información relacionada</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml/lang-etee.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Joonis 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Seostuv teave</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-fifi.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Kuva 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">”quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Aiheeseen liittyviä tietoja</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frbe.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">« quote »</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frca.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">« quote »</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frch.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">« quote »</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frfr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">« quote »</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml/lang-heil.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">תרשים 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">„quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>מידע קשור</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hiin.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">संख्या 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>संबंधित जानकारी</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hrhr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Slika 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Srodne informacije</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml/lang-huhu.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">1. Ábra </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Kapcsolódó tájékoztatás</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml/lang-isis.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Mynd 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Skyldar upplýsingar</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itch.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">«quote»</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itit.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">«quote»</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-jajp.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">図 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">「quote」</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>関連情報</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-kokr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">그림 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>관련 정보</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ltlt.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Piešinys 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Susijusi informacija</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml/lang-lvlv.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Attēls 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Saistītā informācija</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-mkmk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Слика 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Сродни информации</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlbe.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figuur 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlnl.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figuur 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nono.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Beslektet informasjon</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-plpl.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Rysunek 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informacje pokrewne</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptbr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptpt.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml/lang-roro.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">„quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Informaţii înrudite</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ruru.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Рис. 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">«quote»</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Информация, связанная с данной</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-sksk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Obrázok 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Súvisiace informácie</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-slsi.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Slika 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>S tem povezane informacije</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-srsp.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Илустрација 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Сродна информација</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml/lang-svse.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">”quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Närliggande information</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml/lang-thth.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">รูปที่ 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>ข้อมูลที่เกี่ยวข้อง</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-trtr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Şekil 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>İlgili bilgiler</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ukua.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Мал. 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>Інформація з пов'язаних питань</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-urpk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">تصویر 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>متعلقہ معلومات</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhcn.html
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>相关信息</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">圖 1. </span>figure title</span>
-<p class="p">test <span class="q">"quote"</span> in a figure</p>
+<p class="p">test <span class="q">“quote”</span> in a figure</p>
 
 </div>
 
@@ -131,7 +131,7 @@
 
 <div class="linklist linklist relinfo"><strong>相關資訊</strong><br />
 
-<div><a class="link" href="http://www.ibm.com/" target="_blank" target="_blank">http://www.ibm.com/</a></div></div>
+<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
 </div>
 </div>
 


### PR DESCRIPTION
Use the same quotation mark string variables in both PDF2 and common. PDF2 `#quote-start` and `#quote-end` are redirected to common `OpenQuote` and `CloseQuote`.