### PR TITLE
Fix invalid content generated by filtered elements #2701

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/properties.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/properties.xsl
@@ -21,6 +21,9 @@ See the accompanying LICENSE file for applicable license.
       <propdesc class="- topic/stentry reference/propdesc "/>
     </property>
   </xsl:variable>
+  
+  <xsl:template match="*[contains(@class, ' reference/property ')]
+    [empty(*[contains(@class,' reference/proptype ') or contains(@class,' reference/propvalue ') or contains(@class,' reference/propdesc ')])]" priority="10"/>
 
   <xsl:template match="*[contains(@class, ' reference/property ')]">
     <xsl:variable name="property" select="." as="element()"/>

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -13,6 +13,10 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot dita2html related-links">
+  
+  <xsl:template match="*[contains(@class, ' reference/properties ')]
+    [empty(*[contains(@class,' reference/property ')]/
+    *[contains(@class,' reference/proptype ') or contains(@class,' reference/propvalue ') or contains(@class,' reference/propdesc ')])]" priority="10"/>
 
   <xsl:template match="*[contains(@class,' reference/properties ')]" name="reference.properties">
     <xsl:call-template name="spec-title"/>

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -156,6 +156,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="suffix" as="xs:string"/>
     <xsl:sequence select="string-join((generate-id($el), $suffix), '-')"/>
   </xsl:function>
