### PR TITLE
Fix variable failure from xref without format

### DIFF
--- a/src/main/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/xsl/preprocess/topicpullImpl.xsl
@@ -593,9 +593,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:when>
       <xsl:otherwise>
         <!-- Scope must be peer or external or format is not dita, use any local text. -->
-        <xsl:variable name="format" as="xs:string"
+        <xsl:variable name="format" as="xs:string?"
           select="dita-ot:get-link-format(.)"/>
-        <xsl:variable name="scope" as="xs:string"
+        <xsl:variable name="scope" as="xs:string?"
           select="dita-ot:get-link-scope(., 'local')"/>
         <xsl:choose>
           <xsl:when test="contains(@class,' topic/link ') and *[not(contains(@class, ' topic/desc '))]">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I have an external link without a specified `@format`. This is to a DITA topic so defaulting to `dita` is fine for the value.

The topicpull step sets format with a variable, and expects an `xs:string` result:
```
<xsl:variable name="format" as="xs:string"
           select="dita-ot:get-link-format(.)"/>
```

However, the function call does not pass in a default, and the function itself (with or without the default) is set to return optional `xs:string?`. My test case below returns an empty value, and results in the build error:
`[topicpull] Failed to transform document: An empty sequence is not allowed as the value of variable $format`

The fix just updates the variable to expect an optional value, which is what the function already declares.

Test document:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN"  "topic.dtd">
<topic id="topic" xml:lang="en-us">
<title>Test external DITA xref</title>
<body>
<p>Try this out: <xref
href="https://www.ibm.com/support/knowledgecenter/SSFHJY_1.0.6/using/text/document/d_changing_the_default_file_format.dita"
scope="external"/></p>
</body>
</topic>
```