### PR TITLE
Topics exploded by chunk should be written to the topic folder

### DIFF
--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -243,7 +243,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final FileInfo cfi = job.getFileInfo(currentFile);
         URI result = cfi.result.resolve(id + FILE_EXTENSION_DITA);
         URI temp = tempFileNameScheme.generateTempFileName(result);
-        if (id == null || new File(currentFile.resolve(temp)).exists()) { //job.getFileInfo(result) != null
+        if (id == null || new File(currentParsingFile.resolve(temp)).exists()) { //job.getFileInfo(result) != null
             final URI t = temp;
 
             result = cfi.result.resolve(generateFilename());
@@ -257,9 +257,9 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
                     .build();
             job.add(fi);
 
-            conflictTable.put(currentFile.resolve(temp), currentFile.resolve(t));
+            conflictTable.put(currentParsingFile.resolve(temp), currentParsingFile.resolve(t));
         }
-        return currentFile.resolve(temp);
+        return currentParsingFile.resolve(temp);
     }
 
     Attributes processAttributes(final Attributes atts) {

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -75,6 +75,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
         this.currentFile = currentFile;
         final URI hrefValue = toURI(getValue(rootTopicref, ATTRIBUTE_NAME_HREF));
         final URI copytoValue = toURI(getValue(rootTopicref, ATTRIBUTE_NAME_COPY_TO));
+        final URI resolveBase;
         final String scopeValue = getCascadeValue(rootTopicref, ATTRIBUTE_NAME_SCOPE);
         // Chimera path, has fragment
         URI parseFilePath;
@@ -96,6 +97,9 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
             // if the path to target file make sense
             currentParsingFile = currentFile.resolve(parseFilePath);
             URI outputFileName;
+
+            resolveBase = copytoValue == null ? currentParsingFile : currentFile;
+
             /*
              * FIXME: we have code flaws here, references in ditamap need to
              * be updated to new created file.
@@ -135,10 +139,10 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                 topicDoc = getTopicDoc(currentFile.resolve(parseFilePath));
 
                 if (firstTopicID != null) {
-                    outputFileName = resolve(currentFile, firstTopicID + FILE_EXTENSION_DITA);
+                    outputFileName = resolve(resolveBase, firstTopicID + FILE_EXTENSION_DITA);
                     targetTopicId = firstTopicID;
                 } else {
-                    outputFileName = resolve(currentParsingFile, null);
+                    outputFileName = resolve(resolveBase, null);
                     dotchunk = true;
                     targetTopicId = null;
                 }
@@ -146,12 +150,12 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
             }
             if (copytoValue != null) {
                 // use @copy-to value as the new file name
-                outputFileName = resolve(currentFile, copytoValue.toString());
+                outputFileName = resolve(resolveBase, copytoValue.toString());
             }
 
             if (new File(outputFileName).exists()) {
                 final URI t = outputFileName;
-                outputFileName = resolve(currentFile, generateFilename());
+                outputFileName = resolve(resolveBase, generateFilename());
                 conflictTable.put(outputFileName, t);
                 dotchunk = false;
             }


### PR DESCRIPTION
## Description
Topics exploded by chunk should be written to the topic folder (not to the dtamap folder).

## Motivation and Context
Suggested approach to implement https://github.com/dita-ot/dita-ot/issues/2655

## How Has This Been Tested?
- $ ./gradlew test
- [chunk_path.tar.gz](https://github.com/dita-ot/dita-ot/files/1291433/chunk_path.tar.gz)

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- I have signed-off my commits per http://www.dita-ot.org/DCO.
- Builds & tests completed successfully (`./gradlew test integrationTest`).
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
