### PR TITLE
Allow any attribute to be used for profiling

### DIFF
--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -6,7 +6,8 @@
 #DITA-OT configuration properties
 default.cascade = merge
 temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$DefaultTempFileScheme
-filter-any-attribute = false
+#filter-attributes =
+#flag-attributes =
 cli.color = true
 
 # Integration

--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -6,6 +6,7 @@
 #DITA-OT configuration properties
 default.cascade = merge
 temp-file-name-scheme = org.dita.dost.module.GenMapAndTopicListModule$DefaultTempFileScheme
+filter-any-attribute = false
 cli.color = true
 
 # Integration

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -353,6 +353,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Using 'scope' attribute value 'external'.</response>
   </message>
 
+  <message id="DOTJ074W" type="WARN">
+    <reason>Rev attribute cannot be used with prop filter.</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -136,16 +136,25 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     }
 
-    /**
-     * TODO: This should be generalized to be a DOM to XML stream utility function and moved to XMLUtils.
-     */
     private void writeConditions(XMLStreamWriter export, NodeList conditionElements, URI ditavalDirectory) {
         try {
             for (int i = 0; i < conditionElements.getLength(); i++) {
-                switch (conditionElements.item(i).getNodeType()) {
+                final Node node = conditionElements.item(i);
+                switch (node.getNodeType()) {
                 case Node.ELEMENT_NODE:
-                    export.writeStartElement(conditionElements.item(i).getNodeName());
-                    final NamedNodeMap atts = conditionElements.item(i).getAttributes();
+                    final Element elem = (Element) node;
+                    export.writeStartElement(node.getNodeName());
+                    final NamedNodeMap atts = node.getAttributes();
+                    for (int j = 0; j < atts.getLength(); j++) {
+                        final String value = atts.item(j).getNodeValue().trim();
+                        if (value.indexOf(':') != -1) {
+                            final String prefix = value.substring(0, value.indexOf(':'));
+                            final String ns = elem.lookupNamespaceURI(prefix);
+                            if (ns != null) {
+                                export.writeNamespace(prefix, ns);
+                            }
+                        }
+                    }
                     if (atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null ||
                             atts.getNamedItem(ATTRIBUTE_NAME_IMG) != null ) {
                         final String imagerefAtt = atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null ? 
@@ -160,11 +169,11 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
                     for (int j = 0; j < atts.getLength(); j++) {
                         export.writeAttribute(atts.item(j).getNodeName(), atts.item(j).getNodeValue());
                     }
-                    writeConditions(export, conditionElements.item(i).getChildNodes(), ditavalDirectory);
+                    writeConditions(export, node.getChildNodes(), ditavalDirectory);
                     export.writeEndElement();
                     break;
                 case Node.TEXT_NODE:
-                    export.writeCharacters(conditionElements.item(i).getNodeValue());
+                    export.writeCharacters(node.getNodeValue());
                     break;
                 }
             }

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -25,6 +25,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -34,6 +35,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 
+import static javax.xml.XMLConstants.XML_NS_PREFIX;
+import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FilterUtils.DEFAULT;
 import static org.dita.dost.util.URLUtils.getRelativePath;
@@ -177,7 +180,22 @@ public final class DitaValReader implements AbstractReader {
                 attName = QName.valueOf(ATTRIBUTE_NAME_REV);
             } else {
                 final String attValue = getValue(elem, ATTRIBUTE_NAME_ATT);
-                attName = attValue == null ? null : QName.valueOf(attValue);
+                if (attValue != null) {
+                    if (attValue.contains(":")) {
+                        final String[] parts = attValue.split(":");
+                        final String uri;
+                        if (parts[0].equals(XML_NS_PREFIX)) {
+                            uri = XML_NS_URI;
+                        } else {
+                            uri = elem.lookupNamespaceURI(parts[0]);
+                        }
+                        attName = new QName(uri, parts[1], parts[0]);
+                    } else {
+                        attName = QName.valueOf(attValue);
+                    }
+                } else {
+                    attName = null;
+                }
             }
             final String attValue = getValue(elem, ATTRIBUTE_NAME_VAL);
             final FilterKey key = attName != null ? new FilterKey(attName, attValue) : DEFAULT;

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -217,11 +217,11 @@ public final class DitaValReader implements AbstractReader {
                 } else {
                     attName = null;
                 }
-            }
-            if (attName != null && attName.equals(REV)
-                    && !filterAttributes.isEmpty() && !filterAttributes.contains(REV)) {
-                logger.warn(MessageUtils.getMessage("DOTJ074W").toString());
-                return;
+                if (attName != null && attName.equals(REV)
+                        && !filterAttributes.isEmpty() && !filterAttributes.contains(REV)) {
+                    logger.warn(MessageUtils.getMessage("DOTJ074W").toString());
+                    return;
+                }
             }
             final String attValue = getValue(elem, ATTRIBUTE_NAME_VAL);
             final FilterKey key = attName != null ? new FilterKey(attName, attValue) : DEFAULT;

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -9,10 +9,10 @@
 package org.dita.dost.reader;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageUtils;
-import org.dita.dost.module.GenMapAndTopicListModule;
 import org.dita.dost.module.GenMapAndTopicListModule.TempFileNameScheme;
 import org.dita.dost.util.Configuration;
 import org.dita.dost.util.FilterUtils.Action;
@@ -27,7 +27,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -36,6 +35,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static javax.xml.XMLConstants.XML_NS_PREFIX;
 import static javax.xml.XMLConstants.XML_NS_URI;
@@ -43,7 +44,6 @@ import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FilterUtils.DEFAULT;
 import static org.dita.dost.util.URLUtils.getRelativePath;
 import static org.dita.dost.util.XMLUtils.*;
-
 
 /**
  * DitaValReader reads and parses the information from ditaval file which
@@ -53,7 +53,10 @@ import static org.dita.dost.util.XMLUtils.*;
  */
 public final class DitaValReader implements AbstractReader {
 
-    private boolean anyAttribute;
+    private static final QName REV = QName.valueOf(ATTRIBUTE_NAME_REV);
+
+    private Set<QName> filterAttributes;
+    private Set<QName> flagAttributes;
     protected DITAOTLogger logger;
     protected Job job;
     private final Map<FilterKey, Action> filterMap;
@@ -87,13 +90,21 @@ public final class DitaValReader implements AbstractReader {
         } catch (final ParserConfigurationException e) {
             throw new RuntimeException(e);
         }
-        this.anyAttribute = Boolean.parseBoolean(Configuration.configuration.getOrDefault("filter-any-attribute", "false"));
+        filterAttributes = Stream.of(Configuration.configuration.getOrDefault("filter-attributes", "")
+                .trim().split("\\s*,\\s*"))
+                .map(QName::valueOf)
+                .collect(Collectors.toSet());
+        flagAttributes = Stream.of(Configuration.configuration.getOrDefault("flag-attributes", "")
+                .trim().split("\\s*,\\s*"))
+                .map(QName::valueOf)
+                .collect(Collectors.toSet());
     }
 
     @VisibleForTesting
-    DitaValReader(boolean anyAttribute) {
+    DitaValReader(Set<QName> filterAttributes, Set<QName> flagAttributes) {
         this();
-        this.anyAttribute = anyAttribute;
+        this.filterAttributes = Sets.union(this.filterAttributes, filterAttributes);
+        this.flagAttributes = Sets.union(this.flagAttributes, flagAttributes);
     }
 
     @Override
@@ -187,7 +198,7 @@ public final class DitaValReader implements AbstractReader {
         if (action != null) {
             final QName attName;
             if (elem.getTagName().equals(ELEMENT_NAME_REVPROP)) {
-                attName = QName.valueOf(ATTRIBUTE_NAME_REV);
+                attName = REV;
             } else {
                 final String attValue = getValue(elem, ATTRIBUTE_NAME_ATT);
                 if (attValue != null) {
@@ -207,7 +218,8 @@ public final class DitaValReader implements AbstractReader {
                     attName = null;
                 }
             }
-            if (!anyAttribute && attName != null && attName.equals(QName.valueOf(ATTRIBUTE_NAME_REV))) {
+            if (attName != null && attName.equals(REV)
+                    && !filterAttributes.isEmpty() && !filterAttributes.contains(REV)) {
                 logger.warn(MessageUtils.getMessage("DOTJ074W").toString());
                 return;
             }

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -73,7 +73,7 @@ public final class FilterUtils {
 
     public static final FilterKey DEFAULT = new FilterKey(QName.valueOf(DEFAULT_ACTION), null);
 
-    private final boolean anyAttribute;
+    private boolean anyAttribute;
     private DITAOTLogger logger;
     /** Actions for filter keys. */
     private final Map<FilterKey, Action> filterMap;
@@ -89,7 +89,7 @@ public final class FilterUtils {
         this.filterMap = new HashMap<>(filterMap);
         this.foregroundConflictColor = foregroundConflictColor;
         this.backgroundConflictColor = backgroundConflictColor;
-        this.anyAttribute = Boolean.parseBoolean(Configuration.configuration.getOrDefault("filter-any-attribute", "true"));
+        this.anyAttribute = Boolean.parseBoolean(Configuration.configuration.getOrDefault("filter-any-attribute", "false"));
     }
 
     /**
@@ -123,7 +123,14 @@ public final class FilterUtils {
         this.filterMap = dfm;
         this.foregroundConflictColor = foregroundConflictColor;
         this.backgroundConflictColor = backgroundConflictColor;
-        this.anyAttribute = Boolean.parseBoolean(Configuration.configuration.getOrDefault("filter-any-attribute", "true"));
+        this.anyAttribute = Boolean.parseBoolean(Configuration.configuration.getOrDefault("filter-any-attribute", "false"));
+    }
+
+    @VisibleForTesting
+    public FilterUtils(boolean isPrintType, Map<FilterKey, Action> filterMap,
+                       String foregroundConflictColor, String backgroundConflictColor, boolean anyAttribute) {
+        this(isPrintType, filterMap, foregroundConflictColor, backgroundConflictColor);
+        this.anyAttribute = anyAttribute;
     }
 
     public void setLogger(final DITAOTLogger logger) {

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -317,7 +317,7 @@ public final class XMLUtils {
      * @param value attribute value
      */
     public static void addOrSetAttribute(final AttributesImpl atts, final QName name, final String value) {
-        addOrSetAttribute(atts, name.getNamespaceURI(), name.getLocalPart(), name.toString(), "CDATA", value);
+        addOrSetAttribute(atts, name.getNamespaceURI(), name.getLocalPart(), name.getPrefix()  + ":" + name.getLocalPart(), "CDATA", value);
     }
 
     /**
@@ -753,6 +753,17 @@ public final class XMLUtils {
          */
         public AttributesBuilder add(final String uri, final String localName, final String value) {
             return add(uri, localName, localName, "CDATA", value);
+        }
+
+        /**
+         * Add or set attribute. Convenience method for {@link #add(String, String, String, String, String)}.
+         *
+         * @param name name
+         * @param value attribute value
+         * @return this builder
+         */
+        public AttributesBuilder add(final QName name, final String value) {
+            return add(name.getNamespaceURI(), name.getLocalPart(), name.getPrefix()  + ":" + name.getLocalPart(), "CDATA", value);
         }
         
         /**

--- a/src/test/java/org/dita/dost/reader/TestDitaValReader.java
+++ b/src/test/java/org/dita/dost/reader/TestDitaValReader.java
@@ -8,6 +8,7 @@
 package org.dita.dost.reader;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.FilterUtils;
@@ -21,9 +22,11 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptySet;
 import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestDitaValReader {
 
@@ -33,6 +36,9 @@ public class TestDitaValReader {
     private static final QName PROPS = QName.valueOf("props");
     private static final QName KEYWORD = QName.valueOf("keyword");
     private static final QName REV = QName.valueOf("rev");
+    private static final QName LANG = new QName(XML_NS_URI, "lang", "xml");
+    private static final QName CONFIDENTIALITY = new QName("http://www.cms.com/", "confidentiality");
+
 
     private final File resourceDir = TestUtils.getResourceDir(TestDitaValReader.class);
 
@@ -63,10 +69,11 @@ public class TestDitaValReader {
         reader.setLogger(logger);
         reader.read(ditavalFile.toURI());
         final Map<FilterKey, Action> act = reader.getFilterMap();
+
         final Map<FilterKey, Action> exp = ImmutableMap.of(
                 new FilterKey(PLATFORM, "windows"), Action.EXCLUDE,
-                new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE,
-                new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE,
+                new FilterKey(LANG, "fr"), Action.EXCLUDE,
+                new FilterKey(CONFIDENTIALITY, "confidential"), Action.EXCLUDE,
                 new FilterKey(QName.valueOf("default"), null), Action.INCLUDE
         );
         assertEquals(exp, act);
@@ -76,13 +83,15 @@ public class TestDitaValReader {
     @Test
     public void testAnyAttribute() throws DITAOTException{
         final File ditavalFile = new File(resourceDir, "src" + File.separator + "any.ditaval");
-        DitaValReader reader = new DitaValReader(true);
+        DitaValReader reader = new DitaValReader(ImmutableSet.of(LANG, CONFIDENTIALITY, REV), emptySet());
+        TestUtils.CachingLogger logger = new TestUtils.CachingLogger();
+        reader.setLogger(logger);
         reader.read(ditavalFile.toURI());
         final Map<FilterKey, Action> act = reader.getFilterMap();
         final Map<FilterKey, Action> exp = ImmutableMap.of(
                 new FilterKey(PLATFORM, "windows"), Action.EXCLUDE,
-                new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE,
-                new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE,
+                new FilterKey(LANG, "fr"), Action.EXCLUDE,
+                new FilterKey(CONFIDENTIALITY, "confidential"), Action.EXCLUDE,
                 new FilterKey(REV, "10"), Action.EXCLUDE,
                 new FilterKey(QName.valueOf("default"), null), Action.INCLUDE
         );

--- a/src/test/java/org/dita/dost/reader/TestDitaValReader.java
+++ b/src/test/java/org/dita/dost/reader/TestDitaValReader.java
@@ -18,6 +18,7 @@ import javax.xml.namespace.QName;
 import java.io.File;
 import java.util.Map;
 
+import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.junit.Assert.assertTrue;
 
 
@@ -28,6 +29,7 @@ public class TestDitaValReader {
     private static final QName AUDIENCE = QName.valueOf("audience");
     private static final QName PROPS = QName.valueOf("props");
     private static final QName KEYWORD = QName.valueOf("keyword");
+    private static final QName REV = QName.valueOf("rev");
 
     private final File resourceDir = TestUtils.getResourceDir(TestDitaValReader.class);
 
@@ -48,6 +50,20 @@ public class TestDitaValReader {
         assertTrue(map.get(new FilterKey(KEYWORD, "key2")) instanceof FilterUtils.Flag);
         assertTrue(map.get(new FilterKey(KEYWORD, "key3")) instanceof FilterUtils.Include);
         assertTrue(map.get(new FilterKey(PROPS, null)) instanceof FilterUtils.Include);
+    }
+
+    @Test
+    public void testAnyAttribute() throws DITAOTException{
+        final File ditavalFile = new File(resourceDir, "src" + File.separator + "any.ditaval");
+        DitaValReader reader = new DitaValReader();
+        reader.read(ditavalFile.toURI());
+        final Map<FilterKey, Action> map = reader.getFilterMap();
+        assertTrue(map.get(new FilterKey(PLATFORM, "windows")) instanceof FilterUtils.Exclude);
+        assertTrue(map.get(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"))
+                instanceof FilterUtils.Exclude);
+        assertTrue(map.get(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"))
+                instanceof FilterUtils.Exclude);
+        assertTrue(map.get(new FilterKey(REV, "10")) instanceof FilterUtils.Exclude);
     }
 
 }

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -9,13 +9,16 @@ package org.dita.dost.util;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
+import static javax.xml.XMLConstants.XML_NS_PREFIX;
 import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.dita.dost.util.Constants.*;
 import static org.junit.Assert.*;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.dita.dost.TestUtils;
 import org.dita.dost.util.FilterUtils.Action;
 import org.dita.dost.util.FilterUtils.FilterKey;
@@ -27,6 +30,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 import org.junit.Test;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 
 public class FilterUtilsTest {
@@ -67,38 +71,44 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(attr(PLATFORM, "windows"), new QName[0][0]));
     }
 
+    private final QName lang = new QName(XML_NS_URI, "lang", XML_NS_PREFIX);
+    private final QName confidentiality = new QName("http://www.cms.com/", "confidentiality", "cms");
+
     @Test
     public void testFilterAnyAttribute() {
+
         final Map<FilterKey, Action> fm = new HashMap<>();
         fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
-        fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
-        fm.put(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE);
-        final FilterUtils f = new FilterUtils(false, fm, null, null, true);
+        fm.put(new FilterKey(lang, "fr"), Action.EXCLUDE);
+        fm.put(new FilterKey(confidentiality, "confidential"), Action.EXCLUDE);
+        final FilterUtils f = new FilterUtils(false, fm, null, null,
+            ImmutableSet.of(QName.valueOf(ATTRIBUTE_NAME_REV), lang, confidentiality), emptySet()
+        );
         f.setLogger(new TestUtils.TestLogger());
 
         assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
-        assertTrue(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
-        assertTrue(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "confidential").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "public").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(lang, "en").build(), new QName[0][0]));
+        assertTrue(f.needExclude(new AttributesBuilder().add(lang, "fr").build(), new QName[0][0]));
+        assertTrue(f.needExclude(new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
     }
 
     @Test
     public void testFilterAnyAttributeDisabled() {
         final Map<FilterKey, Action> fm = new HashMap<>();
         fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
-        fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
-        fm.put(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE);
+        fm.put(new FilterKey(lang, "fr"), Action.EXCLUDE);
+        fm.put(new FilterKey(confidentiality, "confidential"), Action.EXCLUDE);
         final FilterUtils f = new FilterUtils(false, fm, null, null);
         f.setLogger(new TestUtils.TestLogger());
 
         assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "confidential").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "public").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(lang, "en").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(lang, "fr").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
     }
 
     @Test

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -72,6 +72,7 @@ public class FilterUtilsTest {
         final Map<FilterKey, Action> fm = new HashMap<>();
         fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
         fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
+        fm.put(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE);
         final FilterUtils f = new FilterUtils(false, fm, null, null);
         f.setLogger(new TestUtils.TestLogger());
 
@@ -80,6 +81,8 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
+        assertTrue(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "public").build(), new QName[0][0]));
     }
 
     @Test

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -73,15 +73,31 @@ public class FilterUtilsTest {
         fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
         fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
         fm.put(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE);
-        final FilterUtils f = new FilterUtils(false, fm, null, null);
+        final FilterUtils f = new FilterUtils(false, fm, null, null, true);
         f.setLogger(new TestUtils.TestLogger());
 
-        assertFalse(f.needExclude(new AttributesImpl(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "public").build(), new QName[0][0]));
+    }
+
+    @Test
+    public void testFilterAnyAttributeDisabled() {
+        final Map<FilterKey, Action> fm = new HashMap<>();
+        fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
+        fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
+        fm.put(new FilterKey(new QName("http://www.cms.com/", "confidentiality"), "confidential"), Action.EXCLUDE);
+        final FilterUtils f = new FilterUtils(false, fm, null, null);
+        f.setLogger(new TestUtils.TestLogger());
+
+        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "confidential").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add("http://www.cms.com/", "confidentiality", "public").build(), new QName[0][0]));
     }
 

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -9,6 +9,8 @@ package org.dita.dost.util;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.util.Constants.*;
 import static org.junit.Assert.*;
 
 import java.util.*;
@@ -19,6 +21,7 @@ import org.dita.dost.util.FilterUtils.Action;
 import org.dita.dost.util.FilterUtils.FilterKey;
 
 import org.dita.dost.util.FilterUtils.Flag;
+import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -62,6 +65,21 @@ public class FilterUtilsTest {
         assertFalse(f.needExclude(attr(PLATFORM, "amiga unix windows"), new QName[0][0]));
         assertTrue(f.needExclude(attr(PLATFORM, "amiga windows"), new QName[0][0]));
         assertTrue(f.needExclude(attr(PLATFORM, "windows"), new QName[0][0]));
+    }
+
+    @Test
+    public void testFilterAnyAttribute() {
+        final Map<FilterKey, Action> fm = new HashMap<>();
+        fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
+        fm.put(new FilterKey(new QName(XML_NS_URI, "lang", "xml"), "fr"), Action.EXCLUDE);
+        final FilterUtils f = new FilterUtils(false, fm, null, null);
+        f.setLogger(new TestUtils.TestLogger());
+
+        assertFalse(f.needExclude(new AttributesImpl(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
+        assertTrue(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
+        assertFalse(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "en").build(), new QName[0][0]));
+        assertTrue(f.needExclude(new AttributesBuilder().add(XML_NS_URI, "lang", "fr").build(), new QName[0][0]));
     }
 
     @Test

--- a/src/test/resources/TestDitaValReader/src/any.ditaval
+++ b/src/test/resources/TestDitaValReader/src/any.ditaval
@@ -1,0 +1,7 @@
+<val xmlns:cms="http://www.cms.com/">
+  <prop att="platform" val="windows" action="exclude"/>
+  <prop att="xml:lang" val="fr" action="exclude"/>
+  <prop att="cms:confidentiality" val="confidential" action="exclude"/>
+  <prop att="rev" val="10" action="exclude"/>
+  <prop action="include"/>
+</val>

--- a/src/test/resources/messages.xml
+++ b/src/test/resources/messages.xml
@@ -438,6 +438,11 @@
     <response></response>
   </message>
 
+  <message id="DOTJ074W" type="WARN">
+    <reason>Rev attribute cannot be used with prop filter.</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -118,6 +118,7 @@ DOTJ012F=Failed to parse the input file ''{0}''.
 DOTX012W=When you conref another topic or an item in another topic, the domains attribute of the target topic must be equal to or a subset of the current topic''s domains attribute. Put your target under an appropriate domain. You can see the messages guide for more help.
 DOTJ028E=No format attribute was found on a reference to file ''{0}'', which does not appear to be a DITA file. If this is not a DITA file, set the format attribute to an appropriate value, otherwise set the format attribute to "dita".
 DOTJ071E=Cannot find the specified DITAVAL ''{0}''.
+DOTJ074W=Rev attribute cannot be used with prop filter.
 DOTX048I=In order to include peer or external topic ''{0}'' in your help file, you may need to recompile the CHM file after making the file available.
 DOTX008W=File ''{0}'' cannot be loaded, and no navigation title is specified for the table of contents.
 DOTX071W=Parameter "{0}" on template "{1}" is deprecated. Use parameter "{2}" instead.


### PR DESCRIPTION
Modify DITAVAL reader and processing to allow using any attribute for filtering and flagging.

Spec compliant DITA implementation will only allow filtering and flagging by profiling attributes or specializations of `@props`. However, in some cases users should be allowed to filter by e.g. `@importance` or namespaced extension attributes.

Because this adds functionality that's explicitly not allowed by DITA 1.3, this has been implemented as an opt-in functionality. Users must add `filter-attributes` and `flag-attributes` properties to configuration to specify which attributes can be used in filtering and flagging, respectively, in addition to the spec defined attributes. The value of the properties is a comma separated list of attribute QNames in Clark notation.

For example, the following is added to `config/configuration.properties`:

```properties
filter-attributes = importance, status
flag-attributes = {http://www.cms.com/}review
```

This will allow using `@importance` and `@status` in filtering, and custom `@cms:review` in flagging.