+  
+  <xsl:template match="*[contains(@class,' topic/simpletable ')]
+    [empty(*[contains(@class,' topic/strow ')]/*[contains(@class,' topic/stentry ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/strow ') or contains(@class,' topic/sthead ')][empty(*[contains(@class,' topic/stentry ')])]" priority="10"/>
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" name="topic.simpletable">
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -471,6 +471,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="setid"/>
     <xsl:apply-templates select="." mode="css-class"/>
   </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/table ')]
+    [empty(*[contains(@class,' topic/tgroup ')]/*[contains(@class,' topic/tbody ')]/*[contains(@class,' topic/row ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/tgroup ')]
+    [empty(*[contains(@class,' topic/tbody ')]/*[contains(@class,' topic/row ')])]" priority="10"/>
 
   <xsl:template match="*[contains(@class,' topic/table ')]" name="topic.table">
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -314,6 +314,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
   
   <!-- nested steps - 1 level of nesting only -->
+  <xsl:template match="*[contains(@class, ' task/substeps ')][empty(*[contains(@class,' task/substep ')])]" priority="10"/>
+  
   <xsl:template match="*[contains(@class,' task/substeps ')]" name="topic.task.substeps">
    <!-- If there's a block element somewhere in the step list, expand the whole list -->
     <xsl:variable name="sub_step_expand"> <!-- set & save sub_step_expand=yes/no for expanding/compacting list items -->
@@ -352,6 +354,8 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <!-- choices contain choice items -->
+  <xsl:template match="*[contains(@class, ' task/choices ')][empty(*[contains(@class,' task/choice ')])]" priority="10"/>
+  
   <xsl:template match="*[contains(@class,' task/choices ')]" name="topic.task.choices">
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -594,6 +594,11 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- =========== SINGLE PART LISTS =========== -->
   
+  <!-- Ignore empty lists with all content filtered out -->
+  <xsl:template match="*[contains(@class, ' topic/ol ')][empty(*[contains(@class,' topic/li ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' topic/ul ')][empty(*[contains(@class,' topic/li ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' topic/sl ')][empty(*[contains(@class,' topic/sli ')])]" priority="10"/>
+  
   <!-- Unordered List -->
   <!-- handle all levels thru browser processing -->
   <xsl:template match="*[contains(@class, ' topic/ul ')]" name="topic.ul">
@@ -711,6 +716,8 @@ See the accompanying LICENSE file for applicable license.
   <!-- =========== DEFINITION LIST =========== -->
   
   <!-- DL -->
+  <xsl:template match="*[contains(@class,' topic/dl ')][empty(*[contains(@class,' topic/dlentry ')])]" priority="10"/>
+  
   <xsl:template match="*[contains(@class, ' topic/dl ')]" name="topic.dl">
     <xsl:call-template name="setaname"/>
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -95,15 +95,6 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="maxCharsInShortDesc" as="xs:integer">
         <xsl:call-template name="getMaxCharsForShortdescKeep"/>
     </xsl:variable>
-
-    <xsl:template match="*[@conref]" priority="99">
-        <fo:block xsl:use-attribute-sets="__unresolved__conref">
-            <xsl:apply-templates select="." mode="insertReferenceTitle">
-                <xsl:with-param name="href" select="@conref"/>
-                <xsl:with-param name="titlePrefix" select="'Content-Reference'"/>
-            </xsl:apply-templates>
-        </fo:block>
-    </xsl:template>
  
     <xsl:template name="startPageNumbering" as="attribute()*">
         <!--BS: uncomment if you need reset page numbering at first chapter-->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -57,6 +57,12 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' reference/properties ')]
+    [empty(*[contains(@class,' reference/property ')]/
+           *[contains(@class,' reference/proptype ') or contains(@class,' reference/propvalue ') or contains(@class,' reference/propdesc ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' reference/property ')]
+    [empty(*[contains(@class,' reference/proptype ') or contains(@class,' reference/propvalue ') or contains(@class,' reference/propdesc ')])]" priority="10"/>
 
   <xsl:template match="*[contains(@class, ' reference/properties ')]">
     <fo:table xsl:use-attribute-sets="properties">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -26,6 +26,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="table.colsep-default" select="'0'"/>
 
     <!--Definition list-->
+    <xsl:template match="*[contains(@class,' topic/dl ')][empty(*[contains(@class,' topic/dlentry ')])]" priority="10"/>
+    
     <xsl:template match="*[contains(@class, ' topic/dl ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:table xsl:use-attribute-sets="dl">
@@ -46,6 +48,9 @@ See the accompanying LICENSE file for applicable license.
         </fo:table>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
+    
+    <xsl:template match="*[contains(@class,' topic/dlhead ')]
+        [empty(*[contains(@class,' topic/dthd ')] | *[contains(@class,' topic/ddhd ')])]" priority="10"/>
 
     <xsl:template match="*[contains(@class, ' topic/dl ')]/*[contains(@class, ' topic/dlhead ')]">
         <fo:table-header xsl:use-attribute-sets="dl.dlhead">
@@ -81,9 +86,11 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="commonattributes"/>
             <fo:table-cell xsl:use-attribute-sets="dlentry.dt">
                 <xsl:apply-templates select="*[contains(@class, ' topic/dt ')]"/>
+                <xsl:if test="empty(*[contains(@class, ' topic/dt ')])"><fo:block/></xsl:if>
             </fo:table-cell>
             <fo:table-cell xsl:use-attribute-sets="dlentry.dd">
                 <xsl:apply-templates select="*[contains(@class, ' topic/dd ')]"/>
+                <xsl:if test="empty(*[contains(@class, ' topic/dd ')])"><fo:block/></xsl:if>
             </fo:table-cell>
         </fo:table-row>
     </xsl:template>
@@ -873,7 +880,9 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
   
-    <xsl:template match="*[contains(@class, ' topic/simpletable ')][empty(*)]" priority="10"/>
+    <xsl:template match="*[contains(@class,' topic/simpletable ')]
+        [empty(*[contains(@class,' topic/strow ')]/*[contains(@class,' topic/stentry ')])]" priority="10"/>
+    <xsl:template match="*[contains(@class,' topic/strow ') or contains(@class,' topic/sthead ')][empty(*[contains(@class,' topic/stentry ')])]" priority="10"/>
 
     <xsl:template name="createSimpleTableColumns">
         <xsl:param name="theColumnWidthes" as="xs:string"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -324,6 +324,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <!--Substeps-->
+    <xsl:template match="*[contains(@class, ' task/substeps ')][empty(*[contains(@class,' task/substep ')])]" priority="10"/>
+  
     <xsl:template match="*[contains(@class, ' task/substeps ')]">
         <fo:list-block xsl:use-attribute-sets="substeps">
             <xsl:call-template name="commonattributes"/>
@@ -360,6 +362,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <!--Choices-->
+    <xsl:template match="*[contains(@class, ' task/choices ')][empty(*[contains(@class,' task/choice ')])]" priority="10"/>
     <xsl:template match="*[contains(@class, ' task/choices ')]">
         <fo:list-block xsl:use-attribute-sets="choices">
             <xsl:call-template name="commonattributes"/>
@@ -386,7 +389,10 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
   <!-- Choice tables -->
-
+  <xsl:template match="*[contains(@class, ' task/choicetable ')]
+    [empty(*[contains(@class,' task/chrow ')]/*[contains(@class,' task/choption ') or contains(@class,' task/chdesc ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' task/chrow ')]
+    [empty(*[contains(@class,' task/choption ') or contains(@class,' task/chdesc ')])]" priority="10"/>
   <xsl:template match="*[contains(@class, ' task/choicetable ')]">
     <fo:table xsl:use-attribute-sets="choicetable">
       <xsl:call-template name="commonattributes"/>
@@ -411,20 +417,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:otherwise>
           <fo:table-header xsl:use-attribute-sets="chhead">
             <fo:table-row xsl:use-attribute-sets="chhead__row">
-              <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
-                <fo:block xsl:use-attribute-sets="chhead.choptionhd__content">
-                  <xsl:call-template name="getVariable">
-                    <xsl:with-param name="id" select="'Option'"/>
-                  </xsl:call-template>
-                </fo:block>
-              </fo:table-cell>
-              <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
-                <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
-                  <xsl:call-template name="getVariable">
-                    <xsl:with-param name="id" select="'Description'"/>
-                  </xsl:call-template>
-                </fo:block>
-              </fo:table-cell>
+              <xsl:apply-templates select="." mode="emptyChoptionHd"/>
+              <xsl:apply-templates select="." mode="emptyDescHd"/>
             </fo:table-row>
           </fo:table-header>
         </xsl:otherwise>
@@ -436,12 +430,38 @@ See the accompanying LICENSE file for applicable license.
 
     </fo:table>
   </xsl:template>
+  
+  <xsl:template match="*" mode="emptyChoptionHd">
+    <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
+      <fo:block xsl:use-attribute-sets="chhead.choptionhd__content">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'Option'"/>
+        </xsl:call-template>
+      </fo:block>
+    </fo:table-cell>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="emptyChdescHd">
+    <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
+      <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'Description'"/>
+        </xsl:call-template>
+      </fo:block>
+    </fo:table-cell>
+  </xsl:template>
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]">
     <fo:table-header xsl:use-attribute-sets="chhead">
       <xsl:call-template name="commonattributes"/>
       <fo:table-row xsl:use-attribute-sets="chhead__row">
+        <xsl:if test="empty(*[contains(@class,' task/choptionhd ')])">
+          <xsl:apply-templates select="." mode="emptyChoptionHd"/>
+        </xsl:if>
         <xsl:apply-templates/>
+        <xsl:if test="empty(*[contains(@class,' task/chdeschd ')])">
+          <xsl:apply-templates select="." mode="emptyDescHd"/>
+        </xsl:if>
       </fo:table-row>
     </fo:table-header>
   </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -742,6 +742,11 @@ See the accompanying LICENSE file for applicable license.
 
 
 <!-- =========== SINGLE PART LISTS =========== -->
+  
+  <!-- Ignore empty lists with all content filtered out -->
+  <xsl:template match="*[contains(@class, ' topic/ol ')][empty(*[contains(@class,' topic/li ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' topic/ul ')][empty(*[contains(@class,' topic/li ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class, ' topic/sl ')][empty(*[contains(@class,' topic/sli ')])]" priority="10"/>
 
 <!-- Unordered List -->
 <!-- handle all levels thru browser processing -->
@@ -869,6 +874,8 @@ See the accompanying LICENSE file for applicable license.
 <!-- =========== DEFINITION LIST =========== -->
 
 <!-- DL -->
+  <xsl:template match="*[contains(@class,' topic/dl ')][empty(*[contains(@class,' topic/dlentry ')])]" priority="10"/>
+  
 <xsl:template match="*[contains(@class, ' topic/dl ')]" name="topic.dl">
   <xsl:call-template name="setaname"/>
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -27,6 +27,11 @@ See the accompanying LICENSE file for applicable license.
   <!-- Override this to use a local convention for setting table's @summary attribute,
        until OASIS provides a standard mechanism for setting. -->
 </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/table ')]
+    [empty(*[contains(@class,' topic/tgroup ')]/*[contains(@class,' topic/tbody ')]/*[contains(@class,' topic/row ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/tgroup ')]
+    [empty(*[contains(@class,' topic/tbody ')]/*[contains(@class,' topic/row ')])]" priority="10"/>
 
 <xsl:template match="*[contains(@class, ' topic/table ')]" name="topic.table">
   <xsl:value-of select="$newline"/>
@@ -681,6 +686,11 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <!-- =========== SimpleTable - SEMANTIC TABLE =========== -->
+  
+  <xsl:template match="*[contains(@class,' topic/simpletable ')]
+    [empty(*[contains(@class,' topic/strow ')]/*[contains(@class,' topic/stentry ')])]" priority="10"/>
+  <xsl:template match="*[contains(@class,' topic/strow ') or contains(@class,' topic/sthead ')][empty(*[contains(@class,' topic/stentry ')])]" priority="10"/>
+  
 
 <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-summary-attribute">
   <!-- Override this to use a local convention for setting table's @summary attribute,

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -315,6 +315,8 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
 <!-- nested steps - 1 level of nesting only -->
+  <xsl:template match="*[contains(@class, ' task/substeps ')][empty(*[contains(@class,' task/substep ')])]" priority="10"/>
+  
 <xsl:template match="*[contains(@class,' task/substeps ')]" name="topic.task.substeps">
  <!-- If there's a block element somewhere in the step list, expand the whole list -->
   <xsl:variable name="sub_step_expand"> <!-- set & save sub_step_expand=yes/no for expanding/compacting list items -->
@@ -353,6 +355,8 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <!-- choices contain choice items -->
+  <xsl:template match="*[contains(@class, ' task/choices ')][empty(*[contains(@class,' task/choice ')])]" priority="10"/>
+  
 <xsl:template match="*[contains(@class,' task/choices ')]" name="topic.task.choices">
   <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="setaname"/>


### PR DESCRIPTION
As reported in #2701, if a conref fails to resolve, in some cases the empty element will be retained. PDF code has a special rule for unresolved conref that does not account for context; this rule with `priority="99"` results in bad FO that causes a build to fail. The bad conref already generates messages in the conref resolution step, so there is no reason for this rule.

At a more general level, this is caused by code that expects required elements to be present. When they are missing (due to unresolved conref, or due to filtering, or due to bad input), bad XSL-FO is generated that generally kills FOP. The same markup will generate bad XHTML / HTML5; while browsers typically handle this, we should not generate invalid output. Additionally, simpletable processing currently fails in XHTML / HTML5 when it encounters a table with no entries.

This pull request will:

- Where we do not already do so, it will ignore lists and tables that have no content for PDF - fixing a variety of related build crashes
- Refactor the generated headings for choice tables, to avoid a build crash when one or both header entries is filtered out
- In XHTML / HTML5, ignore simpletables with no entries, fixing a build crash when calculating entries within a row
- In XHTML / HTML5, ignore lists with no list items + tables with no entries, to avoid generating invalid XHTML / HTML5