### PR TITLE
Preserve submap elements when merging

### DIFF
--- a/src/main/xsl/preprocess/clean-map.xsl
+++ b/src/main/xsl/preprocess/clean-map.xsl
@@ -29,6 +29,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' ditaot-d/submap-title ')]"/>
   <xsl:template match="*[contains(@class, ' ditaot-d/submap-topicmeta ')]"/>
+  <xsl:template match="*[contains(@class, ' ditaot-d/submap-topicmeta-container ')]"/>
   
   <xsl:template match="*[contains(@class, ' ditaot-d/keydef ')]"/>
   

--- a/src/main/xsl/preprocess/clean-map.xsl
+++ b/src/main/xsl/preprocess/clean-map.xsl
@@ -27,6 +27,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates/>
   </xsl:template>
   
+  <xsl:template match="*[contains(@class, ' ditaot-d/submap-title ')]"/>
+  <xsl:template match="*[contains(@class, ' ditaot-d/submap-topicmeta ')]"/>
+  
   <xsl:template match="*[contains(@class, ' ditaot-d/keydef ')]"/>
   
   <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle ')]">

--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -128,6 +128,9 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:variable>
+            <xsl:variable name="targetTitleAndTopicmeta" as="element()*">
+              <xsl:sequence select="$file/*/*[contains(@class,' topic/title ') or contains(@class,' map/topicmeta ')]"/>
+            </xsl:variable>
             <xsl:variable name="contents" as="node()*">
               <xsl:choose>
                 <xsl:when test="not(contains($href,'://') or empty($element-id) or $file/*[contains(@class,' map/map ')][@id = $element-id])">
@@ -169,6 +172,8 @@ See the accompanying LICENSE file for applicable license.
               </xsl:if>
               <xsl:apply-templates select="$target/@chunk"/>
               <xsl:apply-templates select="@* except (@class, @href, @dita-ot:orig-href, @format, @dita-ot:orig-format, @keys, @keyscope, @type)"/>
+              <xsl:apply-templates select="$target/@*" mode="preserve-submap-attributes"/>
+              <xsl:apply-templates select="$targetTitleAndTopicmeta" mode="preserve-submap-title-and-topicmeta"/>
               <xsl:apply-templates select="*[contains(@class, ' ditavalref-d/ditavalref ')]"/>
               <xsl:apply-templates select="$contents">
                 <xsl:with-param name="refclass" select="$refclass"/>
@@ -387,6 +392,23 @@ See the accompanying LICENSE file for applicable license.
       <xsl:with-param name="relative-path" select="$relative-path"/>
       <xsl:with-param name="mapref-id-path" select="$mapref-id-path"/>
     </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="@*" mode="preserve-submap-attributes">
+    <xsl:attribute name="dita-ot:submap-{local-name()}" select="."/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/title ')]" mode="preserve-submap-title-and-topicmeta">
+    <dita-ot:submap-title class="+ topic/foreign ditaot-d/submap-title ">
+      <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
+      <xsl:apply-templates select="*|processing-instruction()|text()"/>
+    </dita-ot:submap-title>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' map/topicmeta ')]" mode="preserve-submap-title-and-topicmeta">
+    <dita-ot:submap-topicmeta class="+ topic/foreign ditaot-d/submap-topicmeta ">
+      <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
+      <xsl:apply-templates select="*|processing-instruction()|text()"/>
+    </dita-ot:submap-topicmeta>
   </xsl:template>
 
   <xsl:template match="@* | node()" mode="reltable-copy">

--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -399,16 +399,18 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' topic/title ')]" mode="preserve-submap-title-and-topicmeta">
-    <dita-ot:submap-title class="+ topic/foreign ditaot-d/submap-title ">
-      <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
-      <xsl:apply-templates select="*|processing-instruction()|text()"/>
-    </dita-ot:submap-title>
+    <submap-topicmeta class="+ map/topicmeta ditaot-d/submap-topicmeta ">
+      <submap-title class="+ topic/navtitle ditaot-d/submap-title ">
+        <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
+        <xsl:apply-templates select="*|processing-instruction()|text()"/>
+      </submap-title>
+    </submap-topicmeta>
   </xsl:template>
   <xsl:template match="*[contains(@class,' map/topicmeta ')]" mode="preserve-submap-title-and-topicmeta">
