### PR TITLE
Fix mappull failure when target doc missing

### DIFF
--- a/src/main/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/xsl/preprocess/mappullImpl.xsl
@@ -501,7 +501,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
 
           <!--finding type based on name of the target element in a particular topic in another file-->
           <xsl:when test="$topicpos='otherfile'">
-            <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
+            <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
             <xsl:choose>
               <xsl:when test="$target[contains(@class, $classval)]">
                 <xsl:attribute name="type">
@@ -536,7 +536,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
       <!-- Type is set locally for a dita topic; warn if it is not correct. -->
       <xsl:when test="$scope!='external' and $scope!='peer' and ($format='#none#' or $format='dita')">
-        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
+        <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
         <xsl:if test="$topicid!='#none#' and not($target[contains(@class, ' topic/topic ')])">
           <!-- topicid does not point to a valid topic -->
           <xsl:call-template name="output-message">
@@ -635,7 +635,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       <xsl:when test="@href=''"/>
       <!--grabbing text from a particular topic in another file-->
       <xsl:when test="$topicpos='otherfile'">
-        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
+        <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
         <xsl:choose>
           <xsl:when
             test="$target[contains(@class, $classval)]/*[contains(@class, ' topic/titlealts ')]/*[contains(@class, ' topic/navtitle ')]">
@@ -888,7 +888,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
 
             <!--grabbing text from a particular topic in another file-->
             <xsl:when test="$topicpos='otherfile'">
-              <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
+              <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
               <xsl:choose>
                 <xsl:when test="$target[contains(@class, $classval)]/*[contains(@class, ' topic/title ')]">
                   <xsl:variable name="grabbed-value" as="xs:string">
@@ -996,7 +996,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:when>
       <!--try retrieving from a particular topic in another file-->
       <xsl:when test="$topicpos='otherfile'">
-        <xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>
+        <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
         <xsl:if
             test="($target[contains(@class, $classval)])[1]/*[contains(@class, ' topic/shortdesc ')]|
                   ($target[contains(@class, $classval)])[1]/*[contains(@class, ' topic/abstract ')]/*[contains(@class, ' topic/shortdesc ')]">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

The refactoring in https://github.com/dita-ot/dita-ot/pull/2716/commits/2c87116d6d6f11b1d2cec7b803c744d2d27e930c that fixed one error in `mappull` introduced another. As part of the refactoring, checking a target topic was refactored / simplified to use a key:
`<xsl:variable name="target" select="key('topic-by-id', $topicid, $doc)[1]" as="element()?"/>`

The same DITA-OT user that found the original problem got a different failure with the updated code in 2.5.1. Her map referenced a document that was filtered out based on conditions on the root element (there was a warning early in the log that the topic would not produce output). When the `mappull` code set the `$doc` variable, it resulted in an empty document node. Using that in the key caused Saxon to fail and the build to halt:
`Error: Failed to run pipeline: Failed to transform document: An empty sequence is not allowed as the third argument of key()`

The fix just checks to ensure `$doc` exists before evaluating each instance of the key. This fix is intended for 2.5.2 but opening against `master` because we don't have a 2.5.2 branch yet.