### PR TITLE
Warn about broken tables, and avoid FOP crash

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -9,8 +9,9 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   version="2.0"
-  exclude-result-prefixes="xs">
+  exclude-result-prefixes="xs dita-ot">
 
     <xsl:template match="*[contains(@class, ' topic/dt ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dt__content">
@@ -29,5 +30,19 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="@id" mode="dlentry-id-for-fop">
         <fo:inline id="{.}"/>
     </xsl:template>
+
+  <xsl:template match="*[contains(@class,' topic/entry ')]">
+    <xsl:choose>
+      <xsl:when test="dita-ot:get-entry-end-position(.) gt number(ancestor::*[contains(@class,' topic/tgroup ')][1]/@cols)">
+        <!-- FOP crashes if an entry extends beyond the table width -->
+        <xsl:call-template name="output-message">
+          <xsl:with-param name="id" select="'PDFX012E'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -89,4 +89,8 @@ See the accompanying LICENSE file for applicable license.
     <reason>The index term '%2' uses both an index-see element and %1 element.</reason>
     <response>Convert the index-see element to index-see-also.</response>
   </message>
+  <message id="PDFX012E" type="ERROR">
+    <reason>Found a table row with more entries than allowed.</reason>
+    <response/>
+  </message>
 </messages>  


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description
We found an old DITA topic that included an invalid table -- the `<tgroup>` element used `@cols="3"`, indicating three columns, but somehow an author added a fourth column. HTML output tolerates the markup and everything appears. When processing the topic for PDF, FOP crashes with a Java error. Antenna House returns a PDF, but the text of the "extra" column appears to the right of the table, in a one-character column.

The fix adds an error message when PDF2 code detects an entry beyond the specified number of columns. It operates based off of the generated `@dita-ot:x` and `@dita-ot:morecols` attributes added during `preprocess`. It's possible (but difficult) to get a table without those, so the code falls back to current behavior if they are not specified. When the last column of the current entry is beyond the specified number of columns, a new error message is generated. In the FOP override, the entry is dropped after generating that message.

FWIW, having too *few* entries in a row does not break either Antenna House or FOP, and you end up with an empty cell in the PDF.

## How Has This Been Tested?

Integration tests pass. The table used to test the specific fix is a trimmed down version of the original topic. It tests a row with an extra cell (no spanning), and a row that has an extra cell due to spanned columns.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN"
 "task.dtd">
<task id="wonkywonk" xml:lang="en-us">
<title>Wonky Table</title>
<shortdesc>The tables are wonky. REALLY WONKY!</shortdesc>
<taskbody>
<result>
<table frame="all" id="table_vt3_ll5_r4">
<title>Extra cell</title>
<tgroup cols="2">
<colspec colname="c1" colnum="1" colwidth="1.0*"/>
<colspec colname="c2" colnum="2" colwidth="1.0*"/>
<thead>
<row>
<entry>head!</entry>
<entry>Head!</entry>
</row>
</thead>
<tbody>
<row>
<entry>a</entry>
<entry>b</entry>
</row>
<row>
<entry>a</entry>
<entry>b</entry>
<entry>THIS IS EXTRA</entry>
</row>
<row>
<entry>a</entry>
<entry>b</entry>
</row>
</tbody>
</tgroup>
</table>
<table frame="all" rowsep="1" colsep="1" id="table_qg3_kpb_fbb">
<title>Extra cell due to spans</title>
<tgroup cols="2">
<colspec colname="c1" colnum="1" colwidth="1*"/>
<colspec colname="c2" colnum="2" colwidth="1*"/>
<thead>
<row>
<entry>header1</entry>
<entry>header2</entry>
</row>
</thead>
<tbody>
<row>
<entry>normal</entry>
<entry>normal</entry>
</row>
<row>
<entry namest="c1" nameend="c2">spanned cols = next cell is invalid</entry>
<entry>This is invalid</entry>
</row>
<row>
<entry>normal</entry>
<entry>normal</entry>
</row>
</tbody>
</tgroup>
</table>
</result>
</taskbody>
</task>
```

Not sure how best to add to test suite due to general lack of PDF-specific test cases.