-    <dita-ot:submap-topicmeta class="+ topic/foreign ditaot-d/submap-topicmeta ">
+    <submap-topicmeta-container class="+ topic/foreign ditaot-d/submap-topicmeta-container ">
       <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
       <xsl:apply-templates select="*|processing-instruction()|text()"/>
-    </dita-ot:submap-topicmeta>
+    </submap-topicmeta-container>
   </xsl:template>
 
   <xsl:template match="@* | node()" mode="reltable-copy">

--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -128,9 +128,8 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:variable>
-            <xsl:variable name="targetTitleAndTopicmeta" as="element()*">
-              <xsl:sequence select="$file/*/*[contains(@class,' topic/title ') or contains(@class,' map/topicmeta ')]"/>
-            </xsl:variable>
+            <xsl:variable name="targetTitleAndTopicmeta" as="element()*"
+              select="$file/*/*[contains(@class,' topic/title ') or contains(@class,' map/topicmeta ')]"/>
             <xsl:variable name="contents" as="node()*">
               <xsl:choose>
                 <xsl:when test="not(contains($href,'://') or empty($element-id) or $file/*[contains(@class,' map/map ')][@id = $element-id])">


### PR DESCRIPTION
(I'm not sure the current design is the best for what I'm trying to accomplish, but opening this up to start discussion.)

Currently, the `mapref` process merges all maps into a single map, with a `<submap>` grouping element in place to mark boundaries as needed (such as for key scopes / precedence, or to retain chunk information). However, it loses a lot of information from the submaps:

- Most attributes from the submap itself (like `@outputclass`, `@audience`, `@xml:lang`, etc)
- Titles from the submap
- `<topicmeta>` from the submap

In most cases, this isn't a problem. For my use case, some of the submaps correspond to distinct output artifacts (similar to what `chunk="to-navigation"` was originally intended for). This is a straightforward step that runs after preprocess, with a tweak to the `clean-map` step so they're not removed -- I simply key off of the appropriate `<submap>` elements and chunk the maps.

However, in my case, losing the title means I cannot produce the output I need - the title is a critical part of the individual artifacts. 

This pull request preserves that information, using namespaced elements and attributes (the namespace is the same `dita-ot:` prefix used to preserve a small number of attributes today, like `dita-ot:orig-format` and `dita-ot:orig-href`). The information is preserved as follows:

1. All attributes from the original referenced map are added to the generated `<submap>` element, using the prefix `dita-ot:submap-XXX` where `XXX` is the local name of the attribute. So, the 3 I mentioned above would become `@dita-ot:submap-outputclass`, `@dita-ot:submap-audience`, and `@dita-ot:lang`. Some of these probably are not useful, but I saved them all because a) they won't cause any problems and b) I would rather not pick the ones I consider useful and miss ones others need.
1. Any title in the map is preserved as `<dita-ot:submap-title class="+ topic/foreign ditaot-d/submap-title ">`. This is where I'm not sure about the design. In a map, this would be the first child, and would be a title. `- topic/title ` is not allowed inside `<topicref>` so using it directly would break things. Making it a specialization of `foreign` means our processes should happily ignore it, and also means that whatever elements appear in that title would be legal as well. (Another thought - because the name of an element is not really relevant, this probably should be `<submap-title>` rather than `<dita-ot:submap-title>`?)
1. Any `topicmeta` in the map is preserved as `<dita-ot:submap-topicmeta class="+ topic/foreign ditaot-d/submap-topicmeta ">`. Again, making it foreign means this will be ignored by default (nothing existing today will break), and means the overall structure is valid against core DITA (2 `foreign` elements as a child of the container is good, while a `foreign` title followed by `topicmeta` would not be). The primary purpose here is that when needed, any general metadata for the submap is now _available_ for use by those who need it.
1. In the `clean-map` step today that strips out generated `<submap>` elements, the additional `dita-ot:submap-title` and `dita-ot:submap-topicmeta` are also stripped out. So, no customization or transform type that uses `preprocess` as a whole will not see any change.

The change has been tested against the `gradle test` and integration test with no impact (and I've verified that the test includes submaps with titles). Also tested with my own specialized maps, and it preserves both `map/@title` and `map/title` so that I can restore them later.

There is currently no documentation in our dev section about the `<submap>` element, so if you don't dig into the preprocess code, you never know it's there. I'm not sure if this is by design (probably not?), but it might be useful to have a topic in the developer docs that explain how `<submap>` is used, along with a description of these elements if/when the pull request is accepted.