### PR TITLE
"Copy files" task fails build when target directory doesn't exist

### DIFF
--- a/src/main/java/org/dita/dost/util/DITAOTCopy.java
+++ b/src/main/java/org/dita/dost/util/DITAOTCopy.java
@@ -88,8 +88,8 @@ public final class DITAOTCopy extends Task {
         if (destDir == null) {
             throw new BuildException("Destination directory not defined");
         }
-        if (!destDir.exists()) {
-            throw new BuildException("Destination directory " + destDir + " does not exists");
+        if (!destDir.exists() && !destDir.mkdirs()) {
+            throw new BuildException(new IOException("Destination directory " + destDir + " cannot be created"));
         }
         try {
             final FileUtils fileUtils = FileUtils.newFileUtils();


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description
The class `org.dita.dost.util.DITAOTCopy` is used by Ant in a couple locations to copy files. It takes a destination directory as a parameter (the place to put the copied files). Currently, if the destination directory does not exist, the entire build halts with the message, including the typo of "exists" instead of "exist":
`Destination directory [directory] does not exists`

I have several transform types that use the `temp.output.dir.name` parameter -- placing "output" into a directory in temp, so that we can postprocess and return a zip. When I use a ditaval file, the `copy-flag` target runs that class and the build fails because nothing has created that "output" directory yet:
```
copy-flag:
[job-helper] Processing C:\DCS\2.5\test\P025072\temp\.job.xml to C:\DCS\2.5\test\P025072\temp\flagimage.list
[job-helper] Loading stylesheet C:\DCS\2.5\xsl\job-helper.xsl
Error: Destination directory C:\DCS\2.5\test\P025072\temp\temp_jar_dir does not exists
```

This happens even when the DITAVAL does not specify any flags.

This fix changes the copy process so that if the directory does not exist, we try to create it; we only fail if it does not exist and cannot be created.

## How Has This Been Tested?

Tested with the transform type that failed previously; using the original 2.5 code + the newly built `dost.jar` from this branch, the build continues happily with no failure.

Also tested with the unit / integration tests, and passes the Travis CI build.

## Type of Changes

Bug fix