### PR TITLE
Fix for broken revprop processing

### DIFF
--- a/src/main/xsl/preprocess/flagImpl.xsl
+++ b/src/main/xsl/preprocess/flagImpl.xsl
@@ -277,8 +277,8 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
        Commented out section shows how to insert a default start flag of "delta.gif"
        by creating the proper ditaval syntax -->
   <xsl:template name="default-rev-start">
-    <xsl:param name="lang" as="xs:string"/>
-    <xsl:param name="biditest" as="xs:string"/>
+    <xsl:param name="lang" as="xs:string?"/>
+    <xsl:param name="biditest" as="xs:string?"/>
     <!--
     <xsl:param name="startRevImage">
       <xsl:choose>
@@ -296,8 +296,8 @@ LOOK FOR FIXME TO FIX SCHEMEDEF STUFF
   </xsl:template>
   <!-- output the DEFAULT ending revision graphic & ALT text -->
   <xsl:template name="default-rev-end">
-    <xsl:param name="lang" as="xs:string"/>
-    <xsl:param name="biditest" as="xs:string"/>
+    <xsl:param name="lang" as="xs:string?"/>
+    <xsl:param name="biditest" as="xs:string?"/>
     <!--
     <xsl:param name="endRevImage">
       <xsl:choose>

--- a/src/test/resources/filterlist/exp/xhtml/simpletopic.html
+++ b/src/test/resources/filterlist/exp/xhtml/simpletopic.html
@@ -26,6 +26,11 @@
 
       <p class="p"><img src="delta2.gif" alt="This is an image in second ditaval:" />This is "flag" in the second ditaval</p>
 
+      <p class="p">This is the default revision</p>
+    
+      <p style="color:red;" class="p">This is a colorful revision</p>
+      
+      <p class="p"><img src="delta.gif" alt="Start revision:" />This is revised with images<img src="delta.gif" alt=":End revision" /></p>
       
   </div>
 

--- a/src/test/resources/filterlist/src/filter1.ditaval
+++ b/src/test/resources/filterlist/src/filter1.ditaval
@@ -7,4 +7,14 @@
             <alt-text>This is an image in main dir:</alt-text>
         </startflag>
     </prop>
+    <revprop action="flag" val="default"/>
+    <revprop action="flag" val="revcolor" color="red"/>
+    <revprop action="flag" val="revimage">
+        <startflag imageref="delta.gif">
+            <alt-text>Start revision:</alt-text>
+        </startflag>
+        <endflag imageref="delta.gif">
+            <alt-text>:End revision</alt-text>
+        </endflag>
+    </revprop>
 </val>

--- a/src/test/resources/filterlist/src/simpletopic.dita
+++ b/src/test/resources/filterlist/src/simpletopic.dita
@@ -9,5 +9,8 @@
       <p otherprops="subinclude">This is "include" in the second ditaval</p>
       <p otherprops="subflag">This is "flag" in the second ditaval</p>
       <p otherprops="subexclude">This is "exclude" in the second ditaval</p>
+      <p rev="default">This is the default revision</p>
+      <p rev="revcolor">This is a colorful revision</p>
+      <p rev="revimage">This is revised with images</p>
   </body>
 </topic>


### PR DESCRIPTION
## Description

If I have a revision that is set to `flag` but does not specify an image, it results in this failure from the flag module:
```
[preprocess_flag] Failed to transform document: A value must be supplied for the
 parameter because the default value is not a valid instance of the required type
```

This occurs because when the flag module was updated to add typing to parameters and variables, two parameters for `default-rev-start` and `default-rev-end` were set to `xs:string`, but our code for handling default revisions calls those templates without any parameters (the 2 `with-param` elements are actually there but commented out).

## Motivation and Context

The default start/end templates are there so that a process can add default start/end formatting (we've typically added a start-rev and end-rev graphic). By default they do nothing. Because the default parameters do not match the expected parameters, the whole module fails, and no flagging is added.

## How Has This Been Tested?

This issue highlighted that we do not actually have any integration tests that use revision flags, so I've updated an existing test for `<prop>` flags so that it also tests `<revprop>` flags. The test now includes full default (flagged but no action), flag with color (no image) and flag with specified image.

## Type of Changes

In addition to the updated test case, this fix changes 4 instances of `xs:string` so that they are now `xs:string?`.

An alternate fix would be to un-comment the sections that pass `$lang` and `$bidi`. I'm not sure which fix is better, or if it matters. Those have been commented out for a long time, so not knowing the reason, I left them commented out.

The fix is intended for `hotfix/2.5.2` but opened against `master` because that branch doesn't yet exist.