### PR TITLE
Use stable ID generation in HTML5 for choicetables, properties tables

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -154,7 +154,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:function name="simpletable:generate-headers" as="xs:string">
     <xsl:param name="el" as="element()"/>
     <xsl:param name="suffix" as="xs:string"/>
-    <xsl:sequence select="string-join((generate-id($el), $suffix), '-')"/>
+    <xsl:sequence select="string-join((dita-ot:generate-html-id($el), $suffix), '-')"/>
   </xsl:function>
   
   <xsl:template match="*[contains(@class,' topic/simpletable ')]


### PR DESCRIPTION
## Description
Earlier PR#2276 stabilized most generated IDs except for choicetables & properties tables. This PR adds stable ID generation for choicetables & properties tables.

## Motivation and Context
Amends #2276 for improved stability of generated HTML5 output.

## How Has This Been Tested?
Generated output building the WebAssign help content to verify the change.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- I have signed-off my commits per http://www.dita-ot.org/DCO.
