### PR TITLE
Restore support for spectitle, specentry

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -164,6 +164,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" name="topic.simpletable">
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
 
+    <xsl:call-template name="spec-title"/>
     <table>
       <xsl:apply-templates select="." mode="table:common"/>
       <xsl:call-template name="dita2html:simpletable-cols"/>
@@ -220,7 +221,14 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/stentry ')]" mode="simpletable:entry">
     <xsl:apply-templates select="." mode="table:common"/>
     <xsl:apply-templates select="." mode="headers"/>
-    <xsl:apply-templates/>
+    <xsl:choose>
+      <xsl:when test="*|text()|processing-instruction()">
+        <xsl:apply-templates/>
+      </xsl:when>
+      <xsl:when test="@specentry">
+        <xsl:apply-templates select="@specentry"/>
+      </xsl:when>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="*[simpletable:is-head-entry(.)]" mode="headers">


### PR DESCRIPTION
The HTML5 refactoring for tables dropped support for two odd attributes, `simpletable/@spectitle` and `stentry/@specentry`.

This pull request restores the call to `spec-title` that supports `@spectitle` (that named template is used in XHTML and still exists in HTML5) It also restores the older processing for entries -- if content or PIs, use that, else if `@specentry`, use that, else use a non-breaking-space that prevents collapsing `<td/>`. The `nbsp` support is there because collapsed `<td/>` has caused a lot of browser issues in the past -- not sure how relevant that is for modern HTML5 browsers but doesn't hurt and seems like a good thing to restore.

[For the named `spec-title` template ... I think we really should have done apply-templates on `@spectitle` itself rather than using the named template, to allow by-element overrides, but `spec-title` is called in quite a few spots so I've left that. Seems a useful cleanup item for 3.0.]

Signed-off-by: Robert D Anderson <robander@us.ibm.com>