### PR TITLE
Fix chunk errors on Windows #2706

### DIFF
--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -33,7 +33,6 @@ import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static org.dita.dost.reader.ChunkMapReader.*;
 import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.isAbsolutePath;
 import static org.dita.dost.util.URLUtils.*;
 import static org.dita.dost.util.XMLUtils.*;
 import static org.dita.dost.writer.ImageMetadataFilter.DITA_OT_NS;
@@ -414,13 +413,13 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     /**
      * Get the first topic id from the given dita file.
      *
-     * @param absolutePathToFile The absolute path to a dita file.
+     * @param ditaTopicFile a dita file.
      * @return The first topic id from the given dita file if success, otherwise
      * {@code null} string is returned.
      */
-    String getFirstTopicId(final String absolutePathToFile) {
-        assert new File(absolutePathToFile).isAbsolute();
-        if (!isAbsolutePath(absolutePathToFile)) {
+    String getFirstTopicId(final File ditaTopicFile) {
+        assert ditaTopicFile.isAbsolute();
+        if (!ditaTopicFile.isAbsolute()) {
             return null;
         }
         final StringBuilder firstTopicId = new StringBuilder();
@@ -428,7 +427,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         try {
             final XMLReader reader = getXMLReader();
             reader.setContentHandler(parser);
-            reader.parse(new File(absolutePathToFile).toURI().toString());
+            reader.parse(ditaTopicFile.toURI().toString());
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -128,7 +128,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                                 outputFileName = currentFile.resolve(hrefValue.getFragment() + FILE_EXTENSION_DITA);
                             } else {
                                 // Find the first topic id in target file if any.
-                                final String firstTopic = getFirstTopicId(new File(currentFile.resolve(hrefValue).getPath()));
+                                final String firstTopic = getFirstTopicId(new File(stripFragment(currentFile.resolve(hrefValue))));
                                 if (firstTopic != null) {
                                     outputFileName = currentFile.resolve(firstTopic + FILE_EXTENSION_DITA);
                                 } else {

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -128,7 +128,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                                 outputFileName = currentFile.resolve(hrefValue.getFragment() + FILE_EXTENSION_DITA);
                             } else {
                                 // Find the first topic id in target file if any.
-                                final String firstTopic = getFirstTopicId(currentFile.resolve(hrefValue).getPath());
+                                final String firstTopic = getFirstTopicId(new File(currentFile.resolve(hrefValue).getPath()));
                                 if (firstTopic != null) {
                                     outputFileName = currentFile.resolve(firstTopic + FILE_EXTENSION_DITA);
                                 } else {
@@ -166,7 +166,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                 if (path.getFragment() != null) {
                     newpath = setFragment(outputFileName, path.getFragment());
                 } else {
-                    final String firstTopicID = getFirstTopicId(new File(path).getAbsolutePath());
+                    final String firstTopicID = getFirstTopicId(new File(path));
                     if (firstTopicID != null) {
                         newpath = setFragment(outputFileName, firstTopicID);
                     } else {

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -110,7 +110,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     startFromFirstTopic = false;
                     selectMethod = CHUNK_SELECT_BRANCH;
                 } else if (chunkValue.contains(CHUNK_SELECT_DOCUMENT)) {
-                    firstTopicID = getFirstTopicId(new File(currentFile.resolve(parseFilePath).getPath()));
+                    firstTopicID = getFirstTopicId(new File(stripFragment(currentFile.resolve(parseFilePath))));
 
                     topicDoc = getTopicDoc(currentFile.resolve(parseFilePath));
 
@@ -130,7 +130,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     selectMethod = CHUNK_SELECT_TOPIC;
                 }
             } else {
-                firstTopicID = getFirstTopicId(new File(currentFile.resolve(parseFilePath).getPath()));
+                firstTopicID = getFirstTopicId(new File(stripFragment(currentFile.resolve(parseFilePath))));
 
                 topicDoc = getTopicDoc(currentFile.resolve(parseFilePath));
 

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -110,7 +110,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     startFromFirstTopic = false;
                     selectMethod = CHUNK_SELECT_BRANCH;
                 } else if (chunkValue.contains(CHUNK_SELECT_DOCUMENT)) {
-                    firstTopicID = getFirstTopicId(currentFile.resolve(parseFilePath).getPath());
+                    firstTopicID = getFirstTopicId(new File(currentFile.resolve(parseFilePath).getPath()));
 
                     topicDoc = getTopicDoc(currentFile.resolve(parseFilePath));
 
@@ -130,7 +130,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     selectMethod = CHUNK_SELECT_TOPIC;
                 }
             } else {
-                firstTopicID = getFirstTopicId(currentFile.resolve(parseFilePath).getPath());
+                firstTopicID = getFirstTopicId(new File(currentFile.resolve(parseFilePath).getPath()));
 
                 topicDoc = getTopicDoc(currentFile.resolve(parseFilePath));
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Addresses the issue reported in #2706.

Tracked down to an issue with Windows only: our `isAbsolutePath` method fails with some path styles, on Windows only. I haven't (yet) fixed that issue. Instead, the chunking method that used `isAbsolutePath` was updated so that it deals with files, and relies on the native `File.isAbsolute()` method. (Previously, URIs were converted to Strings, which were converted back to files.)

As an added benefit, this resolves long-standing issues with the `gradlew test` command that I hadn't taken time to figure out -- 14 of the existing chunk test cases failed with every Windows test, but worked on Mac / Linux. With this update, the `gradlew test` run is now clean on Windows.

## Type of Changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that changes existing functionality)_

## Checklist
- [X] Builds & tests completed successfully (`./gradlew test integrationTest`).
- [X] My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- [ ] I have updated the unit tests to reflect the changes in my code. _This change allows existing tests to run successfully, so no new tests are needed_
- [ ] My change requires a change to the documentation. @dita-ot/docs
- [ ] I will update the documentation accordingly or create a new [docs][] issue.

