### PR TITLE
Add PI for path to root map

### DIFF
--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.util.*;
 
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.getRelativeUnixPath;
 import static org.dita.dost.util.Job.FileInfo;
 import static org.dita.dost.util.Job.Generate;
 import static org.dita.dost.util.URLUtils.*;
@@ -203,7 +204,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             return;
         }
         final File path2project = getPathtoProject(copytoTargetFilename, target, inputMapInTemp, job);
-        XMLFilter filter = new CopyToFilter(workdir, path2project, src, target);
+        final File path2rootmap = getPathtoRootmap(target, inputMapInTemp);
+        XMLFilter filter = new CopyToFilter(workdir, path2project, path2rootmap, src, target);
 
         logger.info("Processing " + src + " to " + target);
         try {
@@ -222,20 +224,23 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
      * <li>{@link Constants#PI_WORKDIR_TARGET_URI PI_WORKDIR_TARGET_URI}</li>
      * <li>{@link Constants#PI_PATH2PROJ_TARGET PI_PATH2PROJ_TARGET}</li>
      * <li>{@link Constants#PI_PATH2PROJ_TARGET_URI PI_PATH2PROJ_TARGET_URI}</li>
+     * <li>{@link Constants#PI_PATH2ROOTMAP_TARGET_URI PI_PATH2ROOTMAP_TARGET_URI}</li>
      * </ul>
      */
     private static final class CopyToFilter extends XMLFilterImpl {
 
         private final File workdir;
         private final File path2project;
+        private final File path2rootmap;
         private final URI src;
         private final URI dst;
 
-        CopyToFilter(final File workdir, final File path2project, final URI src, final URI dst) {
+        CopyToFilter(final File workdir, final File path2project, final File path2rootmap, final URI src, final URI dst) {
             super();
             assert workdir != null;
             this.workdir = workdir;
             this.path2project = path2project;
+            this.path2rootmap = path2rootmap;
             this.src = src;
             this.dst = dst;
         }
@@ -294,6 +299,16 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
                         d = "";
                     }
                     break;
+                case PI_PATH2ROOTMAP_TARGET_URI:
+                    if (path2rootmap != null) {
+                        d = toURI(path2rootmap).toString();
+                        if (!d.endsWith(URI_SEPARATOR)) {
+                            d = d + URI_SEPARATOR;
+                        }
+                    } else {
+                        d = "";
+                    }
+                    break;
             }
             getContentHandler().processingInstruction(target, d);
         }
@@ -322,6 +337,19 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
         } else {
             return toFile(URLUtils.getRelativePath(filename));
         }
+    }
+    
+    /**
+     * Get path to root map
+     *
+     * @param traceFilename absolute input file
+     * @param inputMap      absolute path to start file
+     * @return path to base directory, {@code null} if not available
+     */
+    public static File getPathtoRootmap(final URI traceFilename, final URI inputMap) {
+        assert traceFilename.isAbsolute();
+        assert inputMap.isAbsolute();
+        return toFile(getRelativePath(traceFilename, inputMap)).getParentFile();
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.util.*;
 
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.getRelativeUnixPath;
 import static org.dita.dost.util.Job.FileInfo;
 import static org.dita.dost.util.Job.Generate;
 import static org.dita.dost.util.URLUtils.*;

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -83,6 +83,7 @@ public final class ChunkMapReader extends AbstractDomFilter {
     private ProcessingInstruction workdirUrl = null;
     private ProcessingInstruction path2proj = null;
     private ProcessingInstruction path2projUrl = null;
+    private ProcessingInstruction path2rootmapUrl = null;
 
     private final ChunkFilenameGenerator chunkFilenameGenerator = ChunkFilenameGeneratorFactory.newInstance();
 
@@ -271,6 +272,8 @@ public final class ChunkMapReader extends AbstractDomFilter {
                     path2proj = pi;
                 } else if (pi.getNodeName().equals(PI_PATH2PROJ_TARGET_URI)) {
                     path2projUrl = pi;
+                } else if (pi.getNodeName().equals(PI_PATH2ROOTMAP_TARGET_URI)) {
+                    path2rootmapUrl = pi;
                 }
             }
         }
@@ -308,6 +311,9 @@ public final class ChunkMapReader extends AbstractDomFilter {
         }
         if (path2projUrl != null) {
             doc.appendChild(doc.importNode(path2projUrl, true));
+        }
+        if (path2rootmapUrl != null) {
+            doc.appendChild(doc.importNode(path2rootmapUrl, true));
         }
         doc.appendChild(doc.importNode(root, true));
         return doc;

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -983,6 +983,7 @@ public final class Constants {
     @Deprecated
     public static final String PI_PATH2PROJ_TARGET = "path2project";
     public static final String PI_PATH2PROJ_TARGET_URI = "path2project-uri";
+    public static final String PI_PATH2ROOTMAP_TARGET_URI = "path2rootmap-uri";
     /** Deprecated since 2.3 */
     @Deprecated
     public static final String PI_WORKDIR_TARGET = "workdir";

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -160,7 +160,8 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
                 || PI_WORKDIR_TARGET.equals(target)
                 || PI_WORKDIR_TARGET_URI.equals(target)
                 || PI_PATH2PROJ_TARGET.equals(target)
-                || PI_PATH2PROJ_TARGET_URI.equals(target)) {
+                || PI_PATH2PROJ_TARGET_URI.equals(target)
+                || PI_PATH2ROOTMAP_TARGET_URI.equals(target)) {
             writeProcessingInstruction(output, target, data);
         }
     }

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -28,6 +28,7 @@ import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FileUtils.*;
 import static org.dita.dost.util.StringUtils.split;
 import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.URLUtils.getRelativePath;
 import static org.dita.dost.util.XMLUtils.*;
 
 /**
@@ -303,6 +304,9 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                     writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET, UNIX_SEPARATOR + new File(workDir).getAbsolutePath());
                 }
                 writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET_URI, workDir.toString());
+                
+                final File path2rootmap = toFile(getRelativePath(outputFileName, job.getInputMap())).getParentFile();
+                writeProcessingInstruction(ditaFileOutput, PI_PATH2ROOTMAP_TARGET_URI, path2rootmap == null ? "./" : toURI(path2rootmap).toString());
 
                 if (conflictTable.get(outputFileName) != null) {
                     final String relativePath = getRelativeUnixPath(new File(currentFile.resolve(".")) + UNIX_SEPARATOR + FILE_NAME_STUB_DITAMAP,

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -41,16 +41,19 @@ import static org.dita.dost.reader.GenListModuleReader.*;
  * 
  * <p>The following processing instructions are added before the root element:</p>
  * <dl>
- *   <dt>{@link Constants#PI_WORKDIR_TARGET}<dt>
+ *   <dt>{@link Constants#PI_WORKDIR_TARGET}</dt>
  *   <dd>Absolute system path of the file parent directory. On Windows, a {@code /}
  *     is added to beginning of the path.</dd>
- *   <dt>{@link Constants#PI_WORKDIR_TARGET_URI}<dt>
+ *   <dt>{@link Constants#PI_WORKDIR_TARGET_URI}</dt>
  *   <dd>Absolute URI of the file parent directory.</dd>
- *   <dt>{@link Constants#PI_PATH2PROJ_TARGET}<dt>
+ *   <dt>{@link Constants#PI_PATH2PROJ_TARGET}</dt>
  *   <dd>Relative system path to the output directory, with a trailing directory separator.
  *     When the source file is in the project root directory, processing instruction has no value.</dd>
- *   <dt>{@link Constants#PI_PATH2PROJ_TARGET_URI}<dt>
+ *   <dt>{@link Constants#PI_PATH2PROJ_TARGET_URI}</dt>
  *   <dd>Relative URI to the output directory, with a trailing path separator.
+ *     When the source file is in the project root directory, processing instruction has value {@code ./}.</dd>
+ *   <dt>{@link Constants#PI_PATH2ROOTMAP_TARGET_URI}</dt>
+ *   <dd>Relative URI to the root map directory, with a trailing path separator.
  *     When the source file is in the project root directory, processing instruction has value {@code ./}.</dd>
  * </dl>
  *
@@ -116,6 +119,7 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
                 toFile(currentFile),
                 toFile(job.getInputFile()),
                 job);
+        final File path2rootmap = new File(getRelativeUnixPath(toFile(currentFile).getAbsolutePath(), toFile(job.getInputFile()).getAbsolutePath())).getParentFile();
         getContentHandler().startDocument();
         if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
             getContentHandler().processingInstruction(PI_WORKDIR_TARGET, outputFile.getParentFile().getAbsolutePath());
@@ -131,6 +135,11 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
         } else {
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET, "");
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET_URI, "." + URI_SEPARATOR);
+        }
+        if (path2rootmap != null) {
+            getContentHandler().processingInstruction(PI_PATH2ROOTMAP_TARGET_URI, toURI(path2rootmap).toString() + URI_SEPARATOR);
+        } else {
+            getContentHandler().processingInstruction(PI_PATH2ROOTMAP_TARGET_URI, "." + URI_SEPARATOR);
         }
         getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
     }

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -11,12 +11,8 @@ package org.dita.dost.writer;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.GenMapAndTopicListModule;
 import org.dita.dost.module.GenMapAndTopicListModule.TempFileNameScheme;
-import org.dita.dost.util.Constants;
-import org.dita.dost.util.DitaClass;
-import org.dita.dost.util.Job;
+import org.dita.dost.util.*;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.StringUtils;
-import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
@@ -32,6 +28,7 @@ import java.util.Map;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FileUtils.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.URLUtils.getRelativePath;
 import static org.dita.dost.util.XMLUtils.nonDitaContext;
 import static org.dita.dost.reader.GenListModuleReader.*;
 
@@ -115,11 +112,11 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
         classes.clear();
 
         // XXX May be require fixup
-        final File path2Project = DebugAndFilterModule.getPathtoProject(getRelativePath(toFile(job.getInputFile()), toFile(currentFile)),
+        final File path2Project = DebugAndFilterModule.getPathtoProject(FileUtils.getRelativePath(toFile(job.getInputFile()), toFile(currentFile)),
                 toFile(currentFile),
                 toFile(job.getInputFile()),
                 job);
-        final File path2rootmap = new File(getRelativeUnixPath(toFile(currentFile).getAbsolutePath(), toFile(job.getInputFile()).getAbsolutePath())).getParentFile();
+        final File path2rootmap = toFile(getRelativePath(currentFile, job.getInputFile())).getParentFile();
         getContentHandler().startDocument();
         if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
             getContentHandler().processingInstruction(PI_WORKDIR_TARGET, outputFile.getParentFile().getAbsolutePath());

--- a/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.dita.dost.util.Constants.INPUT_DIR_URI;
+import static org.dita.dost.util.Constants.INPUT_DITAMAP_URI;
 import static org.dita.dost.util.URLUtils.toURI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -48,6 +49,7 @@ public class ChunkMapReaderTest {
     public void testRead() throws IOException {
         final Job job = new Job(tempDir);
         job.setProperty(INPUT_DIR_URI, srcDir.toURI().toString());
+        job.setProperty(INPUT_DITAMAP_URI, URI.create("maps/gen.ditamap").toString());
 
         final ChunkMapReader mapReader = new ChunkMapReader();
         mapReader.setLogger(new TestUtils.TestLogger());
@@ -146,6 +148,7 @@ public class ChunkMapReaderTest {
     private Job createJob(final String map, final String... topics) throws IOException {
         final Job job = new Job(tempDir);
         job.setProperty(INPUT_DIR_URI, srcDir.toURI().toString());
+        job.setProperty(INPUT_DITAMAP_URI, URI.create(map).toString());
 
         TestUtils.copy(new File(srcDir, map), new File(tempDir, map));
         job.add(new Job.FileInfo.Builder()


### PR DESCRIPTION
I've got several different situations going on that I've realized could all be resolved if my topics had a `path2rootmap` PI to go along with the existing `path2project` PI.

First - I've got a lot of content with uplevels processing (starting to feel like most of our content has it). This is generally processed with `generate.copy.outer=3`, which is why `path2proj` doesn't get me to the map.

In some cases, even if I don't really want all the output, using `generate.copy.outer=3` is the only way to get files (like images) generated in the correct location relative to the maps and topics -- that is, it's a way to get around other reported issues with `generate.copy.outer=1` when the content has uplevel references.

In addition, I've got preprocessing steps that copy files into the root map's directory, and other steps that generate SVG files in an output location relative to the map directory. Generated HTML5 and XHTML topics reference these SVG images with a relative path. That is currently based on `path2proj`, which means the references are broken when using content that has uplevels and using `generate.copy.outer=3`.

I've adapted the current code that works with the `path2proj-uri` PI and added a matching PI for the root map directory. It is working well in my tests:

- files in the map directory have `./`
- files in a subdirectory have the correct `../` path
- files in a peer directory have the correct `../mapdir/` path
- files copied from one directory to another with `copy-to` have the correct path in the new location
- chunked files also contain the correct PI (though this test led me to #2706 

At the same time, it's failing 3 tests in `ChunkMapReaderTest.java`. I'm having trouble figuring out why. They only fail for me locally when `ChunkTopicParser.java` generates the PI. But local valid chunk tests that run through the same portion of code work without the NPE.

Sample files:
[2707.zip](https://github.com/dita-ot/dita-ot/files/1030697/2707.zip)

Signed-off-by: Robert D Anderson <robander@us.ibm.com>

