### PR TITLE
Add SUPPORT file

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,20 @@
+# DITA-OT Support 
+
+DITA-OT is maintained by a [small group of volunteers][1]  who work on the project in their spare time. 
+
+With these limited resources, we can't offer direct support, but the DITA community offers several other forums, including:
+
+* The [DITA-OT project website][2] at [dita-ot.org][2] provides information about the latest toolkit releases, including [download links][3], release notes, and [documentation][4] for recent DITA-OT versions.
+* The [Yahoo! dita-users group][5] is the original DITA list-serv and a vital resource for the DITA community. People post regularly, both asking for and offering help. While the archived messages can be difficult to search, this is a treasure trove of information.
+* The [DITA-OT Users Google Group][6] is a general interest DITA-OT product forum, for questions on any aspect of the toolkit — from installation and getting started to questions about specific overrides, plug-ins, and customizations.
+* The StackOverflow developer community includes [topics related to DITA-OT][7]. 
+
+--- 
+
+[1]: http://www.dita-ot.org/who_we_are
+[2]: http://www.dita-ot.org
+[3]: http://www.dita-ot.org/download
+[4]: http://www.dita-ot.org/dev
+[5]: http://groups.yahoo.com/group/dita-users
+[6]: https://groups.google.com/d/forum/dita-ot-users
+[7]: http://stackoverflow.com/questions/tagged/dita-ot

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][7]](http://slack.dita-ot.org/)
 
-The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source tool that provides processing for OASIS DITA content. 
+The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_. 
 
 See [dita-ot.org][2] for documentation, information about releases, and download packages. 
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,10 @@
 # DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][7]](http://slack.dita-ot.org/)
 
-The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source tool that provides processing for OASIS DITA content. See [dita-ot.org][2] for documentation, information about releases, and download packages.
+The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source tool that provides processing for OASIS DITA content. 
+
+See [dita-ot.org][2] for documentation, information about releases, and download packages. 
+
+For information on additional DITA and DITA-OT resources, see [SUPPORT][8]. 
 
 ## Prerequisites
 
@@ -61,3 +65,4 @@ The DITA Open Toolkit is licensed for use under the [Apache License 2.0][6].
 [5]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
 [6]: http://www.apache.org/licenses/LICENSE-2.0
 [7]: http://slack.dita-ot.org/badge.svg
+[8]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md


### PR DESCRIPTION
Per https://github.com/blog/2400-support-file-support:

> SUPPORT files work just like CONTRIBUTING files. They can live in your repository root, `.github/`, or `docs/` folder, and […] can be used to direct users to dedicated support resources, such as community forums, FAQ documents, or corporate support channels.
