### PR TITLE
Fix key resolution text #2014 and more

### DIFF
--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -618,11 +618,15 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_MAPREF = "mapref";
     /**navtitle attribute.*/
     public static final String ATTRIBUTE_NAME_NAVTITLE = "navtitle";
+    /**locktitle attribute.*/
+    public static final String ATTRIBUTE_NAME_LOCKTITLE = "locktitle";
+    /**locktitle="yes" value.*/
+    public static final String ATTRIBUTE_NAME_LOCKTITLE_VALUE_YES = "yes";
     /**format attribute.*/
     public static final String ATTRIBUTE_NAME_FORMAT = "format";
     /**charset attribute.*/
     public static final String ATTRIBUTE_NAME_CHARSET = "charset";
-    /**charset attribute.*/
+    /**lang attribute.*/
     public static final String ATTRIBUTE_NAME_LANG = "lang";
     /**att attribute.*/
     public static final String ATTRIBUTE_NAME_ATT = "att";

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -291,7 +291,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 final NodeList linktext = elem.getElementsByTagName(TOPIC_LINKTEXT.localName);
                                 if (linktext.getLength() > 0) {
                                     domToSax((Element) linktext.item(0), true);
-                                } else if (fallbackToNavtitle(elem)) {
+                                } else if (fallbackToNavtitleOrHref(elem)) {
                                     final NodeList navtitleElement = elem.getElementsByTagName(TOPIC_NAVTITLE.localName);
                                     if (navtitleElement.getLength() > 0) {
                                         final AttributesImpl atts = new AttributesImpl();
@@ -308,10 +308,20 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                             final char[] ch = navtitle.toCharArray();
                                             getContentHandler().characters(ch, 0, ch.length);
                                             getContentHandler().endElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName);
+                                        } else {
+                                            final String hrefAtt = elem.getAttribute(ATTRIBUTE_NAME_HREF);
+                                            if (!hrefAtt.trim().isEmpty()) {
+                                                final AttributesImpl atts = new AttributesImpl();
+                                                XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, TOPIC_LINKTEXT.toString());
+                                                getContentHandler().startElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName, atts);
+                                                final char[] ch = hrefAtt.toCharArray();
+                                                getContentHandler().characters(ch, 0, ch.length);
+                                                getContentHandler().endElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName);
+                                            }
                                         }
                                     }
                                 }
-                            } else if (fallbackToNavtitle(elem)) {
+                            } else if (fallbackToNavtitleOrHref(elem)) {
                                 final NodeList linktext = elem.getElementsByTagName(TOPIC_LINKTEXT.localName);
                                 if (linktext.getLength() > 0) {
                                     domToSax((Element) linktext.item(0), false);
@@ -324,6 +334,12 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                         if (!navtitle.trim().isEmpty()) {
                                             final char[] ch = navtitle.toCharArray();
                                             getContentHandler().characters(ch, 0, ch.length);
+                                        } else {
+                                            final String hrefAtt = elem.getAttribute(ATTRIBUTE_NAME_HREF);
+                                            if (!hrefAtt.trim().isEmpty()) {
+                                                final char[] ch = hrefAtt.toCharArray();
+                                                getContentHandler().characters(ch, 0, ch.length);
+                                            }
                                         }
                                     }
                                 }
@@ -541,7 +557,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      * @param elem Key definition element
      * @return
      */
