### PR TITLE
Avoid crash caused by empty ditavalref

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -435,6 +435,9 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
      * Read and cache filter.
      **/
     private FilterUtils getFilterUtils(final Element ditavalRef) {
+        if (ditavalRef.getAttribute(ATTRIBUTE_NAME_HREF).isEmpty()) {
+            return null;
+        }
         final URI href = toURI(ditavalRef.getAttribute(ATTRIBUTE_NAME_HREF));
         final URI tmp = currentFile.resolve(href);
         final FileInfo fi = job.getFileInfo(tmp);


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

If I have an empty `<ditavalref>` element in my map, my build crashes with a null pointer error.

This is caused by trying to retrieve `FileInfo.src` for the `ditavalref` -- the HREF is empty, meaning we get FileInfo for the empty string, and trying to get the source for that with `final URI ditaval = fi.src;` results in:

```
branch-filter:
[branch-filter] Processing file:/C:/Users/IBM_AD~1/AppData/Local/Temp/temp20170828131045013/samples/hierarchy.ditamap
Error: java.lang.NullPointerException
```

The fix doesn't do anything fancy with the `ditavalref` but allows the `branch-filter` step to continue as if it were not specified (meaning it allows the build to finish).

Can be tested by adding `<ditavalref></ditavalref>` into any map, I used `docsrc/samples/hierarchy.ditamap`