### PR TITLE
Fix bug with duplicate IDs in topic

### DIFF
--- a/src/main/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/xsl/preprocess/mappullImpl.xsl
@@ -63,6 +63,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
     </xsl:choose>
   </xsl:function>
+  
+  <xsl:key name="topic-by-id" match="*[contains(@class,' topic/topic ')]" use="@id"/>
 
   <!-- Find the relative path to another topic or map -->
   <xsl:template name="find-relative-path">
@@ -499,7 +501,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
 
           <!--finding type based on name of the target element in a particular topic in another file-->
           <xsl:when test="$topicpos='otherfile'">
-            <xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>
+            <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
             <xsl:choose>
               <xsl:when test="$target[contains(@class, $classval)]">
                 <xsl:attribute name="type">
@@ -534,7 +536,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
       <!-- Type is set locally for a dita topic; warn if it is not correct. -->
       <xsl:when test="$scope!='external' and $scope!='peer' and ($format='#none#' or $format='dita')">
-        <xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>
+        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
         <xsl:if test="$topicid!='#none#' and not($target[contains(@class, ' topic/topic ')])">
           <!-- topicid does not point to a valid topic -->
           <xsl:call-template name="output-message">
@@ -633,7 +635,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       <xsl:when test="@href=''"/>
       <!--grabbing text from a particular topic in another file-->
       <xsl:when test="$topicpos='otherfile'">
-        <xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>
+        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
         <xsl:choose>
           <xsl:when
             test="$target[contains(@class, $classval)]/*[contains(@class, ' topic/titlealts ')]/*[contains(@class, ' topic/navtitle ')]">
@@ -886,7 +888,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
 
             <!--grabbing text from a particular topic in another file-->
             <xsl:when test="$topicpos='otherfile'">
-              <xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>
+              <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
               <xsl:choose>
                 <xsl:when test="$target[contains(@class, $classval)]/*[contains(@class, ' topic/title ')]">
                   <xsl:variable name="grabbed-value" as="xs:string">
@@ -994,7 +996,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
       <!--try retrieving from a particular topic in another file-->
       <xsl:when test="$topicpos='otherfile'">
-        <xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>
+        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
         <xsl:if
             test="($target[contains(@class, $classval)])[1]/*[contains(@class, ' topic/shortdesc ')]|
                   ($target[contains(@class, $classval)])[1]/*[contains(@class, ' topic/abstract ')]/*[contains(@class, ' topic/shortdesc ')]">

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -795,5 +795,15 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .put("outer.control", "quiet")
                 .test();
     }
+    
+    @Test
+    public void testmappull_topicid() throws Throwable {
+        builder().name("mappull-topicid")
+                .transtype(preprocess)
+                .input(Paths.get("reftopicid.ditamap"))
+                .put("validate", "false")
+                .warnCount(1)
+                .test();
+    }
 
 }

--- a/src/test/resources/mappull-topicid/exp/preprocess/reftopicid.ditamap
+++ b/src/test/resources/mappull-topicid/exp/preprocess/reftopicid.ditamap
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?workdir /C:\Users\IBM_ADMIN\github\robander\dita-ot\src\main\temp?>
+<?workdir-uri file:/C:/Users/IBM_ADMIN/github/robander/dita-ot/src/main/temp/?>
+<?path2project?>
+<?path2project-uri ./?>
+<?path2rootmap-uri ./?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" cascade="merge" class="- map/map " domains="(map)">
+  <title class="- topic/title ">Test ref to a topic ID with matching element ID</title>
+  <topicref class="- map/topicref " href="tables.dita#table" type="topic">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Use the topic ID in the topic</navtitle><?ditaot gentext?><linktext class="- map/linktext ">Use the topic ID in the topic</linktext></topicmeta></topicref>
+</map>

--- a/src/test/resources/mappull-topicid/exp/preprocess/tables.dita
+++ b/src/test/resources/mappull-topicid/exp/preprocess/tables.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic id="table" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" domains="(topic)" class="- topic/topic ">
+ <title class="- topic/title ">Use the topic ID in the topic</title>
+ <body class="- topic/body ">
+  <simpletable  class="- topic/simpletable " id="table">
+   <strow  class="- topic/strow "><stentry class="- topic/stentry ">table entry</stentry></strow>
+  </simpletable>
+ </body>
+</topic>
+

--- a/src/test/resources/mappull-topicid/src/reftopicid.ditamap
+++ b/src/test/resources/mappull-topicid/src/reftopicid.ditamap
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" domains="(map)" class="- map/map " cascade="merge">
+  <title class="- topic/title ">Test ref to a topic ID with matching element ID</title>
+  <topicref href="tables.dita#table" class="- map/topicref "/>
+</map>
+

--- a/src/test/resources/mappull-topicid/src/tables.dita
+++ b/src/test/resources/mappull-topicid/src/tables.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic id="table" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" domains="(topic)" class="- topic/topic ">
+ <title class="- topic/title ">Use the topic ID in the topic</title>
+ <body class="- topic/body ">
+  <simpletable  class="- topic/simpletable " id="table">
+   <strow  class="- topic/strow "><stentry class="- topic/stentry ">table entry</stentry></strow>
+  </simpletable>
+ </body>
+</topic>
+


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I have a map that references a topic using an ID:
`<topicref href="resource.dita#duplicate"/>`

In the mappull step, we have several sections that will try to put the target topic into a variable, which is then used to pull text / validate attributes / etc. They're all currently set like this:
`<xsl:variable name="target" select="$doc//*[@id=$topicid]" as="element()?"/>`

I ran into a topic where `resourceid/@id` had to match the topic's ID. When that variable is evaluated, this crashes with the following error because we end up with 2 elements in the variable:
```
[move-meta] Loading stylesheet C:\DITA-OT\dita-ot-2.5\xsl\preprocess\mappull.xsl
Error: Failed to run pipeline: Failed to transform document: A sequence of more than one item is not allowed as the value of variable $target (<concept/>, <resourceid/>)
```

The various templates that set up `$target` this way should only be checking for an ID match on a topic (Because a the map level, the DITA spec says we should only be referencing topics); additionally, adding `[1]` at the end ensures that if somebody ends up with conflicting topic IDs in one document we only grab the first. 

(An alternative might be to change `element()?` to `element()*` and then make tests within each location more complicated - to allow for more than one potential match - but this seems cleaner / better, and duplicate topic IDs is not valid to begin with.)