-    private boolean fallbackToNavtitle(final Element elem) {
+    private boolean fallbackToNavtitleOrHref(final Element elem) {
         final String hrefValue = elem.getAttribute(ATTRIBUTE_NAME_HREF);
         final String locktitleValue = elem.getAttribute(ATTRIBUTE_NAME_LOCKTITLE);
         return ((ATTRIBUTE_NAME_LOCKTITLE_VALUE_YES.equals(locktitleValue)) ||

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -68,6 +68,7 @@ public class KeyrefPaserTest {
         TestUtils.normalize(new File(srcDir, "b.ditamap"), new File(tempDir, "b.ditamap"));
         TestUtils.normalize(new File(srcDir, "subdir" + File.separator + "c.ditamap"), new File(tempDir, "subdir" + File.separator + "c.ditamap"));
         TestUtils.normalize(new File(srcDir, "id.xml"), new File(tempDir, "id.xml"));
+        TestUtils.normalize(new File(srcDir, "fallback.xml"), new File(tempDir, "fallback.xml"));
         resolver = CatalogUtils.getCatalogResolver();
 
         TestUtils.resetXMLUnit();
@@ -104,6 +105,19 @@ public class KeyrefPaserTest {
 
         assertXMLEqual(new InputSource(new File(expDir, "id.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "id.xml").toURI().toString()));
+    }
+    
+    @Test
+    public void testFallback() throws Exception {
+        final KeyrefPaser parser = new KeyrefPaser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(tempDir));
+        parser.setKeyDefinition(keyDefinition);
+        parser.setCurrentFile(new File(tempDir, "fallback.xml").toURI());
+        parser.write(new File(tempDir, "fallback.xml"));
+
+        assertXMLEqual(new InputSource(new File(expDir, "fallback.xml").toURI().toString()),
+                new InputSource(new File(tempDir, "fallback.xml").toURI().toString()));
     }
 
     @Test

--- a/src/test/resources/KeyrefPaserTest/exp/a.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/a.xml
@@ -6,18 +6,18 @@
     <link class="- topic/link " keyref="empty"/>
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" class="- topic/link " href="a.xml"/>
-      <link keyref="scope-peer" class="- topic/link " href="b.xml" scope="peer"/>
-      <link keyref="scope-external" class="- topic/link " href="http://www.example.com/" format="html" scope="external"/>
+      <link keyref="scope-peer" class="- topic/link " href="b.xml" scope="peer"><linktext class="- topic/linktext ">b.xml</linktext></link>
+      <link keyref="scope-external" class="- topic/link " href="http://www.example.com/" format="html" scope="external"><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" href="a.xml" class="- topic/link "/>
-      <link keyref="scope-peer" href="b.xml" class="- topic/link " scope="peer"/>
-      <link keyref="scope-external" href="http://www.example.com/" class="- topic/link " format="html" scope="external"/>
+      <link keyref="scope-peer" href="b.xml" class="- topic/link " scope="peer"><linktext class="- topic/linktext ">b.xml</linktext></link>
+      <link keyref="scope-external" href="http://www.example.com/" class="- topic/link " format="html" scope="external"><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" href="a.xml" class="- topic/link "/>
-      <link keyref="scope-peer" href="b.xml" scope="peer" class="- topic/link "/>
-      <link keyref="scope-external" href="http://www.example.com/" format="html" scope="external" class="- topic/link "/>
+      <link keyref="scope-peer" href="b.xml" scope="peer" class="- topic/link "><linktext class="- topic/linktext ">b.xml</linktext></link>
+      <link keyref="scope-external" href="http://www.example.com/" format="html" scope="external" class="- topic/link "><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
   </related-links>
   <topic class="- topic/topic "

--- a/src/test/resources/KeyrefPaserTest/exp/a.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/a.xml
@@ -46,6 +46,7 @@
       <p class="- topic/p ">
         <xref class="- topic/xref " keyref="xref">
           <keyword class="- topic/keyword ">xref keyword</keyword>
+          <keyword class="- topic/keyword ">xref keyword B</keyword>
         </xref>
         <cite class="- topic/cite " keyref="cite">cite keyword</cite>
         <keyword class="- topic/keyword " keyref="keyword">keyword keyword</keyword>
@@ -120,6 +121,7 @@
       <p class="- topic/p ">
         <xref class="- topic/xref " href="a.xml" keyref="xref_link" type="dead">
           <keyword class="- topic/keyword ">xref keyword</keyword>
+          <keyword class="- topic/keyword ">xref keyword B</keyword>
         </xref>
         <cite class="- topic/cite " href="a.xml" keyref="cite_link">cite keyword</cite>
         <keyword class="- topic/keyword " href="a.xml" keyref="keyword_link">keyword keyword</keyword>

--- a/src/test/resources/KeyrefPaserTest/exp/fallback.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/fallback.xml
@@ -1,0 +1,77 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic)"
+  id="fall" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Test keyref fallback against DITA 1.3</title>
+  <body class="- topic/body ">
+    <section class="- topic/section ">
+      <title class="- topic/title ">When no other match, every element should use link text</title>
+      <p class="- topic/p ">cite, keyword, xref using key with plain-text linktext (cite, keyword fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="linktext">Everything should use linktext fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="linktext">Everything should use linktext fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="linktext">Everything should use linktext fallback</foo></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref using key that has keyword subelement (fixed all in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="linktext_sub">Use all linktext; BROKEN if only keyword appears</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="linktext_sub">Use all linktext; BROKEN if only keyword appears</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="linktext_sub">Use all linktext; BROKEN if only keyword appears</foo></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when no other match, use navtitle element, then attribute</title>
+      <p class="- topic/p ">cite, keyword, xref using key with navtitle element (all fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="navtitle_el">Test navtitle element fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="navtitle_el">Test navtitle element fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="navtitle_el">Test navtitle element fallback</foo></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref using key with navtitle attribute (cite, keyword fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="navtitle_att">Test navtitle attribute fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="navtitle_att">Test navtitle attribute fallback</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="navtitle_att">Test navtitle attribute fallback</foo></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when no other match, use href if not local DITA</title>
+      <p class="- topic/p ">cite, keyword, xref ignore navtitle for local DITA:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite "  href="localdita1.dita" keyref="ignore_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword "  href="localdita1.dita" keyref="ignore_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/xref "  href="localdita1.dita" keyref="ignore_navtitle"/></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref use navtitle for local DITA when locked:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " href="localdita2.dita" keyref="lock_navtitle" locktitle="yes">Lock navtitle, should be used</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " href="localdita2.dita" keyref="lock_navtitle" locktitle="yes">Lock navtitle, should be used</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " href="localdita2.dita" keyref="lock_navtitle" locktitle="yes">Lock navtitle, should be used</foo></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref use navtitle for non-DITA:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="nondita_use_navtitle" href="http://dita-ot.org" scope="external" format="html">Non-DITA, navtitle should be used</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="nondita_use_navtitle" href="http://dita-ot.org" scope="external" format="html">Non-DITA, navtitle should be used</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="nondita_use_navtitle" href="http://dita-ot.org" scope="external" format="html">Non-DITA, navtitle should be used</foo></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when non-DITA, and no other text found, and uses href, use href</title>
+      <p class="- topic/p ">cite, keyword, xref use href for non-DITA with no other option:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html">http://www.dita-ot.org/2.5/</foo></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html">http://www.dita-ot.org/2.5/</foo></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html">http://www.dita-ot.org/2.5/</foo></li>
+      </ul>
+    </section>
+  </body>
+  <related-links class="- topic/related-links ">
+    <link class="- topic/link " keyref="linktext"><linktext class="- topic/linktext ">Everything should use linktext fallback</linktext></link>
+    <link class="- topic/link " keyref="linktext_sub"><linktext class="- topic/linktext ">Use all linktext; <keyword class="- topic/keyword ">BROKEN</keyword> if only keyword appears</linktext></link>
+    <link class="- topic/link " keyref="navtitle_att"><linktext class="- topic/linktext ">Test navtitle attribute fallback</linktext></link>
+    <link class="- topic/link " keyref="navtitle_el"><linktext class="- topic/linktext ">Test navtitle element fallback</linktext></link>
+    <link class="- topic/link " keyref="ignore_navtitle" href="localdita1.dita"/>
+    <link class="- topic/link " keyref="lock_navtitle" href="localdita2.dita" locktitle="yes"><linktext class="- topic/linktext ">Lock navtitle, should be used</linktext></link>
+    <link class="- topic/link " keyref="nondita_use_navtitle" href="http://dita-ot.org" scope="external" format="html"><linktext class="- topic/linktext ">Non-DITA, navtitle should be used</linktext></link>
+    <link class="- topic/link " keyref="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html"><linktext class="- topic/linktext ">http://www.dita-ot.org/2.5/</linktext></link>
+  </related-links>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/fallback.xml
+++ b/src/test/resources/KeyrefPaserTest/src/fallback.xml
@@ -1,0 +1,77 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic)"
+  id="fall" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Test keyref fallback against DITA 1.3</title>
+  <body class="- topic/body ">
+    <section class="- topic/section ">
+      <title class="- topic/title ">When no other match, every element should use link text</title>
+      <p class="- topic/p ">cite, keyword, xref using key with plain-text linktext (cite, keyword fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="linktext"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="linktext"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="linktext"/></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref using key that has keyword subelement (fixed all in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="linktext_sub"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="linktext_sub"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="linktext_sub"/></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when no other match, use navtitle element, then attribute</title>
+      <p class="- topic/p ">cite, keyword, xref using key with navtitle element (all fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="navtitle_el"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="navtitle_el"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="navtitle_el"/></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref using key with navtitle attribute (cite, keyword fixed in 2.5.1):</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="navtitle_att"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="navtitle_att"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="navtitle_att"/></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when no other match, use href if not local DITA</title>
+      <p class="- topic/p ">cite, keyword, xref ignore navtitle for local DITA:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="ignore_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="ignore_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="ignore_navtitle"/></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref use navtitle for local DITA when locked:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="lock_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="lock_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="lock_navtitle"/></li>
+      </ul>
+      <p class="- topic/p ">cite, keyword, xref use navtitle for non-DITA:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="nondita_use_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="nondita_use_navtitle"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="nondita_use_navtitle"/></li>
+      </ul>
+    </section>
+    <section class="- topic/section ">
+      <title class="- topic/title ">Else when non-DITA, and no other text found, and uses href, use href</title>
+      <p class="- topic/p ">cite, keyword, xref use href for non-DITA with no other option:</p>
+      <ul class="- topic/ul ">
+        <li class="- topic/li "><foo class="- topic/cite " keyref="nondita_use_href"/></li>
+        <li class="- topic/li "><foo class="- topic/keyword " keyref="nondita_use_href"/></li>
+        <li class="- topic/li "><foo class="- topic/xref " keyref="nondita_use_href"/></li>
+      </ul>
+    </section>
+  </body>
+  <related-links class="- topic/related-links ">
+    <link class="- topic/link " keyref="linktext"/>
+    <link class="- topic/link " keyref="linktext_sub"/>
+    <link class="- topic/link " keyref="navtitle_att"/>
+    <link class="- topic/link " keyref="navtitle_el"/>
+    <link class="- topic/link " keyref="ignore_navtitle"/>
+    <link class="- topic/link " keyref="lock_navtitle"/>
+    <link class="- topic/link " keyref="nondita_use_navtitle"/>
+    <link class="- topic/link " keyref="nondita_use_href"/>
+  </related-links>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/keys.ditamap
@@ -472,4 +472,40 @@
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="root" href="a.xml"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="root-with-id" href="a.xml#a"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="nested-with-id" href="a.xml#nolink"/>
+  <!-- Keys to test fallback text resolution against DITA 1.3 rules, cases not covered above
+  http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/processing-keyref-for-text.html
+  -->
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="linktext">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">Everything should use linktext fallback</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="linktext_sub">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">Use all linktext; <keyword class="- topic/keyword ">BROKEN</keyword> if only keyword appears</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="navtitle_att" navtitle="Test navtitle attribute fallback"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="navtitle_el">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Test navtitle element fallback</navtitle>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="ignore_navtitle" href="localdita1.dita">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Ignore navtitle, will be pulled from topic</navtitle>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="lock_navtitle" href="localdita2.dita" locktitle="yes">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Lock navtitle, should be used</navtitle>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="nondita_use_navtitle" href="http://dita-ot.org" scope="external" format="html">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Non-DITA, navtitle should be used</navtitle>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html"/>  
+
 </map>

--- a/src/test/resources/keyref/exp/preprocess/a.xml
+++ b/src/test/resources/keyref/exp/preprocess/a.xml
@@ -36,17 +36,17 @@
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" class="- topic/link " href="a.xml" type="topic"><?ditaot gentext?><linktext class="- topic/linktext ">a</linktext></link>
       <link keyref="scope-peer" class="- topic/link " href="b.xml" scope="peer"><?ditaot usertext?><linktext class="- topic/linktext ">b</linktext></link>
-      <link keyref="scope-external" class="- topic/link " href="http://www.example.com/" format="html" scope="external"/>
+      <link keyref="scope-external" class="- topic/link " href="http://www.example.com/" format="html" scope="external"><?ditaot usertext?><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" href="a.xml" class="- topic/link " type="topic"><?ditaot gentext?><linktext class="- topic/linktext ">a</linktext></link>
       <link keyref="scope-peer" href="b.xml" class="- topic/link " scope="peer"><?ditaot usertext?><linktext class="- topic/linktext ">b</linktext></link>
-      <link keyref="scope-external" href="http://www.example.com/" class="- topic/link " format="html" scope="external"/>
+      <link keyref="scope-external" href="http://www.example.com/" class="- topic/link " format="html" scope="external"><?ditaot usertext?><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
     <linklist class="- topic/linklist ">
       <link keyref="scope-local" href="a.xml" class="- topic/link " type="topic"><?ditaot gentext?><linktext class="- topic/linktext ">a</linktext></link>
       <link keyref="scope-peer" href="b.xml" scope="peer" class="- topic/link "><?ditaot usertext?><linktext class="- topic/linktext ">b</linktext></link>
-      <link keyref="scope-external" href="http://www.example.com/" scope="external" format="html" class="- topic/link "/>
+      <link keyref="scope-external" href="http://www.example.com/" scope="external" format="html" class="- topic/link "><?ditaot usertext?><linktext class="- topic/linktext ">http://www.example.com/</linktext></link>
     </linklist>
   </related-links>
 </topic>


### PR DESCRIPTION
The DITA 1.3 spec topic about [generated text based on key references](http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/processing-keyref-for-text.html#processing_key_references) is clear that when the primary rules do not work, all elements with `@keyref` should look to `<linktext>`. This is not working today for elements without `@href`, as reported in #2014.

After starting with @raducoravu 's suggested fix, I extended my test case and found quite a few more edge cases that are either broken (wrong output) or bad (no output when we could provide something). This pull request covers all of the following updates:

- In rule number 2, the spec topic says non-linking elements should look for `<keyword>` inside of `<keywords>` and consider that as matching content. **Today: broken for all elements when keyword appears outside of keywords.** The code looks for `<keyword>` _anywhere_ within the key definition. So if I have `<linktext><keyword>book</keyword> title</linktext>`, matching text for all elements becomes "book" instead of "book title".
- The spec explicitly says that for linking elements, if there are multiple keyword elements in `<keywords>`, all should be used (rule 3 has an example). **Today: broken, we only use the first.** This pull request takes them all, though I consider this an edge case - the rule carried over from DITA 1.2.
- Getting to rule 4, this request adds support for the full content of `<linktext>` as the next fallback for all elements. **Today: broken for all non-linking elements, broken for all elements if keyword appears in linktext.**
- Based on rule 5 in the spec topic, linking elements today fall back to `@navtitle`. **Today: broken for navtitle element, sort of working for navtitle attribute on linking elements, and gives null result for non-linking elements.** There are a couple of problems here:
  - If using navtitle, it should prefer `<navtitle>` (today that is ignored), so I've added that.
  - Non linking elements never get here, and give bad output. Having reached the end of the specification algorithm, with no good output, I think it's foolish to ignore the available `navtitle`, so I've added that as another fallback for non-linking elements.
  - If the target is a local DITA topic, we should _not_ pull the `navtitle` unless that title is locked, because the true title will be pulled from that topic later
- Additionally in rule 5, the specification says that "normal rules apply", which is clearly implementation specific. In links without keys, we fall back to the URI as the last resort, so I've added that as well. Again this is only for non-DITA or non-local content, because local DITA should wait and retrieve link text from the target.

Basically, the focus of this report is on
1. Getting linktext to work so that key definitions have a universal fallback (this is specifically described in the spec as a best practice, and is broken today.
1. Fixing output that today is broken (or just bad), and can easily be made correct (or at least reasonable).