### PR TITLE
Do not add peer references to resource-only collection #2759

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -405,7 +405,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
         final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
         final String scope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
-        if (href != null && !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope)) {
+        if (href != null && !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
             if (!(MAP_TOPICREF.matches(cls))) {
                 nonTopicrefReferenceSet.add(stripFragment(currentDir.resolve(href)));
             } else if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(processingRole)) {

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -22,7 +22,7 @@ public class IntegrationTest extends AbstractIntegrationTest {
 
     Transtype xhtml = XHTML;
     Transtype preprocess = PREPROCESS;
-
+    
     @Test
     public void test03() throws Throwable {
         builder().name("03")
@@ -803,6 +803,24 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .input(Paths.get("reftopicid.ditamap"))
                 .put("validate", "false")
                 .warnCount(1)
+                .test();
+    }
+    
+    @Test
+    public void testonlytopic_in_map() throws Throwable {
+        builder().name("onlytopic.in.map")
+                .transtype(xhtml)
+                .input(Paths.get("input.ditamap"))
+                .put("onlytopic.in.map", "true")
+                .test();
+    }
+    
+    @Test
+    public void testonlytopic_in_map_false() throws Throwable {
+        builder().name("onlytopic.in.map.false")
+                .transtype(xhtml)
+                .input(Paths.get("input.ditamap"))
+                .put("onlytopic.in.map", "false")
                 .test();
     }
 

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<meta name="copyright" content="(C) Copyright 2017" />
+<meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="DC.Type" content="topic" />
+<meta name="DC.Title" content="Title" />
+<meta name="DC.Relation" scheme="URI" content="localditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="peerditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="externalditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="peerhtmllink.html" />
+<meta name="DC.Relation" scheme="URI" content="externalhtmllink.html" />
+<meta name="DC.Format" content="XHTML" />
+<meta name="DC.Identifier" content="Id1" />
+<link rel="stylesheet" type="text/css" href="commonltr.css" />
+<title>Title</title>
+</head>
+<body id="Id1">
+
+<h1 class="title topictitle1" id="ariaid-title1">Title</h1>
+
+<div class="body">
+<ul class="ul">
+<li class="li"><a class="xref" href="localditaxref.html">Local DITA xref, evaluate but do not generate</a></li>
+
+<li class="li"><a class="xref" href="peerditaxref.html">Peer topic, do not get it</a></li>
+
+<li class="li"><a class="xref" href="externalditaxref.dita" target="_blank">External topic, do not get it</a></li>
+
+<li class="li"><a class="xref" href="peerhtmlxref.html">Peer HTML xref</a></li>
+
+<li class="li"><a class="xref" href="externalhtmlxref.html" target="_blank">External HTML xref</a></li>
+
+</ul>
+
+</div>
+
+<div class="related-links">
+<div class="linklist linklist relinfo"><strong>Related information</strong><br />
+
+<div><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></div>
+<div><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></div>
+<div><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></div>
+<div><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></div>
+<div><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></div></div>
+</div>
+</body>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditalink.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditalink.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<meta name="copyright" content="(C) Copyright 2017" />
+<meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="DC.Type" content="topic" />
+<meta name="DC.Title" content="Local DITA link, evaluate but do not generate" />
+<meta name="DC.Format" content="XHTML" />
+<meta name="DC.Identifier" content="localditalink" />
+<link rel="stylesheet" type="text/css" href="commonltr.css" />
+<title>Local DITA link, evaluate but do not generate</title>
+</head>
+<body id="localditalink">
+
+<h1 class="title topictitle1" id="ariaid-title1">Local DITA link, evaluate but do not generate</h1>
+
+<div class="body">
+<p class="p">Content</p>
+
+</div>
+
+</body>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditaxref.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditaxref.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<meta name="copyright" content="(C) Copyright 2017" />
+<meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="DC.Type" content="topic" />
+<meta name="DC.Title" content="Local DITA xref, evaluate but do not generate" />
+<meta name="DC.Format" content="XHTML" />
+<meta name="DC.Identifier" content="localditaxref" />
+<link rel="stylesheet" type="text/css" href="commonltr.css" />
+<title>Local DITA xref, evaluate but do not generate</title>
+</head>
+<body id="localditaxref">
+
+  <h1 class="title topictitle1" id="ariaid-title1">Local DITA xref, evaluate but do not generate</h1>
+
+  <div class="body">
+    <p class="p">Content</p>
+
+  </div>
+
+</body>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localhtmllink.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localhtmllink.html
@@ -1,0 +1,6 @@
+<html>
+<title>THIS FILE IS NOT COPIED</title>
+<body>
+<p>LINK to local HTML file, when that file is not in the map, does not result in copying HTML file
+to output directory. If that changes, update this file so that it matches the one in src/</p>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localhtmlxref.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localhtmlxref.html
@@ -1,0 +1,6 @@
+<html>
+<title>THIS FILE IS NOT COPIED</title>
+<body>
+<p>XREF to local HTML file, when that file is not in the map, does not result in copying HTML file
+to output directory. If that changes, update this file so that it matches the one in src/</p>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/src/generate.dita
+++ b/src/test/resources/onlytopic.in.map.false/src/generate.dita
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "file:/C:/shaoxr/DITA-OT1.3.1/dtd/topic.dtd">
+<topic id="Id1">
+<title>Title</title>
+<body>
+<ul>
+<li><xref href="localditaxref.dita"/></li>
+<li><xref href="peerditaxref.dita" scope="peer">Peer topic, do not get it</xref></li>
+<li><xref href="externalditaxref.dita" scope="external">External topic, do not get it</xref></li>
+<li><xref href="peerhtmlxref.html" scope="peer" format="html">Peer HTML xref</xref></li>
+<li><xref href="externalhtmlxref.html" scope="external" format="html">External HTML xref</xref></li>
+</ul>
+</body>
+<related-links>
+<link href="localditalink.dita"/>
+<link href="peerditalink.dita" scope="peer"><linktext>Peer topic link, do not get it</linktext></link>
+<link href="externalditalink.dita" scope="external"><linktext>External topic link, do not get it</linktext></link>
+<link href="peerhtmllink.html" scope="peer" format="html"><linktext>Peer html link, do not get it</linktext></link>
+<link href="externalhtmllink.html" scope="external" format="html"><linktext>External html link, do not get it</linktext></link>
+</related-links>
+</topic>
+

--- a/src/test/resources/onlytopic.in.map.false/src/input.ditamap
+++ b/src/test/resources/onlytopic.in.map.false/src/input.ditamap
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <title>Test onlytopic.in.map</title>
+  <topicref href="generate.dita"/>
+</map>

--- a/src/test/resources/onlytopic.in.map.false/src/localditalink.dita
+++ b/src/test/resources/onlytopic.in.map.false/src/localditalink.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="localditalink">
+<title>Local DITA link, evaluate but do not generate</title>
+<body>
+<p>Content</p>
+</body>
+</topic>

--- a/src/test/resources/onlytopic.in.map.false/src/localditaxref.dita
+++ b/src/test/resources/onlytopic.in.map.false/src/localditaxref.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="localditaxref">
+  <title>Local DITA xref, evaluate but do not generate</title>
+  <body>
+    <p>Content</p>
+  </body>
+</topic>

--- a/src/test/resources/onlytopic.in.map.false/src/localhtmllink.html
+++ b/src/test/resources/onlytopic.in.map.false/src/localhtmllink.html
@@ -1,0 +1,3 @@
+<html>
+<title>Local HTML file, ref with xref</title>
+</html>

--- a/src/test/resources/onlytopic.in.map.false/src/localhtmlxref.html
+++ b/src/test/resources/onlytopic.in.map.false/src/localhtmlxref.html
@@ -1,0 +1,3 @@
+<html>
+<title>Local HTML file, ref with xref</title>
+</html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<meta name="copyright" content="(C) Copyright 2017" />
+<meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="DC.Type" content="topic" />
+<meta name="DC.Title" content="Title" />
+<meta name="DC.Relation" scheme="URI" content="localditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="peerditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="externalditalink.html" />
+<meta name="DC.Relation" scheme="URI" content="peerhtmllink.html" />
+<meta name="DC.Relation" scheme="URI" content="externalhtmllink.html" />
+<meta name="DC.Format" content="XHTML" />
+<meta name="DC.Identifier" content="Id1" />
+<link rel="stylesheet" type="text/css" href="commonltr.css" />
+<title>Title</title>
+</head>
+<body id="Id1">
+
+<h1 class="title topictitle1" id="ariaid-title1">Title</h1>
+
+<div class="body">
+<ul class="ul">
+<li class="li"><a class="xref" href="localditaxref.html">Local DITA xref, evaluate but do not generate</a></li>
+
+<li class="li"><a class="xref" href="peerditaxref.html">Peer topic, do not get it</a></li>
+
+<li class="li"><a class="xref" href="externalditaxref.dita" target="_blank">External topic, do not get it</a></li>
+
+<li class="li"><a class="xref" href="peerhtmlxref.html">Peer HTML xref</a></li>
+
+<li class="li"><a class="xref" href="externalhtmlxref.html" target="_blank">External HTML xref</a></li>
+
+</ul>
+
+</div>
+
+<div class="related-links">
+<div class="linklist linklist relinfo"><strong>Related information</strong><br />
+
+<div><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></div>
+<div><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></div>
+<div><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></div>
+<div><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></div>
+<div><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></div></div>
+</div>
+</body>
+</html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/localditalink.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/localditalink.html
@@ -1,0 +1,7 @@
+<html>
+<title>THIS FILE SHOULD NOT BE GENERATED</title>
+<body>
+<p>This is designed to test onlytopic.in.map=true.
+If this file was generated from src/ then the test fails,
+and the generated content will not match this file.</p>
+</html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/localditaxref.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/localditaxref.html
@@ -1,0 +1,7 @@
+<html>
+<title>THIS FILE SHOULD NOT BE GENERATED</title>
+<body>
+<p>This is designed to test onlytopic.in.map=true.
+If this file was generated from src/ then the test fails,
+and the generated content will not match this file.</p>
+</html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/localhtmllink.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/localhtmllink.html
@@ -1,0 +1,7 @@
+<html>
+<title>THIS FILE SHOULD NOT BE COPIED</title>
+<body>
+<p>This is designed to test onlytopic.in.map=true.
+If this file was copied from src/ then the test fails,
+and the copied content will not match this file.</p>
+</html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/localhtmlxref.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/localhtmlxref.html
@@ -1,0 +1,7 @@
+<html>
+<title>THIS FILE SHOULD NOT BE COPIED</title>
+<body>
+<p>This is designed to test onlytopic.in.map=true.
+If this file was copied from src/ then the test fails,
+and the copied content will not match this file.</p>
+</html>

--- a/src/test/resources/onlytopic.in.map/src/generate.dita
+++ b/src/test/resources/onlytopic.in.map/src/generate.dita
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "file:/C:/shaoxr/DITA-OT1.3.1/dtd/topic.dtd">
+<topic id="Id1">
+<title>Title</title>
+<body>
+<ul>
+<li><xref href="localditaxref.dita"/></li>
+<li><xref href="peerditaxref.dita" scope="peer">Peer topic, do not get it</xref></li>
+<li><xref href="externalditaxref.dita" scope="external">External topic, do not get it</xref></li>
+<li><xref href="peerhtmlxref.html" scope="peer" format="html">Peer HTML xref</xref></li>
+<li><xref href="externalhtmlxref.html" scope="external" format="html">External HTML xref</xref></li>
+</ul>
+</body>
+<related-links>
+<link href="localditalink.dita"/>
+<link href="peerditalink.dita" scope="peer"><linktext>Peer topic link, do not get it</linktext></link>
+<link href="externalditalink.dita" scope="external"><linktext>External topic link, do not get it</linktext></link>
+<link href="peerhtmllink.html" scope="peer" format="html"><linktext>Peer html link, do not get it</linktext></link>
+<link href="externalhtmllink.html" scope="external" format="html"><linktext>External html link, do not get it</linktext></link>
+</related-links>
+</topic>
+

--- a/src/test/resources/onlytopic.in.map/src/input.ditamap
+++ b/src/test/resources/onlytopic.in.map/src/input.ditamap
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <title>Test onlytopic.in.map</title>
+  <topicref href="generate.dita"/>
+</map>

--- a/src/test/resources/onlytopic.in.map/src/localditalink.dita
+++ b/src/test/resources/onlytopic.in.map/src/localditalink.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="localditalink">
+<title>Local DITA link, evaluate but do not generate</title>
+<body>
+<p>Content</p>
+</body>
+</topic>

--- a/src/test/resources/onlytopic.in.map/src/localditaxref.dita
+++ b/src/test/resources/onlytopic.in.map/src/localditaxref.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="localditaxref">
+  <title>Local DITA xref, evaluate but do not generate</title>
+  <body>
+    <p>Content</p>
+  </body>
+</topic>

--- a/src/test/resources/onlytopic.in.map/src/localhtmllink.html
+++ b/src/test/resources/onlytopic.in.map/src/localhtmllink.html
@@ -1,0 +1,3 @@
+<html>
+<title>Local HTML file, ref with xref</title>
+</html>

--- a/src/test/resources/onlytopic.in.map/src/localhtmlxref.html
+++ b/src/test/resources/onlytopic.in.map/src/localhtmlxref.html
@@ -1,0 +1,3 @@
+<html>
+<title>Local HTML file, ref with xref</title>
+</html>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Provides a fix for #2759.

With 2.5 we collect non-topicref references so that they can be avoid generating output (in combination with the `onlytopic.in.map` and `generate.copy.outer` parameters). 

When those references are marked with `scope="external"` we ignore them. If they are marked with `scope="peer"` we still add them to the list of referenced files, causing later steps to try reading them (even when they are not DITA).

In other cases we avoid adding / tracking both external and peer; adding the test for peer in this case prevents numerous errors from coming up later in the build / prevents later DITA-OT steps from trying to read peer or non-DITA files as if they are local DITA.

## How Has This Been Tested?

1. Tested against the original files that demonstrated the error
2. Tested against unit / integration tests

