### PR TITLE
Support language-independent variable files

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | تمهﻳد | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | تمهﻳد | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">المحتوﻳات</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">تمهﻳد: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">تمهﻳد</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">المحتوﻳات: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,25 +148,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
+    <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">قاموس المصطلحات</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
@@ -292,6 +157,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">الأشكال</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
@@ -7,154 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | تمهﻳد | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | تمهﻳد | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">المحتوﻳات</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">استمرار</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, أنظر </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">أنظر أﻳضا </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">الفصل <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">الملحق <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">الجزء <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">تمهﻳد: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">تمهﻳد</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">المحتوﻳات: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">الشكل <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">الشكل <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">الجدول <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">الجدول <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">المعلومات المتعلقة</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">الفصل <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">الملحق <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">الجزء <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[الاخلاء المطلوب]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> بالصفحة <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> الصفحة <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">اختياري:</variable>
-    <variable id="Required Step">مطلوب:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">قاموس المصطلحات</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">الجداول</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">الأشكال</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | تمهﻳد | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | تمهﻳد | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">المحتوﻳات</variable>
+  <variable id="Index Continued String">استمرار</variable>
+  <variable id="Index See String">, أنظر </variable>
+  <variable id="Index See Also String">أنظر أﻳضا </variable>
+  <variable id="Table of Contents Chapter">الفصل <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">الملحق <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">الجزء <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">تمهﻳد: </variable>
+  <variable id="Preface title">تمهﻳد</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">المحتوﻳات: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">الشكل <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">الشكل <param ref-name="number"/></variable>
+  <variable id="Table.title">الجدول <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">الجدول <param ref-name="number"/></variable>
+  <variable id="Related Links">المعلومات المتعلقة</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">الفصل <param ref-name="number"/></variable>
+  <variable id="Appendix with number">الملحق <param ref-name="number"/></variable>
+  <variable id="Part with number">الجزء <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[الاخلاء المطلوب]</variable>
+  <variable id="On the page"> بالصفحة <param ref-name="pagenum"/></variable>
+  <variable id="Page"> الصفحة <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">اختياري:</variable>
+  <variable id="Required Step">مطلوب:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">قاموس المصطلحات</variable>
+  <variable id="List of Tables">الجداول</variable>
+  <variable id="List of Figures">الأشكال</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
@@ -7,155 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Прадмова | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Прадмова | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Змест</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">працяг</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Гл. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Гл. таксама </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Раздзел <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Дадатак <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Дэталь <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Прадмова: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Прадмова</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Змест: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Малюнак <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Малюнак <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Табліца <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Табліца <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Адпаведная інфармацыя</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Раздзел <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Дадатак <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Дэталь <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Патрэбна выпраўленне]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> на стар. <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Старонка <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Неабавазкова:</variable>
-    <variable id="Required Step">Абавязкова:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-    <!-- The heading string to put at the top of the Glossary -->
-    <variable id="Glossary">Гласарый</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Табліцы</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Малюнкі</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Прадмова | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Прадмова | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Змест</variable>
+  <variable id="Index Continued String">працяг</variable>
+  <variable id="Index See String">, Гл. </variable>
+  <variable id="Index See Also String">Гл. таксама </variable>
+  <variable id="Table of Contents Chapter">Раздзел <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Дадатак <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Дэталь <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Прадмова: </variable>
+  <variable id="Preface title">Прадмова</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Змест: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Малюнак <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Малюнак <param ref-name="number"/></variable>
+  <variable id="Table.title">Табліца <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Табліца <param ref-name="number"/></variable>
+  <variable id="Related Links">Адпаведная інфармацыя</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Раздзел <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Дадатак <param ref-name="number"/></variable>
+  <variable id="Part with number">Дэталь <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Патрэбна выпраўленне]</variable>
+  <variable id="On the page"> на стар. <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Старонка <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Неабавазкова:</variable>
+  <variable id="Required Step">Абавязкова:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Гласарый</variable>
+  <variable id="List of Tables">Табліцы</variable>
+  <variable id="List of Figures">Малюнкі</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Прадмова | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Прадмова | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Змест</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Прадмова: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Прадмова</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Змест: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,26 +148,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Гласарый</variable>
+    <!-- The heading string to put at the top of the Glossary -->
+    <variable id="Glossary">Гласарый</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
      <variable id="List of Tables">Табліцы</variable>
@@ -292,6 +158,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Малюнкі</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
@@ -7,152 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Съдържание</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">продължение</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Вижте </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Вижте също </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Глава <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Приложение <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents.
-         (Not sure why Bulgarian provided the same translation for Part and Chapter) -->
-    <variable id="Table of Contents Part">Глава <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Предговор: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Предговор</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Съдържание: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Фигура <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Фигура <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Таблица <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Таблица <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Свързана информация</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Глава <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Приложение <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Глава <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Необходимо прочистване]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> на страница <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Страница <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Избираем:</variable>
-    <variable id="Required Step">Задължителен:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Терминологичен речник</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Таблици</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Фигури</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Съдържание</variable>
+  <variable id="Index Continued String">продължение</variable>
+  <variable id="Index See String">, Вижте </variable>
+  <variable id="Index See Also String">Вижте също </variable>
+  <variable id="Table of Contents Chapter">Глава <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Приложение <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Глава <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Предговор: </variable>
+  <variable id="Preface title">Предговор</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Съдържание: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Фигура <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Фигура <param ref-name="number"/></variable>
+  <variable id="Table.title">Таблица <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Таблица <param ref-name="number"/></variable>
+  <variable id="Related Links">Свързана информация</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Глава <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Приложение <param ref-name="number"/></variable>
+  <variable id="Part with number">Глава <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Необходимо прочистване]</variable>
+  <variable id="On the page"> на страница <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Страница <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Избираем:</variable>
+  <variable id="Required Step">Задължителен:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Терминологичен речник</variable>
+  <variable id="List of Tables">Таблици</variable>
+  <variable id="List of Figures">Фигури</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Съдържание</variable>
@@ -132,10 +48,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Предговор: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Предговор</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -145,8 +58,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Съдържание: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -216,38 +127,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -266,24 +145,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Терминологичен речник</variable>
      
@@ -293,6 +155,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Фигури</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sadržaj</variable>
-
-    <!-- TODO: Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">continued</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vidi </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vidi takođe </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Predgovor: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Predgovor</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Sadržaj: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Slika <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tablice <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tablice <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Srodne informacije</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Dio <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Potrebno čišćenje]</variable>
-
-    <!-- TODO: Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
-
-    <!-- TODO: Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> page <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcionalno:</variable>
-    <variable id="Required Step">Potrebno:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Rječnik</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tablice</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Slike</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sadržaj</variable>
+  <variable id="Index Continued String">continued</variable>
+  <variable id="Index See String">, Vidi </variable>
+  <variable id="Index See Also String">Vidi takođe </variable>
+  <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Predgovor: </variable>
+  <variable id="Preface title">Predgovor</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title"-->
+  <variable id="Mini Toc">Sadržaj: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Slika <param ref-name="number"/></variable>
+  <variable id="Table.title">Tablice <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tablice <param ref-name="number"/></variable>
+  <variable id="Related Links">Srodne informacije</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
+  <variable id="Part with number">Dio <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Potrebno čišćenje]</variable>
+  <variable id="On the page"> on page <param ref-name="pagenum"/></variable><!--TODO:On the page-->
+  <variable id="Page"> page <param ref-name="pagenum"/></variable><!--TODO:page-->
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcionalno:</variable>
+  <variable id="Required Step">Potrebno:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Rječnik</variable>
+  <variable id="List of Tables">Tablice</variable>
+  <variable id="List of Figures">Slike</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sadržaj</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Predgovor: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Predgovor</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Sadržaj: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Rječnik</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prefaci | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prefaci | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Contingut</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">continuació</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vegeu </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vegeu també </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Capítol <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Apèndix <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Peça <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prefaci: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Prefaci</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Contingut: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figura <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Taula <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Taula <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Informació relacionada</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Capítol <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Apèndix <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Peça <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Per revisar]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> a la pàgina <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> pàgina <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcional:</variable>
-    <variable id="Required Step">Necessari:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glossari</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Taules</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Figures</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prefaci | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prefaci | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Contingut</variable>
+  <variable id="Index Continued String">continuació</variable>
+  <variable id="Index See String">, Vegeu </variable>
+  <variable id="Index See Also String">Vegeu també </variable>
+  <variable id="Table of Contents Chapter">Capítol <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Apèndix <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Peça <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prefaci: </variable>
+  <variable id="Preface title">Prefaci</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Contingut: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figura <param ref-name="number"/></variable>
+  <variable id="Table.title">Taula <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Taula <param ref-name="number"/></variable>
+  <variable id="Related Links">Informació relacionada</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Capítol <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Apèndix <param ref-name="number"/></variable>
+  <variable id="Part with number">Peça <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Per revisar]</variable>
+  <variable id="On the page"> a la pàgina <param ref-name="pagenum"/></variable>
+  <variable id="Page"> pàgina <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcional:</variable>
+  <variable id="Required Step">Necessari:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossari</variable>
+  <variable id="List of Tables">Taules</variable>
+  <variable id="List of Figures">Figures</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prefaci | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prefaci | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Contingut</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prefaci: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Prefaci</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Contingut: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glossari</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figures</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2017 IBM Corporation
+
+See the accompanying LICENSE file for applicable license.
+-->
+<vars xmlns="http://www.idiominc.com/opentopic/vars">
+  <!-- 
+   
+    This file defines common variables that appear in the published output.
+    These variables do not use any localized text, although they
+    may use variables that supply localized text.
+    
+    Any common variable may be copied into <locale ISO code>.xml to provide a 
+    locale-specific version of the variable.
+    
+  -->
+
+  <!-- Product name to be placed inside headers etc. -->
+  <variable id="Product Name"/>
+
+  <!-- The header that appears on the odd-numbered table of contents pages. --> 
+  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
+
+  <!-- The header that appears on the odd-numbered table of contents pages. --> 
+  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+
+  <!-- The footer that appears on odd-numbered pages. -->
+  <variable id="Body odd footer"/>
+
+  <!-- The footer that appears on even-numbered pages. -->
+  <variable id="Body even footer"/>
+
+  <!-- The footer that appears on the first page of a chapter. -->
+  <variable id="Body first footer"/>
+
+  <!-- The header that appears on the first page of a chapter. -->
+  <variable id="Body first header"/>
+
+  <!-- The header that appears on odd-numbered pages. -->
+  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
+
+  <!-- The header that appears on even-numbered pages. -->
+  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+
+  <!-- The footer that appears on Preface odd-numbered pages. -->
+  <variable id="Preface odd footer"/>
+
+  <!-- The footer that appears on Preface even-numbered pages. -->
+  <variable id="Preface even footer"/>
+
+  <!-- The footer that appears on the first page of a Preface -->
+  <variable id="Preface first footer"/>
+
+  <!-- The header that appears on Preface first page. -->
+  <variable id="Preface first header"/>
+
+  <!-- The footer that appears on the odd-numbered table of contents pages. --> 
+  <variable id="Toc odd footer"/>
+
+  <!-- The footer that appears on the even-numbered table of contents pages. --> 
+  <variable id="Toc even footer"/>
+
+  <!-- The footer that appears on the odd-numbered index pages. -->
+  <variable id="Index odd footer"/>
+
+  <!-- The footer that appears on the even-numbered index pages. -->
+  <variable id="Index even footer"/>
+
+  <!-- The header that appears on the odd-numbered index pages. -->
+  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
+
+  <!-- The header that appears on the even-numbered index pages. -->
+  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+  
+  <!-- The footer that appears on the odd-numbered glossary pages. -->
+  <variable id="Glossary odd footer"/>
+  
+  <!-- The footer that appears on the even-numbered glossary pages. -->
+  <variable id="Glossary even footer"/>
+  
+  <!-- The header that appears on the odd-numbered glossary pages. -->
+  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
+  
+  <!-- The header that appears on the even-numbered glossary pages. -->
+  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+
+  <!-- The formatting used to display ordered lists (e.g., "1., 2." or "1), 2)" -->
+  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
+  <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
+  <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
+  <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
+  <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
+  <variable id="Ordered List Format 1">1</variable>
+  <variable id="Ordered List Format 2">a</variable>
+  <variable id="Ordered List Format 3">1</variable>
+  <variable id="Ordered List Format 4">a</variable>
+
+  <!-- The unordered list bullet   -->
+  <variable id="Unordered List bullet">•</variable>
+  <variable id="Unordered List bullet 1">•</variable>
+  <variable id="Unordered List bullet 2">•</variable>
+  <variable id="Unordered List bullet 3">•</variable>
+  <variable id="Unordered List bullet 4">•</variable>
+
+  <!-- The string used to label a preface within the table of contents. -->
+  <variable id="Table of Contents Notices"/>
+
+  <!-- French, Japanese override #note-separator -->
+  <variable id="#note-separator">: </variable>
+
+  <!-- To restore finger image used before 2.2, reference the image: Configuration/OpenTopic/cfg/common/artwork/hand.gif -->
+  <!-- Image path to use for a note of "note" type. -->
+  <variable id="note Note Image Path"></variable>
+  <!-- Image path to use for a note of "notice" type. -->
+  <variable id="notice Note Image Path"></variable>
+  <!-- Image path to use for a note of "attention" type. -->
+  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <!-- Image path to use for a note of "caution" type. -->
+  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <!-- Image path to use for a note of "danger" type. -->
+  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <!-- Image path to use for a note of "warning" type. -->
+  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <!-- Image path to use for a note of "fastpath" type. -->
+  <variable id="fastpath Note Image Path"></variable>
+  <!-- Image path to use for a note of "important" type. -->
+  <variable id="important Note Image Path"></variable>
+  <!-- Image path to use for a note of "remember" type. -->
+  <variable id="remember Note Image Path"></variable>
+  <!-- Image path to use for a note of "restriction" type. -->
+  <variable id="restriction Note Image Path"></variable>
+  <!-- Image path to use for a note of "tip" type. -->
+  <variable id="tip Note Image Path"></variable>
+  <!-- Image path to use for a note of "troubleshooting" type. -->
+  <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <!-- Image path to use for a note of "other" type. -->
+  <variable id="other Note Image Path"></variable>
+
+  <!--Numbering and format for task steps-->
+  <variable id="Step Number"><param ref-name="number"/>. </variable>
+  <variable id="Step Format">1</variable>
+  <variable id="Substep Number"><param ref-name="number"/>) </variable>
+  <variable id="Substep Format">a</variable>
+
+  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
+  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
+    
+</vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Úvod | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Úvod | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Obsah</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">pokračování</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Viz </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Viz též </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Kapitola <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatek <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Část <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Úvod: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Úvod</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Obsah: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Obrázek <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Obrázek <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabulka <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabulka <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Související informace</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Část <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Nutno opravit]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na stránce <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> stránka <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Volitelné:</variable>
-    <variable id="Required Step">Požadované:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Slovníček</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabulky</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Obrázky</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Úvod | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Úvod | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Obsah</variable>
+  <variable id="Index Continued String">pokračování</variable>
+  <variable id="Index See String">, Viz </variable>
+  <variable id="Index See Also String">Viz též </variable>
+  <variable id="Table of Contents Chapter">Kapitola <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatek <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Část <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Úvod: </variable>
+  <variable id="Preface title">Úvod</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Obsah: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Obrázek <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Obrázek <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabulka <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabulka <param ref-name="number"/></variable>
+  <variable id="Related Links">Související informace</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
+  <variable id="Part with number">Část <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Nutno opravit]</variable>
+  <variable id="On the page"> na stránce <param ref-name="pagenum"/></variable>
+  <variable id="Page"> stránka <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Volitelné:</variable>
+  <variable id="Required Step">Požadované:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Slovníček</variable>
+  <variable id="List of Tables">Tabulky</variable>
+  <variable id="List of Figures">Obrázky</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Úvod | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Úvod | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Obsah</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Úvod: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Úvod</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Obsah: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Slovníček</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Obrázky</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Indholdsfortegnelse</variable>
@@ -124,16 +40,13 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Tillæg <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Del <param ref-name="number"/>: </variable>
 
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Forord: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Forord</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -143,8 +56,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Indholdsfortegnelse: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -214,38 +125,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -264,24 +143,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Ordliste</variable>
      
@@ -291,6 +153,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figurer</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -7,150 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Indholdsfortegnelse</variable>
-
-    <variable id="Index Continued String"></variable>
-
-    <!--string before see element-->
-    <variable id="Index See String">, Se </variable>
-
-    <!--string before see also element-->
-    <variable id="Index See Also String">Se også </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Tillæg <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Del <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Forord: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Forord</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Indholdsfortegnelse: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figur <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figur <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabel <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Beslægtede oplysninger</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Kapitel <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Tillæg <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Del <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Påkrævet oprydning]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> på side <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> side <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Valgfrit:</variable>
-    <variable id="Required Step">Påkrævet:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Ordliste</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabeller</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Figurer</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Indholdsfortegnelse</variable>
+  <variable id="Index Continued String"></variable>
+  <variable id="Index See String">, Se </variable>
+  <variable id="Index See Also String">Se også </variable>
+  <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Tillæg <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Del <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Forord: </variable>
+  <variable id="Preface title">Forord</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Indholdsfortegnelse: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Figur <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figur <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabel <param ref-name="number"/></variable>
+  <variable id="Related Links">Beslægtede oplysninger</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Kapitel <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Tillæg <param ref-name="number"/></variable>
+  <variable id="Part with number">Del <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Påkrævet oprydning]</variable>
+  <variable id="On the page"> på side <param ref-name="pagenum"/></variable>
+  <variable id="Page"> side <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Valgfrit:</variable>
+  <variable id="Required Step">Påkrævet:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Ordliste</variable>
+  <variable id="List of Tables">Tabeller</variable>
+  <variable id="List of Figures">Figurer</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -30,138 +30,50 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Inhalt</variable>
-
-    <variable id="Index Continued String">Fortsetzung</variable>
-    <variable id="Index See String">, Siehe </variable>
-    <variable id="Index See Also String">Siehe auch </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Anhang <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Teil <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Einleitung </variable>
-
-    <variable id="Preface title">Einleitung</variable>
-    
-    <!-- The string used to label an notices in body text. -->
-    <variable id="Notices title"/>
-    
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">Themen: </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Abbildung  <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Abbildung  <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabelle <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabelle <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Verwandte Links</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Querverweis auf: </variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Inhaltsverweis auf: </variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">Listenelement.</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">Fußnote.</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigationstitel</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Suchtitel</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Kapitel  <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Anhang  <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Teil <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Erforderliche Bereinigung]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> auf Seite <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Seite <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">diese Verbindung</variable>
-
-    <!-- The title of the links to child topics -->
-    <variable id="Child topics"/>
-
-    <!-- The title of the links to Related references -->
-    <variable id="Related references"/>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Optional:</variable>
-    <variable id="Required Step">Erforderlich:</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-    <variable id="Glossary">Glossar</variable>
-    <variable id="List of Tables">Tabellenverzeichnis</variable>
-    <variable id="List of Figures">Abbildungsverzeichnis</variable>
-
+  <variable id="Preface odd header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
+  <variable id="Table of Contents">Inhalt</variable>
+  <variable id="Index Continued String">Fortsetzung</variable>
+  <variable id="Index See String">, Siehe </variable>
+  <variable id="Index See Also String">Siehe auch </variable>
+  <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Anhang <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Teil <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Einleitung </variable>
+  <variable id="Preface title">Einleitung</variable>
+  <variable id="Notices title"><!--TODO:Notices title--></variable>
+  <variable id="Mini Toc">Themen: </variable>
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title">Abbildung  <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Abbildung  <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabelle <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabelle <param ref-name="number"/></variable>
+  <variable id="Related Links">Verwandte Links</variable>
+  <variable id="Cross-Reference">Querverweis auf: </variable><!--UNUSED-->
+  <variable id="Content-Reference">Inhaltsverweis auf: </variable><!--UNUSED-->
+  <variable id="List item">Listenelement.</variable>
+  <variable id="Foot note">Fußnote.</variable>
+  <variable id="Navigation title">Navigationstitel</variable>
+  <variable id="Search title">Suchtitel</variable>
+  <variable id="Chapter with number">Kapitel  <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Anhang  <param ref-name="number"/></variable>
+  <variable id="Part with number">Teil <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Erforderliche Bereinigung]</variable>
+  <variable id="On the page"> auf Seite <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Seite <param ref-name="pagenum"/></variable>
+  <variable id="This link">diese Verbindung</variable><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references"/><!--UNUSED-->
+  <variable id="Optional Step">Optional:</variable>
+  <variable id="Required Step">Erforderlich:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossar</variable>
+  <variable id="List of Tables">Tabellenverzeichnis</variable>
+  <variable id="List of Figures">Abbildungsverzeichnis</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -40,96 +40,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <!-- Inhaltsverzeichnis -->
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Inhalt</variable>
@@ -150,9 +65,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Einleitung </variable>
 
-    <!-- The string used to label Notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
     <variable id="Preface title">Einleitung</variable>
     
     <!-- The string used to label an notices in body text. -->
@@ -161,8 +73,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
     <variable id="Mini Toc">Themen: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice"><!--TODO:Notice--></variable>
@@ -231,38 +141,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">diese Verbindung</variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- The title of the links to child topics -->
     <variable id="Child topics"/>
 
@@ -281,18 +159,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+    
     <variable id="Glossary">Glossar</variable>
     <variable id="List of Tables">Tabellenverzeichnis</variable>
     <variable id="List of Figures">Abbildungsverzeichnis</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Πρόλογος | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Πρόλογος | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Περιεχόμενα</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">συνέχεια</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Βλ. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Βλ. επίσης </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Κεϕάλαιο <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Παράρτημα <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Μέρος <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Πρόλογος: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Πρόλογος</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Περιεχόμενα: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Σχήμα <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Σχήμα <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Πίνακας <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Πίνακας <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Συναφείς πληροφορίες</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Κεϕάλαιο <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Παράρτημα <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Μέρος <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Απαιτείται διόρθωση]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> στη σελίδα <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Σελίδα <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Προαιρετικά:</variable>
-    <variable id="Required Step">Απαιτείται:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Γλωσσάρι</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Πίνακες</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Σχήματα</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Πρόλογος | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Πρόλογος | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Περιεχόμενα</variable>
+  <variable id="Index Continued String">συνέχεια</variable>
+  <variable id="Index See String">, Βλ. </variable>
+  <variable id="Index See Also String">Βλ. επίσης </variable>
+  <variable id="Table of Contents Chapter">Κεϕάλαιο <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Παράρτημα <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Μέρος <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Πρόλογος: </variable>
+  <variable id="Preface title">Πρόλογος</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Περιεχόμενα: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Σχήμα <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Σχήμα <param ref-name="number"/></variable>
+  <variable id="Table.title">Πίνακας <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Πίνακας <param ref-name="number"/></variable>
+  <variable id="Related Links">Συναφείς πληροφορίες</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Κεϕάλαιο <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Παράρτημα <param ref-name="number"/></variable>
+  <variable id="Part with number">Μέρος <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Απαιτείται διόρθωση]</variable>
+  <variable id="On the page"> στη σελίδα <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Σελίδα <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Προαιρετικά:</variable>
+  <variable id="Required Step">Απαιτείται:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Γλωσσάρι</variable>
+  <variable id="List of Tables">Πίνακες</variable>
+  <variable id="List of Figures">Σχήματα</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Πρόλογος | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Πρόλογος | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Περιεχόμενα</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Πρόλογος: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Πρόλογος</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Περιεχόμενα: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Γλωσσάρι</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Σχήματα</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -33,10 +33,15 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- 
      
-      This file controls strings that appear in the published output.  
+      This file controls strings that appear in the published output.
       There is one version of this file per language.  To add support 
       for a new language, simply create a copy of this file and name 
       it using the <locale ISO code>.xml format.
+      
+      Variables with no localized text, common to all (or nearly all)
+      languages, are stored in commonstrings.xml. Any common string
+      may be copied into <locale ISO code>.xml to provide a 
+      local-specific value for the common variable.
       
     -->
 
@@ -44,91 +49,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Introduction | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Introduction | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Contents</variable>
@@ -147,16 +72,13 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Appendix <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Part <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Preface: </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Preface</variable>
 
     <!-- The string used to label an notices in body text. -->
@@ -165,8 +87,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
     <variable id="Mini Toc">Topics: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -235,40 +155,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">this link</variable>
 
-    <!-- Since 2.2, remove the default pointing finger icon for note, notice, fastpath, important, remember, restriction, tip, other. -->
-    <!-- To restore for any note type, reference the image: Configuration/OpenTopic/cfg/common/artwork/hand.gif -->
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- The title of the links to child topics -->
     <variable id="Child topics">Child Topics</variable>
 
@@ -287,23 +173,6 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
      
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glossary</variable>
@@ -313,7 +182,5 @@ See the accompanying LICENSE file for applicable license.
      
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">List of Figures</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
+     
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -30,157 +30,146 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
+  <!-- 
+   
+    This file controls strings that appear in the published output.
+    There is one version of this file per language.  To add support 
+    for a new language, simply create a copy of this file and name 
+    it using the <locale ISO code>.xml format.
+    
+    Variables with no localized text, common to all (or nearly all)
+    languages, are stored in commonstrings.xml. Any common string
+    may be copied into <locale ISO code>.xml to provide a 
+    local-specific value for the common variable.
+    
+  -->
 
-    <!-- 
+  <!-- The header that appears on Preface odd-numbered pages. -->
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Introduction | <param ref-name="pagenum"/></variable>
+
+  <!-- The header that appears on Preface even-numbered pages. -->
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Introduction | <param ref-name="prodname"/></variable>
+
+  <!-- The heading to put at the top of the Table of Contents -->
+  <variable id="Table of Contents">Contents</variable>
+
+  <!-- Indicates when an index continues from the previous page -->
+  <variable id="Index Continued String">continued</variable>
+
+  <!-- Appears before <index-see> element content -->
+  <variable id="Index See String">, See </variable>
+
+  <!-- Appears before <index-see-also> element content -->
+  <variable id="Index See Also String">See also </variable>
+
+  <!-- Label for a chapter within the table of contents. -->
+  <variable id="Table of Contents Chapter">Chapter <param ref-name="number"/>: </variable>
+
+  <!-- Label for an appendix within the table of contents. -->
+  <variable id="Table of Contents Appendix">Appendix <param ref-name="number"/>: </variable>
+
+  <!-- Label for a part within the table of contents. -->
+  <variable id="Table of Contents Part">Part <param ref-name="number"/>: </variable>
+
+  <!-- Label for a preface within the table of contents. -->
+  <variable id="Table of Contents Preface">Preface: </variable>
+
+  <!-- Heading for a preface in body text. -->
+  <variable id="Preface title">Preface</variable>
+
+  <!-- Heading for the Notices topic in body text. -->
+  <variable id="Notices title">Notice</variable>
+
+  <!-- Heading to put at the top a chapter-level "mini-TOC" -->
+  <variable id="Mini Toc">Topics: </variable>
+
+  <!-- Text to use for 'Notice' label generated from <note> element. -->
+  <variable id="Notice">Notice</variable>
+
+  <!-- Text to use for figure titles, with title text or only figure number. -->
+  <variable id="Figure.title">Figure <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figure <param ref-name="number"/></variable>
+
+  <!-- Text to use for table titles, with title text or only table number. -->
+  <variable id="Table.title">Table <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Table <param ref-name="number"/></variable>
+
+  <!-- Text to use for related links label. -->
+  <variable id="Related Links">Related Links</variable>
+
+  <!-- UNUSED: Default cross-reference text prefix. Previously used to generate reference 
+       text in case text is unresolvable and not specified in source. -->
+  <variable id="Cross-Reference">Cross-Reference to:</variable>
+
+  <!-- UNUSED: Previously used for unresolved content reference. -->
+  <variable id="Content-Reference">Unresolved content reference to:</variable>
+
+  <!-- Default title text for references to a list item. Used when reference
+       has no specified  content, reference target is a list item, and
+       no list item number can be determined. -->
+  <variable id="List item">List item.</variable>
+
+  <!-- Default title text for referenced footnote. Used when reference has
+       no specified content, reference target is a footnote, and footnote
+       label cannot be determined. -->
+  <variable id="Foot note">Footnote.</variable>
+
+  <!-- Label for a navigation title, included when publishing draft content. -->
+  <variable id="Navigation title">Navigation title</variable>
+
+  <!-- Label for a search title, included when publishing draft content. -->
+  <variable id="Search title">Search title</variable>
+
+  <!-- Heading prefix for chapter titles.-->
+  <variable id="Chapter with number">Chapter <param ref-name="number"/></variable>
+
+  <!-- Heading prefix for appendix titles.-->
+  <variable id="Appendix with number">Appendix <param ref-name="number"/></variable>
+
+  <!-- Heading prefix for part titles.-->
+  <variable id="Part with number">Part <param ref-name="number"/></variable>
+
+  <!-- Label for content of <required-cleanup> element. -->
+  <variable id="Required-Cleanup">[Required-Cleanup]</variable>
+
+  <!-- Template for generated page number of a reference in printed manual. -->
+  <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
+
+  <!-- Template for generated page number of a reference
+       in printed manual, when referenced element has no title. -->
+  <variable id="Page"> page <param ref-name="pagenum"/></variable>
+
+  <!-- UNUSED: Template for generated page number of a reference
+       in chm/html, when referenced element has no title. -->
+  <variable id="This link">this link</variable>
+
+  <!-- UNUSED: The title of links to child topics. -->
+  <variable id="Child topics">Child Topics</variable>
+
+  <!-- UNUSED: The title of links to Related references -->
+  <variable id="Related references">Related References</variable>
+
+  <!-- Labels for a step with importance="optional" or importance="required" -->
+  <variable id="Optional Step">Optional:</variable>
+  <variable id="Required Step">Required:</variable>
+
+  <!--Labels for task sections. These are kept for backwards compatibility, actual
+      labels are now stored in common strings files. -->
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
      
-      This file controls strings that appear in the published output.
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-      Variables with no localized text, common to all (or nearly all)
-      languages, are stored in commonstrings.xml. Any common string
-      may be copied into <locale ISO code>.xml to provide a 
-      local-specific value for the common variable.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Introduction | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Introduction | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Contents</variable>
-
-    <variable id="Index Continued String">continued</variable>
-
-    <!--string before see element-->
-    <variable id="Index See String">, See </variable>
-
-    <!--string before see also element-->
-    <variable id="Index See Also String">See also </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Chapter <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Appendix <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Part <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Preface: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Preface</variable>
-
-    <!-- The string used to label an notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">Topics: </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figure <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figure <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Table <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Table <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Related Links</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Chapter <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Appendix <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Part <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Required-Cleanup]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> page <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">this link</variable>
-
-    <!-- The title of the links to child topics -->
-    <variable id="Child topics">Child Topics</variable>
-
-    <!-- The title of the links to Related references -->
-    <variable id="Related references">Related References</variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Optional:</variable>
-    <variable id="Required Step">Required:</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
+  <!-- Heading for a Glossary topic -->
+  <variable id="Glossary">Glossary</variable>
      
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glossary</variable>
+  <!-- Heading for a generated List of Tables -->
+  <variable id="List of Tables">List of Tables</variable>
      
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">List of Tables</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">List of Figures</variable>
+  <!-- Heading for a generated List of Figures -->
+  <variable id="List of Figures">List of Figures</variable>
      
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -40,96 +40,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prefacio | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prefacio | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <!-- Contenido -->
-    <variable id="Toc odd header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Contents</variable>
@@ -150,16 +65,11 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prefacio </variable>
 
-    <!-- The string used to label Notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
     <variable id="Preface title">Prefacio</variable>
 
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
     <variable id="Mini Toc">Temas: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice"><!--TODO:Notice--></variable>
@@ -228,38 +138,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">este acoplamiento</variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>
     <variable id="Required Step">Necesario:</variable>
@@ -272,18 +150,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+    
     <variable id="Glossary">Glosario</variable>
     <variable id="List of Tables">Lista de tablas</variable>
     <variable id="List of Figures">Lista de figuras</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -30,130 +30,48 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format. 
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prefacio | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prefacio | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Contents</variable>
-
-    <variable id="Index Continued String">continuado</variable>
-    <variable id="Index See String">, Ver </variable>
-    <variable id="Index See Also String">Ver también </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Apéndice <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prefacio </variable>
-
-    <variable id="Preface title">Prefacio</variable>
-    <variable id="Notices title"/>
-     
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">Temas: </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figura  <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figura  <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabla <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabla <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Vínculos relacionados</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Referencia cruzada a: </variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Referencia de contenido a: </variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">Elemento de lista.</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">Nota al pie.</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Título de navegación</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Buscar título</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Apéndice <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Parte <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Limpie Requerido]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> en la página <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> página <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">este acoplamiento</variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcional:</variable>
-    <variable id="Required Step">Necesario:</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-    <variable id="Glossary">Glosario</variable>
-    <variable id="List of Tables">Lista de tablas</variable>
-    <variable id="List of Figures">Lista de figuras</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prefacio | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prefacio | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Contents</variable>
+  <variable id="Index Continued String">continuado</variable>
+  <variable id="Index See String">, Ver </variable>
+  <variable id="Index See Also String">Ver también </variable>
+  <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Apéndice <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prefacio </variable>
+  <variable id="Preface title">Prefacio</variable>
+  <variable id="Notices title"><!--TODO:Notices title--></variable>
+  <variable id="Mini Toc">Temas: </variable>
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title">Figura  <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figura  <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabla <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabla <param ref-name="number"/></variable>
+  <variable id="Related Links">Vínculos relacionados</variable>
+  <variable id="Cross-Reference">Referencia cruzada a: </variable><!--UNUSED-->
+  <variable id="Content-Reference">Referencia de contenido a: </variable><!--UNUSED-->
+  <variable id="List item">Elemento de lista.</variable>
+  <variable id="Foot note">Nota al pie.</variable>
+  <variable id="Navigation title">Título de navegación</variable>
+  <variable id="Search title">Buscar título</variable>
+  <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Apéndice <param ref-name="number"/></variable>
+  <variable id="Part with number">Parte <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Limpie Requerido]</variable>
+  <variable id="On the page"> en la página <param ref-name="pagenum"/></variable>
+  <variable id="Page"> página <param ref-name="pagenum"/></variable>
+  <variable id="This link">este acoplamiento</variable><!--UNUSED-->
+  <variable id="Optional Step">Opcional:</variable>
+  <variable id="Required Step">Necesario:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosario</variable>
+  <variable id="List of Tables">Lista de tablas</variable>
+  <variable id="List of Figures">Lista de figuras</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -66,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Table of Contents Preface">Prefacio </variable>
 
     <variable id="Preface title">Prefacio</variable>
-
+    <variable id="Notices title"/>
+     
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
     <variable id="Mini Toc">Temas: </variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Eessõna | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Eessõna | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sisukord</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">jätkub</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vt </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vt ka </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Peatükk <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Lisa <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Osa <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Eessõna: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Eessõna</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Sisukord: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Joonis <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Joonis <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabel <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Seostuv teave</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Peatükk <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Lisa <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Osa <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Puhastus nõutav]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> leheküljel <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> lehekülg <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Mittenõutav:</variable>
-    <variable id="Required Step">Nõutav:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Sõnastik</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabelid</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Joonised</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Eessõna | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Eessõna | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sisukord</variable>
+  <variable id="Index Continued String">jätkub</variable>
+  <variable id="Index See String">, Vt </variable>
+  <variable id="Index See Also String">Vt ka </variable>
+  <variable id="Table of Contents Chapter">Peatükk <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Lisa <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Osa <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Eessõna: </variable>
+  <variable id="Preface title">Eessõna</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Sisukord: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Joonis <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Joonis <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabel <param ref-name="number"/></variable>
+  <variable id="Related Links">Seostuv teave</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Peatükk <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Lisa <param ref-name="number"/></variable>
+  <variable id="Part with number">Osa <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Puhastus nõutav]</variable>
+  <variable id="On the page"> leheküljel <param ref-name="pagenum"/></variable>
+  <variable id="Page"> lehekülg <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Mittenõutav:</variable>
+  <variable id="Required Step">Nõutav:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Sõnastik</variable>
+  <variable id="List of Tables">Tabelid</variable>
+  <variable id="List of Figures">Joonised</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Eessõna | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Eessõna | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sisukord</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Eessõna: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Eessõna</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Sisukord: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Sõnastik</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Joonised</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Taulu <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Table Number">Taulu <param ref-name="number"/></variable>
   <variable id="Related Links"><!--TODO:Related Links--></variable>
-  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
-  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
+  <variable id="Cross-Reference"/><!--UNUSED-->
+  <variable id="Content-Reference"/><!--UNUSED-->
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -38,9 +38,9 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup"><!--TODO:[Required-Cleanup]--></variable>
   <variable id="On the page"/>
   <variable id="Page"> sivu <param ref-name="pagenum"/></variable>
-  <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="Child topics"><!--TODO:Child Topics--></variable>
-  <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>  
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable><!--UNUSED-->
   <variable id="Optional Step">Valinnainen:</variable>
   <variable id="Required Step">Pakollinen:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -7,43 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | <variable id="Preface title"/> | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | <variable id="Preface title"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Sisällys</variable>
-  
   <variable id="Index Continued String">jatkoa</variable>
   <variable id="Index See String">, Katso </variable>
   <variable id="Index See Also String">Katso myös </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Liite <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Osa <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Preface">Esipuhe: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Esipuhe</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>
-  <variable id="Mini Toc"><!--TODO:Topics: --></variable>
-  <variable id="#note-separator">: </variable>
-  
+  <variable id="Mini Toc"><!--TODO:Topics: --></variable>  
   <variable id="Notice"><!--TODO:Notice--></variable>
-
   <variable id="Figure.title">Kuva <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Figure Number">Kuva <param ref-name="number"/></variable>
   <variable id="Table.title">Taulu <param ref-name="number"/>. <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"/>
   <variable id="Page"> sivu <param ref-name="pagenum"/></variable>
   <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics"><!--TODO:Child Topics--></variable>
-
-  <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>
-  
+  <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>  
   <variable id="Optional Step">Valinnainen:</variable>
   <variable id="Required Step">Pakollinen:</variable>
   <!--Labels for task sections, now reused from common-->
@@ -103,18 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">Sanasto</variable>
   <variable id="List of Tables">Luettelo tauluista</variable>
   <variable id="List of Figures">Luettelo kuvista</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -31,6 +31,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
+  <variable id="Search title"><!--TODO:Search title--></variable>
   <variable id="Chapter with number">Luku <param ref-name="number"/></variable>
   <variable id="Appendix with number">Liite <param ref-name="number"/></variable>
   <variable id="Part with number">Osa <param ref-name="number"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -66,6 +66,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Table of Contents Preface">Préface </variable>
 
     <variable id="Preface title">Préface</variable>
+    <variable id="Notices title"/>
 
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -40,96 +40,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-  
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Préface | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Préface | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <!-- Table des matières -->
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Table des matières</variable>
@@ -149,9 +64,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Préface </variable>
-
-    <!-- The string used to label Notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
 
     <variable id="Preface title">Préface</variable>
 
@@ -228,38 +140,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">ce lien</variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Facultatif :</variable>
     <variable id="Required Step">Obligatoire :</variable>
@@ -272,18 +152,8 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
     <variable id="Glossary">Glossaire</variable>
     <variable id="List of Tables">Liste des tableaux</variable>
     <variable id="List of Figures">Liste des illustrations</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -30,131 +30,49 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format. 
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Préface | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Préface | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Table des matières</variable>
-
-    <variable id="Index Continued String">a continué</variable>
-    <variable id="Index See String">, Voir </variable>
-    <variable id="Index See Also String">Voir aussi </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Chapitre <param ref-name="number"/> : </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Annexe <param ref-name="number"/> : </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Partie <param ref-name="number"/> : </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Préface </variable>
-
-    <variable id="Preface title">Préface</variable>
-    <variable id="Notices title"/>
-
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">Sujets :</variable>
-
-    <variable id="#note-separator"> : </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Illustration <param ref-name="number"/> : <param ref-name="title"/></variable>
-    <variable id="Figure Number">Illustration <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tableau <param ref-name="number"/> : <param ref-name="title"/></variable>
-    <variable id="Table Number">Tableau <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Liens connexes</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Référence croisée vers :</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Référence de contenu vers :</variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">Articles.</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">Note de bas de page.</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Titre de navigation</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Titre de recherche</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Chapitre <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Annexe <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Partie <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Nettoyage obligatoire]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> à la page <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> la page <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">ce lien</variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Facultatif :</variable>
-    <variable id="Required Step">Obligatoire :</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    <variable id="Glossary">Glossaire</variable>
-    <variable id="List of Tables">Liste des tableaux</variable>
-    <variable id="List of Figures">Liste des illustrations</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Préface | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Préface | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Table des matières</variable>
+  <variable id="Index Continued String">a continué</variable>
+  <variable id="Index See String">, Voir </variable>
+  <variable id="Index See Also String">Voir aussi </variable>
+  <variable id="Table of Contents Chapter">Chapitre <param ref-name="number"/> : </variable>
+  <variable id="Table of Contents Appendix">Annexe <param ref-name="number"/> : </variable>
+  <variable id="Table of Contents Part">Partie <param ref-name="number"/> : </variable>
+  <variable id="Table of Contents Preface">Préface </variable>
+  <variable id="Preface title">Préface</variable>
+  <variable id="Notices title"><!--TODO:Notices title--></variable>
+  <variable id="Mini Toc">Sujets :</variable>
+  <variable id="#note-separator"> : </variable>
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title">Illustration <param ref-name="number"/> : <param ref-name="title"/></variable>
+  <variable id="Figure Number">Illustration <param ref-name="number"/></variable>
+  <variable id="Table.title">Tableau <param ref-name="number"/> : <param ref-name="title"/></variable>
+  <variable id="Table Number">Tableau <param ref-name="number"/></variable>
+  <variable id="Related Links">Liens connexes</variable>
+  <variable id="Cross-Reference">Référence croisée vers :</variable><!--UNUSED-->
+  <variable id="Content-Reference">Référence de contenu vers :</variable><!--UNUSED-->
+  <variable id="List item">Articles.</variable>
+  <variable id="Foot note">Note de bas de page.</variable>
+  <variable id="Navigation title">Titre de navigation</variable>
+  <variable id="Search title">Titre de recherche</variable>
+  <variable id="Chapter with number">Chapitre <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Annexe <param ref-name="number"/></variable>
+  <variable id="Part with number">Partie <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Nettoyage obligatoire]</variable>
+  <variable id="On the page"> à la page <param ref-name="pagenum"/></variable>
+  <variable id="Page"> la page <param ref-name="pagenum"/></variable>
+  <variable id="This link">ce lien</variable><!--UNUSED-->
+  <variable id="Optional Step">Facultatif :</variable>
+  <variable id="Required Step">Obligatoire :</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossaire</variable>
+  <variable id="List of Tables">Liste des tableaux</variable>
+  <variable id="List of Figures">Liste des illustrations</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -31,6 +31,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
+  <variable id="Search title"><!--TODO:Search title--></variable>
   <variable id="Chapter with number">פרק <param ref-name="number"/></variable>
   <variable id="Appendix with number">נספח <param ref-name="number"/></variable>
   <variable id="Part with number">חלק <param ref-name="number"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">טבלה <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Table Number">טבלה <param ref-name="number"/></variable>
   <variable id="Related Links"><!--TODO:Related Links--></variable>
-  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
-  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
+  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable><!--UNUSED-->
+  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable><!--UNUSED-->
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -38,12 +38,11 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup"><!--TODO:[Required-Cleanup]--></variable>
   <variable id="On the page">בעמוד <param ref-name="pagenum"/></variable>
   <variable id="Page">עמוד <param ref-name="pagenum"/></variable>
-  <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="Child topics"><!--TODO:Child Topics--></variable>
-  <variable id="Related references">תיעוד קשור</variable>
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references">תיעוד קשור</variable><!--UNUSED-->
   <variable id="Optional Step">אופציונלי:</variable>
   <variable id="Required Step">דרוש:</variable>
-  <!--Labels for task sections, now reused from common-->
   <variable id="Task Prereq"></variable>
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -7,43 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | <variable id="Preface title"/> | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | <variable id="Preface title"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">תוכן העניינים</variable>
-  
   <variable id="Index Continued String">המשך</variable>
   <variable id="Index See String">, ראה </variable>
   <variable id="Index See Also String">ראה גם </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">נספח <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">חלק <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Preface">מבוא: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">מבוא</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>
   <variable id="Mini Toc">נושאים: </variable>
-  <variable id="#note-separator">: </variable>
-  
   <variable id="Notice"><!--TODO:Notice--></variable>
-
   <variable id="Figure.title">איור <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Figure Number">איור <param ref-name="number"/></variable>
   <variable id="Table.title">טבלה <param ref-name="number"/>. <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page">בעמוד <param ref-name="pagenum"/></variable>
   <variable id="Page">עמוד <param ref-name="pagenum"/></variable>
   <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics"><!--TODO:Child Topics--></variable>
-
   <variable id="Related references">תיעוד קשור</variable>
-  
   <variable id="Optional Step">אופציונלי:</variable>
   <variable id="Required Step">דרוש:</variable>
   <!--Labels for task sections, now reused from common-->
@@ -103,18 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">מילון מונחים</variable>
   <variable id="List of Tables">רשימת טבלאות</variable>
   <variable id="List of Figures">רשימת איורים</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | मुखबंध | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | मुखबंध | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">सामग्री</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">निरंतर</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, देखें </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">यह भी देखें </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">अध्याय <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">परिशिष्ट <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">भाग <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">मुखबंध: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">मुखबंध</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">सामग्री: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">आकृति <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">आकृति <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">टेबल <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">टेबल <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">संबंधित जानकारी</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">अध्याय <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">परिशिष्ट <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">भाग <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[आवश्यक परिमार्जन]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> पेज पर <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> पेज <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!--    Label for a step with importance="optional"-->
-    <variable id="Optional Step">वैकल्पिक:</variable>
-    <variable id="Required Step">आवश्यक:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">शब्दावली</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">टेबल्स</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">आंकड़े</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | मुखबंध | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | मुखबंध | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">सामग्री</variable>
+  <variable id="Index Continued String">निरंतर</variable>
+  <variable id="Index See String">, देखें </variable>
+  <variable id="Index See Also String">यह भी देखें </variable>
+  <variable id="Table of Contents Chapter">अध्याय <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">परिशिष्ट <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">भाग <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">मुखबंध: </variable>
+  <variable id="Preface title">मुखबंध</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">सामग्री: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">आकृति <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">आकृति <param ref-name="number"/></variable>
+  <variable id="Table.title">टेबल <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">टेबल <param ref-name="number"/></variable>
+  <variable id="Related Links">संबंधित जानकारी</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">अध्याय <param ref-name="number"/></variable>
+  <variable id="Appendix with number">परिशिष्ट <param ref-name="number"/></variable>
+  <variable id="Part with number">भाग <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[आवश्यक परिमार्जन]</variable>
+  <variable id="On the page"> पेज पर <param ref-name="pagenum"/></variable>
+  <variable id="Page"> पेज <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">वैकल्पिक:</variable>
+  <variable id="Required Step">आवश्यक:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">शब्दावली</variable>
+  <variable id="List of Tables">टेबल्स</variable>
+  <variable id="List of Figures">आंकड़े</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | मुखबंध | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | मुखबंध | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">सामग्री</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">मुखबंध: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">मुखबंध</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">सामग्री: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">शब्दावली</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">आंकड़े</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sadržaj</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">nastavak</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vidi </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vidi također </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Predgovor: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Predgovor</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Sadržaj: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Slika <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tablica <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tablica <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Srodne informacije</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Dio <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Zahtijevano čišćenje]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na stranici <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Stranica <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- UPDATE: Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcijsko:</variable>
-    <variable id="Required Step">Zahtijevano:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Rječnik</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tablice</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Slike</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sadržaj</variable>
+  <variable id="Index Continued String">nastavak</variable>
+  <variable id="Index See String">, Vidi </variable>
+  <variable id="Index See Also String">Vidi također </variable>
+  <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Predgovor: </variable>
+  <variable id="Preface title">Predgovor</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Sadržaj: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Slika <param ref-name="number"/></variable>
+  <variable id="Table.title">Tablica <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tablica <param ref-name="number"/></variable>
+  <variable id="Related Links">Srodne informacije</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
+  <variable id="Part with number">Dio <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Zahtijevano čišćenje]</variable>
+  <variable id="On the page"> na stranici <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Stranica <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcijsko:</variable>
+  <variable id="Required Step">Zahtijevano:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Rječnik</variable>
+  <variable id="List of Tables">Tablice</variable>
+  <variable id="List of Figures">Slike</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sadržaj</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Predgovor: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Predgovor</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Sadržaj: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Rječnik</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Bevezető | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Bevezető | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Tartalom</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">folytatás</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Lásd </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Lásd még </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter"><param ref-name="number"/>. fejezet: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix"><param ref-name="number"/>. függelék: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Rész <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Bevezető: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Bevezető</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Tartalom: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">ábra <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">ábra <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">táblázat <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">táblázat <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Kapcsolódó tájékoztatás</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number"><param ref-name="number"/>. fejezet</variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number"><param ref-name="number"/>. függelék</variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Rész <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Tisztázandó]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> oldalszám: <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> oldal <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Választható:</variable>
-    <variable id="Required Step">Kötelező:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Fogalomtár</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Táblázatok</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Ábrák</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Bevezető | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Bevezető | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Tartalom</variable>
+  <variable id="Index Continued String">folytatás</variable>
+  <variable id="Index See String">, Lásd </variable>
+  <variable id="Index See Also String">Lásd még </variable>
+  <variable id="Table of Contents Chapter"><param ref-name="number"/>. fejezet: </variable>
+  <variable id="Table of Contents Appendix"><param ref-name="number"/>. függelék: </variable>
+  <variable id="Table of Contents Part">Rész <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Bevezető: </variable>
+  <variable id="Preface title">Bevezető</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Tartalom: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">ábra <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">ábra <param ref-name="number"/></variable>
+  <variable id="Table.title">táblázat <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">táblázat <param ref-name="number"/></variable>
+  <variable id="Related Links">Kapcsolódó tájékoztatás</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number"><param ref-name="number"/>. fejezet</variable>
+  <variable id="Appendix with number"><param ref-name="number"/>. függelék</variable>
+  <variable id="Part with number">Rész <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Tisztázandó]</variable>
+  <variable id="On the page"> oldalszám: <param ref-name="pagenum"/></variable>
+  <variable id="Page"> oldal <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Választható:</variable>
+  <variable id="Required Step">Kötelező:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Fogalomtár</variable>
+  <variable id="List of Tables">Táblázatok</variable>
+  <variable id="List of Figures">Ábrák</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Bevezető | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Bevezető | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Tartalom</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Bevezető: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Bevezető</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Tartalom: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Fogalomtár</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Ábrák</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Daftar Isi</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prakata: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Prakata</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Daftar Isi: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glosarium</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Gambar</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Daftar Isi</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">dilanjutkan</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Lihat </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Lihat juga </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Bab <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Apendiks <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Bagian <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prakata: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Prakata</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Daftar Isi: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Gambar <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Gambar <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabel <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Informasi terkait</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Apendiks <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Bagian <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Pembersihan diperlukan]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> pada halaman <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> halaman <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opsional:</variable>
-    <variable id="Required Step">Diperlukan:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glosarium</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Table</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Gambar</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Daftar Isi</variable>
+  <variable id="Index Continued String">dilanjutkan</variable>
+  <variable id="Index See String">, Lihat </variable>
+  <variable id="Index See Also String">Lihat juga </variable>
+  <variable id="Table of Contents Chapter">Bab <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Apendiks <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Bagian <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prakata: </variable>
+  <variable id="Preface title">Prakata</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Daftar Isi: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Gambar <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Gambar <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabel <param ref-name="number"/></variable>
+  <variable id="Related Links">Informasi terkait</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Apendiks <param ref-name="number"/></variable>
+  <variable id="Part with number">Bagian <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Pembersihan diperlukan]</variable>
+  <variable id="On the page"> pada halaman <param ref-name="pagenum"/></variable>
+  <variable id="Page"> halaman <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opsional:</variable>
+  <variable id="Required Step">Diperlukan:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosarium</variable>
+  <variable id="List of Tables">Table</variable>
+  <variable id="List of Figures">Gambar</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Formáli | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Formáli | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Efnisyfirlit</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">framhald</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Sjá </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Sjá einnig </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter"><param ref-name="number"/>. kafli</variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Viðauki <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Hluti <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Formáli: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Formáli</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Efnisyfirlit: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Mynd <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Mynd <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tafla <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tafla <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Skyldar upplýsingar</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number"><param ref-name="number"/>. kafli</variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Viðauki <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Hluti <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Nauðsynleg hreinsun]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> á blaðsíðu <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Síða <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- UPDATE: Label for a step with importance="optional"-->
-    <variable id="Optional Step">Valfrjáls:</variable>
-    <variable id="Required Step">Tilskilið:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Orðskýringar</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Töflur</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Myndir</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Formáli | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Formáli | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Efnisyfirlit</variable>
+  <variable id="Index Continued String">framhald</variable>
+  <variable id="Index See String">, Sjá </variable>
+  <variable id="Index See Also String">Sjá einnig </variable>
+  <variable id="Table of Contents Chapter"><param ref-name="number"/>. kafli</variable>
+  <variable id="Table of Contents Appendix">Viðauki <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Hluti <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Formáli: </variable>
+  <variable id="Preface title">Formáli</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Efnisyfirlit: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Mynd <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Mynd <param ref-name="number"/></variable>
+  <variable id="Table.title">Tafla <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tafla <param ref-name="number"/></variable>
+  <variable id="Related Links">Skyldar upplýsingar</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number"><param ref-name="number"/>. kafli</variable>
+  <variable id="Appendix with number">Viðauki <param ref-name="number"/></variable>
+  <variable id="Part with number">Hluti <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Nauðsynleg hreinsun]</variable>
+  <variable id="On the page"> á blaðsíðu <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Síða <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Valfrjáls:</variable>
+  <variable id="Required Step">Tilskilið:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Orðskýringar</variable>
+  <variable id="List of Tables">Töflur</variable>
+  <variable id="List of Figures">Myndir</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Formáli | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Formáli | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Efnisyfirlit</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Formáli: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Formáli</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Efnisyfirlit: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Orðskýringar</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Myndir</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -30,130 +30,48 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Introduzione | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Introduzione | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sommario</variable>
-
-    <variable id="Index Continued String">continuato</variable>
-    <variable id="Index See String">, Vedi </variable>
-    <variable id="Index See Also String">Vedi anche </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Capitolo <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Appendice <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Introduzione </variable>
-
-    <variable id="Preface title">Introduzione</variable>
-    <variable id="Notices title"/>
-
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">Argomenti: </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title"> Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number"> Figura <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabella <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabella <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Collegamenti correlati</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Riferimento incrociato a: </variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Riferimento di contenuto a: </variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">Voce di elenco.</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">Piè di pagina.</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Titolo navigazione</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Titolo di ricerca</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Capitolo <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Appendice <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Parte <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Cleanup richiesto]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> alla pagina <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> pagina <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">questo collegamento</variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opzionale:</variable>
-    <variable id="Required Step">Richiesto:</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-    <variable id="Glossary">Glossario</variable>
-    <variable id="List of Tables">Lista delle tabelle</variable>
-    <variable id="List of Figures">Lista delle figure</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Introduzione | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Introduzione | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sommario</variable>
+  <variable id="Index Continued String">continuato</variable>
+  <variable id="Index See String">, Vedi </variable>
+  <variable id="Index See Also String">Vedi anche </variable>
+  <variable id="Table of Contents Chapter">Capitolo <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Appendice <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Introduzione </variable>
+  <variable id="Preface title">Introduzione</variable>
+  <variable id="Notices title"><!--TODO:Notices title--></variable>
+  <variable id="Mini Toc">Argomenti: </variable>
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title"> Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number"> Figura <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabella <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabella <param ref-name="number"/></variable>
+  <variable id="Related Links">Collegamenti correlati</variable>
+  <variable id="Cross-Reference">Riferimento incrociato a: </variable><!--UNUSED-->
+  <variable id="Content-Reference">Riferimento di contenuto a: </variable><!--UNUSED-->
+  <variable id="List item">Voce di elenco.</variable>
+  <variable id="Foot note">Piè di pagina.</variable>
+  <variable id="Navigation title">Titolo navigazione</variable>
+  <variable id="Search title">Titolo di ricerca</variable>
+  <variable id="Chapter with number">Capitolo <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Appendice <param ref-name="number"/></variable>
+  <variable id="Part with number">Parte <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Cleanup richiesto]</variable>
+  <variable id="On the page"> alla pagina <param ref-name="pagenum"/></variable>
+  <variable id="Page"> pagina <param ref-name="pagenum"/></variable>
+  <variable id="This link">questo collegamento</variable><!--UNUSED-->
+  <variable id="Optional Step">Opzionale:</variable>
+  <variable id="Required Step">Richiesto:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossario</variable>
+  <variable id="List of Tables">Lista delle tabelle</variable>
+  <variable id="List of Figures">Lista delle figure</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -66,6 +66,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Table of Contents Preface">Introduzione </variable>
 
     <variable id="Preface title">Introduzione</variable>
+    <variable id="Notices title"/>
 
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
@@ -140,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opzionale:</variable>
-    <variable id="Optional Step">Richiesto:</variable>
+    <variable id="Required Step">Richiesto:</variable>
 
     <!--Labels for task sections, now reused from common-->
     <variable id="Task Prereq"></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -40,96 +40,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Introduzione | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Introduzione | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <!-- Indice generale -->
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sommario</variable>
@@ -150,16 +65,11 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Introduzione </variable>
 
-    <!-- The string used to label Notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
     <variable id="Preface title">Introduzione</variable>
 
     <!-- The heading to put at the top of a chapter when creating a
          chapter-level "mini-TOC" -->
     <variable id="Mini Toc">Argomenti: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice"><!--TODO:Notice--></variable>
@@ -228,38 +138,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">questo collegamento</variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opzionale:</variable>
     <variable id="Optional Step">Richiesto:</variable>
@@ -272,18 +150,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+    
     <variable id="Glossary">Glossario</variable>
     <variable id="List of Tables">Lista delle tabelle</variable>
     <variable id="List of Figures">Lista delle figure</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -40,95 +40,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | はじめに | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | はじめに | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">目次</variable>
@@ -147,16 +63,13 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">付録 <param ref-name="number"/> : </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">第 <param ref-name="number"/> 部 : </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">序文 : </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">序文</variable>
 
     <!-- The string used to label an notices in body text. -->
@@ -235,38 +148,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link">リンク</variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- The title of the links to child topics -->
     <variable id="Child topics">下位のトピック</variable>
 
@@ -285,19 +166,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
+    
     <variable id="Glossary">用語集</variable>
     <variable id="List of Tables">表の一覧</variable>
     <variable id="List of Figures">図の一覧</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -30,145 +30,51 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | はじめに | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | はじめに | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">目次</variable>
-
-    <variable id="Index Continued String">続く</variable>
-
-    <!--string before see element-->
-    <variable id="Index See String">次を参照 :  </variable>
-
-    <!--string before see also element-->
-    <variable id="Index See Also String">次も参照 :  </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 : </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">付録 <param ref-name="number"/> : </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">第 <param ref-name="number"/> 部 : </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">序文 : </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">序文</variable>
-
-    <!-- The string used to label an notices in body text. -->
-    <variable id="Notices title">特記事項</variable>
-
-    <!-- The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC" -->
-    <variable id="Mini Toc">トピック : </variable>
-
-    <variable id="#note-separator"> : </variable>
-
-    <!-- Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">図 <param ref-name="number"/> : <param ref-name="title"/></variable>
-    <variable id="Figure Number">図 <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">表 <param ref-name="number"/> : <param ref-name="title"/></variable>
-    <variable id="Table Number">表 <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">関連リンク</variable>
-
-    <!-- Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">相互参照 : </variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">コンテンツ参照 : </variable>
-
-    <!-- Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">リスト項目</variable>
-
-    <!-- Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. -->
-    <variable id="Foot note">脚注</variable>
-
-    <!-- Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">ナビゲーション タイトル</variable>
-
-    <!-- Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">検索タイトル</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">付録 <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">第 <param ref-name="number"/> 部</variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[クリーンアップが必要]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page">（<param ref-name="pagenum"/>ページ）</variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> <param ref-name="pagenum"/> ページ</variable>
-
-    <!-- Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link">リンク</variable>
-
-    <!-- The title of the links to child topics -->
-    <variable id="Child topics">下位のトピック</variable>
-
-    <!-- The title of the links to Related references -->
-    <variable id="Related references">関連参照</variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">オプション:</variable>
-    <variable id="Required Step">必須:</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-    <variable id="Glossary">用語集</variable>
-    <variable id="List of Tables">表の一覧</variable>
-    <variable id="List of Figures">図の一覧</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | はじめに | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | はじめに | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">目次</variable>
+  <variable id="Index Continued String">続く</variable>
+  <variable id="Index See String">次を参照 :  </variable>
+  <variable id="Index See Also String">次も参照 :  </variable>
+  <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 : </variable>
+  <variable id="Table of Contents Appendix">付録 <param ref-name="number"/> : </variable>
+  <variable id="Table of Contents Part">第 <param ref-name="number"/> 部 : </variable>
+  <variable id="Table of Contents Preface">序文 : </variable>
+  <variable id="Preface title">序文</variable>
+  <variable id="Notices title">特記事項</variable>
+  <variable id="Mini Toc">トピック : </variable>
+  <variable id="#note-separator"> : </variable>
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title">図 <param ref-name="number"/> : <param ref-name="title"/></variable>
+  <variable id="Figure Number">図 <param ref-name="number"/></variable>
+  <variable id="Table.title">表 <param ref-name="number"/> : <param ref-name="title"/></variable>
+  <variable id="Table Number">表 <param ref-name="number"/></variable>
+  <variable id="Related Links">関連リンク</variable>
+  <variable id="Cross-Reference">相互参照 : </variable><!--UNUSED-->
+  <variable id="Content-Reference">コンテンツ参照 : </variable><!--UNUSED-->
+  <variable id="List item">リスト項目</variable>
+  <variable id="Foot note">脚注</variable>
+  <variable id="Navigation title">ナビゲーション タイトル</variable>
+  <variable id="Search title">検索タイトル</variable>
+  <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
+  <variable id="Appendix with number">付録 <param ref-name="number"/></variable>
+  <variable id="Part with number">第 <param ref-name="number"/> 部</variable>
+  <variable id="Required-Cleanup">[クリーンアップが必要]</variable>
+  <variable id="On the page">（<param ref-name="pagenum"/>ページ）</variable>
+  <variable id="Page"> <param ref-name="pagenum"/> ページ</variable>
+  <variable id="This link">リンク</variable><!--UNUSED-->
+  <variable id="Child topics">下位のトピック</variable><!--UNUSED-->
+  <variable id="Related references">関連参照</variable><!--UNUSED-->
+  <variable id="Optional Step">オプション:</variable>
+  <variable id="Required Step">必須:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">用語集</variable>
+  <variable id="List of Tables">表の一覧</variable>
+  <variable id="List of Figures">図の一覧</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Кіріспе | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Кіріспе | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Мазмұны</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">жалғасы бар</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Қараңыз </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Сондай-ақ қараңыз </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Бөлім <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Қосымша <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Бөлім <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Кіріспе: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Кіріспе</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Мазмұны: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Сурет <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Сурет <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Кесте <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Кесте <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Өзара байланысты ақпарат</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Бөлім <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Қосымша <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Бөлім <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">Қажет тазалау</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> бетте <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Бет <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Қосымша:</variable>
-    <variable id="Required Step">Қажет:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Глоссарий</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Кестелер</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Суреттер</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Кіріспе | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Кіріспе | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Мазмұны</variable>
+  <variable id="Index Continued String">жалғасы бар</variable>
+  <variable id="Index See String">, Қараңыз </variable>
+  <variable id="Index See Also String">Сондай-ақ қараңыз </variable>
+  <variable id="Table of Contents Chapter">Бөлім <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Қосымша <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Бөлім <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Кіріспе: </variable>
+  <variable id="Preface title">Кіріспе</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Мазмұны: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Сурет <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Сурет <param ref-name="number"/></variable>
+  <variable id="Table.title">Кесте <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Кесте <param ref-name="number"/></variable>
+  <variable id="Related Links">Өзара байланысты ақпарат</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Бөлім <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Қосымша <param ref-name="number"/></variable>
+  <variable id="Part with number">Бөлім <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">Қажет тазалау</variable>
+  <variable id="On the page"> бетте <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Бет <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Қосымша:</variable>
+  <variable id="Required Step">Қажет:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Глоссарий</variable>
+  <variable id="List of Tables">Кестелер</variable>
+  <variable id="List of Figures">Суреттер</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Кіріспе | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Кіріспе | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Мазмұны</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Кіріспе: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Кіріспе</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Мазмұны: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Глоссарий</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Суреттер</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | 서문 | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | 서문 | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">목차</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">서문: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">서문</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">목차: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">용어</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">그림</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | 서문 | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | 서문 | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">목차</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">계속</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, 참고: </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">참조: </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">제 <param ref-name="number"/> 장 </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">부록 <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">제 <param ref-name="number"/> 부 </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">서문: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">서문</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">목차: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">그림 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">그림 <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">표 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">표 <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">관련 정보</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">제 <param ref-name="number"/> 장 </variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">부록 <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">제 <param ref-name="number"/> 부</variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[수정 필요]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> 페이지 <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> 페이지 <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">옵션:</variable>
-    <variable id="Required Step">필수:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">용어</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">표</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">그림</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | 서문 | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | 서문 | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">목차</variable>
+  <variable id="Index Continued String">계속</variable>
+  <variable id="Index See String">, 참고: </variable>
+  <variable id="Index See Also String">참조: </variable>
+  <variable id="Table of Contents Chapter">제 <param ref-name="number"/> 장 </variable>
+  <variable id="Table of Contents Appendix">부록 <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">제 <param ref-name="number"/> 부 </variable>
+  <variable id="Table of Contents Preface">서문: </variable>
+  <variable id="Preface title">서문</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">목차: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">그림 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">그림 <param ref-name="number"/></variable>
+  <variable id="Table.title">표 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">표 <param ref-name="number"/></variable>
+  <variable id="Related Links">관련 정보</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">제 <param ref-name="number"/> 장 </variable>
+  <variable id="Appendix with number">부록 <param ref-name="number"/></variable>
+  <variable id="Part with number">제 <param ref-name="number"/> 부</variable>
+  <variable id="Required-Cleanup">[수정 필요]</variable>
+  <variable id="On the page"> 페이지 <param ref-name="pagenum"/></variable>
+  <variable id="Page"> 페이지 <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">옵션:</variable>
+  <variable id="Required Step">필수:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">용어</variable>
+  <variable id="List of Tables">표</variable>
+  <variable id="List of Figures">그림</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Įžanga | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Įžanga | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Turinys</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Įžanga: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Įžanga</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Turinys: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Klasynas</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Piešiniai</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Įžanga | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Įžanga | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Turinys</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">tęsinys</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Žr. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Taip pat žr. </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Skyrius <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Priedas <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Gaminys <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Įžanga: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Įžanga</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Turinys: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Piešinys <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Piešinys <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Lentelė <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Lentelė <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Susijusi informacija</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Skyrius <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Priedas <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Gaminys <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Reikalingas valymas]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> puslapyje <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Puslapis <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- UPDATE: Label for a step with importance="optional"-->
-    <variable id="Optional Step">Nebūtina:</variable>
-    <variable id="Required Step">Būtina:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Klasynas</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Lentelės</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Piešiniai</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Įžanga | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Įžanga | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Turinys</variable>
+  <variable id="Index Continued String">tęsinys</variable>
+  <variable id="Index See String">, Žr. </variable>
+  <variable id="Index See Also String">Taip pat žr. </variable>
+  <variable id="Table of Contents Chapter">Skyrius <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Priedas <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Gaminys <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Įžanga: </variable>
+  <variable id="Preface title">Įžanga</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Turinys: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Piešinys <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Piešinys <param ref-name="number"/></variable>
+  <variable id="Table.title">Lentelė <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Lentelė <param ref-name="number"/></variable>
+  <variable id="Related Links">Susijusi informacija</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Skyrius <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Priedas <param ref-name="number"/></variable>
+  <variable id="Part with number">Gaminys <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Reikalingas valymas]</variable>
+  <variable id="On the page"> puslapyje <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Puslapis <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Nebūtina:</variable>
+  <variable id="Required Step">Būtina:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Klasynas</variable>
+  <variable id="List of Tables">Lentelės</variable>
+  <variable id="List of Figures">Piešiniai</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Priekšvārds | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Priekšvārds | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Saturs</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">turpināts</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Sk. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Sk. arī </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Nodaļa <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Pielikums <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Detaļa <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Priekšvārds: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Priekšvārds</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Saturs: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Attēls <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Attēls <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabula <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabula <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Saistītā informācija</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Nodaļa <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Pielikums <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Detaļa <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Nepieciešama tīrīšana]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> lpp. <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Lpp. <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Neobligāts:</variable>
-    <variable id="Required Step">Nepieciešams:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glosārijs</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabulas</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Attēli</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Priekšvārds | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Priekšvārds | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Saturs</variable>
+  <variable id="Index Continued String">turpināts</variable>
+  <variable id="Index See String">, Sk. </variable>
+  <variable id="Index See Also String">Sk. arī </variable>
+  <variable id="Table of Contents Chapter">Nodaļa <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Pielikums <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Detaļa <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Priekšvārds: </variable>
+  <variable id="Preface title">Priekšvārds</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Saturs: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Attēls <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Attēls <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabula <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabula <param ref-name="number"/></variable>
+  <variable id="Related Links">Saistītā informācija</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Nodaļa <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Pielikums <param ref-name="number"/></variable>
+  <variable id="Part with number">Detaļa <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Nepieciešama tīrīšana]</variable>
+  <variable id="On the page"> lpp. <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Lpp. <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Neobligāts:</variable>
+  <variable id="Required Step">Nepieciešams:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosārijs</variable>
+  <variable id="List of Tables">Tabulas</variable>
+  <variable id="List of Figures">Attēli</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Priekšvārds | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Priekšvārds | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Saturs</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Priekšvārds: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Priekšvārds</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Saturs: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glosārijs</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Attēli</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Содржина</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Предговор: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Предговор</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Содржина: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Терминолошки речник</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Слики</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Содржина</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">продолжено</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Види </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Види исто </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Поглавје <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Додаток <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Дел <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Предговор: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Предговор</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Содржина: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Слика <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Слика <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Табела <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Табела <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Сродни информации</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Поглавје <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Додаток <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Дел <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Потребно средување]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> на страна <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Страна <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Изборен:</variable>
-    <variable id="Required Step">Потребен:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Терминолошки речник</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Табели</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Слики</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Содржина</variable>
+  <variable id="Index Continued String">продолжено</variable>
+  <variable id="Index See String">, Види </variable>
+  <variable id="Index See Also String">Види исто </variable>
+  <variable id="Table of Contents Chapter">Поглавје <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Додаток <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Дел <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Предговор: </variable>
+  <variable id="Preface title">Предговор</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Содржина: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Слика <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Слика <param ref-name="number"/></variable>
+  <variable id="Table.title">Табела <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Табела <param ref-name="number"/></variable>
+  <variable id="Related Links">Сродни информации</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Поглавје <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Додаток <param ref-name="number"/></variable>
+  <variable id="Part with number">Дел <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Потребно средување]</variable>
+  <variable id="On the page"> на страна <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Страна <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Изборен:</variable>
+  <variable id="Required Step">Потребен:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Терминолошки речник</variable>
+  <variable id="List of Tables">Табели</variable>
+  <variable id="List of Figures">Слики</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
+     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Kandungan</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prakata: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Prakata</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Kandungan: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glosari</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Rajah</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-     <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Kandungan</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">bersambuhg</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Lihat </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Lihat juga </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Bab <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Lampiran <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Bahagian <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prakata: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Prakata</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Kandungan: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Rajah <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Rajah <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Jadual <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Jadual <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Maklumat berkaitan</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Lampiran <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Bahagian <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Pembersihan diperlukan]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> pada halaman <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> halaman <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opsyenal:</variable>
-    <variable id="Required Step">Diperlukan:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glosari</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Jadual</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Rajah</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prakata | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prakata | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Kandungan</variable>
+  <variable id="Index Continued String">bersambuhg</variable>
+  <variable id="Index See String">, Lihat </variable>
+  <variable id="Index See Also String">Lihat juga </variable>
+  <variable id="Table of Contents Chapter">Bab <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Lampiran <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Bahagian <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prakata: </variable>
+  <variable id="Preface title">Prakata</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Kandungan: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Rajah <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Rajah <param ref-name="number"/></variable>
+  <variable id="Table.title">Jadual <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Jadual <param ref-name="number"/></variable>
+  <variable id="Related Links">Maklumat berkaitan</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Bab <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Lampiran <param ref-name="number"/></variable>
+  <variable id="Part with number">Bahagian <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Pembersihan diperlukan]</variable>
+  <variable id="On the page"> pada halaman <param ref-name="pagenum"/></variable>
+  <variable id="Page"> halaman <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opsyenal:</variable>
+  <variable id="Required Step">Diperlukan:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosari</variable>
+  <variable id="List of Tables">Jadual</variable>
+  <variable id="List of Figures">Rajah</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
   <variable id="Table Number">Tabel <param ref-name="number"/></variable>
   <variable id="Related Links">Verwante onderwerpen</variable>
-  <variable id="Cross-Reference">Verwijzing naar:</variable>
-  <variable id="Content-Reference">Verwijzing naar:</variable>
+  <variable id="Cross-Reference">Verwijzing naar:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Verwijzing naar:</variable><!--UNUSED-->
   <variable id="List item">Lijst onderdeel.</variable>
   <variable id="Foot note">Voetnoot.</variable>
   <variable id="Navigation title">Navigatietitel</variable>
@@ -38,12 +38,11 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup">[Controle nodig]</variable>
   <variable id="On the page"> op pagina <param ref-name="pagenum"/></variable>
   <variable id="Page"> pagina <param ref-name="pagenum"/></variable>
-  <variable id="This link">deze verwijzing</variable>
-  <variable id="Child topics">Onderliggende onderwerpen</variable>
-  <variable id="Related references">Verwante verwijzingen</variable>
+  <variable id="This link">deze verwijzing</variable><!--UNUSED-->
+  <variable id="Child topics">Onderliggende onderwerpen</variable><!--UNUSED-->
+  <variable id="Related references">Verwante verwijzingen</variable><!--UNUSED-->
   <variable id="Optional Step">Optioneel:</variable>
   <variable id="Required Step">Vereist:</variable>
-  <!-- Task strings now reused from common -->
   <variable id="Task Prereq"></variable>
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>
@@ -51,10 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-  <!-- The heading string to put at the top of the Glossary -->
   <variable id="Glossary">Verklarende woordenlijst</variable>
-  <!-- The heading string to put at the top of the List of Tables -->
   <variable id="List of Tables">Tabellen</variable>
-  <!-- The heading string to put at the top of the List of Figures -->
   <variable id="List of Figures">Figuren</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -20,6 +20,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Preface title">Voorwoord</variable>
   <variable id="Notices title">Let op</variable>
   <variable id="Mini Toc">Onderwerpen: </variable>
+  <variable id="Notice"><!--TODO:Notice, from note with type="notice"--></variable>
   <variable id="Figure.title">Figuur <param ref-name="number"/>: <param ref-name="title"/></variable>
   <variable id="Figure Number">Figuur <param ref-name="number"/></variable>
   <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -7,44 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | Inleiding | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Inleiding | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <!-- Inhoud -->
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Inhoudsopgave</variable>
-  
   <variable id="Index Continued String">Vervolg</variable>
   <variable id="Index See String">, zie </variable>
   <variable id="Index See Also String">Zie ook </variable>
@@ -52,12 +17,9 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Bijlage <param ref-name="number"/>: </variable>
   <variable id="Table of Contents Part">Deel <param ref-name="number"/>: </variable>
   <variable id="Table of Contents Preface">Voorwoord: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Voorwoord</variable>
   <variable id="Notices title">Let op</variable>
   <variable id="Mini Toc">Onderwerpen: </variable>
-  <variable id="#note-separator">: </variable>
-
   <variable id="Figure.title">Figuur <param ref-name="number"/>: <param ref-name="title"/></variable>
   <variable id="Figure Number">Figuur <param ref-name="number"/></variable>
   <variable id="Table.title">Tabel <param ref-name="number"/>: <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"> op pagina <param ref-name="pagenum"/></variable>
   <variable id="Page"> pagina <param ref-name="pagenum"/></variable>
   <variable id="This link">deze verwijzing</variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics">Onderliggende onderwerpen</variable>
-
   <variable id="Related references">Verwante verwijzingen</variable>
-  
   <variable id="Optional Step">Optioneel:</variable>
   <variable id="Required Step">Vereist:</variable>
   <!-- Task strings now reused from common -->
@@ -103,27 +50,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-
-  <!--Glossary Variables-->
-  <!-- The footer that appears on the odd-numbered glossary pages. -->
-  <variable id="Glossary odd footer"/>
-  <!-- The footer that appears on the even-numbered glossary pages. -->
-  <variable id="Glossary even footer"/>
-  <!-- The header that appears on the odd-numbered glossary pages. -->
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <!-- The header that appears on the even-numbered glossary pages. -->
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <!-- The heading string to put at the top of the Glossary -->
   <variable id="Glossary">Verklarende woordenlijst</variable>
   <!-- The heading string to put at the top of the List of Tables -->
   <variable id="List of Tables">Tabellen</variable>
   <!-- The heading string to put at the top of the List of Figures -->
   <variable id="List of Figures">Figuren</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Innhold</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">fortsettelse</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Se </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Se også </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Kapittel <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Tillegg <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Del <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Forord: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Forord</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Innhold: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figur <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figur <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabell <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabell <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Beslektet informasjon</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Kapittel <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Tillegg <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Del <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Opprydning nødvendig]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> på side <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> side <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Valgfritt:</variable>
-    <variable id="Required Step">Nødvendig:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Ordliste</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabeller</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Figurer</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Innhold</variable>
+  <variable id="Index Continued String">fortsettelse</variable>
+  <variable id="Index See String">, Se </variable>
+  <variable id="Index See Also String">Se også </variable>
+  <variable id="Table of Contents Chapter">Kapittel <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Tillegg <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Del <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Forord: </variable>
+  <variable id="Preface title">Forord</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Innhold: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Figur <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figur <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabell <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabell <param ref-name="number"/></variable>
+  <variable id="Related Links">Beslektet informasjon</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Kapittel <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Tillegg <param ref-name="number"/></variable>
+  <variable id="Part with number">Del <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Opprydning nødvendig]</variable>
+  <variable id="On the page"> på side <param ref-name="pagenum"/></variable>
+  <variable id="Page"> side <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Valgfritt:</variable>
+  <variable id="Required Step">Nødvendig:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Ordliste</variable>
+  <variable id="List of Tables">Tabeller</variable>
+  <variable id="List of Figures">Figurer</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Innhold</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Forord: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Forord</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Innhold: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Ordliste</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figurer</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
@@ -7,150 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Wstęp | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Wstęp | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Spis treści</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">kontynuacja</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Patrz </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Patrz także </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Rozdział <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatek <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Numer <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Wstęp: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Wstęp</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Spis treści: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Rysunek <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Rysunek <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabela <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Informacje pokrewne</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Rozdział <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Numer <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Wymagana korekta]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na stronie <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Strona <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcjonalne:</variable>
-    <variable id="Required Step">Wymagane:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glosariusz</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabele</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Rysunki</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Wstęp | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Wstęp | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Spis treści</variable>
+  <variable id="Index Continued String">kontynuacja</variable>
+  <variable id="Index See String">, Patrz </variable>
+  <variable id="Index See Also String">Patrz także </variable>
+  <variable id="Table of Contents Chapter">Rozdział <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatek <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Numer <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Wstęp: </variable>
+  <variable id="Preface title">Wstęp</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Spis treści: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Rysunek <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Rysunek <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabela <param ref-name="number"/></variable>
+  <variable id="Related Links">Informacje pokrewne</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Rozdział <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
+  <variable id="Part with number">Numer <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Wymagana korekta]</variable>
+  <variable id="On the page"> na stronie <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Strona <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcjonalne:</variable>
+  <variable id="Required Step">Wymagane:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosariusz</variable>
+  <variable id="List of Tables">Tabele</variable>
+  <variable id="List of Figures">Rysunki</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Wstęp | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Wstęp | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Spis treści</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Wstęp: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Wstęp</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Spis treści: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,25 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
+    <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glosariusz</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
@@ -292,6 +153,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Rysunki</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Índice</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prefácio: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Prefácio</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Índice: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,25 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
+    <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glossário</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
@@ -292,6 +153,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figuras</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
@@ -7,150 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Índice</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">continuação</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Consulte </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Consulte também </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Apêndice <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prefácio: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Prefácio</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Índice: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figura <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabela <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Informações relacionadas</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Apêndice <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Parte <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Limpeza necessária]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na página <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> página <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcional:</variable>
-    <variable id="Required Step">Necessário:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glossário</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabelas</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Figuras</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Índice</variable>
+  <variable id="Index Continued String">continuação</variable>
+  <variable id="Index See String">, Consulte </variable>
+  <variable id="Index See Also String">Consulte também </variable>
+  <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Apêndice <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Parte <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prefácio: </variable>
+  <variable id="Preface title">Prefácio</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Índice: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figura <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabela <param ref-name="number"/></variable>
+  <variable id="Related Links">Informações relacionadas</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Apêndice <param ref-name="number"/></variable>
+  <variable id="Part with number">Parte <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Limpeza necessária]</variable>
+  <variable id="On the page"> na página <param ref-name="pagenum"/></variable>
+  <variable id="Page"> página <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcional:</variable>
+  <variable id="Required Step">Necessário:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossário</variable>
+  <variable id="List of Tables">Tabelas</variable>
+  <variable id="List of Figures">Figuras</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Índice</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Prefácio: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Prefácio</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Índice: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glossário</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Figuras</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Índice</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">continuação</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Veja </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Veja também </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Apêndice <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Número <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Prefácio: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Prefácio</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Índice: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Figura <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabela <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Informações relacionadas</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Apêndice <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Número <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Limpeza necessária]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na página <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> página <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcional:</variable>
-    <variable id="Required Step">Necessário:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glossário</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabelas</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Figuras</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Prefácio | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Prefácio | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Índice</variable>
+  <variable id="Index Continued String">continuação</variable>
+  <variable id="Index See String">, Veja </variable>
+  <variable id="Index See Also String">Veja também </variable>
+  <variable id="Table of Contents Chapter">Capítulo <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Apêndice <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Número <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Prefácio: </variable>
+  <variable id="Preface title">Prefácio</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Índice: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Figura <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Figura <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabela <param ref-name="number"/></variable>
+  <variable id="Related Links">Informações relacionadas</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Capítulo <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Apêndice <param ref-name="number"/></variable>
+  <variable id="Part with number">Número <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Limpeza necessária]</variable>
+  <variable id="On the page"> na página <param ref-name="pagenum"/></variable>
+  <variable id="Page"> página <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcional:</variable>
+  <variable id="Required Step">Necessário:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glossário</variable>
+  <variable id="List of Tables">Tabelas</variable>
+  <variable id="List of Figures">Figuras</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Tabel <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Table Number">Tabel <param ref-name="number"/></variable>
   <variable id="Related Links"><!--TODO:Related Links--></variable>
-  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
-  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
+  <variable id="Cross-Reference"/><!--UNUSED-->
+  <variable id="Content-Reference"/><!--UNUSED-->
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -38,12 +38,11 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup"><!--TODO:[Required-Cleanup]--></variable>
   <variable id="On the page"/>
   <variable id="Page"><!--TODO: page <param ref-name="pagenum"/>--></variable>
-  <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="Child topics"><!--TODO:Child Topics--></variable>
-  <variable id="Related references">Referinţe înrudite</variable>
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references">Referinţe înrudite</variable><!--UNUSED-->
   <variable id="Optional Step">Opţional:</variable>
   <variable id="Required Step">Necesar:</variable>
-  <!-- Task strings now reused from common -->
   <variable id="Task Prereq"></variable>
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -7,43 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | <variable id="Preface title"/> | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | <variable id="Preface title"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Cuprins</variable>
-  
   <variable id="Index Continued String">continuare</variable>
   <variable id="Index See String">, Vezi </variable>
   <variable id="Index See Also String">Vezi și </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Anexa <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Parte <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Preface">Prefață: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Prefață</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>
   <variable id="Mini Toc"><!--TODO:Topics: --></variable>
-  <variable id="#note-separator">: </variable>
-  
   <variable id="Notice"><!--TODO:Notice--></variable>
-
   <variable id="Figure.title">Fig. <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Figure Number">Fig. <param ref-name="number"/></variable>
   <variable id="Table.title">Tabel <param ref-name="number"/>. <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"/>
   <variable id="Page"><!--TODO: page <param ref-name="pagenum"/>--></variable>
   <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics"><!--TODO:Child Topics--></variable>
-
   <variable id="Related references">Referinţe înrudite</variable>
-  
   <variable id="Optional Step">Opţional:</variable>
   <variable id="Required Step">Necesar:</variable>
   <!-- Task strings now reused from common -->
@@ -103,18 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">Glosar</variable>
   <variable id="List of Tables">Listă de tabele</variable>
   <variable id="List of Figures">Listă de figuri</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -31,6 +31,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
+  <variable id="Search title"><!--TODO:Search title--></variable>
   <variable id="Chapter with number">Cap. <param ref-name="number"/></variable>
   <variable id="Appendix with number">Anexa <param ref-name="number"/></variable>
   <variable id="Part with number">Parte <param ref-name="number"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Таблица <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Table Number">Таблица <param ref-name="number"/></variable>
   <variable id="Related Links"><!--TODO:Related Links--></variable>
-  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
-  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
+  <variable id="Cross-Reference"/><!--UNUSED-->
+  <variable id="Content-Reference"/><!--UNUSED-->
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -38,12 +38,11 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup"><!--TODO:[Required-Cleanup]--></variable>
   <variable id="On the page"><!--TODO: on page <param ref-name="pagenum"/>--></variable>
   <variable id="Page"><!--TODO: page <param ref-name="pagenum"/>--></variable>
-  <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="Child topics"><!--TODO:Child Topics--></variable>
-  <variable id="Related references">Ссылки, связанные с данной</variable>
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references">Ссылки, связанные с данной</variable><!--UNUSED-->
   <variable id="Optional Step">Необязательно:</variable>
   <variable id="Required Step">Обязательно:</variable>
-  <!-- Task strings now reused from common -->
   <variable id="Task Prereq"></variable>
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -31,6 +31,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
+  <variable id="Search title"><!--TODO:Search title--></variable>
   <variable id="Chapter with number">Глава <param ref-name="number"/></variable>
   <variable id="Appendix with number">Приложение <param ref-name="number"/></variable>
   <variable id="Part with number">Часть <param ref-name="number"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -7,43 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | <variable id="Preface title"/> | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | <variable id="Preface title"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Содержание</variable>
-  
   <variable id="Index Continued String">продолжение</variable>
   <variable id="Index See String">, См. </variable>
   <variable id="Index See Also String">См. также </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Приложение <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Часть <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Preface">Предисловие: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Предисловие</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>
   <variable id="Mini Toc"><!--TODO:Topics: --></variable>
-  <variable id="#note-separator">: </variable>
-  
   <variable id="Notice"><!--TODO:Notice--></variable>
-
   <variable id="Figure.title">Рисунок <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Figure Number">Рисунок <param ref-name="number"/></variable>
   <variable id="Table.title">Таблица <param ref-name="number"/>. <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"><!--TODO: on page <param ref-name="pagenum"/>--></variable>
   <variable id="Page"><!--TODO: page <param ref-name="pagenum"/>--></variable>
   <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics"><!--TODO:Child Topics--></variable>
-
   <variable id="Related references">Ссылки, связанные с данной</variable>
-  
   <variable id="Optional Step">Необязательно:</variable>
   <variable id="Required Step">Обязательно:</variable>
   <!-- Task strings now reused from common -->
@@ -103,18 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">Глоссарий</variable>
   <variable id="List of Tables">Список таблиц</variable>
   <variable id="List of Figures">Список иллюстраций</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Predhovor | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Predhovor | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Obsah</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">pokračovaný</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Pozri </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Pozri tiež </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Kapitola <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Príloha <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Časť <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Predhovor: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Predhovor</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Obsah: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Obrázok <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Obrázok <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabuľka <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabuľka <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Súvisiace informácie</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Príloha <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Časť <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Požadované čistenie]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na strane <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> strana <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Voliteľný:</variable>
-    <variable id="Required Step">Požadovaný:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Glosár</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabuľky</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Obrázky</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Predhovor | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Predhovor | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Obsah</variable>
+  <variable id="Index Continued String">pokračovaný</variable>
+  <variable id="Index See String">, Pozri </variable>
+  <variable id="Index See Also String">Pozri tiež </variable>
+  <variable id="Table of Contents Chapter">Kapitola <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Príloha <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Časť <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Predhovor: </variable>
+  <variable id="Preface title">Predhovor</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Obsah: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Obrázok <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Obrázok <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabuľka <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabuľka <param ref-name="number"/></variable>
+  <variable id="Related Links">Súvisiace informácie</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Kapitola <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Príloha <param ref-name="number"/></variable>
+  <variable id="Part with number">Časť <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Požadované čistenie]</variable>
+  <variable id="On the page"> na strane <param ref-name="pagenum"/></variable>
+  <variable id="Page"> strana <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Voliteľný:</variable>
+  <variable id="Required Step">Požadovaný:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Glosár</variable>
+  <variable id="List of Tables">Tabuľky</variable>
+  <variable id="List of Figures">Obrázky</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Predhovor | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Predhovor | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Obsah</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Predhovor: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Predhovor</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Obsah: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Glosár</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Obrázky</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -7,43 +7,9 @@ Copyright 2013 Saso Kuncic
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | Uvod | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Uvod | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Kazalo</variable>
-  
   <variable id="Index Continued String">Se nadaljuje</variable>
   <variable id="Index See String">, Gl. </variable>
   <variable id="Index See Also String">Gl.tudi </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Kazalo dodatka <param ref-name="number"/>: </variable>
   <variable id="Table of Contents Part">Kazalo dela <param ref-name="number"/>: </variable>
   <variable id="Table of Contents Preface">Kazalo predgovora: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Predgovor</variable>
   <variable id="Notices title">Opozorilo</variable>
   <variable id="Mini Toc">Teme: </variable>
-  <variable id="#note-separator">: </variable>
-  
   <variable id="Notice">Objava</variable>
-
   <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
   <variable id="Figure Number">Slika <param ref-name="number"/></variable>
   <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
@@ -77,23 +39,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"> na strani <param ref-name="pagenum"/></variable>
   <variable id="Page"> stran <param ref-name="pagenum"/></variable>
   <variable id="This link">ta povezava</variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics">Podrejen</variable>
-
   <variable id="Related references">Sorodne reference</variable>
-  
   <variable id="Optional Step">Izbiren:</variable>
   <variable id="Required Step">Zahtevano:</variable>
   <!-- Prereq was "Predzahteva", changing to common string, currently "Preden začnete" -->
@@ -107,18 +54,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Example"></variable>
   <!-- Postreq was "Kaj storiti zatem", changing to common string, currently "Kako naprej?" -->
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">Besednjak</variable>
   <variable id="List of Tables">Seznam tabel</variable>
   <variable id="List of Figures">Seznam slik</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
   <variable id="Table Number">Tabela <param ref-name="number"/></variable>
   <variable id="Related Links">Sorodne povezave</variable>
-  <variable id="Cross-Reference">Križni sklic na:</variable>
-  <variable id="Content-Reference">Navzkrižni sklic na:</variable>
+  <variable id="Cross-Reference">Križni sklic na:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Navzkrižni sklic na:</variable><!--UNUSED-->
   <variable id="List item">Točka seznama.</variable>
   <variable id="Foot note">Opomba v nogi.</variable>
   <variable id="Navigation title">Poimenovanje krmarjenja</variable>
@@ -38,21 +38,17 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup">[Zahtevano čiščenje]</variable>
   <variable id="On the page"> na strani <param ref-name="pagenum"/></variable>
   <variable id="Page"> stran <param ref-name="pagenum"/></variable>
-  <variable id="This link">ta povezava</variable>
-  <variable id="Child topics">Podrejen</variable>
-  <variable id="Related references">Sorodne reference</variable>
+  <variable id="This link">ta povezava</variable><!--UNUSED-->
+  <variable id="Child topics">Podrejen</variable><!--UNUSED-->
+  <variable id="Related references">Sorodne reference</variable><!--UNUSED-->
   <variable id="Optional Step">Izbiren:</variable>
   <variable id="Required Step">Zahtevano:</variable>
-  <!-- Prereq was "Predzahteva", changing to common string, currently "Preden začnete" -->
   <variable id="Task Prereq"></variable>
-  <!-- Context was "O tem opravilu", changing to common string, currently "O tej nalogi" -->
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>
   <variable id="#steps-unordered-label"></variable>
   <variable id="Task Result"></variable>
-  <!-- Example was "Primer", changing to common string, currently "Zgled" -->
   <variable id="Task Example"></variable>
-  <!-- Postreq was "Kaj storiti zatem", changing to common string, currently "Kako naprej?" -->
   <variable id="Task Postreq"></variable>
   <variable id="Glossary">Besednjak</variable>
   <variable id="List of Tables">Seznam tabel</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sadržaj</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Predgovor: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Predgovor</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Sadržaj: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,25 +148,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
+    <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Riječnik</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
@@ -292,6 +157,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Slike</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -7,154 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sadržaj</variable>
-
-    <!-- TODO: Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">continued</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vidi </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vidi takođe </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Predgovor: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Predgovor</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Sadržaj: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Slika <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabela <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Srodne informacije</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Dio <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Potrebno čišćenje]</variable>
-
-    <!-- TODO: Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
-
-    <!-- TODO: Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> page <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Opcionalno:</variable>
-    <variable id="Required Step">Potrebno:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Riječnik</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabele</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Slike</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sadržaj</variable>
+  <variable id="Index Continued String">continued</variable><!--TODO:Index Continued String-->
+  <variable id="Index See String">, Vidi </variable>
+  <variable id="Index See Also String">Vidi takođe </variable>
+  <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Dio <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Predgovor: </variable>
+  <variable id="Preface title">Predgovor</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Sadržaj: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Slika <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Slika <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabela <param ref-name="number"/></variable>
+  <variable id="Related Links">Srodne informacije</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
+  <variable id="Part with number">Dio <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Potrebno čišćenje]</variable>
+  <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
+  <variable id="Page"> page <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Opcionalno:</variable>
+  <variable id="Required Step">Potrebno:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Riječnik</variable>
+  <variable id="List of Tables">Tabele</variable>
+  <variable id="List of Figures">Slike</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
+     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Sadržaj</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Predgovor: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Predgovor</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Sadržaj: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -214,39 +125,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- UNUSED: Template for generated page number of a reference
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
-
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
+     
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
 
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Pojmovnik</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Ilustracije</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-     <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Sadržaj</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">nastavak</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Vidi </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Vidi Takođe </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Deo <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Predgovor: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Predgovor</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Sadržaj: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Ilustracija <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Ilustracija <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Tabela <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Srodna informacija</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Deo <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Neophodno čišćenje]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> na strani <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Strana <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-     
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Neobavezno:</variable>
-    <variable id="Required Step">Neophodno:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Pojmovnik</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Tabele</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Ilustracije</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Sadržaj</variable>
+  <variable id="Index Continued String">nastavak</variable>
+  <variable id="Index See String">, Vidi </variable>
+  <variable id="Index See Also String">Vidi Takođe </variable>
+  <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Dodatak <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Deo <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Predgovor: </variable>
+  <variable id="Preface title">Predgovor</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Sadržaj: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Ilustracija <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Ilustracija <param ref-name="number"/></variable>
+  <variable id="Table.title">Tabela <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Tabela <param ref-name="number"/></variable>
+  <variable id="Related Links">Srodna informacija</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Poglavlje <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Dodatak <param ref-name="number"/></variable>
+  <variable id="Part with number">Deo <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Neophodno čišćenje]</variable>
+  <variable id="On the page"> na strani <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Strana <param ref-name="pagenum"/></variable>
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references"/><!--UNUSED-->
+  <variable id="Optional Step">Neobavezno:</variable>
+  <variable id="Required Step">Neophodno:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Pojmovnik</variable>
+  <variable id="List of Tables">Tabele</variable>
+  <variable id="List of Figures">Ilustracije</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -7,155 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Садржај</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">наставак</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Види </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Види Такође </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Поглавље <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Додатак <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Део <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Предговор: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Предговор</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Садржај: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Илустрација <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Илустрација <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Табела <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Табела <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Сродна информација</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Поглавље <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Додатак <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Део <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Неопходно чишћење]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> на страни <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Страна <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">Необавезно:</variable>
-    <variable id="Required Step">Неопходно:</variable>
-     
-     <!--Labels for task sections, now reused from common but support legacy variable names-->
-     <variable id="Task Prereq"></variable>
-     <variable id="Task Context"></variable>
-     <variable id="Task Steps"></variable>
-     <variable id="#steps-unordered-label"></variable>
-     <variable id="Task Result"></variable>
-     <variable id="Task Example"></variable>
-     <variable id="Task Postreq"></variable>
-
-    <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Појмовник</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Табеле</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Илустрације</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Садржај</variable>
+  <variable id="Index Continued String">наставак</variable>
+  <variable id="Index See String">, Види </variable>
+  <variable id="Index See Also String">Види Такође </variable>
+  <variable id="Table of Contents Chapter">Поглавље <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Додатак <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Део <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Предговор: </variable>
+  <variable id="Preface title">Предговор</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Садржај: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Илустрација <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Илустрација <param ref-name="number"/></variable>
+  <variable id="Table.title">Табела <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Табела <param ref-name="number"/></variable>
+  <variable id="Related Links">Сродна информација</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Поглавље <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Додатак <param ref-name="number"/></variable>
+  <variable id="Part with number">Део <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Неопходно чишћење]</variable>
+  <variable id="On the page"> на страни <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Страна <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Необавезно:</variable>
+  <variable id="Required Step">Неопходно:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Појмовник</variable>
+  <variable id="List of Tables">Табеле</variable>
+  <variable id="List of Figures">Илустрације</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -139,6 +139,15 @@ See the accompanying LICENSE file for applicable license.
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Необавезно:</variable>
     <variable id="Required Step">Неопходно:</variable>
+     
+     <!--Labels for task sections, now reused from common but support legacy variable names-->
+     <variable id="Task Prereq"></variable>
+     <variable id="Task Context"></variable>
+     <variable id="Task Steps"></variable>
+     <variable id="#steps-unordered-label"></variable>
+     <variable id="Task Result"></variable>
+     <variable id="Task Example"></variable>
+     <variable id="Task Postreq"></variable>
 
     <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Појмовник</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Предговор | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Предговор | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Садржај</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Предговор: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Предговор</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Садржај: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -257,20 +140,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Optional Step">Необавезно:</variable>
     <variable id="Required Step">Неопходно:</variable>
 
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
-     <!-- The heading string to put at the top of the Glossary -->
+    <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Појмовник</variable>
      
      <!-- The heading string to put at the top of the List of Tables -->
@@ -279,6 +149,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Илустрације</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/strings.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/strings.xml
@@ -7,6 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <langlist>
+  <lang filename="commonvariables.xml" xml:lang=""/>
   <lang filename="ar.xml" xml:lang="ar"/>
   <lang filename="be.xml" xml:lang="be"/>
   <lang filename="bg.xml" xml:lang="bg"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table.title">Tabell <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Table Number">Tabell <param ref-name="number"/></variable>
   <variable id="Related Links"><!--TODO:Related Links--></variable>
-  <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
-  <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
+  <variable id="Cross-Reference"/><!--UNUSED-->
+  <variable id="Content-Reference"/><!--UNUSED-->
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -38,12 +38,11 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Required-Cleanup"><!--TODO:[Required-Cleanup]--></variable>
   <variable id="On the page"/>
   <variable id="Page"> sidan <param ref-name="pagenum"/></variable>
-  <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="Child topics"><!--TODO:Child Topics--></variable>
-  <variable id="Related references">Närliggande referens</variable>
+  <variable id="This link"/><!--UNUSED-->
+  <variable id="Child topics"/><!--UNUSED-->
+  <variable id="Related references">Närliggande referens</variable><!--UNUSED-->
   <variable id="Optional Step">Valfritt:</variable>
   <variable id="Required Step">Krävs:</variable>
-  <!--Labels for task sections, now reused from common-->
   <variable id="Task Prereq"></variable>
   <variable id="Task Context"></variable>
   <variable id="Task Steps"></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -31,6 +31,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
+  <variable id="Search title"><!--TODO:Search title--></variable>
   <variable id="Chapter with number">Kapitel <param ref-name="number"/></variable>
   <variable id="Appendix with number">Appendix <param ref-name="number"/></variable>
   <variable id="Part with number">Del <param ref-name="number"/></variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -7,43 +7,9 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Product Name"/>
-  <variable id="Body odd footer"/>
-  <variable id="Body even footer"/>
-  <variable id="Body first footer"/>
-  <variable id="Body first header"/>
-  <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface odd footer"/>
-  <variable id="Preface even footer"/>
-  <variable id="Preface first footer"/>
   <variable id="Preface odd header"><param ref-name="prodname"/> | <variable id="Preface title"/> | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | <variable id="Preface title"/> | <param ref-name="prodname"/></variable>
-  <variable id="Preface first header"/>
-  <variable id="Toc odd footer"/>
-  <variable id="Toc even footer"/>
-  <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Index odd footer"/>
-  <variable id="Index even footer"/>
-  <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-  <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-  <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
   <variable id="Table of Contents">Innehållsförteckning</variable>
-  
   <variable id="Index Continued String">forts</variable>
   <variable id="Index See String">, Se </variable>
   <variable id="Index See Also String">Se Även </variable>
@@ -51,14 +17,10 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Table of Contents Appendix">Appendix <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Part">Del <param ref-name="number"/>. </variable>
   <variable id="Table of Contents Preface">Företal: </variable>
-  <variable id="Table of Contents Notices"/>
   <variable id="Preface title">Företal</variable>
   <variable id="Notices title"><!--TODO:Notice--></variable>
   <variable id="Mini Toc"><!--TODO:Topics: --></variable>
-  <variable id="#note-separator">: </variable>
-  
   <variable id="Notice"><!--TODO:Notice--></variable>
-
   <variable id="Figure.title">Figur <param ref-name="number"/>. <param ref-name="title"/></variable>
   <variable id="Figure Number">Figur <param ref-name="number"/></variable>
   <variable id="Table.title">Tabell <param ref-name="number"/>. <param ref-name="title"/></variable>
@@ -76,23 +38,8 @@ See the accompanying LICENSE file for applicable license.
   <variable id="On the page"/>
   <variable id="Page"> sidan <param ref-name="pagenum"/></variable>
   <variable id="This link"><!--TODO:this link--></variable>
-  <variable id="note Note Image Path"></variable>
-  <variable id="notice Note Image Path"></variable>
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-  <variable id="fastpath Note Image Path"></variable>
-  <variable id="important Note Image Path"></variable>
-  <variable id="remember Note Image Path"></variable>
-  <variable id="restriction Note Image Path"></variable>
-  <variable id="tip Note Image Path"></variable>
-  <variable id="other Note Image Path"></variable>
-
   <variable id="Child topics"><!--TODO:Child Topics--></variable>
-
   <variable id="Related references">Närliggande referens</variable>
-  
   <variable id="Optional Step">Valfritt:</variable>
   <variable id="Required Step">Krävs:</variable>
   <!--Labels for task sections, now reused from common-->
@@ -103,18 +50,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Task Result"></variable>
   <variable id="Task Example"></variable>
   <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-  <variable id="Glossary odd footer"/>
-  <variable id="Glossary even footer"/>
-  <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-  <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
   <variable id="Glossary">Gloslista</variable>
   <variable id="List of Tables">Tabellförteckning</variable>
   <variable id="List of Figures">Figurförteckning</variable>
-
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | คำนำ | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | คำนำ | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">สารบัญ</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">คำนำ: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">คำนำ</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">สารบัญ: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-    
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
 
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">รายการคำศัพท์</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">รูป</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | คำนำ | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | คำนำ | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">สารบัญ</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">ต่อ</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, ดู </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">ดูเพิ่มที่ </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">บทที่ <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">ภาคผนวก <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">ชิ้นส่วน <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">คำนำ: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">คำนำ</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">สารบัญ: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">รูปที่ <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">รูปที่ <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">ตารางที่ <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">ตารางที่ <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">ข้อมูลที่เกี่ยวข้อง</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">บทที่ <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">ภาคผนวก <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">ชิ้นส่วน <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[การแก้ไขที่ต้องการ]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> ในหน้า <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> หน้า <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- UPDATE: Label for a step with importance="optional"-->
-    <variable id="Optional Step">ทางเลือก:</variable>
-    <variable id="Required Step">บังคับ:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">รายการคำศัพท์</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">ตาราง</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">รูป</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | คำนำ | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | คำนำ | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">สารบัญ</variable>
+  <variable id="Index Continued String">ต่อ</variable>
+  <variable id="Index See String">, ดู </variable>
+  <variable id="Index See Also String">ดูเพิ่มที่ </variable>
+  <variable id="Table of Contents Chapter">บทที่ <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">ภาคผนวก <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">ชิ้นส่วน <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">คำนำ: </variable>
+  <variable id="Preface title">คำนำ</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">สารบัญ: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">รูปที่ <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">รูปที่ <param ref-name="number"/></variable>
+  <variable id="Table.title">ตารางที่ <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">ตารางที่ <param ref-name="number"/></variable>
+  <variable id="Related Links">ข้อมูลที่เกี่ยวข้อง</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">บทที่ <param ref-name="number"/></variable>
+  <variable id="Appendix with number">ภาคผนวก <param ref-name="number"/></variable>
+  <variable id="Part with number">ชิ้นส่วน <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[การแก้ไขที่ต้องการ]</variable>
+  <variable id="On the page"> ในหน้า <param ref-name="pagenum"/></variable>
+  <variable id="Page"> หน้า <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">ทางเลือก:</variable>
+  <variable id="Required Step">บังคับ:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">รายการคำศัพท์</variable>
+  <variable id="List of Tables">ตาราง</variable>
+  <variable id="List of Figures">รูป</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Önsöz | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Önsöz | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">İçindekiler</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Önsöz: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Önsöz</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">İçindekiler: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +148,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Özel sözlük</variable>
      
@@ -292,6 +158,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Şekiller</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
@@ -7,155 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Önsöz | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Önsöz | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">İçindekiler</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">devamı var</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Bkz. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Ayrıca bkz. </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Bölüm <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Ek <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Bölüm <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Önsöz: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Önsöz</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">İçindekiler: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Şekil <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Şekil <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Çizelge <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Çizelge <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">İlgili bilgiler</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Bölüm <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Ek <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Bölüm <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Düzeltilmeli]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> sayfa <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Sayfa <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">İsteğe bağlı:</variable>
-    <variable id="Required Step">Gerekli:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Özel sözlük</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Çizelgeler</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Şekiller</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Önsöz | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Önsöz | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">İçindekiler</variable>
+  <variable id="Index Continued String">devamı var</variable>
+  <variable id="Index See String">, Bkz. </variable>
+  <variable id="Index See Also String">Ayrıca bkz. </variable>
+  <variable id="Table of Contents Chapter">Bölüm <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Ek <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Bölüm <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Önsöz: </variable>
+  <variable id="Preface title">Önsöz</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">İçindekiler: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Şekil <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Şekil <param ref-name="number"/></variable>
+  <variable id="Table.title">Çizelge <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Çizelge <param ref-name="number"/></variable>
+  <variable id="Related Links">İlgili bilgiler</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Bölüm <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Ek <param ref-name="number"/></variable>
+  <variable id="Part with number">Bölüm <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Düzeltilmeli]</variable>
+  <variable id="On the page"> sayfa <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Sayfa <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">İsteğe bağlı:</variable>
+  <variable id="Required Step">Gerekli:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Özel sözlük</variable>
+  <variable id="List of Tables">Çizelgeler</variable>
+  <variable id="List of Figures">Şekiller</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Передмова | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Передмова | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Зміст</variable>
@@ -131,10 +51,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Передмова: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Передмова</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +61,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Зміст: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +130,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +148,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Глосарій</variable>
      
@@ -292,6 +158,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Мал.</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
@@ -7,155 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Передмова | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Передмова | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Зміст</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">продовження</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, Див. </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">Див. також </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Розділ <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Додаток <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Частина <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Передмова: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Передмова</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Зміст: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Мал. <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Мал. <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Табл. <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Табл. <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Зв'язана інформація</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Розділ <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Додаток <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Частина <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Необхідна чистка]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> на стор. <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> стор. <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">За бажанням:</variable>
-    <variable id="Required Step">Обов'язково:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Глосарій</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Табл.</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Мал.</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Передмова | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Передмова | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Зміст</variable>
+  <variable id="Index Continued String">продовження</variable>
+  <variable id="Index See String">, Див. </variable>
+  <variable id="Index See Also String">Див. також </variable>
+  <variable id="Table of Contents Chapter">Розділ <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Додаток <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Частина <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Передмова: </variable>
+  <variable id="Preface title">Передмова</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Зміст: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Мал. <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Мал. <param ref-name="number"/></variable>
+  <variable id="Table.title">Табл. <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Табл. <param ref-name="number"/></variable>
+  <variable id="Related Links">Зв'язана інформація</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Розділ <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Додаток <param ref-name="number"/></variable>
+  <variable id="Part with number">Частина <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Необхідна чистка]</variable>
+  <variable id="On the page"> на стор. <param ref-name="pagenum"/></variable>
+  <variable id="Page"> стор. <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">За бажанням:</variable>
+  <variable id="Required Step">Обов'язково:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Глосарій</variable>
+  <variable id="List of Tables">Табл.</variable>
+  <variable id="List of Figures">Мал.</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | مقدمہ | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | مقدمہ | <param ref-name="prodname"/></variable>
-
-    <!--  The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">مشمولات</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">جاری</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, دیکھیں </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">یہ بھی دیکھیں </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">باب <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">ضمیمہ <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">جزو <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">مقدمہ: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">مقدمہ</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">مشمولات: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">اعداد <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">اعداد <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">جدول <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">جدول <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">متعلقہ معلومات</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">باب <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">ضمیمہ <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">جزو <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[مطلوبہ صفائی]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> صفحہ پر <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> صفحہ <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">اختیاری:</variable>
-    <variable id="Required Step">ضروری:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">فرہنگ</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">جدولیں</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">اعداد</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | مقدمہ | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | مقدمہ | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">مشمولات</variable>
+  <variable id="Index Continued String">جاری</variable>
+  <variable id="Index See String">, دیکھیں </variable>
+  <variable id="Index See Also String">یہ بھی دیکھیں </variable>
+  <variable id="Table of Contents Chapter">باب <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">ضمیمہ <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">جزو <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">مقدمہ: </variable>
+  <variable id="Preface title">مقدمہ</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">مشمولات: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">اعداد <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">اعداد <param ref-name="number"/></variable>
+  <variable id="Table.title">جدول <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">جدول <param ref-name="number"/></variable>
+  <variable id="Related Links">متعلقہ معلومات</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">باب <param ref-name="number"/></variable>
+  <variable id="Appendix with number">ضمیمہ <param ref-name="number"/></variable>
+  <variable id="Part with number">جزو <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[مطلوبہ صفائی]</variable>
+  <variable id="On the page"> صفحہ پر <param ref-name="pagenum"/></variable>
+  <variable id="Page"> صفحہ <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">اختیاری:</variable>
+  <variable id="Required Step">ضروری:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">فرہنگ</variable>
+  <variable id="List of Tables">جدولیں</variable>
+  <variable id="List of Figures">اعداد</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | مقدمہ | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | مقدمہ | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!--  The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">مشمولات</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">مقدمہ: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">مقدمہ</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">مشمولات: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">فرہنگ</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">اعداد</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -21,91 +21,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | Lời nói đầu | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | Lời nói đầu | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">Nội dung</variable>
@@ -124,16 +44,13 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">Phụ lục <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">Bộ phận <param ref-name="number"/>: </variable>
 
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">Lời nói đầu: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">Lời nói đầu</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -143,8 +60,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">Nội dung: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -214,38 +129,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -264,24 +147,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">Thuật ngữ</variable>
      
@@ -291,6 +157,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">Hình</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -7,154 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | Lời nói đầu | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | Lời nói đầu | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">Nội dung</variable>
-
-    <variable id="Index Continued String"></variable>
-
-    <!--string before see element-->
-    <variable id="Index See String">, xem </variable>
-
-    <!--string before see also element-->
-    <variable id="Index See Also String">Xem thêm </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">Chương <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">Phụ lục <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">Bộ phận <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">Lời nói đầu: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">Lời nói đầu</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">Nội dung: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">Hình <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">Hình <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">Bảng <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">Bảng <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">Thông tin liên quan</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">Chương <param ref-name="number"/></variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">Phụ lục <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">Bộ phận <param ref-name="number"/></variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[Yêu cầu dọn dẹp]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> trên trang <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> Trang <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">Tùy chọn:</variable>
-    <variable id="Required Step">Yêu cầu:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">Thuật ngữ</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">Các bảng</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">Hình</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Lời nói đầu | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Lời nói đầu | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">Nội dung</variable>
+  <variable id="Index Continued String"></variable>
+  <variable id="Index See String">, xem </variable>
+  <variable id="Index See Also String">Xem thêm </variable>
+  <variable id="Table of Contents Chapter">Chương <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Appendix">Phụ lục <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">Bộ phận <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Preface">Lời nói đầu: </variable>
+  <variable id="Preface title">Lời nói đầu</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">Nội dung: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">Hình <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">Hình <param ref-name="number"/></variable>
+  <variable id="Table.title">Bảng <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">Bảng <param ref-name="number"/></variable>
+  <variable id="Related Links">Thông tin liên quan</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">Chương <param ref-name="number"/></variable>
+  <variable id="Appendix with number">Phụ lục <param ref-name="number"/></variable>
+  <variable id="Part with number">Bộ phận <param ref-name="number"/></variable>
+  <variable id="Required-Cleanup">[Yêu cầu dọn dẹp]</variable>
+  <variable id="On the page"> trên trang <param ref-name="pagenum"/></variable>
+  <variable id="Page"> Trang <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">Tùy chọn:</variable>
+  <variable id="Required Step">Yêu cầu:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">Thuật ngữ</variable>
+  <variable id="List of Tables">Các bảng</variable>
+  <variable id="List of Figures">Hình</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -30,137 +30,48 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | 序言 | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | 序言 | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">内容</variable>
-
-    <variable id="Index Continued String">继续</variable>
-    <variable id="Index See String">，见</variable>
-    <variable id="Index See Also String">参见</variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">附录 <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">第 <param ref-name="number"/> 部分 </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">序言 </variable>
-    <variable id="Preface title">序言</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">内容: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice"><!--TODO:Notice--></variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">图 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">图 <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">表 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">表 <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">相关信息</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">附录 <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">第 <param ref-name="number"/> 部分</variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[需要修正]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> page <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!--Label for a step with importance="optional"-->
-    <variable id="Optional Step">可选：</variable>
-    <variable id="Required Step">必需：</variable>
-
-    <!--Labels for task sections, now reused from common-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <variable id="Glossary">术语表</variable>
-    <variable id="List of Tables">表格清单</variable>
-    <variable id="List of Figures">插图清单</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | 序言 | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | 序言 | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">内容</variable>
+  <variable id="Index Continued String">继续</variable>
+  <variable id="Index See String">，见</variable>
+  <variable id="Index See Also String">参见</variable>
+  <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 </variable>
+  <variable id="Table of Contents Appendix">附录 <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">第 <param ref-name="number"/> 部分 </variable>
+  <variable id="Table of Contents Preface">序言 </variable>
+  <variable id="Preface title">序言</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">内容: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice"><!--TODO:Notice--></variable>
+  <variable id="Figure.title">图 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">图 <param ref-name="number"/></variable>
+  <variable id="Table.title">表 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">表 <param ref-name="number"/></variable>
+  <variable id="Related Links">相关信息</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">第 <param ref-name="number"/> 章</variable>
+  <variable id="Appendix with number">附录 <param ref-name="number"/></variable>
+  <variable id="Part with number">第 <param ref-name="number"/> 部分</variable>
+  <variable id="Required-Cleanup">[需要修正]</variable>
+  <variable id="On the page"> on page <param ref-name="pagenum"/></variable>
+  <variable id="Page"> page <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Optional Step">可选：</variable>
+  <variable id="Required Step">必需：</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">术语表</variable>
+  <variable id="List of Tables">表格清单</variable>
+  <variable id="List of Figures">插图清单</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -44,92 +44,11 @@ See the accompanying LICENSE file for applicable license.
        Strings used in the headers and footers of pages.
     -->
 
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | 序言 | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | 序言 | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <!-- 目录 -->
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">内容</variable>
@@ -144,15 +63,13 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label an appendix within the table of contents. -->
     <variable id="Table of Contents Appendix">附录 <param ref-name="number"/>: </variable>
 
-    <!-- The string used to label an part within the table of contents. -->
+    <!-- The string used to label a part within the table of contents. -->
     <variable id="Table of Contents Part">第 <param ref-name="number"/> 部分 </variable>
 
-    <!-- The string used to label an preface within the table of contents. -->
+    <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">序言 </variable>
     <variable id="Preface title">序言</variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
     <!-- TODO: The string used to label notices in body text. -->
     <variable id="Notices title">Notice</variable>
 
@@ -160,8 +77,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">内容: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice"><!--TODO:Notice--></variable>
@@ -231,38 +146,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">可选：</variable>
     <variable id="Required Step">必需：</variable>
@@ -275,19 +158,9 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
-
-    <variable id="Glossary odd footer"/>
-    <variable id="Glossary even footer"/>
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-    <variable id="Glossary">术语表</variable>
+    
+     <variable id="Glossary">术语表</variable>
     <variable id="List of Tables">表格清单</variable>
     <variable id="List of Figures">插图清单</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
@@ -17,95 +17,11 @@ See the accompanying LICENSE file for applicable license.
       
     -->
 
-    <!-- 
-       Strings used in the headers and footers of pages.
-    -->
-
-    <!-- Product name to be placed inside headers etc. -->
-    <variable id="Product Name"/>
-
-    <!-- The footer that appears on odd-numbered pages. -->
-    <variable id="Body odd footer"/>
-
-    <!-- The footer that appears on even-numbered pages. -->
-    <variable id="Body even footer"/>
-
-    <!-- The footer that appears on the first page of a chapter. -->
-    <variable id="Body first footer"/>
-
-    <!-- The header that appears on the first page of a chapter. -->
-    <variable id="Body first header"/>
-
-    <!-- The header that appears on odd-numbered pages. -->
-    <variable id="Body odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on even-numbered pages. -->
-    <variable id="Body even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd footer"/>
-
-    <!-- The footer that appears on Preface even-numbered pages. -->
-    <variable id="Preface even footer"/>
-
-    <!-- The footer that appears on the first page of a Preface -->
-    <variable id="Preface first footer"/>
-
     <!-- The header that appears on Preface odd-numbered pages. -->
     <variable id="Preface odd header"><param ref-name="prodname"/> | 前言 | <param ref-name="pagenum"/></variable>
 
     <!-- The header that appears on Preface even-numbered pages. -->
     <variable id="Preface even header"><param ref-name="pagenum"/> | 前言 | <param ref-name="prodname"/></variable>
-
-    <!-- The header that appears on Preface first page. -->
-    <variable id="Preface first header"/>
-
-    <!-- The footer that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd footer"/>
-
-    <!-- The footer that appears on the even-numbered table of contents
-         pages. --> 
-    <variable id="Toc even footer"/>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the odd-numbered table of contents
-         pages. --> 
-    <variable id="Toc even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The footer that appears on the odd-numbered index pages. -->
-    <variable id="Index odd footer"/>
-
-    <!-- The footer that appears on the even-numbered index pages. -->
-    <variable id="Index even footer"/>
-
-    <!-- The header that appears on the odd-numbered index pages. -->
-    <variable id="Index odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered index pages. -->
-    <variable id="Index even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-
-    <!-- The formatting used to display ordered lists (e.g., "1., 2." or 
-         "1), 2)" -->
-    <variable id="Ordered List Number"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 1"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 2"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 3"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Number 4"><param ref-name="number"/>. </variable>
-    <variable id="Ordered List Format 1">1</variable>
-    <variable id="Ordered List Format 2">a</variable>
-    <variable id="Ordered List Format 3">1</variable>
-    <variable id="Ordered List Format 4">a</variable>
-
-    <!-- The unordered list bullet   -->
-    <variable id="Unordered List bullet">•</variable>
-    <variable id="Unordered List bullet 1">•</variable>
-    <variable id="Unordered List bullet 2">•</variable>
-    <variable id="Unordered List bullet 3">•</variable>
-    <variable id="Unordered List bullet 4">•</variable>
 
     <!-- The heading string to put at the top of the Table of Contents -->
     <variable id="Table of Contents">目錄</variable>
@@ -131,10 +47,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- The string used to label a preface within the table of contents. -->
     <variable id="Table of Contents Preface">前言: </variable>
 
-    <!-- The string used to label notices within the table of contents. -->
-    <variable id="Table of Contents Notices"/>
-
-    <!-- The string used to label an preface in body text. -->
+    <!-- The string used to label a preface in body text. -->
     <variable id="Preface title">前言</variable>
 
     <!-- TODO: The string used to label notices in body text. -->
@@ -144,8 +57,6 @@ See the accompanying LICENSE file for applicable license.
          chapter-level "mini-TOC". Using general "Contents", 
          may want to replace with translation of "Topics". -->
     <variable id="Mini Toc">目錄: </variable>
-
-    <variable id="#note-separator">: </variable>
 
     <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
     <variable id="Notice">Notice</variable>
@@ -215,38 +126,6 @@ See the accompanying LICENSE file for applicable license.
          in chm/html, when referenced element has no title. -->
     <variable id="This link"></variable>
 
-    <!-- Image path to use for a note of "note" type. -->
-    <variable id="note Note Image Path"></variable>
-    <!-- Image path to use for a note of "notice" type. -->
-    <variable id="notice Note Image Path"></variable>
-    <!-- Image path to use for a note of "attention" type. -->
-    <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "caution" type. -->
-    <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-
-    <!-- Image path to use for a note of "danger" type. -->
-    <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "warning" type. -->
-    <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "fastpath" type. -->
-    <variable id="fastpath Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "important" type. -->
-    <variable id="important Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "remember" type. -->
-    <variable id="remember Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "restriction" type. -->
-    <variable id="restriction Note Image Path"></variable>
-
-    <!-- Image path to use for a note of "tip" type. -->
-    <variable id="tip Note Image Path"></variable>
-    <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
-    <!-- Image path to use for a note of "other" type. -->
-    <variable id="other Note Image Path"></variable>
-
     <!-- UNUSED: The title of the links to child topics -->
     <variable id="Child topics"></variable>
 
@@ -265,24 +144,7 @@ See the accompanying LICENSE file for applicable license.
     <variable id="Task Result"></variable>
     <variable id="Task Example"></variable>
     <variable id="Task Postreq"></variable>
-    <variable id="Step Number"><param ref-name="number"/>. </variable>
-    <variable id="Step Format">1</variable>
-    <variable id="Substep Number"><param ref-name="number"/>) </variable>
-    <variable id="Substep Format">a</variable>
     
-    <!--Glossary Variables-->
-    <!-- The footer that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd footer"/>
-
-    <!-- The footer that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even footer"/>
-
-    <!-- The header that appears on the odd-numbered glossary pages. -->
-    <variable id="Glossary odd header"><param ref-name="prodname"/> | <param ref-name="heading"/> | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on the even-numbered glossary pages. -->
-    <variable id="Glossary even header"><param ref-name="pagenum"/> | <param ref-name="heading"/> | <param ref-name="prodname"/></variable>
-     
      <!-- The heading string to put at the top of the Glossary -->
      <variable id="Glossary">名詞解釋</variable>
      
@@ -292,6 +154,4 @@ See the accompanying LICENSE file for applicable license.
      <!-- The heading string to put at the top of the List of Figures -->
      <variable id="List of Figures">圖</variable>
 
-  <variable id="#quote-start"><variable id="OpenQuote"/></variable>
-  <variable id="#quote-end"><variable id="CloseQuote"/></variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
@@ -7,151 +7,50 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-
-    <!-- 
-     
-      This file controls strings that appear in the published output.  
-      There is one version of this file per language.  To add support 
-      for a new language, simply create a copy of this file and name 
-      it using the <locale ISO code>.xml format.
-      
-    -->
-
-    <!-- The header that appears on Preface odd-numbered pages. -->
-    <variable id="Preface odd header"><param ref-name="prodname"/> | 前言 | <param ref-name="pagenum"/></variable>
-
-    <!-- The header that appears on Preface even-numbered pages. -->
-    <variable id="Preface even header"><param ref-name="pagenum"/> | 前言 | <param ref-name="prodname"/></variable>
-
-    <!-- The heading string to put at the top of the Table of Contents -->
-    <variable id="Table of Contents">目錄</variable>
-
-    <!-- Index continued (not sure if actually used) -->
-    <variable id="Index Continued String">繼續</variable>
-
-    <!-- string before see element-->
-    <variable id="Index See String">, 請參閱 </variable>
-
-    <!-- string before see also element-->
-    <variable id="Index See Also String">請亦參閱 </variable>
-
-    <!-- The string used to label a chapter within the table of contents. -->
-    <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 </variable>
-
-    <!-- The string used to label an appendix within the table of contents. -->
-    <variable id="Table of Contents Appendix">附錄 <param ref-name="number"/>: </variable>
-
-    <!-- The string used to label a part within the table of contents. -->
-    <variable id="Table of Contents Part">第 <param ref-name="number"/> 篇 </variable>
-
-    <!-- The string used to label a preface within the table of contents. -->
-    <variable id="Table of Contents Preface">前言: </variable>
-
-    <!-- The string used to label a preface in body text. -->
-    <variable id="Preface title">前言</variable>
-
-    <!-- TODO: The string used to label notices in body text. -->
-    <variable id="Notices title">Notice</variable>
-
-    <!-- TODO: The heading to put at the top of a chapter when creating a
-         chapter-level "mini-TOC". Using general "Contents", 
-         may want to replace with translation of "Topics". -->
-    <variable id="Mini Toc">目錄: </variable>
-
-    <!-- TODO: Text to use for 'Notice' label generated from <note> element. -->
-    <variable id="Notice">Notice</variable>
-
-    <!-- Text to use for figure titles. Renders as part of <fig>/<title>
-          elements. -->
-    <variable id="Figure.title">圖 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Figure Number">圖 <param ref-name="number"/></variable>
-
-    <!-- Text to use for table titles. Renders as part of <table>/<title> 
-         elements. -->
-    <variable id="Table.title">表 <param ref-name="number"/>: <param ref-name="title"/></variable>
-    <variable id="Table Number">表 <param ref-name="number"/></variable>
-
-    <!-- Text to use for related links label.
-         Currently using alternate translation of "Related information"
-         Renders as part of <related-links> element. -->
-    <variable id="Related Links">相關資訊</variable>
-
-    <!-- UNUSED: Default cross-reference text prefix. Used to generate reference 
-         text in case it's not specified in source. -->
-    <variable id="Cross-Reference">Cross-Reference to:</variable>
-
-    <!-- Prefix for unresolved content reference. Used to generate reference 
-         text in case target cannot be resolved. -->
-    <variable id="Content-Reference">Unresolved content reference to:</variable>
-
-    <!-- TODO: Default title text for referenced list item. Used to generate
-         reference text in case reference has no explicit content and 
-         reference target is a list item. -->
-    <variable id="List item">List item.</variable>
-
-    <!-- TODO: Default title text for referenced footnote. Used to generate 
-         reference text in case reference has no explicit content and 
-         reference target is a footnote. Referenced in code but appears to be unused. -->
-    <variable id="Foot note">Footnote.</variable>
-
-    <!-- TODO: Text to use for a generated label of navigation title. Renders
-         as part of <navtitle> element. -->
-    <variable id="Navigation title">Navigation title</variable>
-
-    <!-- TODO: Text to use for a generated label of search title. Renders 
-         as part of <searchtitle> element. -->
-    <variable id="Search title">Search title</variable>
-
-    <!-- Text to use for chapter titles.-->
-    <variable id="Chapter with number">第 <param ref-name="number"/> 章 </variable>
-
-    <!-- Text to use for appendix titles.-->
-    <variable id="Appendix with number">附錄 <param ref-name="number"/></variable>
-
-    <!-- Text to use for part titles.-->
-    <variable id="Part with number">第 <param ref-name="number"/> 篇 </variable>
-
-    <!-- Text to use for a label generated from <required-cleanup> element. -->
-    <variable id="Required-Cleanup">[必要修正]</variable>
-
-    <!-- Template for generated page number of a reference 
-         in printed manual. -->
-    <variable id="On the page"> 頁 <param ref-name="pagenum"/></variable>
-
-    <!-- Template for generated page number of a reference
-         in printed manual, when referenced element has no title. -->
-    <variable id="Page"> 頁 <param ref-name="pagenum"/></variable>
-
-    <!-- UNUSED: Template for generated page number of a reference
-         in chm/html, when referenced element has no title. -->
-    <variable id="This link"></variable>
-
-    <!-- UNUSED: The title of the links to child topics -->
-    <variable id="Child topics"></variable>
-
-    <!-- UNUSED: The title of the links to Related references -->
-    <variable id="Related references"></variable>
-
-    <!-- Label for a step with importance="optional"-->
-    <variable id="Optional Step">選擇性的:</variable>
-    <variable id="Required Step">必要性的:</variable>
-
-    <!--OVERLAPS WITH COMMON: Labels for task sections-->
-    <variable id="Task Prereq"></variable>
-    <variable id="Task Context"></variable>
-    <variable id="Task Steps"></variable>
-    <variable id="#steps-unordered-label"></variable>
-    <variable id="Task Result"></variable>
-    <variable id="Task Example"></variable>
-    <variable id="Task Postreq"></variable>
-    
-     <!-- The heading string to put at the top of the Glossary -->
-     <variable id="Glossary">名詞解釋</variable>
-     
-     <!-- The heading string to put at the top of the List of Tables -->
-     <variable id="List of Tables">表</variable>
-     
-     <!-- The heading string to put at the top of the List of Figures -->
-     <variable id="List of Figures">圖</variable>
-
+  <variable id="Preface odd header"><param ref-name="prodname"/> | 前言 | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | 前言 | <param ref-name="prodname"/></variable>
+  <variable id="Table of Contents">目錄</variable>
+  <variable id="Index Continued String">繼續</variable>
+  <variable id="Index See String">, 請參閱 </variable>
+  <variable id="Index See Also String">請亦參閱 </variable>
+  <variable id="Table of Contents Chapter">第 <param ref-name="number"/> 章 </variable>
+  <variable id="Table of Contents Appendix">附錄 <param ref-name="number"/>: </variable>
+  <variable id="Table of Contents Part">第 <param ref-name="number"/> 篇 </variable>
+  <variable id="Table of Contents Preface">前言: </variable>
+  <variable id="Preface title">前言</variable>
+  <variable id="Notices title">Notice</variable><!--TODO:Notices title-->
+  <variable id="Mini Toc">目錄: </variable><!-- TODO: replace translation "Contents" with "Topics"-->
+  <variable id="Notice">Notice</variable><!--TODO:Notice-->
+  <variable id="Figure.title">圖 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Figure Number">圖 <param ref-name="number"/></variable>
+  <variable id="Table.title">表 <param ref-name="number"/>: <param ref-name="title"/></variable>
+  <variable id="Table Number">表 <param ref-name="number"/></variable>
+  <variable id="Related Links">相關資訊</variable>
+  <variable id="Cross-Reference">Cross-Reference to:</variable><!--UNUSED-->
+  <variable id="Content-Reference">Unresolved content reference to:</variable><!--UNUSED-->
+  <variable id="List item">List item.</variable><!--TODO:List item-->
+  <variable id="Foot note">Footnote.</variable><!--TODO:Footnote-->
+  <variable id="Navigation title">Navigation title</variable><!--TODO:Navigation title-->
+  <variable id="Search title">Search title</variable><!--TODO:Search title-->
+  <variable id="Chapter with number">第 <param ref-name="number"/> 章 </variable>
+  <variable id="Appendix with number">附錄 <param ref-name="number"/></variable>
+  <variable id="Part with number">第 <param ref-name="number"/> 篇 </variable>
+  <variable id="Required-Cleanup">[必要修正]</variable>
+  <variable id="On the page"> 頁 <param ref-name="pagenum"/></variable>
+  <variable id="Page"> 頁 <param ref-name="pagenum"/></variable>
+  <variable id="This link"></variable><!--UNUSED-->
+  <variable id="Child topics"></variable><!--UNUSED-->
+  <variable id="Related references"></variable><!--UNUSED-->
+  <variable id="Optional Step">選擇性的:</variable>
+  <variable id="Required Step">必要性的:</variable>
+  <variable id="Task Prereq"></variable>
+  <variable id="Task Context"></variable>
+  <variable id="Task Steps"></variable>
+  <variable id="#steps-unordered-label"></variable>
+  <variable id="Task Result"></variable>
+  <variable id="Task Example"></variable>
+  <variable id="Task Postreq"></variable>
+  <variable id="Glossary">名詞解釋</variable>
+  <variable id="List of Tables">表</variable>
+  <variable id="List of Figures">圖</variable>
 </vars>

--- a/src/main/xsl/common/common-strings.xml
+++ b/src/main/xsl/common/common-strings.xml
@@ -6,7 +6,8 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<langlist>  
+<langlist>
+  <lang xml:lang="" filename="strings-common.xml"/>
   <lang xml:lang="ar"    filename="strings-ar-eg.xml"/>
   <lang xml:lang="ar-eg" filename="strings-ar-eg.xml"/>
   <lang xml:lang="be"    filename="strings-be-by.xml"/>

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -62,7 +62,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
 
-  <xsl:variable name="stringFiles" select="document($variableFiles.url)/langlist/lang" as="element(lang)*"/>
+  <xsl:variable name="variableFiles" select="document($variableFiles.url)/langlist/lang" as="element(lang)*"/>
   
   <!-- Deprecated. Use getVariable template instead. -->
   <xsl:template name="getString">
@@ -94,15 +94,15 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="l" select="($ancestorlang, $defaultlang)[1]" as="xs:string?"/>
     <xsl:choose>
       <xsl:when test="exists($l)">
-        <xsl:variable name="stringfile" select="$stringFiles[lower-case(@xml:lang) = lower-case($l)]/@filename" as="xs:string*"/>
-        <xsl:variable name="str" as="element()*">
-          <xsl:for-each select="$stringfile">
-            <xsl:sequence select="document(., $stringFiles[1])/*/*[@name = $id or @id = $id]"/><!-- strings/str/@name opentopic-vars:vars/opentopic-vars:variable/@id -->
+        <xsl:variable name="variablefile" select="$variableFiles[lower-case(@xml:lang) = lower-case($l)]/@filename" as="xs:string*"/>
+        <xsl:variable name="variable" as="element()*">
+          <xsl:for-each select="$variablefile">
+            <xsl:sequence select="document(., $variableFiles[1])/*/*[@name = $id or @id = $id]"/><!-- strings/str/@name opentopic-vars:vars/opentopic-vars:variable/@id -->
           </xsl:for-each>
         </xsl:variable>
         <xsl:choose>
-          <xsl:when test="exists($str)">
-            <xsl:apply-templates select="$str[last()]" mode="processVariableBody">
+          <xsl:when test="exists($variable)">
+            <xsl:apply-templates select="$variable[last()]" mode="processVariableBody">
               <xsl:with-param name="params" select="$params"/>
             </xsl:apply-templates>
             <xsl:if test="empty($ancestorlang)">
@@ -124,11 +124,26 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$id"/>
-        <xsl:call-template name="output-message">
-          <xsl:with-param name="id" select="'DOTX052W'"/>
-          <xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/></xsl:with-param>
-        </xsl:call-template>
+        <xsl:variable name="variablefile" select="$variableFiles[@xml:lang='']/@filename" as="xs:string*"/>
+        <xsl:variable name="variable" as="element()*">
+          <xsl:for-each select="$variablefile">
+            <xsl:sequence select="document(., $variableFiles[1])/*/*[@name = $id or @id = $id]"/>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:choose>
+          <xsl:when test="exists($variable)">
+            <xsl:apply-templates select="$variable[last()]" mode="processVariableBody">
+              <xsl:with-param name="params" select="$params"/>
+            </xsl:apply-templates>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$id"/>
+            <xsl:call-template name="output-message">
+              <xsl:with-param name="id" select="'DOTX052W'"/>
+              <xsl:with-param name="msgparams">%1=<xsl:value-of select="$id"/></xsl:with-param>
+            </xsl:call-template>            
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/src/main/xsl/common/strings-ar-eg.xml
+++ b/src/main/xsl/common/strings-ar-eg.xml
@@ -8,75 +8,55 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <strings xml:lang="ar-eg">        <!-- Arabic -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">شكل</str>
-<str name="Table">جدول</str>
-<str name="Next topic">الموضوع التالي</str>
-<str name="Previous topic">الموضوع السابق</str>
-<str name="Parent topic">الموضوع الأصلي</str>
-<str name="Required cleanup">الاخلاء المطلوب</str>
-<str name="Draft comment">تعليق المسودة</str>
-<str name="Option">اختيار</str>
-<str name="Description">توصيف</str>
-<str name="Optional">اختياري</str>
-<str name="Required">مطلوب</str>
-<str name="Skip visual syntax diagram">تخطي شكل الصيغة المرئية</str>
-<str name="Read syntax diagram">شكل صيغة القراءة</str>
-<str name="Start of change">بداية التغيير</str>
-<str name="End of change">نهاية التغيير</str>
-<str name="Index">الفهرس</str>
-<str name="Special characters">الحروف الخاصة</str>
-<str name="Numerics">أرقام</str>
-<str name="End notes">ملحوظات النهاية</str>
-<str name="Artwork">عمل فني</str>
-<str name="Syntax">الصيغة</str>
-<str name="Type">النوع</str>
-<str name="Value">القيمة</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">ملاحظة</str>
-<str name="Notes">ملاحظات</str>
-<str name="Tip">تلميح</str>
-<str name="Fastpath">طريقة مختصرة</str>
-<str name="Important">هام</str>
-<str name="Attention">تنبيه</str>
-<str name="Caution">تحذير</str>
-<str name="Danger">خطر</str>
-<str name="Remember">تذكر</str>
-<str name="Restriction">ممنوع</str>
-<str name="Warning">تحذﻳر</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">المحتويات</str>
-<str name="Related concepts">المفاهيم المتعلقة</str>
-<str name="Related tasks">المهام المتعلقة</str>
-<str name="Related reference">المرجع المتعلق</str>
-<str name="Related information">المعلومات المتعلقة</str>
-
-<str name="Prerequisite">متطلب رئيسي</str>
-<str name="Prerequisites">متطلبات رئيسية</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">نبذة عن هذه المهمة</str>
-<str name="task_example">مثال</str>
-<str name="task_postreq">ما تريد القيام به بعد الآن</str>
-<str name="task_prereq">قبل البدء</str>
-<str name="task_procedure">اجراء</str>
-<str name="task_procedure_unordered">اجراء</str>
-<str name="task_results">النتائج</str>
-
-<str name="Copyright">حقوق النشر لشركة</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">شكل</str>
+  <str name="Table">جدول</str>
+  <str name="Next topic">الموضوع التالي</str>
+  <str name="Previous topic">الموضوع السابق</str>
+  <str name="Parent topic">الموضوع الأصلي</str>
+  <str name="Required cleanup">الاخلاء المطلوب</str>
+  <str name="Draft comment">تعليق المسودة</str>
+  <str name="Option">اختيار</str>
+  <str name="Description">توصيف</str>
+  <str name="Optional">اختياري</str>
+  <str name="Required">مطلوب</str>
+  <str name="Skip visual syntax diagram">تخطي شكل الصيغة المرئية</str>
+  <str name="Read syntax diagram">شكل صيغة القراءة</str>
+  <str name="Start of change">بداية التغيير</str>
+  <str name="End of change">نهاية التغيير</str>
+  <str name="Index">الفهرس</str>
+  <str name="Special characters">الحروف الخاصة</str>
+  <str name="Numerics">أرقام</str>
+  <str name="End notes">ملحوظات النهاية</str>
+  <str name="Artwork">عمل فني</str>
+  <str name="Syntax">الصيغة</str>
+  <str name="Type">النوع</str>
+  <str name="Value">القيمة</str>
+  <str name="Note">ملاحظة</str>
+  <str name="Notes">ملاحظات</str>
+  <str name="Tip">تلميح</str>
+  <str name="Fastpath">طريقة مختصرة</str>
+  <str name="Important">هام</str>
+  <str name="Attention">تنبيه</str>
+  <str name="Caution">تحذير</str>
+  <str name="Danger">خطر</str>
+  <str name="Remember">تذكر</str>
+  <str name="Restriction">ممنوع</str>
+  <str name="Warning">تحذﻳر</str>
+  <str name="Contents">المحتويات</str>
+  <str name="Related concepts">المفاهيم المتعلقة</str>
+  <str name="Related tasks">المهام المتعلقة</str>
+  <str name="Related reference">المرجع المتعلق</str>
+  <str name="Related information">المعلومات المتعلقة</str>
+  <str name="Prerequisite">متطلب رئيسي</str>
+  <str name="Prerequisites">متطلبات رئيسية</str>
+  <str name="or">or</str>
+  <str name="task_context">نبذة عن هذه المهمة</str>
+  <str name="task_example">مثال</str>
+  <str name="task_postreq">ما تريد القيام به بعد الآن</str>
+  <str name="task_prereq">قبل البدء</str>
+  <str name="task_procedure">اجراء</str>
+  <str name="task_procedure_unordered">اجراء</str>
+  <str name="task_results">النتائج</str>
+  <str name="Copyright">حقوق النشر لشركة</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-be-by.xml
+++ b/src/main/xsl/common/strings-be-by.xml
@@ -6,7 +6,6 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="be-by"> <!-- Belarusian --> 
   <str name="Figure">Малюнак</str> 
   <str name="Table">Табліца</str> 
@@ -31,9 +30,6 @@ See the accompanying LICENSE file for applicable license.
   <str name="Syntax">Сінтакс.</str> 
   <str name="Type">Тып</str> 
   <str name="Value">Значэнне</str> 
-  <!-- Text that goes before a link to a topic -->
-  <str name="intro-to-topic-link"></str>
-  <!-- peril notice labels --> 
   <str name="Note">Заўвага</str> 
   <str name="Notes">Заўвагі</str> 
   <str name="Tip">Парада</str> 
@@ -44,8 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">НЕБЯСПЕКА</str> 
   <str name="Remember">Напамін</str> 
   <str name="Restriction">Абмежаванне</str> 
-  <str name="Warning">Папярэджанне</str> 
-  <!-- default title text for section level generated sections --> 
+  <str name="Warning">Папярэджанне</str>  
   <str name="Contents">Змест</str> 
   <str name="Related concepts">Адпаведныя канцэпцыі</str> 
   <str name="Related tasks">Адпаведныя задачы</str> 
@@ -54,9 +49,6 @@ See the accompanying LICENSE file for applicable license.
   <str name="Prerequisite">Перадумова</str> 
   <str name="Prerequisites">Перадумовы</str> 
   <str name="or">або</str> 
-  <str name="figure-number-separator"> </str>
-
-  <!--Task section labels -->
   <str name="task_context">Аб гэтай задачы</str>
   <str name="task_example">Прыклад</str>
   <str name="task_postreq">Далейшыя дзеяннi</str>
@@ -64,12 +56,6 @@ See the accompanying LICENSE file for applicable license.
   <str name="task_procedure">Парадак выканання</str>
   <str name="task_procedure_unordered">Парадак выканання</str>
   <str name="task_results">Рэзультаты</str>
-
   <str name="Copyright">Copyright</str> 
-  <!-- Symbols --> 
-  <str name="OpenQuote">“</str> 
-  <str name="CloseQuote">”</str> 
-  <str name="ColonSymbol">:</str> 
-  <str name="#menucascade-separator"> &gt; </str> 
   <str name="a11y.and-then"></str> 
 </strings>

--- a/src/main/xsl/common/strings-bg-bg.xml
+++ b/src/main/xsl/common/strings-bg-bg.xml
@@ -8,75 +8,55 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <strings xml:lang="bg-bg">        <!-- Bulgarian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Фигура</str>
-<str name="Table">Таблица</str>
-<str name="Next topic">Следваща тема</str>
-<str name="Previous topic">Предходна тема</str>
-<str name="Parent topic">Тема родител</str>
-<str name="Required cleanup">Необходимо прочистване</str>
-<str name="Draft comment">Коментар на чернова</str>
-<str name="Option">Опция</str>
-<str name="Description">Описание</str>
-<str name="Optional">Избираем</str>
-<str name="Required">Задължителен</str>
-<str name="Skip visual syntax diagram">Пропусни визуална диаграма на синтаксис</str>
-<str name="Read syntax diagram">Четене на диаграма на синтаксис</str>
-<str name="Start of change">Начало на промяна</str>
-<str name="End of change">Край на промяна</str>
-<str name="Index">Индекс</str>
-<str name="Special characters">Специални символи</str>
-<str name="Numerics">Цифри</str>
-<str name="End notes">Крайни забележки</str>
-<str name="Artwork">Илюстрации</str>
-<str name="Syntax">Синтаксис</str>
-<str name="Type">Тип</str>
-<str name="Value">Стойност</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Забележка</str>
-<str name="Notes">Забележки</str>
-<str name="Tip">Съвет</str>
-<str name="Fastpath">Бърз начин</str>
-<str name="Important">Важно</str>
-<str name="Attention">Внимание</str>
-<str name="Caution">ВНИМАНИЕ</str>
-<str name="Danger">ОПАСНО</str>
-<str name="Remember">Запомнете</str>
-<str name="Restriction">Ограничение</str>
-<str name="Warning">Предупреждение</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Съдържание</str>
-<str name="Related concepts">Свързани понятия</str>
-<str name="Related tasks">Свързани дейности</str>
-<str name="Related reference">Свързани справки</str>
-<str name="Related information">Свързана информация</str>
-
-<str name="Prerequisite">Необходимо условие</str>
-<str name="Prerequisites">Необходими условия</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">За тази дейност</str>
-<str name="task_example">Пример</str>
-<str name="task_postreq">Какво да направим после</str>
-<str name="task_prereq">Преди да започнете</str>
-<str name="task_procedure">Процедура</str>
-<str name="task_procedure_unordered">Процедура</str>
-<str name="task_results">Резултати</str>
-
-<str name="Copyright">Авторско право</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Фигура</str>
+  <str name="Table">Таблица</str>
+  <str name="Next topic">Следваща тема</str>
+  <str name="Previous topic">Предходна тема</str>
+  <str name="Parent topic">Тема родител</str>
+  <str name="Required cleanup">Необходимо прочистване</str>
+  <str name="Draft comment">Коментар на чернова</str>
+  <str name="Option">Опция</str>
+  <str name="Description">Описание</str>
+  <str name="Optional">Избираем</str>
+  <str name="Required">Задължителен</str>
+  <str name="Skip visual syntax diagram">Пропусни визуална диаграма на синтаксис</str>
+  <str name="Read syntax diagram">Четене на диаграма на синтаксис</str>
+  <str name="Start of change">Начало на промяна</str>
+  <str name="End of change">Край на промяна</str>
+  <str name="Index">Индекс</str>
+  <str name="Special characters">Специални символи</str>
+  <str name="Numerics">Цифри</str>
+  <str name="End notes">Крайни забележки</str>
+  <str name="Artwork">Илюстрации</str>
+  <str name="Syntax">Синтаксис</str>
+  <str name="Type">Тип</str>
+  <str name="Value">Стойност</str>
+  <str name="Note">Забележка</str>
+  <str name="Notes">Забележки</str>
+  <str name="Tip">Съвет</str>
+  <str name="Fastpath">Бърз начин</str>
+  <str name="Important">Важно</str>
+  <str name="Attention">Внимание</str>
+  <str name="Caution">ВНИМАНИЕ</str>
+  <str name="Danger">ОПАСНО</str>
+  <str name="Remember">Запомнете</str>
+  <str name="Restriction">Ограничение</str>
+  <str name="Warning">Предупреждение</str>
+  <str name="Contents">Съдържание</str>
+  <str name="Related concepts">Свързани понятия</str>
+  <str name="Related tasks">Свързани дейности</str>
+  <str name="Related reference">Свързани справки</str>
+  <str name="Related information">Свързана информация</str>
+  <str name="Prerequisite">Необходимо условие</str>
+  <str name="Prerequisites">Необходими условия</str>
+  <str name="or">or</str>
+  <str name="task_context">За тази дейност</str>
+  <str name="task_example">Пример</str>
+  <str name="task_postreq">Какво да направим после</str>
+  <str name="task_prereq">Преди да започнете</str>
+  <str name="task_procedure">Процедура</str>
+  <str name="task_procedure_unordered">Процедура</str>
+  <str name="task_results">Резултати</str>
+  <str name="Copyright">Авторско право</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-bs-ba.xml
+++ b/src/main/xsl/common/strings-bs-ba.xml
@@ -6,78 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="bs-ba">
-   <!-- Bosnian -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Slika</str>
-   <str name="Table">Tabela</str>
-   <str name="Next topic">Slijedeće poglavlje</str>
-   <str name="Previous topic">Prethodno poglavlje</str>
-   <str name="Parent topic">Nadređeno poglavlje</str>
-   <str name="Required cleanup">Potrebno čišćenje</str>
-   <str name="Draft comment">Komentar nacrta</str>
-   <str name="Option">Opcija</str>
-   <str name="Description">Opis</str>
-   <str name="Optional">Opcionalno</str>
-   <str name="Required">Potrebno</str>
-   <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
-   <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
-   <str name="Start of change">Početak promjene</str>
-   <str name="End of change">Kraj promjene</str>
-   <str name="Index">Indeks</str>
-   <str name="Special characters">Posebni znakovi</str>
-   <str name="Numerics">Brojevi</str>
-   <str name="End notes">Završne napomene</str>
-   <str name="Artwork">Ilustracija</str>
-   <str name="Syntax">Sintaksa</str>
-   <str name="Type">Tip</str>
-   <str name="Value">Vrijednost</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Bilješka</str>
-   <str name="Notes">Bilješke</str>
-   <str name="Tip">Savjet</str>
-   <str name="Fastpath">Brza staza</str>
-   <str name="Important">Važno</str>
-   <str name="Attention">Upozorenje</str>
-   <str name="Caution">Oprez</str>
-   <str name="Danger">OPASNOST</str>
-   <str name="Remember">Zapamtite</str>
-   <str name="Restriction">Ograničenje</str>
-   <str name="Warning">Upozorenje</str>
-<str name="Trouble">Trouble</str> <!-- MISSING-->
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Sadržaj</str>
-   <str name="Related concepts">Srodni koncepti</str>
-   <str name="Related tasks">Srodni zadaci</str>
-   <str name="Related reference">Srodne reference</str>
-   <str name="Related information">Srodne informacije</str>
-
-   <str name="Prerequisite">Preduslov</str>
-   <str name="Prerequisites">Preduslovi</str>
-   <str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">O ovom zadatku</str>
-   <str name="task_example">Primjer</str>
-   <str name="task_postreq">Šta uraditi sljedeće</str>
-   <str name="task_prereq">Prije nego što počnete</str>
-   <str name="task_procedure">Postupak</str>
-   <str name="task_procedure_unordered">Postupak</str>
-   <str name="task_results">Rezultati</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+<strings xml:lang="bs-ba">   <!-- Bosnian -->
+  <str name="Figure">Slika</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Slijedeće poglavlje</str>
+  <str name="Previous topic">Prethodno poglavlje</str>
+  <str name="Parent topic">Nadređeno poglavlje</str>
+  <str name="Required cleanup">Potrebno čišćenje</str>
+  <str name="Draft comment">Komentar nacrta</str>
+  <str name="Option">Opcija</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Opcionalno</str>
+  <str name="Required">Potrebno</str>
+  <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
+  <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
+  <str name="Start of change">Početak promjene</str>
+  <str name="End of change">Kraj promjene</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Posebni znakovi</str>
+  <str name="Numerics">Brojevi</str>
+  <str name="End notes">Završne napomene</str>
+  <str name="Artwork">Ilustracija</str>
+  <str name="Syntax">Sintaksa</str>
+  <str name="Type">Tip</str>
+  <str name="Value">Vrijednost</str>
+  <str name="Note">Bilješka</str>
+  <str name="Notes">Bilješke</str>
+  <str name="Tip">Savjet</str>
+  <str name="Fastpath">Brza staza</str>
+  <str name="Important">Važno</str>
+  <str name="Attention">Upozorenje</str>
+  <str name="Caution">Oprez</str>
+  <str name="Danger">OPASNOST</str>
+  <str name="Remember">Zapamtite</str>
+  <str name="Restriction">Ograničenje</str>
+  <str name="Warning">Upozorenje</str>
+  <str name="Trouble">Trouble</str> <!--TODO:Trouble-->
+  <str name="Contents">Sadržaj</str>
+  <str name="Related concepts">Srodni koncepti</str>
+  <str name="Related tasks">Srodni zadaci</str>
+  <str name="Related reference">Srodne reference</str>
+  <str name="Related information">Srodne informacije</str>
+  <str name="Prerequisite">Preduslov</str>
+  <str name="Prerequisites">Preduslovi</str>
+  <str name="or">or</str>
+  <str name="task_context">O ovom zadatku</str>
+  <str name="task_example">Primjer</str>
+  <str name="task_postreq">Šta uraditi sljedeće</str>
+  <str name="task_prereq">Prije nego što počnete</str>
+  <str name="task_procedure">Postupak</str>
+  <str name="task_procedure_unordered">Postupak</str>
+  <str name="task_results">Rezultati</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ca-es.xml
+++ b/src/main/xsl/common/strings-ca-es.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="ca-es">        <!-- Catalan -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Taula</str>
-<str name="Next topic">Tema següent</str>
-<str name="Previous topic">Tema anterior</str>
-<str name="Parent topic">Tema principal</str>
-<str name="Required cleanup">Per revisar</str>
-<str name="Draft comment">Esborrany: comentaris</str>
-<str name="Option">Opció</str>
-<str name="Description">Descripció</str>
-<str name="Optional">Opcional</str>
-<str name="Required">Necessari</str>
-<str name="Skip visual syntax diagram">Ometre l'esquema de sintaxi visual</str>
-<str name="Read syntax diagram">Llegir l'esquema de sintaxi</str>
-<str name="Start of change">Inici del canvi</str>
-<str name="End of change">Fi del canvi</str>
-<str name="Index">Índex</str>
-<str name="Special characters">Caràcters Especials</str>
-<str name="Numerics">Números</str>
-<str name="End notes">Notes al peu</str>
-<str name="Artwork">Gràfics</str>
-<str name="Syntax">Sintaxi</str>
-<str name="Type">Tipus</str>
-<str name="Value">Valor</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link">apartat</str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Notes</str>
-<str name="Tip">Consell</str>
-<str name="Fastpath">Drecera</str>
-<str name="Important">Important</str>
-<str name="Attention">Atenció</str>
-<str name="Caution">PRECAUCIÓ</str>
-<str name="Danger">PERILL</str>
-<str name="Remember">Recordeu</str>
-<str name="Restriction">Restricció</str>
-<str name="Warning">Avís</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Contingut</str>
-<str name="Related concepts">Conceptes relacionats</str>
-<str name="Related tasks">Tasques relacionades</str>
-<str name="Related reference">Referència relacionada</str>
-<str name="Related information">Informació relacionada</str>
-
-<str name="Prerequisite">Requisit</str>
-<str name="Prerequisites">Requisits</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Quant a aquesta tasca</str>
-<str name="task_example">Exemple</str>
-<str name="task_postreq">Què cal fer posteriorment</str>
-<str name="task_prereq">Abans de començar</str>
-<str name="task_procedure">Procediment</str>
-<str name="task_procedure_unordered">Procediment</str>
-<str name="task_results">Resultats</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Taula</str>
+  <str name="Next topic">Tema següent</str>
+  <str name="Previous topic">Tema anterior</str>
+  <str name="Parent topic">Tema principal</str>
+  <str name="Required cleanup">Per revisar</str>
+  <str name="Draft comment">Esborrany: comentaris</str>
+  <str name="Option">Opció</str>
+  <str name="Description">Descripció</str>
+  <str name="Optional">Opcional</str>
+  <str name="Required">Necessari</str>
+  <str name="Skip visual syntax diagram">Ometre l'esquema de sintaxi visual</str>
+  <str name="Read syntax diagram">Llegir l'esquema de sintaxi</str>
+  <str name="Start of change">Inici del canvi</str>
+  <str name="End of change">Fi del canvi</str>
+  <str name="Index">Índex</str>
+  <str name="Special characters">Caràcters Especials</str>
+  <str name="Numerics">Números</str>
+  <str name="End notes">Notes al peu</str>
+  <str name="Artwork">Gràfics</str>
+  <str name="Syntax">Sintaxi</str>
+  <str name="Type">Tipus</str>
+  <str name="Value">Valor</str>
+  <str name="intro-to-topic-link">apartat</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Notes</str>
+  <str name="Tip">Consell</str>
+  <str name="Fastpath">Drecera</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Atenció</str>
+  <str name="Caution">PRECAUCIÓ</str>
+  <str name="Danger">PERILL</str>
+  <str name="Remember">Recordeu</str>
+  <str name="Restriction">Restricció</str>
+  <str name="Warning">Avís</str>
+  <str name="Contents">Contingut</str>
+  <str name="Related concepts">Conceptes relacionats</str>
+  <str name="Related tasks">Tasques relacionades</str>
+  <str name="Related reference">Referència relacionada</str>
+  <str name="Related information">Informació relacionada</str>
+  <str name="Prerequisite">Requisit</str>
+  <str name="Prerequisites">Requisits</str>
+  <str name="or">or</str>
+  <str name="task_context">Quant a aquesta tasca</str>
+  <str name="task_example">Exemple</str>
+  <str name="task_postreq">Què cal fer posteriorment</str>
+  <str name="task_prereq">Abans de començar</str>
+  <str name="task_procedure">Procediment</str>
+  <str name="task_procedure_unordered">Procediment</str>
+  <str name="task_results">Resultats</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-common.xml
+++ b/src/main/xsl/common/strings-common.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2017 IBM Corporation
+
+See the accompanying LICENSE file for applicable license.
+-->
+<strings xml:lang="">
+  <str name="figure-number-separator"> </str>
+  <str name="OpenQuote">“</str>
+  <str name="CloseQuote">”</str>
+  <str name="ColonSymbol">:</str>
+  <str name="#menucascade-separator"> &gt; </str>
+  <!-- Text that goes before a link to a topic -->
+  <str name="intro-to-topic-link"></str>
+</strings>

--- a/src/main/xsl/common/strings-cs-cz.xml
+++ b/src/main/xsl/common/strings-cs-cz.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="cs-cz">        <!-- Czech -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Obrázek</str>
-<str name="Table">Tabulka</str>
-<str name="Next topic">Následující téma</str>
-<str name="Previous topic">Předchozí téma</str>
-<str name="Parent topic">Nadřazené téma</str>
-<str name="Required cleanup">Nutno opravit</str>
-<str name="Draft comment">Poznámka nanečisto</str>
-<str name="Option">Volba</str>
-<str name="Description">Popis</str>
-<str name="Optional">Volitelné</str>
-<str name="Required">Požadované</str>
-<str name="Skip visual syntax diagram">Vynechat zobrazení syntaktického diagramu</str>
-<str name="Read syntax diagram">Číst syntaktický diagram</str>
-<str name="Start of change">Začátek změn</str>
-<str name="End of change">Konec změn</str>
-<str name="Index">Rejstřík</str>
-<str name="Special characters">Speciální znaky</str>
-<str name="Numerics">Čísla</str>
-<str name="End notes">Vysvětlivky</str>
-<str name="Artwork">Ilustrace</str>
-<str name="Syntax">Syntaxe</str>
-<str name="Type">Typ</str>
-<str name="Value">Hodnota</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Poznámka</str>
-<str name="Notes">Poznámky</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Rychlá cesta</str>
-<str name="Important">Důležité</str>
-<str name="Attention">Upozornění</str>
-<str name="Caution">POZOR</str>
-<str name="Danger">NEBEZPEČÍ</str>
-<str name="Remember">Zapamatujte si</str>
-<str name="Restriction">Omezení</str>
-<str name="Warning">Upozornění</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Obsah</str>
-<str name="Related concepts">Související pojmy</str>
-<str name="Related tasks">Související úlohy</str>
-<str name="Related reference">Související odkazy</str>
-<str name="Related information">Související informace</str>
-
-<str name="Prerequisite">Předpoklad</str>
-<str name="Prerequisites">Předpoklady</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Informace o této úloze</str>
-<str name="task_example">Příklad</str>
-<str name="task_postreq">Jak pokračovat dále</str>
-<str name="task_prereq">Než začnete</str>
-<str name="task_procedure">Procedura</str>
-<str name="task_procedure_unordered">Procedura</str>
-<str name="task_results">Výsledky</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Obrázek</str>
+  <str name="Table">Tabulka</str>
+  <str name="Next topic">Následující téma</str>
+  <str name="Previous topic">Předchozí téma</str>
+  <str name="Parent topic">Nadřazené téma</str>
+  <str name="Required cleanup">Nutno opravit</str>
+  <str name="Draft comment">Poznámka nanečisto</str>
+  <str name="Option">Volba</str>
+  <str name="Description">Popis</str>
+  <str name="Optional">Volitelné</str>
+  <str name="Required">Požadované</str>
+  <str name="Skip visual syntax diagram">Vynechat zobrazení syntaktického diagramu</str>
+  <str name="Read syntax diagram">Číst syntaktický diagram</str>
+  <str name="Start of change">Začátek změn</str>
+  <str name="End of change">Konec změn</str>
+  <str name="Index">Rejstřík</str>
+  <str name="Special characters">Speciální znaky</str>
+  <str name="Numerics">Čísla</str>
+  <str name="End notes">Vysvětlivky</str>
+  <str name="Artwork">Ilustrace</str>
+  <str name="Syntax">Syntaxe</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Hodnota</str>
+  <str name="Note">Poznámka</str>
+  <str name="Notes">Poznámky</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Rychlá cesta</str>
+  <str name="Important">Důležité</str>
+  <str name="Attention">Upozornění</str>
+  <str name="Caution">POZOR</str>
+  <str name="Danger">NEBEZPEČÍ</str>
+  <str name="Remember">Zapamatujte si</str>
+  <str name="Restriction">Omezení</str>
+  <str name="Warning">Upozornění</str>
+  <str name="Contents">Obsah</str>
+  <str name="Related concepts">Související pojmy</str>
+  <str name="Related tasks">Související úlohy</str>
+  <str name="Related reference">Související odkazy</str>
+  <str name="Related information">Související informace</str>
+  <str name="Prerequisite">Předpoklad</str>
+  <str name="Prerequisites">Předpoklady</str>
+  <str name="or">or</str>
+  <str name="task_context">Informace o této úloze</str>
+  <str name="task_example">Příklad</str>
+  <str name="task_postreq">Jak pokračovat dále</str>
+  <str name="task_prereq">Než začnete</str>
+  <str name="task_procedure">Procedura</str>
+  <str name="task_procedure_unordered">Procedura</str>
+  <str name="task_results">Výsledky</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-da-dk.xml
+++ b/src/main/xsl/common/strings-da-dk.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="da-dk">        <!-- Danish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figur</str>
-<str name="Table">Tabel</str>
-<str name="Next topic">Næste emne</str>
-<str name="Previous topic">Forrige emne</str>
-<str name="Parent topic">Overordnet emne</str>
-<str name="Required cleanup">Påkrævet oprydning</str>
-<str name="Draft comment">Kommentar til kladde</str>
-<str name="Option">Valg</str>
-<str name="Description">Beskrivelse</str>
-<str name="Optional">Valgfrit</str>
-<str name="Required">Påkrævet</str>
-<str name="Skip visual syntax diagram">Spring over visuel syntaksdiagram</str>
-<str name="Read syntax diagram">Læs syntaksdiagram</str>
-<str name="Start of change">Start på ændringer</str>
-<str name="End of change">Slut på ændringer</str>
-<str name="Index">Stikordsregister</str>
-<str name="Special characters">Specialtegn</str>
-<str name="Numerics">Numerisk</str>
-<str name="End notes">Slutbemærkninger</str>
-<str name="Artwork">Illustrationer</str>
-<str name="Syntax">Syntaks</str>
-<str name="Type">Type</str>
-<str name="Value">Værdi</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Bemærk</str>
-<str name="Notes">Bemærkninger</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Genvej</str>
-<str name="Important">Vigtigt</str>
-<str name="Attention">Advarsel</str>
-<str name="Caution">Pas på</str>
-<str name="Danger">Fare!</str>
-<str name="Remember">Husk</str>
-<str name="Restriction">Begrænsning</str>
-<str name="Warning">Advarsel</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Indholdsfortegnelse</str>
-<str name="Related concepts">Beslægtede begreber</str>
-<str name="Related tasks">Beslægtede opgaver</str>
-<str name="Related reference">Beslægtet reference</str>
-<str name="Related information">Beslægtede oplysninger</str>
-
-<str name="Prerequisite">Forudsætning</str>
-<str name="Prerequisites">Forudsætninger</str>
-<str name="or">eller</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Om denne opgave</str>
-<str name="task_example">Eksempel</str>
-<str name="task_postreq">Næste trin</str>
-<str name="task_prereq">Inden du begynder</str>
-<str name="task_procedure">Fremgangsmåde</str>
-<str name="task_procedure_unordered">Fremgangsmåde</str>
-<str name="task_results">Resultater</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figur</str>
+  <str name="Table">Tabel</str>
+  <str name="Next topic">Næste emne</str>
+  <str name="Previous topic">Forrige emne</str>
+  <str name="Parent topic">Overordnet emne</str>
+  <str name="Required cleanup">Påkrævet oprydning</str>
+  <str name="Draft comment">Kommentar til kladde</str>
+  <str name="Option">Valg</str>
+  <str name="Description">Beskrivelse</str>
+  <str name="Optional">Valgfrit</str>
+  <str name="Required">Påkrævet</str>
+  <str name="Skip visual syntax diagram">Spring over visuel syntaksdiagram</str>
+  <str name="Read syntax diagram">Læs syntaksdiagram</str>
+  <str name="Start of change">Start på ændringer</str>
+  <str name="End of change">Slut på ændringer</str>
+  <str name="Index">Stikordsregister</str>
+  <str name="Special characters">Specialtegn</str>
+  <str name="Numerics">Numerisk</str>
+  <str name="End notes">Slutbemærkninger</str>
+  <str name="Artwork">Illustrationer</str>
+  <str name="Syntax">Syntaks</str>
+  <str name="Type">Type</str>
+  <str name="Value">Værdi</str>
+  <str name="Note">Bemærk</str>
+  <str name="Notes">Bemærkninger</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Genvej</str>
+  <str name="Important">Vigtigt</str>
+  <str name="Attention">Advarsel</str>
+  <str name="Caution">Pas på</str>
+  <str name="Danger">Fare!</str>
+  <str name="Remember">Husk</str>
+  <str name="Restriction">Begrænsning</str>
+  <str name="Warning">Advarsel</str>
+  <str name="Contents">Indholdsfortegnelse</str>
+  <str name="Related concepts">Beslægtede begreber</str>
+  <str name="Related tasks">Beslægtede opgaver</str>
+  <str name="Related reference">Beslægtet reference</str>
+  <str name="Related information">Beslægtede oplysninger</str>
+  <str name="Prerequisite">Forudsætning</str>
+  <str name="Prerequisites">Forudsætninger</str>
+  <str name="or">eller</str>
+  <str name="task_context">Om denne opgave</str>
+  <str name="task_example">Eksempel</str>
+  <str name="task_postreq">Næste trin</str>
+  <str name="task_prereq">Inden du begynder</str>
+  <str name="task_procedure">Fremgangsmåde</str>
+  <str name="task_procedure_unordered">Fremgangsmåde</str>
+  <str name="task_results">Resultater</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-de-ch.xml
+++ b/src/main/xsl/common/strings-de-ch.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="de-ch">        <!-- Swiss German -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Abbildung</str>
-<str name="Table">Tabelle</str>
-<str name="Next topic">Nächstes Thema</str>
-<str name="Previous topic">Vorheriges Thema</str>
-<str name="Parent topic">Übergeordnetes Thema</str>
-<str name="Required cleanup">Erforderliche Korrektur</str>
-<str name="Draft comment">Kommentar</str>
-<str name="Option">Option</str>
-<str name="Description">Bezeichnung</str>
-<str name="Optional">Optional</str>
-<str name="Required">Erforderlich</str>
-<str name="Skip visual syntax diagram">Syntaxdiagramm überspringen</str>
-<str name="Read syntax diagram">Syntaxdiagramm lesen</str>
-<str name="Start of change">Beginn der Änderung</str>
-<str name="End of change">Ende der Änderung</str>
-<str name="Index">Index</str>
-<str name="Special characters">Sonderzeichen</str>
-<str name="Numerics">Numerische Stichwörter</str>
-<str name="End notes">Endnoten</str>
-<str name="Artwork">Bildmaterial</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Typ</str>
-<str name="Value">Wert</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Anmerkung</str>
-<str name="Notes">Anmerkungen</str>
-<str name="Tip">Tipp</str>
-<str name="Fastpath">Direktaufruf</str>
-<str name="Important">Wichtig</str>
-<str name="Attention">Achtung</str>
-<str name="Caution">ACHTUNG</str>
-<str name="Danger">VORSICHT</str>
-<str name="Remember">Hinweis</str>
-<str name="Restriction">Einschränkung</str>
-<str name="Warning">Warnung</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Inhaltsverzeichnis</str>
-<str name="Related concepts">Zugehörige Konzepte</str>
-<str name="Related tasks">Zugehörige Tasks</str>
-<str name="Related reference">Zugehörige Verweise</str>
-<str name="Related information">Zugehörige Informationen</str>
-
-<str name="Prerequisite">Voraussetzung</str>
-<str name="Prerequisites">Voraussetzungen</str>
-<str name="or">oder</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Warum und wann dieser Vorgang ausgeführt wird</str>
-<str name="task_example">Beispiel</str>
-<str name="task_prereq">Vorbereitungen</str>
-<str name="task_postreq">Nächste Maßnahme</str>
-<str name="task_procedure">Prozedur</str>
-<str name="task_procedure_unordered">Prozedur</str>
-<str name="task_results">Ergebnisse</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">„</str>
-<str name="CloseQuote">“</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Abbildung</str>
+  <str name="Table">Tabelle</str>
+  <str name="Next topic">Nächstes Thema</str>
+  <str name="Previous topic">Vorheriges Thema</str>
+  <str name="Parent topic">Übergeordnetes Thema</str>
+  <str name="Required cleanup">Erforderliche Korrektur</str>
+  <str name="Draft comment">Kommentar</str>
+  <str name="Option">Option</str>
+  <str name="Description">Bezeichnung</str>
+  <str name="Optional">Optional</str>
+  <str name="Required">Erforderlich</str>
+  <str name="Skip visual syntax diagram">Syntaxdiagramm überspringen</str>
+  <str name="Read syntax diagram">Syntaxdiagramm lesen</str>
+  <str name="Start of change">Beginn der Änderung</str>
+  <str name="End of change">Ende der Änderung</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Sonderzeichen</str>
+  <str name="Numerics">Numerische Stichwörter</str>
+  <str name="End notes">Endnoten</str>
+  <str name="Artwork">Bildmaterial</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Wert</str>
+  <str name="Note">Anmerkung</str>
+  <str name="Notes">Anmerkungen</str>
+  <str name="Tip">Tipp</str>
+  <str name="Fastpath">Direktaufruf</str>
+  <str name="Important">Wichtig</str>
+  <str name="Attention">Achtung</str>
+  <str name="Caution">ACHTUNG</str>
+  <str name="Danger">VORSICHT</str>
+  <str name="Remember">Hinweis</str>
+  <str name="Restriction">Einschränkung</str>
+  <str name="Warning">Warnung</str>
+  <str name="Contents">Inhaltsverzeichnis</str>
+  <str name="Related concepts">Zugehörige Konzepte</str>
+  <str name="Related tasks">Zugehörige Tasks</str>
+  <str name="Related reference">Zugehörige Verweise</str>
+  <str name="Related information">Zugehörige Informationen</str>
+  <str name="Prerequisite">Voraussetzung</str>
+  <str name="Prerequisites">Voraussetzungen</str>
+  <str name="or">oder</str>
+  <str name="task_context">Warum und wann dieser Vorgang ausgeführt wird</str>
+  <str name="task_example">Beispiel</str>
+  <str name="task_prereq">Vorbereitungen</str>
+  <str name="task_postreq">Nächste Maßnahme</str>
+  <str name="task_procedure">Prozedur</str>
+  <str name="task_procedure_unordered">Prozedur</str>
+  <str name="task_results">Ergebnisse</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">„</str>
+  <str name="CloseQuote">“</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-de-de.xml
+++ b/src/main/xsl/common/strings-de-de.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="de-de">        <!-- German -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Abbildung</str>
-<str name="Table">Tabelle</str>
-<str name="Next topic">Nächstes Thema</str>
-<str name="Previous topic">Vorheriges Thema</str>
-<str name="Parent topic">Übergeordnetes Thema</str>
-<str name="Required cleanup">Erforderliche Korrektur</str>
-<str name="Draft comment">Kommentar</str>
-<str name="Option">Option</str>
-<str name="Description">Bezeichnung</str>
-<str name="Optional">Optional</str>
-<str name="Required">Erforderlich</str>
-<str name="Skip visual syntax diagram">Syntaxdiagramm überspringen</str>
-<str name="Read syntax diagram">Syntaxdiagramm lesen</str>
-<str name="Start of change">Beginn der Änderung</str>
-<str name="End of change">Ende der Änderung</str>
-<str name="Index">Index</str>
-<str name="Special characters">Sonderzeichen</str>
-<str name="Numerics">Numerische Stichwörter</str>
-<str name="End notes">Endnoten</str>
-<str name="Artwork">Bildmaterial</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Typ</str>
-<str name="Value">Wert</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Anmerkung</str>
-<str name="Notes">Anmerkungen</str>
-<str name="Tip">Tipp</str>
-<str name="Fastpath">Direktaufruf</str>
-<str name="Important">Wichtig</str>
-<str name="Attention">Achtung</str>
-<str name="Caution">ACHTUNG</str>
-<str name="Danger">VORSICHT</str>
-<str name="Remember">Hinweis</str>
-<str name="Restriction">Einschränkung</str>
-<str name="Warning">Warnung</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Inhaltsverzeichnis</str>
-<str name="Related concepts">Zugehörige Konzepte</str>
-<str name="Related tasks">Zugehörige Tasks</str>
-<str name="Related reference">Zugehörige Verweise</str>
-<str name="Related information">Zugehörige Informationen</str>
-
-<str name="Prerequisite">Voraussetzung</str>
-<str name="Prerequisites">Voraussetzungen</str>
-<str name="or">oder</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Warum und wann dieser Vorgang ausgeführt wird</str>
-<str name="task_example">Beispiel</str>
-<str name="task_prereq">Vorbereitungen</str>
-<str name="task_postreq">Nächste Maßnahme</str>
-<str name="task_procedure">Prozedur</str>
-<str name="task_procedure_unordered">Prozedur</str>
-<str name="task_results">Ergebnisse</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">„</str>
-<str name="CloseQuote">“</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Abbildung</str>
+  <str name="Table">Tabelle</str>
+  <str name="Next topic">Nächstes Thema</str>
+  <str name="Previous topic">Vorheriges Thema</str>
+  <str name="Parent topic">Übergeordnetes Thema</str>
+  <str name="Required cleanup">Erforderliche Korrektur</str>
+  <str name="Draft comment">Kommentar</str>
+  <str name="Option">Option</str>
+  <str name="Description">Bezeichnung</str>
+  <str name="Optional">Optional</str>
+  <str name="Required">Erforderlich</str>
+  <str name="Skip visual syntax diagram">Syntaxdiagramm überspringen</str>
+  <str name="Read syntax diagram">Syntaxdiagramm lesen</str>
+  <str name="Start of change">Beginn der Änderung</str>
+  <str name="End of change">Ende der Änderung</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Sonderzeichen</str>
+  <str name="Numerics">Numerische Stichwörter</str>
+  <str name="End notes">Endnoten</str>
+  <str name="Artwork">Bildmaterial</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Wert</str>
+  <str name="Note">Anmerkung</str>
+  <str name="Notes">Anmerkungen</str>
+  <str name="Tip">Tipp</str>
+  <str name="Fastpath">Direktaufruf</str>
+  <str name="Important">Wichtig</str>
+  <str name="Attention">Achtung</str>
+  <str name="Caution">ACHTUNG</str>
+  <str name="Danger">VORSICHT</str>
+  <str name="Remember">Hinweis</str>
+  <str name="Restriction">Einschränkung</str>
+  <str name="Warning">Warnung</str>
+  <str name="Contents">Inhaltsverzeichnis</str>
+  <str name="Related concepts">Zugehörige Konzepte</str>
+  <str name="Related tasks">Zugehörige Tasks</str>
+  <str name="Related reference">Zugehörige Verweise</str>
+  <str name="Related information">Zugehörige Informationen</str>
+  <str name="Prerequisite">Voraussetzung</str>
+  <str name="Prerequisites">Voraussetzungen</str>
+  <str name="or">oder</str>
+  <str name="task_context">Warum und wann dieser Vorgang ausgeführt wird</str>
+  <str name="task_example">Beispiel</str>
+  <str name="task_prereq">Vorbereitungen</str>
+  <str name="task_postreq">Nächste Maßnahme</str>
+  <str name="task_procedure">Prozedur</str>
+  <str name="task_procedure_unordered">Prozedur</str>
+  <str name="task_results">Ergebnisse</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">„</str>
+  <str name="CloseQuote">“</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-el-gr.xml
+++ b/src/main/xsl/common/strings-el-gr.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="el-gr">        <!-- Greek -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Σχήμα</str>
-<str name="Table">Πίνακας</str>
-<str name="Next topic">Επόμενο θέμα</str>
-<str name="Previous topic">Προηγούμενο θέμα</str>
-<str name="Parent topic">Γονικό θέμα</str>
-<str name="Required cleanup">Απαιτείται διόρθωση</str>
-<str name="Draft comment">Πρόχειρο σχόλιο</str>
-<str name="Option">Επιλογή</str>
-<str name="Description">Περιγραφή</str>
-<str name="Optional">Προαιρετικά</str>
-<str name="Required">Απαιτείται</str>
-<str name="Skip visual syntax diagram">Παράλειψη οπτικού διαγράμματος σύνταξης</str>
-<str name="Read syntax diagram">Ανάγνωση διαγράμματος σύνταξης</str>
-<str name="Start of change">Αρχή αλλαγής</str>
-<str name="End of change">Τέλος αλλαγής</str>
-<str name="Index">Ευρετήριο</str>
-<str name="Special characters">Ειδικοί χαρακτήρες</str>
-<str name="Numerics">Αριθμοί</str>
-<str name="End notes">Υποσημειώσεις</str>
-<str name="Artwork">Εικόνα</str>
-<str name="Syntax">Σύνταξη</str>
-<str name="Type">Είδος</str>
-<str name="Value">Τιμή</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Σημείωση</str>
-<str name="Notes">Σημειώσεις</str>
-<str name="Tip">Συμβουλή</str>
-<str name="Fastpath">Άμεση μετάβαση</str>
-<str name="Important">Σημαντικό</str>
-<str name="Attention">Προσοχή</str>
-<str name="Caution">ΠΡΟΣΟΧΗ</str>
-<str name="Danger">ΚΙΝΔΥΝΟΣ</str>
-<str name="Remember">Υπενθύμιση</str>
-<str name="Restriction">Περιορισμός</str>
-<str name="Warning">Προειδοποίηση</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Περιεχόμενα</str>
-<str name="Related concepts">Συναφείς έννοιες</str>
-<str name="Related tasks">Συναφείς εργασίες</str>
-<str name="Related reference">Συναφής αναφορά</str>
-<str name="Related information">Συναφείς πληροφορίες</str>
-
-<str name="Prerequisite">Προϋπόθεση</str>
-<str name="Prerequisites">Προϋποθέσεις</str>
-<str name="or">ή</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Σχετικά με αυτή την εργασία</str>
-<str name="task_example">Παράδειγμα</str>
-<str name="task_postreq">Επόμενες ενέργειες</str>
-<str name="task_prereq">Πριν ξεκινήσετε</str>
-<str name="task_procedure">Διαδικασία</str>
-<str name="task_procedure_unordered">Διαδικασία</str>
-<str name="task_results">Αποτελέσματα</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Σχήμα</str>
+  <str name="Table">Πίνακας</str>
+  <str name="Next topic">Επόμενο θέμα</str>
+  <str name="Previous topic">Προηγούμενο θέμα</str>
+  <str name="Parent topic">Γονικό θέμα</str>
+  <str name="Required cleanup">Απαιτείται διόρθωση</str>
+  <str name="Draft comment">Πρόχειρο σχόλιο</str>
+  <str name="Option">Επιλογή</str>
+  <str name="Description">Περιγραφή</str>
+  <str name="Optional">Προαιρετικά</str>
+  <str name="Required">Απαιτείται</str>
+  <str name="Skip visual syntax diagram">Παράλειψη οπτικού διαγράμματος σύνταξης</str>
+  <str name="Read syntax diagram">Ανάγνωση διαγράμματος σύνταξης</str>
+  <str name="Start of change">Αρχή αλλαγής</str>
+  <str name="End of change">Τέλος αλλαγής</str>
+  <str name="Index">Ευρετήριο</str>
+  <str name="Special characters">Ειδικοί χαρακτήρες</str>
+  <str name="Numerics">Αριθμοί</str>
+  <str name="End notes">Υποσημειώσεις</str>
+  <str name="Artwork">Εικόνα</str>
+  <str name="Syntax">Σύνταξη</str>
+  <str name="Type">Είδος</str>
+  <str name="Value">Τιμή</str>
+  <str name="Note">Σημείωση</str>
+  <str name="Notes">Σημειώσεις</str>
+  <str name="Tip">Συμβουλή</str>
+  <str name="Fastpath">Άμεση μετάβαση</str>
+  <str name="Important">Σημαντικό</str>
+  <str name="Attention">Προσοχή</str>
+  <str name="Caution">ΠΡΟΣΟΧΗ</str>
+  <str name="Danger">ΚΙΝΔΥΝΟΣ</str>
+  <str name="Remember">Υπενθύμιση</str>
+  <str name="Restriction">Περιορισμός</str>
+  <str name="Warning">Προειδοποίηση</str>
+  <str name="Contents">Περιεχόμενα</str>
+  <str name="Related concepts">Συναφείς έννοιες</str>
+  <str name="Related tasks">Συναφείς εργασίες</str>
+  <str name="Related reference">Συναφής αναφορά</str>
+  <str name="Related information">Συναφείς πληροφορίες</str>
+  <str name="Prerequisite">Προϋπόθεση</str>
+  <str name="Prerequisites">Προϋποθέσεις</str>
+  <str name="or">ή</str>
+  <str name="task_context">Σχετικά με αυτή την εργασία</str>
+  <str name="task_example">Παράδειγμα</str>
+  <str name="task_postreq">Επόμενες ενέργειες</str>
+  <str name="task_prereq">Πριν ξεκινήσετε</str>
+  <str name="task_procedure">Διαδικασία</str>
+  <str name="task_procedure_unordered">Διαδικασία</str>
+  <str name="task_results">Αποτελέσματα</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-en-ca.xml
+++ b/src/main/xsl/common/strings-en-ca.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="en-ca">        <!-- Canadian English -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figure</str>
-<str name="Table">Table</str>
-<str name="Next topic">Next topic</str>
-<str name="Previous topic">Previous topic</str>
-<str name="Parent topic">Parent topic</str>
-<str name="Required cleanup">Required cleanup</str>
-<str name="Draft comment">Draft comment</str>
-<str name="Option">Option</str>
-<str name="Description">Description</str>
-<str name="Optional">Optional</str>
-<str name="Required">Required</str>
-<str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
-<str name="Read syntax diagram">Read syntax diagram</str>
-<str name="Start of change">Start of change</str>
-<str name="End of change">End of change</str>
-<str name="Index">Index</str>
-<str name="Special characters">Special characters</str>
-<str name="Numerics">Numerics</str>
-<str name="End notes">End notes</str>
-<str name="Artwork">Artwork</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Type</str>
-<str name="Value">Value</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Note</str>
-<str name="Notes">Notes</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Fastpath</str>
-<str name="Important">Important</str>
-<str name="Attention">Attention</str>
-<str name="Caution">CAUTION</str>
-<str name="Danger">DANGER</str>
-<str name="Remember">Remember</str>
-<str name="Restriction">Restriction</str>
-<str name="Warning">Warning</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Contents</str>
-<str name="Related concepts">Related concepts</str>
-<str name="Related tasks">Related tasks</str>
-<str name="Related reference">Related reference</str>
-<str name="Related information">Related information</str>
-
-<str name="Prerequisite">Prerequisite</str>
-<str name="Prerequisites">Prerequisites</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">About this task</str>
-<str name="task_example">Example</str>
-<str name="task_postreq">What to do next</str>
-<str name="task_prereq">Before you begin</str>
-<str name="task_procedure">Procedure</str>
-<str name="task_procedure_unordered">Procedure</str>
-<str name="task_results">Results</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figure</str>
+  <str name="Table">Table</str>
+  <str name="Next topic">Next topic</str>
+  <str name="Previous topic">Previous topic</str>
+  <str name="Parent topic">Parent topic</str>
+  <str name="Required cleanup">Required cleanup</str>
+  <str name="Draft comment">Draft comment</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Optional</str>
+  <str name="Required">Required</str>
+  <str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
+  <str name="Read syntax diagram">Read syntax diagram</str>
+  <str name="Start of change">Start of change</str>
+  <str name="End of change">End of change</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Special characters</str>
+  <str name="Numerics">Numerics</str>
+  <str name="End notes">End notes</str>
+  <str name="Artwork">Artwork</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Type</str>
+  <str name="Value">Value</str>
+  <str name="Note">Note</str>
+  <str name="Notes">Notes</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Fastpath</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Attention</str>
+  <str name="Caution">CAUTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">Remember</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Warning</str>
+  <str name="Contents">Contents</str>
+  <str name="Related concepts">Related concepts</str>
+  <str name="Related tasks">Related tasks</str>
+  <str name="Related reference">Related reference</str>
+  <str name="Related information">Related information</str>
+  <str name="Prerequisite">Prerequisite</str>
+  <str name="Prerequisites">Prerequisites</str>
+  <str name="or">or</str>
+  <str name="task_context">About this task</str>
+  <str name="task_example">Example</str>
+  <str name="task_postreq">What to do next</str>
+  <str name="task_prereq">Before you begin</str>
+  <str name="task_procedure">Procedure</str>
+  <str name="task_procedure_unordered">Procedure</str>
+  <str name="task_results">Results</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-en-gb.xml
+++ b/src/main/xsl/common/strings-en-gb.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="en-gb">        <!-- British English -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figure</str>
-<str name="Table">Table</str>
-<str name="Next topic">Next topic</str>
-<str name="Previous topic">Previous topic</str>
-<str name="Parent topic">Parent topic</str>
-<str name="Required cleanup">Required cleanup</str>
-<str name="Draft comment">Draft comment</str>
-<str name="Option">Option</str>
-<str name="Description">Description</str>
-<str name="Optional">Optional</str>
-<str name="Required">Required</str>
-<str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
-<str name="Read syntax diagram">Read syntax diagram</str>
-<str name="Start of change">Start of change</str>
-<str name="End of change">End of change</str>
-<str name="Index">Index</str>
-<str name="Special characters">Special characters</str>
-<str name="Numerics">Numerics</str>
-<str name="End notes">End notes</str>
-<str name="Artwork">Artwork</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Type</str>
-<str name="Value">Value</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Note</str>
-<str name="Notes">Notes</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Fastpath</str>
-<str name="Important">Important</str>
-<str name="Attention">Attention</str>
-<str name="Caution">CAUTION</str>
-<str name="Danger">DANGER</str>
-<str name="Remember">Remember</str>
-<str name="Restriction">Restriction</str>
-<str name="Warning">Warning</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Contents</str>
-<str name="Related concepts">Related concepts</str>
-<str name="Related tasks">Related tasks</str>
-<str name="Related reference">Related reference</str>
-<str name="Related information">Related information</str>
-
-<str name="Prerequisite">Prerequisite</str>
-<str name="Prerequisites">Prerequisites</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">About this task</str>
-<str name="task_example">Example</str>
-<str name="task_postreq">What to do next</str>
-<str name="task_prereq">Before you begin</str>
-<str name="task_procedure">Procedure</str>
-<str name="task_procedure_unordered">Procedure</str>
-<str name="task_results">Results</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figure</str>
+  <str name="Table">Table</str>
+  <str name="Next topic">Next topic</str>
+  <str name="Previous topic">Previous topic</str>
+  <str name="Parent topic">Parent topic</str>
+  <str name="Required cleanup">Required cleanup</str>
+  <str name="Draft comment">Draft comment</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Optional</str>
+  <str name="Required">Required</str>
+  <str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
+  <str name="Read syntax diagram">Read syntax diagram</str>
+  <str name="Start of change">Start of change</str>
+  <str name="End of change">End of change</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Special characters</str>
+  <str name="Numerics">Numerics</str>
+  <str name="End notes">End notes</str>
+  <str name="Artwork">Artwork</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Type</str>
+  <str name="Value">Value</str>
+  <str name="Note">Note</str>
+  <str name="Notes">Notes</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Fastpath</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Attention</str>
+  <str name="Caution">CAUTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">Remember</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Warning</str>
+  <str name="Contents">Contents</str>
+  <str name="Related concepts">Related concepts</str>
+  <str name="Related tasks">Related tasks</str>
+  <str name="Related reference">Related reference</str>
+  <str name="Related information">Related information</str>
+  <str name="Prerequisite">Prerequisite</str>
+  <str name="Prerequisites">Prerequisites</str>
+  <str name="or">or</str>
+  <str name="task_context">About this task</str>
+  <str name="task_example">Example</str>
+  <str name="task_postreq">What to do next</str>
+  <str name="task_prereq">Before you begin</str>
+  <str name="task_procedure">Procedure</str>
+  <str name="task_procedure_unordered">Procedure</str>
+  <str name="task_results">Results</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-en-us.xml
+++ b/src/main/xsl/common/strings-en-us.xml
@@ -6,77 +6,90 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="en-us">        <!-- US English -->
+  <!-- 
+    This file controls strings that appear in published output.
+    There is one version of this file per language or locale.  To add support 
+    for a new language, create a copy of this file, name 
+    it using the strings-<locale ISO code>.xml format, and
+    add a mapping for the language into the strings.xml file.
+    
+    Strings with no localized text, common to all (or nearly all)
+    languages, are stored in strings-common.xml. Any common string
+    may be copied into strings-<locale ISO code>.xml to provide a 
+    locale-specific value for the common string.
+  -->
+  <str name="Figure">Figure</str>
+  <str name="Table">Table</str>
+  <str name="Next topic">Next topic</str>
+  <str name="Previous topic">Previous topic</str>
+  <str name="Parent topic">Parent topic</str>
+  <str name="Required cleanup">Required cleanup</str>
+  <str name="Draft comment">Draft comment</str>
+  <!-- Option is used as a heading for the choption column
+       in task choice tables -->
+  <str name="Option">Option</str>
+  <!-- Description is used as a heading for both the chdesc
+       column in <choicetable> in <task> topics and the propdesc
+       column in <property> tables in <reference> topics -->
+  <str name="Description">Description</str>
+  <str name="Optional">Optional</str>
+  <str name="Required">Required</str>
+  <!-- Text available for links that skip visual syntax diagrams -->
+  <str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
+  <str name="Read syntax diagram">Read syntax diagram</str>
+  <str name="Start of change">Start of change</str>
+  <str name="End of change">End of change</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Special characters</str>
+  <str name="Numerics">Numerics</str>
+  <str name="End notes">End notes</str>
+  <str name="Artwork">Artwork</str>
+  <str name="Syntax">Syntax</str>
+    
+  <!-- Type and Value are used as headings for the proptype and propvalue
+       columns in a property table in <reference> topics -->
+  <str name="Type">Type</str>
+  <str name="Value">Value</str>
 
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figure</str>
-<str name="Table">Table</str>
-<str name="Next topic">Next topic</str>
-<str name="Previous topic">Previous topic</str>
-<str name="Parent topic">Parent topic</str>
-<str name="Required cleanup">Required cleanup</str>
-<str name="Draft comment">Draft comment</str>
-<str name="Option">Option</str>
-<str name="Description">Description</str>
-<str name="Optional">Optional</str>
-<str name="Required">Required</str>
-<str name="Skip visual syntax diagram">Skip visual syntax diagram</str>
-<str name="Read syntax diagram">Read syntax diagram</str>
-<str name="Start of change">Start of change</str>
-<str name="End of change">End of change</str>
-<str name="Index">Index</str>
-<str name="Special characters">Special characters</str>
-<str name="Numerics">Numerics</str>
-<str name="End notes">End notes</str>
-<str name="Artwork">Artwork</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Type</str>
-<str name="Value">Value</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
+  <!-- peril notice labels for various <note> types -->
+  <str name="Note">Note</str>
+  <str name="Notes">Notes</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Fastpath</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Attention</str>
+  <str name="Caution">CAUTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">Remember</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Warning</str>
+  <str name="Trouble">Trouble</str>
+  
+  <!-- Title text for Table of contents -->
+  <str name="Contents">Contents</str>
+  <!-- Title text for generated link sections -->
+  <str name="Related concepts">Related concepts</str>
+  <str name="Related tasks">Related tasks</str>
+  <str name="Related reference">Related reference</str>
+  <str name="Related information">Related information</str>
 
-<!-- peril notice labels -->
-<str name="Note">Note</str>
-<str name="Notes">Notes</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Fastpath</str>
-<str name="Important">Important</str>
-<str name="Attention">Attention</str>
-<str name="Caution">CAUTION</str>
-<str name="Danger">DANGER</str>
-<str name="Remember">Remember</str>
-<str name="Restriction">Restriction</str>
-<str name="Warning">Warning</str>
-<str name="Trouble">Trouble</str>
+  <str name="Prerequisite">Prerequisite</str>
+  <str name="Prerequisites">Prerequisites</str>
+  <str name="or">or</str>
 
-<!-- default title text for section level generated sections -->
-<str name="Contents">Contents</str>
-<str name="Related concepts">Related concepts</str>
-<str name="Related tasks">Related tasks</str>
-<str name="Related reference">Related reference</str>
-<str name="Related information">Related information</str>
+  <!--Task section labels -->
+  <str name="task_context">About this task</str>
+  <str name="task_example">Example</str>
+  <str name="task_postreq">What to do next</str>
+  <str name="task_prereq">Before you begin</str>
+  <str name="task_procedure">Procedure</str>
+  <str name="task_procedure_unordered">Procedure</str>
+  <str name="task_results">Results</str>
 
-<str name="Prerequisite">Prerequisite</str>
-<str name="Prerequisites">Prerequisites</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">About this task</str>
-<str name="task_example">Example</str>
-<str name="task_postreq">What to do next</str>
-<str name="task_prereq">Before you begin</str>
-<str name="task_procedure">Procedure</str>
-<str name="task_procedure_unordered">Procedure</str>
-<str name="task_results">Results</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then">and then</str>
+  <str name="Copyright">Copyright</str>
+  <!-- Accessible text for the default > character 
+       generated between menu cascade items (the character
+       itself comes from string name "#menucascade-separator") -->
+  <str name="a11y.and-then">and then</str>
 </strings>

--- a/src/main/xsl/common/strings-es-es.xml
+++ b/src/main/xsl/common/strings-es-es.xml
@@ -6,77 +6,59 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="es-es">        <!-- Spanish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Tabla</str>
-<str name="Next topic">Tema siguiente</str>
-<str name="Previous topic">Tema anterior</str>
-<str name="Parent topic">Tema principal</str>
-<str name="Required cleanup">Por revisar</str>
-<str name="Draft comment">Borrador: comentarios</str>
-<str name="Option">Opción</str>
-<str name="Description">Descripción</str>
-<str name="Optional">Opcional</str>
-<str name="Required">Necesario</str>
-<str name="Skip visual syntax diagram">Omitir el esquema de sintaxis visual</str>
-<str name="Read syntax diagram">Leer el esquema de sintaxis</str>
-<str name="Start of change">Inicio del cambio</str>
-<str name="End of change">Fin del cambio</str>
-<str name="Index">Índice</str>
-<str name="Special characters">Caracteres Especiales</str>
-<str name="Numerics">Números</str>
-<str name="End notes">Notas al pie</str>
-<str name="Artwork">Gráficos e imágenes</str>
-<str name="Syntax">Sintaxis</str>
-<str name="Type">Tipo</str>
-<str name="Value">Valor</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link">apartado</str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Notas</str>
-<str name="Tip">Consejo</str>
-<str name="Fastpath">Vía de acceso rápida</str>
-<str name="Important">Importante</str>
-<str name="Attention">Atención</str>
-<str name="Caution">PRECAUCIÓN</str>
-<str name="Danger">PELIGRO</str>
-<str name="Remember">Recuerde</str>
-<str name="Restriction">Restricción</str>
-<str name="Warning">Aviso</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Contenido</str>
-<str name="Related concepts">Conceptos relacionados</str>
-<str name="Related tasks">Tareas relacionadas</str>
-<str name="Related reference">Referencia relacionada</str>
-<str name="Related information">Información relacionada</str>
-
-<str name="Prerequisite">Requisito</str>
-<str name="Prerequisites">Requisitos</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_prereq">Antes de empezar</str>
-<str name="task_context">Por qué y cuándo se efectúa esta tarea</str>
-<str name="task_example">Ejemplo</str>
-<str name="task_postreq">Qué hacer a continuación</str>
-<str name="task_procedure">Procedimiento</str>
-<str name="task_procedure_unordered">Procedimiento</str>
-<str name="task_results">Resultados</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">«</str>
-<str name="CloseQuote">»</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabla</str>
+  <str name="Next topic">Tema siguiente</str>
+  <str name="Previous topic">Tema anterior</str>
+  <str name="Parent topic">Tema principal</str>
+  <str name="Required cleanup">Por revisar</str>
+  <str name="Draft comment">Borrador: comentarios</str>
+  <str name="Option">Opción</str>
+  <str name="Description">Descripción</str>
+  <str name="Optional">Opcional</str>
+  <str name="Required">Necesario</str>
+  <str name="Skip visual syntax diagram">Omitir el esquema de sintaxis visual</str>
+  <str name="Read syntax diagram">Leer el esquema de sintaxis</str>
+  <str name="Start of change">Inicio del cambio</str>
+  <str name="End of change">Fin del cambio</str>
+  <str name="Index">Índice</str>
+  <str name="Special characters">Caracteres Especiales</str>
+  <str name="Numerics">Números</str>
+  <str name="End notes">Notas al pie</str>
+  <str name="Artwork">Gráficos e imágenes</str>
+  <str name="Syntax">Sintaxis</str>
+  <str name="Type">Tipo</str>
+  <str name="Value">Valor</str>
+  <str name="intro-to-topic-link">apartado</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Notas</str>
+  <str name="Tip">Consejo</str>
+  <str name="Fastpath">Vía de acceso rápida</str>
+  <str name="Important">Importante</str>
+  <str name="Attention">Atención</str>
+  <str name="Caution">PRECAUCIÓN</str>
+  <str name="Danger">PELIGRO</str>
+  <str name="Remember">Recuerde</str>
+  <str name="Restriction">Restricción</str>
+  <str name="Warning">Aviso</str>
+  <str name="Contents">Contenido</str>
+  <str name="Related concepts">Conceptos relacionados</str>
+  <str name="Related tasks">Tareas relacionadas</str>
+  <str name="Related reference">Referencia relacionada</str>
+  <str name="Related information">Información relacionada</str>
+  <str name="Prerequisite">Requisito</str>
+  <str name="Prerequisites">Requisitos</str>
+  <str name="or">or</str>
+  <str name="task_prereq">Antes de empezar</str>
+  <str name="task_context">Por qué y cuándo se efectúa esta tarea</str>
+  <str name="task_example">Ejemplo</str>
+  <str name="task_postreq">Qué hacer a continuación</str>
+  <str name="task_procedure">Procedimiento</str>
+  <str name="task_procedure_unordered">Procedimiento</str>
+  <str name="task_results">Resultados</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">«</str>
+  <str name="CloseQuote">»</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-et-ee.xml
+++ b/src/main/xsl/common/strings-et-ee.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="et-ee">        <!-- Estonian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Joonis</str>
-<str name="Table">Tabel</str>
-<str name="Next topic">Järgmine teema</str>
-<str name="Previous topic">Eelmine teema</str>
-<str name="Parent topic">Peateema</str>
-<str name="Required cleanup">Puhastus nõutav</str>
-<str name="Draft comment">Mustandi kommentaar</str>
-<str name="Option">Suvand</str>
-<str name="Description">Kirjeldus</str>
-<str name="Optional">Mittenõutav</str>
-<str name="Required">Nõutav</str>
-<str name="Skip visual syntax diagram">Jäta süntaksidiagramm vahele</str>
-<str name="Read syntax diagram">Loe süntaksidiagrammi</str>
-<str name="Start of change">Muudatuse algus</str>
-<str name="End of change">Muudatuse lõpp</str>
-<str name="Index">Register</str>
-<str name="Special characters">Erimärgid</str>
-<str name="Numerics">Numbrid</str>
-<str name="End notes">Lõpumärkused</str>
-<str name="Artwork">Pilt</str>
-<str name="Syntax">Süntaks</str>
-<str name="Type">Tüüp</str>
-<str name="Value">Väärtus</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Märkus</str>
-<str name="Notes">Märkused</str>
-<str name="Tip">Soovitus</str>
-<str name="Fastpath">Kiirtee</str>
-<str name="Important">Tähtis</str>
-<str name="Attention">Tähelepanu</str>
-<str name="Caution">ETTEVAATUST</str>
-<str name="Danger">OHT</str>
-<str name="Remember">Pidage meeles</str>
-<str name="Restriction">Piirang</str>
-<str name="Warning">Hoiatus</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Sisukord</str>
-<str name="Related concepts">Seostuvad mõisted</str>
-<str name="Related tasks">Seostuvad tegevused</str>
-<str name="Related reference">Seostuv viide</str>
-<str name="Related information">Seostuv teave</str>
-
-<str name="Prerequisite">Eeltingimus</str>
-<str name="Prerequisites">Eeltingimused</str>
-<str name="or">või</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Teave selle toimingu kohta</str>
-<str name="task_example">Näide</str>
-<str name="task_postreq">Mis saab edasi?</str>
-<str name="task_prereq">Enne alustamist</str>
-<str name="task_procedure">Toimimisviis</str>
-<str name="task_procedure_unordered">Toimimisviis</str>
-<str name="task_results">Tulemused</str>
-
-<str name="Copyright">Autoriõigus</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Joonis</str>
+  <str name="Table">Tabel</str>
+  <str name="Next topic">Järgmine teema</str>
+  <str name="Previous topic">Eelmine teema</str>
+  <str name="Parent topic">Peateema</str>
+  <str name="Required cleanup">Puhastus nõutav</str>
+  <str name="Draft comment">Mustandi kommentaar</str>
+  <str name="Option">Suvand</str>
+  <str name="Description">Kirjeldus</str>
+  <str name="Optional">Mittenõutav</str>
+  <str name="Required">Nõutav</str>
+  <str name="Skip visual syntax diagram">Jäta süntaksidiagramm vahele</str>
+  <str name="Read syntax diagram">Loe süntaksidiagrammi</str>
+  <str name="Start of change">Muudatuse algus</str>
+  <str name="End of change">Muudatuse lõpp</str>
+  <str name="Index">Register</str>
+  <str name="Special characters">Erimärgid</str>
+  <str name="Numerics">Numbrid</str>
+  <str name="End notes">Lõpumärkused</str>
+  <str name="Artwork">Pilt</str>
+  <str name="Syntax">Süntaks</str>
+  <str name="Type">Tüüp</str>
+  <str name="Value">Väärtus</str>
+  <str name="Note">Märkus</str>
+  <str name="Notes">Märkused</str>
+  <str name="Tip">Soovitus</str>
+  <str name="Fastpath">Kiirtee</str>
+  <str name="Important">Tähtis</str>
+  <str name="Attention">Tähelepanu</str>
+  <str name="Caution">ETTEVAATUST</str>
+  <str name="Danger">OHT</str>
+  <str name="Remember">Pidage meeles</str>
+  <str name="Restriction">Piirang</str>
+  <str name="Warning">Hoiatus</str>
+  <str name="Contents">Sisukord</str>
+  <str name="Related concepts">Seostuvad mõisted</str>
+  <str name="Related tasks">Seostuvad tegevused</str>
+  <str name="Related reference">Seostuv viide</str>
+  <str name="Related information">Seostuv teave</str>
+  <str name="Prerequisite">Eeltingimus</str>
+  <str name="Prerequisites">Eeltingimused</str>
+  <str name="or">või</str>
+  <str name="task_context">Teave selle toimingu kohta</str>
+  <str name="task_example">Näide</str>
+  <str name="task_postreq">Mis saab edasi?</str>
+  <str name="task_prereq">Enne alustamist</str>
+  <str name="task_procedure">Toimimisviis</str>
+  <str name="task_procedure_unordered">Toimimisviis</str>
+  <str name="task_results">Tulemused</str>
+  <str name="Copyright">Autoriõigus</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-fi-fi.xml
+++ b/src/main/xsl/common/strings-fi-fi.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="fi-fi">        <!-- Finnish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Kuva</str>
-<str name="Table">Taulukko</str>
-<str name="Next topic">Seuraava aihe</str>
-<str name="Previous topic">Edellinen aihe</str>
-<str name="Parent topic">Pääaihe</str>
-<str name="Required cleanup">Edellyttää tarkistusta</str>
-<str name="Draft comment">Käsittelijän huomautus</str>
-<str name="Option">Valinta</str>
-<str name="Description">Kuvaus</str>
-<str name="Optional">Valinnainen</str>
-<str name="Required">Pakollinen</str>
-<str name="Skip visual syntax diagram">Graafisen syntaksikuvauksen ohitus</str>
-<str name="Read syntax diagram">Graafisen syntaksikuvauksen luku</str>
-<str name="Start of change">muutoksen alku</str>
-<str name="End of change">muutoksen loppu</str>
-<str name="Index">Hakemisto</str>
-<str name="Special characters">Erikoismerkit</str>
-<str name="Numerics">Numerot</str>
-<str name="End notes">Loppuviitteet</str>
-<str name="Artwork">Kuva</str>
-<str name="Syntax">Syntaksi</str>
-<str name="Type">Laji</str>
-<str name="Value">Arvo</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Huomautus</str>
-<str name="Notes">Huomautuksia</str>
-<str name="Tip">Vihje</str>
-<str name="Fastpath">Pikaohje</str>
-<str name="Important">Tärkeää</str>
-<str name="Attention">Huomio</str>
-<str name="Caution">Varoitus</str>
-<str name="Danger">VAARA</str>
-<str name="Remember">Muistutus</str>
-<str name="Restriction">Rajoitus</str>
-<str name="Warning">Varoitus</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Sisältö</str>
-<str name="Related concepts">Aiheeseen liittyviä käsitteitä</str>
-<str name="Related tasks">Aiheeseen liittyviä tehtäviä</str>
-<str name="Related reference">Aiheeseen liittyviä tietolähteitä</str>
-<str name="Related information">Aiheeseen liittyviä tietoja</str>
-
-<str name="Prerequisite">Esitiedot</str>
-<str name="Prerequisites">Esitiedot</str>
-<str name="or">tai</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Tietoja tästä tehtävästä</str>
-<str name="task_example">Esimerkki</str>
-<str name="task_postreq">Seuraavat toimet</str>
-<str name="task_prereq">Ennen aloitusta</str>
-<str name="task_procedure">Toimintosarja</str>
-<str name="task_procedure_unordered">Toimintosarja</str>
-<str name="task_results">Tulokset</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">”</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Kuva</str>
+  <str name="Table">Taulukko</str>
+  <str name="Next topic">Seuraava aihe</str>
+  <str name="Previous topic">Edellinen aihe</str>
+  <str name="Parent topic">Pääaihe</str>
+  <str name="Required cleanup">Edellyttää tarkistusta</str>
+  <str name="Draft comment">Käsittelijän huomautus</str>
+  <str name="Option">Valinta</str>
+  <str name="Description">Kuvaus</str>
+  <str name="Optional">Valinnainen</str>
+  <str name="Required">Pakollinen</str>
+  <str name="Skip visual syntax diagram">Graafisen syntaksikuvauksen ohitus</str>
+  <str name="Read syntax diagram">Graafisen syntaksikuvauksen luku</str>
+  <str name="Start of change">muutoksen alku</str>
+  <str name="End of change">muutoksen loppu</str>
+  <str name="Index">Hakemisto</str>
+  <str name="Special characters">Erikoismerkit</str>
+  <str name="Numerics">Numerot</str>
+  <str name="End notes">Loppuviitteet</str>
+  <str name="Artwork">Kuva</str>
+  <str name="Syntax">Syntaksi</str>
+  <str name="Type">Laji</str>
+  <str name="Value">Arvo</str>
+  <str name="Note">Huomautus</str>
+  <str name="Notes">Huomautuksia</str>
+  <str name="Tip">Vihje</str>
+  <str name="Fastpath">Pikaohje</str>
+  <str name="Important">Tärkeää</str>
+  <str name="Attention">Huomio</str>
+  <str name="Caution">Varoitus</str>
+  <str name="Danger">VAARA</str>
+  <str name="Remember">Muistutus</str>
+  <str name="Restriction">Rajoitus</str>
+  <str name="Warning">Varoitus</str>
+  <str name="Contents">Sisältö</str>
+  <str name="Related concepts">Aiheeseen liittyviä käsitteitä</str>
+  <str name="Related tasks">Aiheeseen liittyviä tehtäviä</str>
+  <str name="Related reference">Aiheeseen liittyviä tietolähteitä</str>
+  <str name="Related information">Aiheeseen liittyviä tietoja</str>
+  <str name="Prerequisite">Esitiedot</str>
+  <str name="Prerequisites">Esitiedot</str>
+  <str name="or">tai</str>
+  <str name="task_context">Tietoja tästä tehtävästä</str>
+  <str name="task_example">Esimerkki</str>
+  <str name="task_postreq">Seuraavat toimet</str>
+  <str name="task_prereq">Ennen aloitusta</str>
+  <str name="task_procedure">Toimintosarja</str>
+  <str name="task_procedure_unordered">Toimintosarja</str>
+  <str name="task_results">Tulokset</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">”</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-fr-be.xml
+++ b/src/main/xsl/common/strings-fr-be.xml
@@ -6,73 +6,59 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="fr-be">        <!-- Belgian French -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Figure</str>
-   <str name="Table">Tableau</str>
-   <str name="Next topic">Sujet suivant</str>
-   <str name="Previous topic">Sujet précédent</str>
-   <str name="Parent topic">Sujet parent</str>
-   <str name="Required cleanup">A revoir</str>
-   <str name="Draft comment">Commentaire de travail</str>
-   <str name="Option">Option</str>
-   <str name="Description">Description</str>
-   <str name="Optional">Facultatif </str>
-   <str name="Required">Obligatoire</str>
-   <str name="Skip visual syntax diagram">Sauter le diagramme</str>
-   <str name="Read syntax diagram">Lire le diagramme</str>
-   <str name="Start of change">Début de modification</str>
-   <str name="End of change">Fin de modification</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Caractères spéciaux</str>
-   <str name="Numerics">Nombres</str>
-   <str name="End notes">Notes finales</str>
-   <str name="Artwork">Graphique</str>
-   <str name="Syntax">Syntaxe</str>
-   <str name="Type">Type</str>
-   <str name="Value">Valeur</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-   <!-- peril notice labels -->
-   <str name="Note">Remarque</str>
-   <str name="Notes">Remarques</str>
-   <str name="Tip">Conseil</str>
-   <str name="Fastpath">Raccourci</str>
-   <str name="Important">Important</str>
-   <str name="Attention">Avertissement</str>
-   <str name="Caution">ATTENTION</str>
-   <str name="Danger">DANGER</str>
-   <str name="Remember">A faire</str>
-   <str name="Restriction">Restriction</str>
-   <str name="Warning">Avertissement</str>
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Table des matières</str>
-   <str name="Related concepts">Concepts associés</str>
-   <str name="Related tasks">Tâches associées</str>
-   <str name="Related reference">Référence associée</str>
-   <str name="Related information">Information associée</str>
-
-   <str name="Prerequisite">Préambule</str>
-   <str name="Prerequisites">Préambules</str>
-   <str name="or">ou</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
-   <str name="task_example">Exemple</str>
-   <str name="task_prereq">Avant de commencer</str>
-   <str name="task_postreq">Que faire ensuite</str>
-   <str name="task_procedure">Procédure</str>
-   <str name="task_procedure_unordered">Procédure</str>
-   <str name="task_results">Résultats</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">« </str>
-   <str name="CloseQuote"> »</str>
-   <str name="ColonSymbol"> :</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
+  <str name="Figure">Figure</str>
+  <str name="Table">Tableau</str>
+  <str name="Next topic">Sujet suivant</str>
+  <str name="Previous topic">Sujet précédent</str>
+  <str name="Parent topic">Sujet parent</str>
+  <str name="Required cleanup">A revoir</str>
+  <str name="Draft comment">Commentaire de travail</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Facultatif </str>
+  <str name="Required">Obligatoire</str>
+  <str name="Skip visual syntax diagram">Sauter le diagramme</str>
+  <str name="Read syntax diagram">Lire le diagramme</str>
+  <str name="Start of change">Début de modification</str>
+  <str name="End of change">Fin de modification</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Caractères spéciaux</str>
+  <str name="Numerics">Nombres</str>
+  <str name="End notes">Notes finales</str>
+  <str name="Artwork">Graphique</str>
+  <str name="Syntax">Syntaxe</str>
+  <str name="Type">Type</str>
+  <str name="Value">Valeur</str>
+  <str name="Note">Remarque</str>
+  <str name="Notes">Remarques</str>
+  <str name="Tip">Conseil</str>
+  <str name="Fastpath">Raccourci</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Avertissement</str>
+  <str name="Caution">ATTENTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">A faire</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Avertissement</str>
+  <str name="Contents">Table des matières</str>
+  <str name="Related concepts">Concepts associés</str>
+  <str name="Related tasks">Tâches associées</str>
+  <str name="Related reference">Référence associée</str>
+  <str name="Related information">Information associée</str>
+  <str name="Prerequisite">Préambule</str>
+  <str name="Prerequisites">Préambules</str>
+  <str name="or">ou</str>
+  <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
+  <str name="task_example">Exemple</str>
+  <str name="task_prereq">Avant de commencer</str>
+  <str name="task_postreq">Que faire ensuite</str>
+  <str name="task_procedure">Procédure</str>
+  <str name="task_procedure_unordered">Procédure</str>
+  <str name="task_results">Résultats</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">« </str>
+  <str name="CloseQuote"> »</str>
+  <str name="ColonSymbol"> :</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-fr-ca.xml
+++ b/src/main/xsl/common/strings-fr-ca.xml
@@ -6,73 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="fr-ca">        <!-- Canadian French -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Figure</str>
-   <str name="Table">Tableau</str>
-   <str name="Next topic">Sujet suivant</str>
-   <str name="Previous topic">Sujet précédent</str>
-   <str name="Parent topic">Sujet parent</str>
-   <str name="Required cleanup">A revoir</str>
-   <str name="Draft comment">Commentaire de travail</str>
-   <str name="Option">Option</str>
-   <str name="Description">Description</str>
-   <str name="Optional">Facultatif </str>
-   <str name="Required">Obligatoire</str>
-   <str name="Skip visual syntax diagram">Sauter le diagramme</str>
-   <str name="Read syntax diagram">Lire le diagramme</str>
-   <str name="Start of change">Début de modification</str>
-   <str name="End of change">Fin de modification</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Caractères spéciaux</str>
-   <str name="Numerics">Nombres</str>
-   <str name="End notes">Notes finales</str>
-   <str name="Artwork">Graphique</str>
-   <str name="Syntax">Syntaxe</str>
-   <str name="Type">Type</str>
-   <str name="Value">Valeur</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-   <!-- peril notice labels -->
-   <str name="Note">Remarque</str>
-   <str name="Notes">Remarques</str>
-   <str name="Tip">Conseil</str>
-   <str name="Fastpath">Raccourci</str>
-   <str name="Important">Important</str>
-   <str name="Attention">Avertissement</str>
-   <str name="Caution">ATTENTION</str>
-   <str name="Danger">DANGER</str>
-   <str name="Remember">A faire</str>
-   <str name="Restriction">Restriction</str>
-   <str name="Warning">Avertissement</str>
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Table des matières</str>
-   <str name="Related concepts">Concepts associés</str>
-   <str name="Related tasks">Tâches associées</str>
-   <str name="Related reference">Référence associée</str>
-   <str name="Related information">Information associée</str>
-
-   <str name="Prerequisite">Préambule</str>
-   <str name="Prerequisites">Préambules</str>
-   <str name="or">ou</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
-   <str name="task_example">Exemple</str>
-   <str name="task_prereq">Avant de commencer</str>
-   <str name="task_postreq">Que faire ensuite</str>
-   <str name="task_procedure">Procédure</str>
-   <str name="task_procedure_unordered">Procédure</str>
-   <str name="task_results">Résultats</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">« </str>
-   <str name="CloseQuote"> »</str>
-   <str name="ColonSymbol">:</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
+  <str name="Figure">Figure</str>
+  <str name="Table">Tableau</str>
+  <str name="Next topic">Sujet suivant</str>
+  <str name="Previous topic">Sujet précédent</str>
+  <str name="Parent topic">Sujet parent</str>
+  <str name="Required cleanup">A revoir</str>
+  <str name="Draft comment">Commentaire de travail</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Facultatif </str>
+  <str name="Required">Obligatoire</str>
+  <str name="Skip visual syntax diagram">Sauter le diagramme</str>
+  <str name="Read syntax diagram">Lire le diagramme</str>
+  <str name="Start of change">Début de modification</str>
+  <str name="End of change">Fin de modification</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Caractères spéciaux</str>
+  <str name="Numerics">Nombres</str>
+  <str name="End notes">Notes finales</str>
+  <str name="Artwork">Graphique</str>
+  <str name="Syntax">Syntaxe</str>
+  <str name="Type">Type</str>
+  <str name="Value">Valeur</str>
+  <str name="Note">Remarque</str>
+  <str name="Notes">Remarques</str>
+  <str name="Tip">Conseil</str>
+  <str name="Fastpath">Raccourci</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Avertissement</str>
+  <str name="Caution">ATTENTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">A faire</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Avertissement</str>
+  <str name="Contents">Table des matières</str>
+  <str name="Related concepts">Concepts associés</str>
+  <str name="Related tasks">Tâches associées</str>
+  <str name="Related reference">Référence associée</str>
+  <str name="Related information">Information associée</str>
+  <str name="Prerequisite">Préambule</str>
+  <str name="Prerequisites">Préambules</str>
+  <str name="or">ou</str>
+  <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
+  <str name="task_example">Exemple</str>
+  <str name="task_prereq">Avant de commencer</str>
+  <str name="task_postreq">Que faire ensuite</str>
+  <str name="task_procedure">Procédure</str>
+  <str name="task_procedure_unordered">Procédure</str>
+  <str name="task_results">Résultats</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">« </str>
+  <str name="CloseQuote"> »</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-fr-ch.xml
+++ b/src/main/xsl/common/strings-fr-ch.xml
@@ -6,73 +6,59 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="fr-ch">        <!-- Swiss French -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Figure</str>
-   <str name="Table">Tableau</str>
-   <str name="Next topic">Sujet suivant</str>
-   <str name="Previous topic">Sujet précédent</str>
-   <str name="Parent topic">Sujet parent</str>
-   <str name="Required cleanup">A revoir</str>
-   <str name="Draft comment">Commentaire de travail</str>
-   <str name="Option">Option</str>
-   <str name="Description">Description</str>
-   <str name="Optional">Facultatif </str>
-   <str name="Required">Obligatoire</str>
-   <str name="Skip visual syntax diagram">Sauter le diagramme</str>
-   <str name="Read syntax diagram">Lire le diagramme</str>
-   <str name="Start of change">Début de modification</str>
-   <str name="End of change">Fin de modification</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Caractères spéciaux</str>
-   <str name="Numerics">Nombres</str>
-   <str name="End notes">Notes finales</str>
-   <str name="Artwork">Graphique</str>
-   <str name="Syntax">Syntaxe</str>
-   <str name="Type">Type</str>
-   <str name="Value">Valeur</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-   <!-- peril notice labels -->
-   <str name="Note">Remarque</str>
-   <str name="Notes">Remarques</str>
-   <str name="Tip">Conseil</str>
-   <str name="Fastpath">Raccourci</str>
-   <str name="Important">Important</str>
-   <str name="Attention">Avertissement</str>
-   <str name="Caution">ATTENTION</str>
-   <str name="Danger">DANGER</str>
-   <str name="Remember">A faire</str>
-   <str name="Restriction">Restriction</str>
-   <str name="Warning">Avertissement</str>
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Table des matières</str>
-   <str name="Related concepts">Concepts associés</str>
-   <str name="Related tasks">Tâches associées</str>
-   <str name="Related reference">Référence associée</str>
-   <str name="Related information">Information associée</str>
-
-   <str name="Prerequisite">Préambule</str>
-   <str name="Prerequisites">Préambules</str>
-   <str name="or">ou</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
-   <str name="task_example">Exemple</str>
-   <str name="task_prereq">Avant de commencer</str>
-   <str name="task_postreq">Que faire ensuite</str>
-   <str name="task_procedure">Procédure</str>
-   <str name="task_procedure_unordered">Procédure</str>
-   <str name="task_results">Résultats</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">« </str>
-   <str name="CloseQuote"> »</str>
-   <str name="ColonSymbol"> :</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
+  <str name="Figure">Figure</str>
+  <str name="Table">Tableau</str>
+  <str name="Next topic">Sujet suivant</str>
+  <str name="Previous topic">Sujet précédent</str>
+  <str name="Parent topic">Sujet parent</str>
+  <str name="Required cleanup">A revoir</str>
+  <str name="Draft comment">Commentaire de travail</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Facultatif </str>
+  <str name="Required">Obligatoire</str>
+  <str name="Skip visual syntax diagram">Sauter le diagramme</str>
+  <str name="Read syntax diagram">Lire le diagramme</str>
+  <str name="Start of change">Début de modification</str>
+  <str name="End of change">Fin de modification</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Caractères spéciaux</str>
+  <str name="Numerics">Nombres</str>
+  <str name="End notes">Notes finales</str>
+  <str name="Artwork">Graphique</str>
+  <str name="Syntax">Syntaxe</str>
+  <str name="Type">Type</str>
+  <str name="Value">Valeur</str>
+  <str name="Note">Remarque</str>
+  <str name="Notes">Remarques</str>
+  <str name="Tip">Conseil</str>
+  <str name="Fastpath">Raccourci</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Avertissement</str>
+  <str name="Caution">ATTENTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">A faire</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Avertissement</str>
+  <str name="Contents">Table des matières</str>
+  <str name="Related concepts">Concepts associés</str>
+  <str name="Related tasks">Tâches associées</str>
+  <str name="Related reference">Référence associée</str>
+  <str name="Related information">Information associée</str>
+  <str name="Prerequisite">Préambule</str>
+  <str name="Prerequisites">Préambules</str>
+  <str name="or">ou</str>
+  <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
+  <str name="task_example">Exemple</str>
+  <str name="task_prereq">Avant de commencer</str>
+  <str name="task_postreq">Que faire ensuite</str>
+  <str name="task_procedure">Procédure</str>
+  <str name="task_procedure_unordered">Procédure</str>
+  <str name="task_results">Résultats</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">« </str>
+  <str name="CloseQuote"> »</str>
+  <str name="ColonSymbol"> :</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-fr-fr.xml
+++ b/src/main/xsl/common/strings-fr-fr.xml
@@ -6,75 +6,59 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="fr-fr">
-   <!-- French -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Figure</str>
-   <str name="Table">Tableau</str>
-   <str name="Next topic">Sujet suivant</str>
-   <str name="Previous topic">Sujet précédent</str>
-   <str name="Parent topic">Sujet parent</str>
-   <str name="Required cleanup">A revoir</str>
-   <str name="Draft comment">Commentaire de travail</str>
-   <str name="Option">Option</str>
-   <str name="Description">Description</str>
-   <str name="Optional">Facultatif </str>
-   <str name="Required">Obligatoire</str>
-   <str name="Skip visual syntax diagram">Sauter le diagramme</str>
-   <str name="Read syntax diagram">Lire le diagramme</str>
-   <str name="Start of change">Début de modification</str>
-   <str name="End of change">Fin de modification</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Caractères spéciaux</str>
-   <str name="Numerics">Nombres</str>
-   <str name="End notes">Notes finales</str>
-   <str name="Artwork">Graphique</str>
-   <str name="Syntax">Syntaxe</str>
-   <str name="Type">Type</str>
-   <str name="Value">Valeur</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-   <!-- peril notice labels -->
-   <str name="Note">Remarque</str>
-   <str name="Notes">Remarques</str>
-   <str name="Tip">Conseil</str>
-   <str name="Fastpath">Raccourci</str>
-   <str name="Important">Important</str>
-   <str name="Attention">Avertissement</str>
-   <str name="Caution">ATTENTION</str>
-   <str name="Danger">DANGER</str>
-   <str name="Remember">A faire</str>
-   <str name="Restriction">Restriction</str>
-   <str name="Warning">Avertissement</str>
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Table des matières</str>
-   <str name="Related concepts">Concepts associés</str>
-   <str name="Related tasks">Tâches associées</str>
-   <str name="Related reference">Référence associée</str>
-   <str name="Related information">Information associée</str>
-
-   <str name="Prerequisite">Préambule</str>
-   <str name="Prerequisites">Préambules</str>
-   <str name="or">ou</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
-   <str name="task_example">Exemple</str>
-   <str name="task_prereq">Avant de commencer</str>
-   <str name="task_postreq">Que faire ensuite</str>
-   <str name="task_procedure">Procédure</str>
-   <str name="task_procedure_unordered">Procédure</str>
-   <str name="task_results">Résultats</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">« </str>
-   <str name="CloseQuote"> »</str>
-   <str name="ColonSymbol"> :</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
-   
+<strings xml:lang="fr-fr">     <!-- French -->
+  <str name="Figure">Figure</str>
+  <str name="Table">Tableau</str>
+  <str name="Next topic">Sujet suivant</str>
+  <str name="Previous topic">Sujet précédent</str>
+  <str name="Parent topic">Sujet parent</str>
+  <str name="Required cleanup">A revoir</str>
+  <str name="Draft comment">Commentaire de travail</str>
+  <str name="Option">Option</str>
+  <str name="Description">Description</str>
+  <str name="Optional">Facultatif </str>
+  <str name="Required">Obligatoire</str>
+  <str name="Skip visual syntax diagram">Sauter le diagramme</str>
+  <str name="Read syntax diagram">Lire le diagramme</str>
+  <str name="Start of change">Début de modification</str>
+  <str name="End of change">Fin de modification</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Caractères spéciaux</str>
+  <str name="Numerics">Nombres</str>
+  <str name="End notes">Notes finales</str>
+  <str name="Artwork">Graphique</str>
+  <str name="Syntax">Syntaxe</str>
+  <str name="Type">Type</str>
+  <str name="Value">Valeur</str>
+  <str name="Note">Remarque</str>
+  <str name="Notes">Remarques</str>
+  <str name="Tip">Conseil</str>
+  <str name="Fastpath">Raccourci</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Avertissement</str>
+  <str name="Caution">ATTENTION</str>
+  <str name="Danger">DANGER</str>
+  <str name="Remember">A faire</str>
+  <str name="Restriction">Restriction</str>
+  <str name="Warning">Avertissement</str>
+  <str name="Contents">Table des matières</str>
+  <str name="Related concepts">Concepts associés</str>
+  <str name="Related tasks">Tâches associées</str>
+  <str name="Related reference">Référence associée</str>
+  <str name="Related information">Information associée</str>
+  <str name="Prerequisite">Préambule</str>
+  <str name="Prerequisites">Préambules</str>
+  <str name="or">ou</str>
+  <str name="task_context">Pourquoi et quand exécuter cette tâche</str>
+  <str name="task_example">Exemple</str>
+  <str name="task_prereq">Avant de commencer</str>
+  <str name="task_postreq">Que faire ensuite</str>
+  <str name="task_procedure">Procédure</str>
+  <str name="task_procedure_unordered">Procédure</str>
+  <str name="task_results">Résultats</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">« </str>
+  <str name="CloseQuote"> »</str>
+  <str name="ColonSymbol"> :</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-he-il.xml
+++ b/src/main/xsl/common/strings-he-il.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="he-il">        <!-- Hebrew -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">תרשים</str>
-<str name="Table">טבלה</str>
-<str name="Next topic">הנושא הבא</str>
-<str name="Previous topic">הנושא הקודם</str>
-<str name="Parent topic">נושא אב</str>
-<str name="Required cleanup">ניקוי דרוש</str>
-<str name="Draft comment">הערות טיוטה</str>
-<str name="Option">אופציה</str>
-<str name="Description">תיאור</str>
-<str name="Optional">אופציונלי</str>
-<str name="Required">דרוש</str>
-<str name="Skip visual syntax diagram">דילוג על תרשים תחביר חזותי</str>
-<str name="Read syntax diagram">קריאת תרשים תחביר</str>
-<str name="Start of change">מצב שינוי</str>
-<str name="End of change">סוף השינוי</str>
-<str name="Index">אינדקס</str>
-<str name="Special characters">תווים מיוחדים</str>
-<str name="Numerics">מספרים</str>
-<str name="End notes">הערות סיום</str>
-<str name="Artwork">עיבוד</str>
-<str name="Syntax">תחביר</str>
-<str name="Type">סוג</str>
-<str name="Value">ערך</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">הערה</str>
-<str name="Notes">הערות</str>
-<str name="Tip">עצה</str>
-<str name="Fastpath">נתיב מהיר</str>
-<str name="Important">חשוב</str>
-<str name="Attention">אל</str>
-<str name="Caution">זהירות</str>
-<str name="Danger">סכנה</str>
-<str name="Remember">נא לזכור</str>
-<str name="Restriction">מגבלה</str>
-<str name="Warning">אזהרה</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">תוכן</str>
-<str name="Related concepts">מושגים קשורים</str>
-<str name="Related tasks">משימות קשורות</str>
-<str name="Related reference">תיעוד קשור</str>
-<str name="Related information">מידע קשור</str>
-
-<str name="Prerequisite">דרישה מוקדמת</str>
-<str name="Prerequisites">דרישות מוקדמות</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">אודות משימה זו</str>
-<str name="task_example">דוגמה</str>
-<str name="task_postreq">איך להמשיך</str>
-<str name="task_prereq">לפני שתתחילו</str>
-<str name="task_procedure">נוהל</str>
-<str name="task_procedure_unordered">נוהל</str>
-<str name="task_results">תוצאות</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">„</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">תרשים</str>
+  <str name="Table">טבלה</str>
+  <str name="Next topic">הנושא הבא</str>
+  <str name="Previous topic">הנושא הקודם</str>
+  <str name="Parent topic">נושא אב</str>
+  <str name="Required cleanup">ניקוי דרוש</str>
+  <str name="Draft comment">הערות טיוטה</str>
+  <str name="Option">אופציה</str>
+  <str name="Description">תיאור</str>
+  <str name="Optional">אופציונלי</str>
+  <str name="Required">דרוש</str>
+  <str name="Skip visual syntax diagram">דילוג על תרשים תחביר חזותי</str>
+  <str name="Read syntax diagram">קריאת תרשים תחביר</str>
+  <str name="Start of change">מצב שינוי</str>
+  <str name="End of change">סוף השינוי</str>
+  <str name="Index">אינדקס</str>
+  <str name="Special characters">תווים מיוחדים</str>
+  <str name="Numerics">מספרים</str>
+  <str name="End notes">הערות סיום</str>
+  <str name="Artwork">עיבוד</str>
+  <str name="Syntax">תחביר</str>
+  <str name="Type">סוג</str>
+  <str name="Value">ערך</str>
+  <str name="Note">הערה</str>
+  <str name="Notes">הערות</str>
+  <str name="Tip">עצה</str>
+  <str name="Fastpath">נתיב מהיר</str>
+  <str name="Important">חשוב</str>
+  <str name="Attention">אל</str>
+  <str name="Caution">זהירות</str>
+  <str name="Danger">סכנה</str>
+  <str name="Remember">נא לזכור</str>
+  <str name="Restriction">מגבלה</str>
+  <str name="Warning">אזהרה</str>
+  <str name="Contents">תוכן</str>
+  <str name="Related concepts">מושגים קשורים</str>
+  <str name="Related tasks">משימות קשורות</str>
+  <str name="Related reference">תיעוד קשור</str>
+  <str name="Related information">מידע קשור</str>
+  <str name="Prerequisite">דרישה מוקדמת</str>
+  <str name="Prerequisites">דרישות מוקדמות</str>
+  <str name="or">or</str>
+  <str name="task_context">אודות משימה זו</str>
+  <str name="task_example">דוגמה</str>
+  <str name="task_postreq">איך להמשיך</str>
+  <str name="task_prereq">לפני שתתחילו</str>
+  <str name="task_procedure">נוהל</str>
+  <str name="task_procedure_unordered">נוהל</str>
+  <str name="task_results">תוצאות</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">„</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-hi-in.xml
+++ b/src/main/xsl/common/strings-hi-in.xml
@@ -7,75 +7,55 @@ Copyright 2009 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <strings xml:lang="hi-in">        <!-- Hindi -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">संख्या</str>
-<str name="Table">तालिका</str>
-<str name="Next topic">अगला विषय</str>
-<str name="Previous topic">पिछला विषय</str>
-<str name="Parent topic">जनक विषय</str>
-<str name="Required cleanup">आवश्यक परिमार्जन</str>
-<str name="Draft comment">मसौदा टिप्पणी</str>
-<str name="Option">विकल्प</str>
-<str name="Description">विवरण</str>
-<str name="Optional">वैकल्पिक</str>
-<str name="Required">आवश्यक</str>
-<str name="Skip visual syntax diagram">दृश्य वाक्यविन्यास आरेख छोड़ जाना</str>
-<str name="Read syntax diagram">पढ़ें वाक्यविन्यास आरेख</str>
-<str name="Start of change">शुरू परिवर्तन</str>
-<str name="End of change">परिवर्तन  समाप्ति</str>
-<str name="Index">सूचकांक</str>
-<str name="Special characters">विशेष वर्ण</str>
-<str name="Numerics">संख्या</str>
-<str name="End notes">अंत नोट</str>
-<str name="Artwork">कलाकृति</str>
-<str name="Syntax">वाक्यविन्यास</str>
-<str name="Type">प्रकार</str>
-<str name="Value">मूल्य</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">नोट</str>
-<str name="Notes">नोट्स</str>
-<str name="Tip">टिप</str>
-<str name="Fastpath">फास्ट पथ</str>
-<str name="Important">महत्वपूर्ण</str>
-<str name="Attention">ध्यान दें</str>
-<str name="Caution">चेतावनी</str>
-<str name="Danger">खतरा</str>
-<str name="Remember">याद करना</str>
-<str name="Restriction">प्रतिबंध</str>
-<str name="Warning">चेतावनी</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">सामग्री</str>
-<str name="Related concepts">संबंधित अवधारणाए</str>
-<str name="Related tasks">संबंधित कार्य</str>
-<str name="Related reference">संबंधित संदर्भ</str>
-<str name="Related information">संबंधित जानकारी</str>
-
-<str name="Prerequisite">शर्त</str>
-<str name="Prerequisites">शर्त</str>
-<str name="or">या</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">इस कार्य के बारे में</str>
-<str name="task_example">उदाहरण</str>
-<str name="task_postreq">क्या करने के लिए अगले</str>
-<str name="task_prereq">इससे पहले कि आप शुरू</str>
-<str name="task_procedure">प्रक्रिया</str>
-<str name="task_procedure_unordered">प्रक्रिया</str>
-<str name="task_results">परिणाम</str>
-
-<str name="Copyright">कॉपीराइट</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">संख्या</str>
+  <str name="Table">तालिका</str>
+  <str name="Next topic">अगला विषय</str>
+  <str name="Previous topic">पिछला विषय</str>
+  <str name="Parent topic">जनक विषय</str>
+  <str name="Required cleanup">आवश्यक परिमार्जन</str>
+  <str name="Draft comment">मसौदा टिप्पणी</str>
+  <str name="Option">विकल्प</str>
+  <str name="Description">विवरण</str>
+  <str name="Optional">वैकल्पिक</str>
+  <str name="Required">आवश्यक</str>
+  <str name="Skip visual syntax diagram">दृश्य वाक्यविन्यास आरेख छोड़ जाना</str>
+  <str name="Read syntax diagram">पढ़ें वाक्यविन्यास आरेख</str>
+  <str name="Start of change">शुरू परिवर्तन</str>
+  <str name="End of change">परिवर्तन  समाप्ति</str>
+  <str name="Index">सूचकांक</str>
+  <str name="Special characters">विशेष वर्ण</str>
+  <str name="Numerics">संख्या</str>
+  <str name="End notes">अंत नोट</str>
+  <str name="Artwork">कलाकृति</str>
+  <str name="Syntax">वाक्यविन्यास</str>
+  <str name="Type">प्रकार</str>
+  <str name="Value">मूल्य</str>
+  <str name="Note">नोट</str>
+  <str name="Notes">नोट्स</str>
+  <str name="Tip">टिप</str>
+  <str name="Fastpath">फास्ट पथ</str>
+  <str name="Important">महत्वपूर्ण</str>
+  <str name="Attention">ध्यान दें</str>
+  <str name="Caution">चेतावनी</str>
+  <str name="Danger">खतरा</str>
+  <str name="Remember">याद करना</str>
+  <str name="Restriction">प्रतिबंध</str>
+  <str name="Warning">चेतावनी</str>
+  <str name="Contents">सामग्री</str>
+  <str name="Related concepts">संबंधित अवधारणाए</str>
+  <str name="Related tasks">संबंधित कार्य</str>
+  <str name="Related reference">संबंधित संदर्भ</str>
+  <str name="Related information">संबंधित जानकारी</str>
+  <str name="Prerequisite">शर्त</str>
+  <str name="Prerequisites">शर्त</str>
+  <str name="or">या</str>
+  <str name="task_context">इस कार्य के बारे में</str>
+  <str name="task_example">उदाहरण</str>
+  <str name="task_postreq">क्या करने के लिए अगले</str>
+  <str name="task_prereq">इससे पहले कि आप शुरू</str>
+  <str name="task_procedure">प्रक्रिया</str>
+  <str name="task_procedure_unordered">प्रक्रिया</str>
+  <str name="task_results">परिणाम</str>
+  <str name="Copyright">कॉपीराइट</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-hr-hr.xml
+++ b/src/main/xsl/common/strings-hr-hr.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="hr-hr">
-   <!-- Croatian -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Slika</str>
-   <str name="Table">Tablica</str>
-   <str name="Next topic">Slijedeće poglavlje</str>
-   <str name="Previous topic">Prethodno poglavlje</str>
-   <str name="Parent topic">Nadređeno poglavlje</str>
-   <str name="Required cleanup">Zahtijevano čišćenje</str>
-   <str name="Draft comment">Komentar nacrta</str>
-   <str name="Option">Opcija</str>
-   <str name="Description">Opis</str>
-   <str name="Optional">Opcijsko</str>
-   <str name="Required">Zahtijevano</str>
-   <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
-   <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
-   <str name="Start of change">Početak promjene</str>
-   <str name="End of change">Kraj promjene</str>
-   <str name="Index">Kazalo</str>
-   <str name="Special characters">Posebni znakovi</str>
-   <str name="Numerics">Brojevi</str>
-   <str name="End notes">Završne napomene</str>
-   <str name="Artwork">Ilustracija</str>
-   <str name="Syntax">Sintaksa</str>
-   <str name="Type">Tip</str>
-   <str name="Value">Vrijednost</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Bilješka</str>
-   <str name="Notes">Bilješke</str>
-   <str name="Tip">Savjet</str>
-   <str name="Fastpath">Brza staza</str>
-   <str name="Important">Važno</str>
-   <str name="Attention">Upozorenje</str>
-   <str name="Caution">Pozor</str>
-   <str name="Danger">OPASNOST</str>
-   <str name="Remember">Zapamtite</str>
-   <str name="Restriction">Ograničenje</str>
-   <str name="Warning">Upozorenje</str>
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Sadržaj</str>
-   <str name="Related concepts">Srodni koncepti</str>
-   <str name="Related tasks">Srodni zadaci</str>
-   <str name="Related reference">Srodne reference</str>
-   <str name="Related information">Srodne informacije</str>
-
-   <str name="Prerequisite">Preduvjet</str>
-   <str name="Prerequisites">Preduvjeti</str>
-   <str name="or">or</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">O ovom zadatku</str>
-   <str name="task_example">Primjer</str>
-   <str name="task_postreq">Što napraviti sljedeće</str>
-   <str name="task_prereq">Prije nego počnete</str>
-   <str name="task_procedure">Postupak</str>
-   <str name="task_procedure_unordered">Postupak</str>
-   <str name="task_results">Rezultati</str>
-
-   <str name="Copyright">Autorska prava</str>
-
-   <!--Symbols-->
-   <str name="OpenQuote">“</str>
-   <str name="CloseQuote">”</str>
-   <str name="ColonSymbol">:</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
-
+<strings xml:lang="hr-hr">    <!-- Croatian -->
+  <str name="Figure">Slika</str>
+  <str name="Table">Tablica</str>
+  <str name="Next topic">Slijedeće poglavlje</str>
+  <str name="Previous topic">Prethodno poglavlje</str>
+  <str name="Parent topic">Nadređeno poglavlje</str>
+  <str name="Required cleanup">Zahtijevano čišćenje</str>
+  <str name="Draft comment">Komentar nacrta</str>
+  <str name="Option">Opcija</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Opcijsko</str>
+  <str name="Required">Zahtijevano</str>
+  <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
+  <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
+  <str name="Start of change">Početak promjene</str>
+  <str name="End of change">Kraj promjene</str>
+  <str name="Index">Kazalo</str>
+  <str name="Special characters">Posebni znakovi</str>
+  <str name="Numerics">Brojevi</str>
+  <str name="End notes">Završne napomene</str>
+  <str name="Artwork">Ilustracija</str>
+  <str name="Syntax">Sintaksa</str>
+  <str name="Type">Tip</str>
+  <str name="Value">Vrijednost</str>
+  <str name="Note">Bilješka</str>
+  <str name="Notes">Bilješke</str>
+  <str name="Tip">Savjet</str>
+  <str name="Fastpath">Brza staza</str>
+  <str name="Important">Važno</str>
+  <str name="Attention">Upozorenje</str>
+  <str name="Caution">Pozor</str>
+  <str name="Danger">OPASNOST</str>
+  <str name="Remember">Zapamtite</str>
+  <str name="Restriction">Ograničenje</str>
+  <str name="Warning">Upozorenje</str>
+  <str name="Contents">Sadržaj</str>
+  <str name="Related concepts">Srodni koncepti</str>
+  <str name="Related tasks">Srodni zadaci</str>
+  <str name="Related reference">Srodne reference</str>
+  <str name="Related information">Srodne informacije</str>
+  <str name="Prerequisite">Preduvjet</str>
+  <str name="Prerequisites">Preduvjeti</str>
+  <str name="or">or</str>
+  <str name="task_context">O ovom zadatku</str>
+  <str name="task_example">Primjer</str>
+  <str name="task_postreq">Što napraviti sljedeće</str>
+  <str name="task_prereq">Prije nego počnete</str>
+  <str name="task_procedure">Postupak</str>
+  <str name="task_procedure_unordered">Postupak</str>
+  <str name="task_results">Rezultati</str>
+  <str name="Copyright">Autorska prava</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-hu-hu.xml
+++ b/src/main/xsl/common/strings-hu-hu.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="hu-hu">        <!-- Hungarian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Ábra</str>
-<str name="Table">Táblázat</str>
-<str name="Next topic">Következő téma</str>
-<str name="Previous topic">Előző téma</str>
-<str name="Parent topic">Szülőtéma</str>
-<str name="Required cleanup">Tisztázandó</str>
-<str name="Draft comment">Szerkesztői megjegyzés</str>
-<str name="Option">Beállítás</str>
-<str name="Description">Leírás</str>
-<str name="Optional">Választható</str>
-<str name="Required">Kötelező</str>
-<str name="Skip visual syntax diagram">Szerkezeti ábra kihagyása</str>
-<str name="Read syntax diagram">Szerkezeti ábra felolvasása</str>
-<str name="Start of change">Módosítás kezdete</str>
-<str name="End of change">Módosítás vége</str>
-<str name="Index">Tárgymutató</str>
-<str name="Special characters">Különleges jelek</str>
-<str name="Numerics">Számok</str>
-<str name="End notes">Végjegyzetek</str>
-<str name="Artwork">Illusztráció</str>
-<str name="Syntax">Szintaxis</str>
-<str name="Type">Típus</str>
-<str name="Value">Érték</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Megjegyzés</str>
-<str name="Notes">Megjegyzések</str>
-<str name="Tip">Tipp</str>
-<str name="Fastpath">Közvetlen almenüre lépés</str>
-<str name="Important">Fontos</str>
-<str name="Attention">Figyelem</str>
-<str name="Caution">FIGYELMEZTETÉS</str>
-<str name="Danger">VESZÉLY!</str>
-<str name="Remember">Ne feledje</str>
-<str name="Restriction">Korlátozás</str>
-<str name="Warning">Figyelmeztetés</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Tartalom</str>
-<str name="Related concepts">Kapcsolódó fogalmak</str>
-<str name="Related tasks">Kapcsolódó feladatok</str>
-<str name="Related reference">Kapcsolódó hivatkozás</str>
-<str name="Related information">Kapcsolódó tájékoztatás</str>
-
-<str name="Prerequisite">Előfeltétel</str>
-<str name="Prerequisites">Előfeltételek</str>
-<str name="or">vagy</str>
-<str name="figure-number-separator">. </str>
-
-<!--Task section labels -->
-<str name="task_context">Erről a feladatról</str>
-<str name="task_example">Példa</str>
-<str name="task_postreq">Mi a következő lépés?</str>
-<str name="task_prereq">Mielőtt elkezdené</str>
-<str name="task_procedure">Eljárás</str>
-<str name="task_procedure_unordered">Eljárás</str>
-<str name="task_results">Eredmények</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Ábra</str>
+  <str name="Table">Táblázat</str>
+  <str name="Next topic">Következő téma</str>
+  <str name="Previous topic">Előző téma</str>
+  <str name="Parent topic">Szülőtéma</str>
+  <str name="Required cleanup">Tisztázandó</str>
+  <str name="Draft comment">Szerkesztői megjegyzés</str>
+  <str name="Option">Beállítás</str>
+  <str name="Description">Leírás</str>
+  <str name="Optional">Választható</str>
+  <str name="Required">Kötelező</str>
+  <str name="Skip visual syntax diagram">Szerkezeti ábra kihagyása</str>
+  <str name="Read syntax diagram">Szerkezeti ábra felolvasása</str>
+  <str name="Start of change">Módosítás kezdete</str>
+  <str name="End of change">Módosítás vége</str>
+  <str name="Index">Tárgymutató</str>
+  <str name="Special characters">Különleges jelek</str>
+  <str name="Numerics">Számok</str>
+  <str name="End notes">Végjegyzetek</str>
+  <str name="Artwork">Illusztráció</str>
+  <str name="Syntax">Szintaxis</str>
+  <str name="Type">Típus</str>
+  <str name="Value">Érték</str>
+  <str name="Note">Megjegyzés</str>
+  <str name="Notes">Megjegyzések</str>
+  <str name="Tip">Tipp</str>
+  <str name="Fastpath">Közvetlen almenüre lépés</str>
+  <str name="Important">Fontos</str>
+  <str name="Attention">Figyelem</str>
+  <str name="Caution">FIGYELMEZTETÉS</str>
+  <str name="Danger">VESZÉLY!</str>
+  <str name="Remember">Ne feledje</str>
+  <str name="Restriction">Korlátozás</str>
+  <str name="Warning">Figyelmeztetés</str>
+  <str name="Contents">Tartalom</str>
+  <str name="Related concepts">Kapcsolódó fogalmak</str>
+  <str name="Related tasks">Kapcsolódó feladatok</str>
+  <str name="Related reference">Kapcsolódó hivatkozás</str>
+  <str name="Related information">Kapcsolódó tájékoztatás</str>
+  <str name="Prerequisite">Előfeltétel</str>
+  <str name="Prerequisites">Előfeltételek</str>
+  <str name="or">vagy</str>
+  <str name="figure-number-separator">. </str>
+  <str name="task_context">Erről a feladatról</str>
+  <str name="task_example">Példa</str>
+  <str name="task_postreq">Mi a következő lépés?</str>
+  <str name="task_prereq">Mielőtt elkezdené</str>
+  <str name="task_procedure">Eljárás</str>
+  <str name="task_procedure_unordered">Eljárás</str>
+  <str name="task_results">Eredmények</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-id-id.xml
+++ b/src/main/xsl/common/strings-id-id.xml
@@ -1,74 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2004, 2005 IBM Corporation
+
+See the accompanying LICENSE file for applicable license.
+-->
 <strings xml:lang="id-id">        <!-- Indonesian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Gambar</str>
-<str name="Table">Tabel</str>
-<str name="Next topic">Topik berikutnya</str>
-<str name="Previous topic">Topik sebelumnya</str>
-<str name="Parent topic">Topik Induk</str>
-<str name="Required cleanup">Pembersihan diperlukan</str>
-<str name="Draft comment">Komentar draf</str>
-<str name="Option">Pilihan</str>
-<str name="Description">Deskripsi</str>
-<str name="Optional">Opsional</str>
-<str name="Required">Diperlukan</str>
-<str name="Skip visual syntax diagram">Lewatkan diagram sintaks visual</str>
-<str name="Read syntax diagram">Baca diagram sintaks</str>
-<str name="Start of change">Mulai perubahan</str>
-<str name="End of change">Akhiri perubahan</str>
-<str name="Index">Indeks</str>
-<str name="Special characters">Karakter khusus</str>
-<str name="Numerics">Numerik</str>
-<str name="End notes">Catatan akhir</str>
-<str name="Artwork">Grafis</str>
-<str name="Syntax">Sintaks</str>
-<str name="Type">Jenis</str>
-<str name="Value">Nilai</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Catatan</str>
-<str name="Notes">Catatan</str>
-<str name="Tip">Kiat</str>
-<str name="Fastpath">Jalur cepat</str>
-<str name="Important">Penting</str>
-<str name="Attention">Perhatian</str>
-<str name="Caution">PERINGATAN</str>
-<str name="Danger">BAHAYA</str>
-<str name="Remember">Ingat</str>
-<str name="Warning">Peringatan</str>
-<str name="Restriction">Pembatasan</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Isi</str>
-<str name="Related concepts">Konsep terkait</str>
-<str name="Related tasks">Tugas terkait</str>
-<str name="Related reference">Referensi terkait</str>
-<str name="Related information">Informasi terkait</str>
-
-<str name="Prerequisite">Prasyarat</str>
-<str name="Prerequisites">Prasyarat</str>
-<str name="or">atau</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Mengenai tugas ini</str>
-<str name="task_example">Contoh</str>
-<str name="task_postreq">Yang harus dilakukan berikutnya</str>
-<str name="task_prereq">Sebelum Anda mulai</str>
-<str name="task_procedure">Prosedur</str>
-<str name="task_procedure_unordered">Prosedur</str>
-<str name="task_results">Hasil</str>
-
-<str name="Copyright">Hak cipta</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Gambar</str>
+  <str name="Table">Tabel</str>
+  <str name="Next topic">Topik berikutnya</str>
+  <str name="Previous topic">Topik sebelumnya</str>
+  <str name="Parent topic">Topik Induk</str>
+  <str name="Required cleanup">Pembersihan diperlukan</str>
+  <str name="Draft comment">Komentar draf</str>
+  <str name="Option">Pilihan</str>
+  <str name="Description">Deskripsi</str>
+  <str name="Optional">Opsional</str>
+  <str name="Required">Diperlukan</str>
+  <str name="Skip visual syntax diagram">Lewatkan diagram sintaks visual</str>
+  <str name="Read syntax diagram">Baca diagram sintaks</str>
+  <str name="Start of change">Mulai perubahan</str>
+  <str name="End of change">Akhiri perubahan</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Karakter khusus</str>
+  <str name="Numerics">Numerik</str>
+  <str name="End notes">Catatan akhir</str>
+  <str name="Artwork">Grafis</str>
+  <str name="Syntax">Sintaks</str>
+  <str name="Type">Jenis</str>
+  <str name="Value">Nilai</str>
+  <str name="Note">Catatan</str>
+  <str name="Notes">Catatan</str>
+  <str name="Tip">Kiat</str>
+  <str name="Fastpath">Jalur cepat</str>
+  <str name="Important">Penting</str>
+  <str name="Attention">Perhatian</str>
+  <str name="Caution">PERINGATAN</str>
+  <str name="Danger">BAHAYA</str>
+  <str name="Remember">Ingat</str>
+  <str name="Warning">Peringatan</str>
+  <str name="Restriction">Pembatasan</str>
+  <str name="Contents">Isi</str>
+  <str name="Related concepts">Konsep terkait</str>
+  <str name="Related tasks">Tugas terkait</str>
+  <str name="Related reference">Referensi terkait</str>
+  <str name="Related information">Informasi terkait</str>
+  <str name="Prerequisite">Prasyarat</str>
+  <str name="Prerequisites">Prasyarat</str>
+  <str name="or">atau</str>
+  <str name="task_context">Mengenai tugas ini</str>
+  <str name="task_example">Contoh</str>
+  <str name="task_postreq">Yang harus dilakukan berikutnya</str>
+  <str name="task_prereq">Sebelum Anda mulai</str>
+  <str name="task_procedure">Prosedur</str>
+  <str name="task_procedure_unordered">Prosedur</str>
+  <str name="task_results">Hasil</str>
+  <str name="Copyright">Hak cipta</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-is-is.xml
+++ b/src/main/xsl/common/strings-is-is.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="is-is">        <!-- Icelandic -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Mynd</str>
-<str name="Table">Tafla</str>
-<str name="Next topic">Næsti kafli</str>
-<str name="Previous topic">Fyrri kafli</str>
-<str name="Parent topic">Yfirkafli</str>
-<str name="Required cleanup">Nauðsynleg hreinsun</str>
-<str name="Draft comment">Tillaga um athugasemd</str>
-<str name="Option">Valkostur</str>
-<str name="Description">Lýsing</str>
-<str name="Optional">Valfrjáls</str>
-<str name="Required">Tilskilið</str>
-<str name="Skip visual syntax diagram">Sleppa sjónrænu flæðiriti málskipunar</str>
-<str name="Read syntax diagram">Lesa flæðirit málskipunar</str>
-<str name="Start of change">Byrjun breytingar</str>
-<str name="End of change">Lok breytingar</str>
-<str name="Index">Atriðaskrá</str>
-<str name="Special characters">Sérstök tákn</str>
-<str name="Numerics">Tölur</str>
-<str name="End notes">Lok athugasemda</str>
-<str name="Artwork">Myndefni</str>
-<str name="Syntax">Málskipan</str>
-<str name="Type">Gerð</str>
-<str name="Value">Gildi</str>
-<!-- Text that goes before a link to a topic (should be empty for most languages) -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Athugið</str>
-<str name="Notes">Athugasemdir</str>
-<str name="Tip">Heilræði</str>
-<str name="Fastpath">Flýtileið</str>
-<str name="Important">Áríðandi</str>
-<str name="Attention">Viðvörun</str>
-<str name="Caution">VARÚÐ</str>
-<str name="Danger">HÆTTA</str>
-<str name="Remember">Mundu</str>
-<str name="Restriction">Takmörkun</str>
-<str name="Warning">Viðvörun</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Efnisyfirlit</str>
-<str name="Related concepts">Skyld hugtök</str>
-<str name="Related tasks">Skyld verkefni</str>
-<str name="Related reference">Skyld tilvísun</str>
-<str name="Related information">Skyldar upplýsingar</str>
-
-<str name="Prerequisite">Forsenda</str>
-<str name="Prerequisites">Forsendur</str>
-<str name="or">eða</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Um þetta verk</str>
-<str name="task_example">Dæmi</str>
-<str name="task_postreq">Það sem gera þarf næst</str>
-<str name="task_prereq">Áður en þú byrjar</str>
-<str name="task_procedure">Aðferð</str>
-<str name="task_procedure_unordered">Aðferð</str>
-<str name="task_results">Niðurstöður</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Mynd</str>
+  <str name="Table">Tafla</str>
+  <str name="Next topic">Næsti kafli</str>
+  <str name="Previous topic">Fyrri kafli</str>
+  <str name="Parent topic">Yfirkafli</str>
+  <str name="Required cleanup">Nauðsynleg hreinsun</str>
+  <str name="Draft comment">Tillaga um athugasemd</str>
+  <str name="Option">Valkostur</str>
+  <str name="Description">Lýsing</str>
+  <str name="Optional">Valfrjáls</str>
+  <str name="Required">Tilskilið</str>
+  <str name="Skip visual syntax diagram">Sleppa sjónrænu flæðiriti málskipunar</str>
+  <str name="Read syntax diagram">Lesa flæðirit málskipunar</str>
+  <str name="Start of change">Byrjun breytingar</str>
+  <str name="End of change">Lok breytingar</str>
+  <str name="Index">Atriðaskrá</str>
+  <str name="Special characters">Sérstök tákn</str>
+  <str name="Numerics">Tölur</str>
+  <str name="End notes">Lok athugasemda</str>
+  <str name="Artwork">Myndefni</str>
+  <str name="Syntax">Málskipan</str>
+  <str name="Type">Gerð</str>
+  <str name="Value">Gildi</str>
+  <str name="Note">Athugið</str>
+  <str name="Notes">Athugasemdir</str>
+  <str name="Tip">Heilræði</str>
+  <str name="Fastpath">Flýtileið</str>
+  <str name="Important">Áríðandi</str>
+  <str name="Attention">Viðvörun</str>
+  <str name="Caution">VARÚÐ</str>
+  <str name="Danger">HÆTTA</str>
+  <str name="Remember">Mundu</str>
+  <str name="Restriction">Takmörkun</str>
+  <str name="Warning">Viðvörun</str>
+  <str name="Contents">Efnisyfirlit</str>
+  <str name="Related concepts">Skyld hugtök</str>
+  <str name="Related tasks">Skyld verkefni</str>
+  <str name="Related reference">Skyld tilvísun</str>
+  <str name="Related information">Skyldar upplýsingar</str>
+  <str name="Prerequisite">Forsenda</str>
+  <str name="Prerequisites">Forsendur</str>
+  <str name="or">eða</str>
+  <str name="task_context">Um þetta verk</str>
+  <str name="task_example">Dæmi</str>
+  <str name="task_postreq">Það sem gera þarf næst</str>
+  <str name="task_prereq">Áður en þú byrjar</str>
+  <str name="task_procedure">Aðferð</str>
+  <str name="task_procedure_unordered">Aðferð</str>
+  <str name="task_results">Niðurstöður</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-it-ch.xml
+++ b/src/main/xsl/common/strings-it-ch.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="it-ch">        <!-- Swiss Italian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Tabella</str>
-<str name="Next topic">Argomento successivo</str>
-<str name="Previous topic">Argomento precedente</str>
-<str name="Parent topic">Argomento principale</str>
-<str name="Required cleanup">Correzione necessaria</str>
-<str name="Draft comment">Commento per la versione bozza</str>
-<str name="Option">Opzione</str>
-<str name="Description">Descrizione</str>
-<str name="Optional">Opzionale</str>
-<str name="Required">Richiesto</str>
-<str name="Skip visual syntax diagram">Salta diagramma di sintassi</str>
-<str name="Read syntax diagram">Leggi diagramma di sintassi</str>
-<str name="Start of change">Inizio modifica</str>
-<str name="End of change">Fine modifica</str>
-<str name="Index">Indice analitico</str>
-<str name="Special characters">Caratteri speciali</str>
-<str name="Numerics">Numerico</str>
-<str name="End notes">Note a pié di pagina</str>
-<str name="Artwork">Figura</str>
-<str name="Syntax">Sintassi</str>
-<str name="Type">Tipo</str>
-<str name="Value">Valore</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Note</str>
-<str name="Tip">Suggerimento</str>
-<str name="Fastpath">Percorso di accesso rapido</str>
-<str name="Important">Importante</str>
-<str name="Attention">Attenzione</str>
-<str name="Caution">Avvertenza</str>
-<str name="Danger">Pericolo</str>
-<str name="Remember">Attenzione</str>
-<str name="Restriction">Limitazione</str>
-<str name="Warning">Avvertenza</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Indice</str>
-<str name="Related concepts">Concetti correlati</str>
-<str name="Related tasks">Attività correlate</str>
-<str name="Related reference">Riferimenti correlati</str>
-<str name="Related information">Informazioni correlate</str>
-
-<str name="Prerequisite">Prerequisito</str>
-<str name="Prerequisites">Prerequisiti</str>
-<str name="or">oppure</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Informazioni su questa attività</str>
-<str name="task_example">Esempio</str>
-<str name="task_prereq">Prima di iniziare</str>
-<str name="task_postreq">Operazioni successive</str>
-<str name="task_procedure">Procedura</str>
-<str name="task_procedure_unordered">Procedura</str>
-<str name="task_results">Risultati</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">«</str>
-<str name="CloseQuote">»</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabella</str>
+  <str name="Next topic">Argomento successivo</str>
+  <str name="Previous topic">Argomento precedente</str>
+  <str name="Parent topic">Argomento principale</str>
+  <str name="Required cleanup">Correzione necessaria</str>
+  <str name="Draft comment">Commento per la versione bozza</str>
+  <str name="Option">Opzione</str>
+  <str name="Description">Descrizione</str>
+  <str name="Optional">Opzionale</str>
+  <str name="Required">Richiesto</str>
+  <str name="Skip visual syntax diagram">Salta diagramma di sintassi</str>
+  <str name="Read syntax diagram">Leggi diagramma di sintassi</str>
+  <str name="Start of change">Inizio modifica</str>
+  <str name="End of change">Fine modifica</str>
+  <str name="Index">Indice analitico</str>
+  <str name="Special characters">Caratteri speciali</str>
+  <str name="Numerics">Numerico</str>
+  <str name="End notes">Note a pié di pagina</str>
+  <str name="Artwork">Figura</str>
+  <str name="Syntax">Sintassi</str>
+  <str name="Type">Tipo</str>
+  <str name="Value">Valore</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Note</str>
+  <str name="Tip">Suggerimento</str>
+  <str name="Fastpath">Percorso di accesso rapido</str>
+  <str name="Important">Importante</str>
+  <str name="Attention">Attenzione</str>
+  <str name="Caution">Avvertenza</str>
+  <str name="Danger">Pericolo</str>
+  <str name="Remember">Attenzione</str>
+  <str name="Restriction">Limitazione</str>
+  <str name="Warning">Avvertenza</str>
+  <str name="Contents">Indice</str>
+  <str name="Related concepts">Concetti correlati</str>
+  <str name="Related tasks">Attività correlate</str>
+  <str name="Related reference">Riferimenti correlati</str>
+  <str name="Related information">Informazioni correlate</str>
+  <str name="Prerequisite">Prerequisito</str>
+  <str name="Prerequisites">Prerequisiti</str>
+  <str name="or">oppure</str>
+  <str name="task_context">Informazioni su questa attività</str>
+  <str name="task_example">Esempio</str>
+  <str name="task_prereq">Prima di iniziare</str>
+  <str name="task_postreq">Operazioni successive</str>
+  <str name="task_procedure">Procedura</str>
+  <str name="task_procedure_unordered">Procedura</str>
+  <str name="task_results">Risultati</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">«</str>
+  <str name="CloseQuote">»</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-it-it.xml
+++ b/src/main/xsl/common/strings-it-it.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="it-it">        <!-- Italian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Tabella</str>
-<str name="Next topic">Argomento successivo</str>
-<str name="Previous topic">Argomento precedente</str>
-<str name="Parent topic">Argomento principale</str>
-<str name="Required cleanup">Correzione necessaria</str>
-<str name="Draft comment">Commento per la versione bozza</str>
-<str name="Option">Opzione</str>
-<str name="Description">Descrizione</str>
-<str name="Optional">Opzionale</str>
-<str name="Required">Richiesto</str>
-<str name="Skip visual syntax diagram">Salta diagramma di sintassi</str>
-<str name="Read syntax diagram">Leggi diagramma di sintassi</str>
-<str name="Start of change">Inizio modifica</str>
-<str name="End of change">Fine modifica</str>
-<str name="Index">Indice analitico</str>
-<str name="Special characters">Caratteri speciali</str>
-<str name="Numerics">Numerico</str>
-<str name="End notes">Note a pié di pagina</str>
-<str name="Artwork">Figura</str>
-<str name="Syntax">Sintassi</str>
-<str name="Type">Tipo</str>
-<str name="Value">Valore</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Note</str>
-<str name="Tip">Suggerimento</str>
-<str name="Fastpath">Percorso di accesso rapido</str>
-<str name="Important">Importante</str>
-<str name="Attention">Attenzione</str>
-<str name="Caution">Avvertenza</str>
-<str name="Danger">Pericolo</str>
-<str name="Remember">Attenzione</str>
-<str name="Restriction">Limitazione</str>
-<str name="Warning">Avvertenza</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Indice</str>
-<str name="Related concepts">Concetti correlati</str>
-<str name="Related tasks">Attività correlate</str>
-<str name="Related reference">Riferimenti correlati</str>
-<str name="Related information">Informazioni correlate</str>
-
-<str name="Prerequisite">Prerequisito</str>
-<str name="Prerequisites">Prerequisiti</str>
-<str name="or">oppure</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Informazioni su questa attività</str>
-<str name="task_example">Esempio</str>
-<str name="task_prereq">Prima di iniziare</str>
-<str name="task_postreq">Operazioni successive</str>
-<str name="task_procedure">Procedura</str>
-<str name="task_procedure_unordered">Procedura</str>
-<str name="task_results">Risultati</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">«</str>
-<str name="CloseQuote">»</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabella</str>
+  <str name="Next topic">Argomento successivo</str>
+  <str name="Previous topic">Argomento precedente</str>
+  <str name="Parent topic">Argomento principale</str>
+  <str name="Required cleanup">Correzione necessaria</str>
+  <str name="Draft comment">Commento per la versione bozza</str>
+  <str name="Option">Opzione</str>
+  <str name="Description">Descrizione</str>
+  <str name="Optional">Opzionale</str>
+  <str name="Required">Richiesto</str>
+  <str name="Skip visual syntax diagram">Salta diagramma di sintassi</str>
+  <str name="Read syntax diagram">Leggi diagramma di sintassi</str>
+  <str name="Start of change">Inizio modifica</str>
+  <str name="End of change">Fine modifica</str>
+  <str name="Index">Indice analitico</str>
+  <str name="Special characters">Caratteri speciali</str>
+  <str name="Numerics">Numerico</str>
+  <str name="End notes">Note a pié di pagina</str>
+  <str name="Artwork">Figura</str>
+  <str name="Syntax">Sintassi</str>
+  <str name="Type">Tipo</str>
+  <str name="Value">Valore</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Note</str>
+  <str name="Tip">Suggerimento</str>
+  <str name="Fastpath">Percorso di accesso rapido</str>
+  <str name="Important">Importante</str>
+  <str name="Attention">Attenzione</str>
+  <str name="Caution">Avvertenza</str>
+  <str name="Danger">Pericolo</str>
+  <str name="Remember">Attenzione</str>
+  <str name="Restriction">Limitazione</str>
+  <str name="Warning">Avvertenza</str>
+  <str name="Contents">Indice</str>
+  <str name="Related concepts">Concetti correlati</str>
+  <str name="Related tasks">Attività correlate</str>
+  <str name="Related reference">Riferimenti correlati</str>
+  <str name="Related information">Informazioni correlate</str>
+  <str name="Prerequisite">Prerequisito</str>
+  <str name="Prerequisites">Prerequisiti</str>
+  <str name="or">oppure</str>
+  <str name="task_context">Informazioni su questa attività</str>
+  <str name="task_example">Esempio</str>
+  <str name="task_prereq">Prima di iniziare</str>
+  <str name="task_postreq">Operazioni successive</str>
+  <str name="task_procedure">Procedura</str>
+  <str name="task_procedure_unordered">Procedura</str>
+  <str name="task_results">Risultati</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">«</str>
+  <str name="CloseQuote">»</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ja-jp.xml
+++ b/src/main/xsl/common/strings-ja-jp.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="ja-jp">        <!-- Japanese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">図</str>
-<str name="Table">表</str>
-<str name="Next topic">次のトピック</str>
-<str name="Previous topic">前のトピック</str>
-<str name="Parent topic">親トピック</str>
-<str name="Required cleanup">クリーンアップ要求</str>
-<str name="Draft comment">ドラフト注釈</str>
-<str name="Option">オプション</str>
-<str name="Description">説明</str> 
-<str name="Optional">オプション</str>
-<str name="Required">必須</str>
-<str name="Skip visual syntax diagram">構文図をスキップする</str>
-<str name="Read syntax diagram">構文図を読む</str>
-<str name="Start of change">変更の始まり</str>
-<str name="End of change">変更の終わり</str>
-<str name="Index">索引</str>
-<str name="Special characters">特殊文字</str>
-<str name="Numerics">数字</str>
-<str name="End notes">脚注</str>
-<str name="Artwork">アートワーク</str>
-<str name="Syntax">構文</str>
-<str name="Type">タイプ</str>
-<str name="Value">値</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">注</str>
-<str name="Notes">注</str>
-<str name="Tip">ヒント</str>
-<str name="Fastpath">ファースト・パス</str>
-<str name="Important">重要</str>
-<str name="Attention">重要</str>
-<str name="Caution">注意</str>
-<str name="Danger">危険</str>
-<str name="Remember">要確認</str>
-<str name="Restriction">制約事項</str>
-<str name="Warning">警告</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">目次</str>
-<str name="Related concepts">関連概念</str>
-<str name="Related tasks">関連タスク</str>
-<str name="Related reference">関連資料</str>
-<str name="Related information">関連情報</str>
-
-<str name="Prerequisite">前提条件</str>
-<str name="Prerequisites">前提条件</str>
-<str name="or">または</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">このタスクについて</str>
-<str name="task_example">例</str>
-<str name="task_prereq">始める前に</str>
-<str name="task_postreq">次のタスク</str>
-<str name="task_procedure">手順</str>
-<str name="task_procedure_unordered">手順</str>
-<str name="task_results">タスクの結果</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">「</str>
-<str name="CloseQuote">」</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">図</str>
+  <str name="Table">表</str>
+  <str name="Next topic">次のトピック</str>
+  <str name="Previous topic">前のトピック</str>
+  <str name="Parent topic">親トピック</str>
+  <str name="Required cleanup">クリーンアップ要求</str>
+  <str name="Draft comment">ドラフト注釈</str>
+  <str name="Option">オプション</str>
+  <str name="Description">説明</str> 
+  <str name="Optional">オプション</str>
+  <str name="Required">必須</str>
+  <str name="Skip visual syntax diagram">構文図をスキップする</str>
+  <str name="Read syntax diagram">構文図を読む</str>
+  <str name="Start of change">変更の始まり</str>
+  <str name="End of change">変更の終わり</str>
+  <str name="Index">索引</str>
+  <str name="Special characters">特殊文字</str>
+  <str name="Numerics">数字</str>
+  <str name="End notes">脚注</str>
+  <str name="Artwork">アートワーク</str>
+  <str name="Syntax">構文</str>
+  <str name="Type">タイプ</str>
+  <str name="Value">値</str>
+  <str name="Note">注</str>
+  <str name="Notes">注</str>
+  <str name="Tip">ヒント</str>
+  <str name="Fastpath">ファースト・パス</str>
+  <str name="Important">重要</str>
+  <str name="Attention">重要</str>
+  <str name="Caution">注意</str>
+  <str name="Danger">危険</str>
+  <str name="Remember">要確認</str>
+  <str name="Restriction">制約事項</str>
+  <str name="Warning">警告</str>
+  <str name="Contents">目次</str>
+  <str name="Related concepts">関連概念</str>
+  <str name="Related tasks">関連タスク</str>
+  <str name="Related reference">関連資料</str>
+  <str name="Related information">関連情報</str>
+  <str name="Prerequisite">前提条件</str>
+  <str name="Prerequisites">前提条件</str>
+  <str name="or">または</str>
+  <str name="task_context">このタスクについて</str>
+  <str name="task_example">例</str>
+  <str name="task_prereq">始める前に</str>
+  <str name="task_postreq">次のタスク</str>
+  <str name="task_procedure">手順</str>
+  <str name="task_procedure_unordered">手順</str>
+  <str name="task_results">タスクの結果</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">「</str>
+  <str name="CloseQuote">」</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-kk-kz.xml
+++ b/src/main/xsl/common/strings-kk-kz.xml
@@ -1,74 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<strings xml:lang="ru-ru">        <!-- US English -->
+<!--
+This file is part of the DITA Open Toolkit project.
 
-<!-- various labels (not author controlled) -->
-<str name="Figure">Сурет</str>
-<str name="Table">Кесте</str>
-<str name="Next topic">Келесі бөлім</str>
-<str name="Previous topic">Бұдан бұрынғы бөлім</str>
-<str name="Parent topic">Негізгі бөлім</str>
-<str name="Required cleanup">Қажет тазалау</str>
-<str name="Draft comment">Жоба түсініктеме</str>
-<str name="Option">Параметр</str>
-<str name="Description">Сипаттама</str>
-<str name="Optional">Қосымша</str>
-<str name="Required">Қажет</str>
-<str name="Skip visual syntax diagram">Визуалдық синтаксистік диаграмманы өткізіп жіберу</str>
-<str name="Read syntax diagram">Синтаксистік диаграмманы оқу</str>
-<str name="Start of change">Өзгертуді бастау</str>
-<str name="End of change">Өзгертуді аяқтау</str>
-<str name="Index">Индекс</str>
-<str name="Special characters">Арнайы таңбалар</str>
-<str name="Numerics">Сандар</str>
-<str name="End notes">Қорытынды ескертулер</str>
-<str name="Artwork">Графика</str>
-<str name="Syntax">Синтаксис</str>
-<str name="Type">Түр</str>
-<str name="Value">Мән</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
+Copyright 2004, 2005 IBM Corporation
 
-<!-- peril notice labels -->
-<str name="Note">Ескерту</str>
-<str name="Notes">Ескертулер</str>
-<str name="Tip">Кеңес</str>
-<str name="Fastpath">Жылдам жол</str>
-<str name="Important">Маңызды</str>
-<str name="Attention">Назар аударыңыз</str>
-<str name="Caution">АБАЙЛАҢЫЗ</str>
-<str name="Danger">ҚАУІП</str>
-<str name="Remember">Есте сақтаңыз</str>
-<str name="Warning">Ескерту</str>
-<str name="Restriction">Шектеу</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Мазмұны</str>
-<str name="Related concepts">Өзара байланысты түсініктер</str>
-<str name="Related tasks">Өзара байланысты тапсырмалар</str>
-<str name="Related reference">Өзара байланысты сілтеме</str>
-<str name="Related information">Өзара байланысты ақпарат</str>
-
-<str name="Prerequisite">Бастапқы шарт</str>
-<str name="Prerequisites">Бастапқы шарттар</str>
-<str name="or">немесе</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Осы тапсырма туралы</str>
-<str name="task_example">Мысал</str>
-<str name="task_postreq">Келесі әрекет</str>
-<str name="task_prereq">Бастаудан бұрын</str>
-<str name="task_procedure">Процедура</str>
-<str name="task_procedure_unordered">Процедура</str>
-<str name="task_results">Нәтижелер</str>
-
-<str name="Copyright">авторлық құқықтары</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+See the accompanying LICENSE file for applicable license.
+-->
+<strings xml:lang="kk-kz">        <!-- Kazakh -->
+  <str name="Figure">Сурет</str>
+  <str name="Table">Кесте</str>
+  <str name="Next topic">Келесі бөлім</str>
+  <str name="Previous topic">Бұдан бұрынғы бөлім</str>
+  <str name="Parent topic">Негізгі бөлім</str>
+  <str name="Required cleanup">Қажет тазалау</str>
+  <str name="Draft comment">Жоба түсініктеме</str>
+  <str name="Option">Параметр</str>
+  <str name="Description">Сипаттама</str>
+  <str name="Optional">Қосымша</str>
+  <str name="Required">Қажет</str>
+  <str name="Skip visual syntax diagram">Визуалдық синтаксистік диаграмманы өткізіп жіберу</str>
+  <str name="Read syntax diagram">Синтаксистік диаграмманы оқу</str>
+  <str name="Start of change">Өзгертуді бастау</str>
+  <str name="End of change">Өзгертуді аяқтау</str>
+  <str name="Index">Индекс</str>
+  <str name="Special characters">Арнайы таңбалар</str>
+  <str name="Numerics">Сандар</str>
+  <str name="End notes">Қорытынды ескертулер</str>
+  <str name="Artwork">Графика</str>
+  <str name="Syntax">Синтаксис</str>
+  <str name="Type">Түр</str>
+  <str name="Value">Мән</str>
+  <str name="Note">Ескерту</str>
+  <str name="Notes">Ескертулер</str>
+  <str name="Tip">Кеңес</str>
+  <str name="Fastpath">Жылдам жол</str>
+  <str name="Important">Маңызды</str>
+  <str name="Attention">Назар аударыңыз</str>
+  <str name="Caution">АБАЙЛАҢЫЗ</str>
+  <str name="Danger">ҚАУІП</str>
+  <str name="Remember">Есте сақтаңыз</str>
+  <str name="Warning">Ескерту</str>
+  <str name="Restriction">Шектеу</str>
+  <str name="Contents">Мазмұны</str>
+  <str name="Related concepts">Өзара байланысты түсініктер</str>
+  <str name="Related tasks">Өзара байланысты тапсырмалар</str>
+  <str name="Related reference">Өзара байланысты сілтеме</str>
+  <str name="Related information">Өзара байланысты ақпарат</str>
+  <str name="Prerequisite">Бастапқы шарт</str>
+  <str name="Prerequisites">Бастапқы шарттар</str>
+  <str name="or">немесе</str>
+  <str name="task_context">Осы тапсырма туралы</str>
+  <str name="task_example">Мысал</str>
+  <str name="task_postreq">Келесі әрекет</str>
+  <str name="task_prereq">Бастаудан бұрын</str>
+  <str name="task_procedure">Процедура</str>
+  <str name="task_procedure_unordered">Процедура</str>
+  <str name="task_results">Нәтижелер</str>
+  <str name="Copyright">авторлық құқықтары</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ko-kr.xml
+++ b/src/main/xsl/common/strings-ko-kr.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="ko-kr">        <!-- Korean -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">그림</str>
-<str name="Table">표</str>
-<str name="Next topic">다음 주제</str>
-<str name="Previous topic">이전 주제</str>
-<str name="Parent topic">상위 주제</str>
-<str name="Required cleanup">수정 필요</str>
-<str name="Draft comment">드래프트 설명</str>
-<str name="Option">옵션</str>
-<str name="Description">설명</str>
-<str name="Optional">옵션</str>
-<str name="Required">필수</str>
-<str name="Skip visual syntax diagram">시각적 구문 도표 생략</str>
-<str name="Read syntax diagram">구문 도표 읽기</str>
-<str name="Start of change">변경 시작</str>
-<str name="End of change">변경 끝</str>
-<str name="Index">색인</str>
-<str name="Special characters">특수 문자</str>
-<str name="Numerics">숫자</str>
-<str name="End notes">미주</str>
-<str name="Artwork">그림</str>
-<str name="Syntax">구문</str>
-<str name="Type">유형</str>
-<str name="Value">값</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">주</str>
-<str name="Notes">주</str>
-<str name="Tip">팁</str>
-<str name="Fastpath">빠른경로</str>
-<str name="Important">중요사항</str>
-<str name="Attention">주의</str>
-<str name="Caution">경고</str>
-<str name="Danger">위험</str>
-<str name="Remember">알아두기</str>
-<str name="Restriction">제한사항</str>
-<str name="Warning">경고</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">목차</str>
-<str name="Related concepts">관련 개념</str>
-<str name="Related tasks">관련 태스크</str>
-<str name="Related reference">관련 참조</str>
-<str name="Related information">관련 정보</str>
-
-<str name="Prerequisite">선행 정보</str>
-<str name="Prerequisites">선행 정보</str>
-<str name="or">또는</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">이 태스크 정보</str>
-<str name="task_example">예</str>
-<str name="task_prereq">시작하기 전에</str>
-<str name="task_postreq">다음에 수행할 작업</str>
-<str name="task_procedure">프로시저</str>
-<str name="task_procedure_unordered">프로시저</str>
-<str name="task_results">결과</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">그림</str>
+  <str name="Table">표</str>
+  <str name="Next topic">다음 주제</str>
+  <str name="Previous topic">이전 주제</str>
+  <str name="Parent topic">상위 주제</str>
+  <str name="Required cleanup">수정 필요</str>
+  <str name="Draft comment">드래프트 설명</str>
+  <str name="Option">옵션</str>
+  <str name="Description">설명</str>
+  <str name="Optional">옵션</str>
+  <str name="Required">필수</str>
+  <str name="Skip visual syntax diagram">시각적 구문 도표 생략</str>
+  <str name="Read syntax diagram">구문 도표 읽기</str>
+  <str name="Start of change">변경 시작</str>
+  <str name="End of change">변경 끝</str>
+  <str name="Index">색인</str>
+  <str name="Special characters">특수 문자</str>
+  <str name="Numerics">숫자</str>
+  <str name="End notes">미주</str>
+  <str name="Artwork">그림</str>
+  <str name="Syntax">구문</str>
+  <str name="Type">유형</str>
+  <str name="Value">값</str>
+  <str name="Note">주</str>
+  <str name="Notes">주</str>
+  <str name="Tip">팁</str>
+  <str name="Fastpath">빠른경로</str>
+  <str name="Important">중요사항</str>
+  <str name="Attention">주의</str>
+  <str name="Caution">경고</str>
+  <str name="Danger">위험</str>
+  <str name="Remember">알아두기</str>
+  <str name="Restriction">제한사항</str>
+  <str name="Warning">경고</str>
+  <str name="Contents">목차</str>
+  <str name="Related concepts">관련 개념</str>
+  <str name="Related tasks">관련 태스크</str>
+  <str name="Related reference">관련 참조</str>
+  <str name="Related information">관련 정보</str>
+  <str name="Prerequisite">선행 정보</str>
+  <str name="Prerequisites">선행 정보</str>
+  <str name="or">또는</str>
+  <str name="task_context">이 태스크 정보</str>
+  <str name="task_example">예</str>
+  <str name="task_prereq">시작하기 전에</str>
+  <str name="task_postreq">다음에 수행할 작업</str>
+  <str name="task_procedure">프로시저</str>
+  <str name="task_procedure_unordered">프로시저</str>
+  <str name="task_results">결과</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-lt-lt.xml
+++ b/src/main/xsl/common/strings-lt-lt.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="lt-lt">        <!-- Lithuanian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Piešinys</str>
-<str name="Table">Lentelė</str>
-<str name="Next topic">Paskesnė tema</str>
-<str name="Previous topic">Ankstesnė tema</str>
-<str name="Parent topic">Pradinė tema</str>
-<str name="Required cleanup">Reikalingas valymas</str>
-<str name="Draft comment">Juodraščio komentarai</str>
-<str name="Option">Variantas</str>
-<str name="Description">Aprašas</str>
-<str name="Optional">Nebūtina</str>
-<str name="Required">Būtina</str>
-<str name="Skip visual syntax diagram">Praleisti vaizdinę sintaksės diagramą</str>
-<str name="Read syntax diagram">Skaityti sintaksės diagramą</str>
-<str name="Start of change">Keitimų pradžia</str>
-<str name="End of change">Keitimų pabaiga</str>
-<str name="Index">Indeksas</str>
-<str name="Special characters">Specialūs ženklai</str>
-<str name="Numerics">Skaitmenys</str>
-<str name="End notes">Galutinės pastabos</str> 
-<str name="Artwork">Paveikslėliai</str> 
-<str name="Syntax">Sintaksė</str> 
-<str name="Type">Tipas</str> 
-<str name="Value">Reikšmė</str> 
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Pastaba</str>
-<str name="Notes">Pastabos</str>
-<str name="Tip">Patarimas</str>
-<str name="Fastpath">Nuoroda</str>
-<str name="Important">Svarbi informacija</str>
-<str name="Attention">Dėmesio!</str>
-<str name="Caution">PERSPĖJIMAS</str>
-<str name="Danger">PAVOJINGA</str>
-<str name="Remember">Atminkite</str>
-<str name="Restriction">APRIBOJIMAS</str>
-<str name="Warning">Įspėjimas</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Turinys</str>
-<str name="Related concepts">Susijusios sąvokos</str>
-<str name="Related tasks">Susijusios užduotys</str>
-<str name="Related reference">Susijusi nuoroda</str>
-<str name="Related information">Susijusi informacija</str>
-
-<str name="Prerequisite">Nuoroda</str>
-<str name="Prerequisites">Nuorodos</str>
-<str name="or">arba</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Apie šią užduotį</str>
-<str name="task_example">Pavyzdys</str>
-<str name="task_postreq">Ką daryti toliau</str>
-<str name="task_prereq">Prieš pradedant</str>
-<str name="task_procedure">Procedūra</str>
-<str name="task_procedure_unordered">Procedūra</str>
-<str name="task_results">Rezultatai</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Piešinys</str>
+  <str name="Table">Lentelė</str>
+  <str name="Next topic">Paskesnė tema</str>
+  <str name="Previous topic">Ankstesnė tema</str>
+  <str name="Parent topic">Pradinė tema</str>
+  <str name="Required cleanup">Reikalingas valymas</str>
+  <str name="Draft comment">Juodraščio komentarai</str>
+  <str name="Option">Variantas</str>
+  <str name="Description">Aprašas</str>
+  <str name="Optional">Nebūtina</str>
+  <str name="Required">Būtina</str>
+  <str name="Skip visual syntax diagram">Praleisti vaizdinę sintaksės diagramą</str>
+  <str name="Read syntax diagram">Skaityti sintaksės diagramą</str>
+  <str name="Start of change">Keitimų pradžia</str>
+  <str name="End of change">Keitimų pabaiga</str>
+  <str name="Index">Indeksas</str>
+  <str name="Special characters">Specialūs ženklai</str>
+  <str name="Numerics">Skaitmenys</str>
+  <str name="End notes">Galutinės pastabos</str> 
+  <str name="Artwork">Paveikslėliai</str> 
+  <str name="Syntax">Sintaksė</str> 
+  <str name="Type">Tipas</str> 
+  <str name="Value">Reikšmė</str> 
+  <str name="Note">Pastaba</str>
+  <str name="Notes">Pastabos</str>
+  <str name="Tip">Patarimas</str>
+  <str name="Fastpath">Nuoroda</str>
+  <str name="Important">Svarbi informacija</str>
+  <str name="Attention">Dėmesio!</str>
+  <str name="Caution">PERSPĖJIMAS</str>
+  <str name="Danger">PAVOJINGA</str>
+  <str name="Remember">Atminkite</str>
+  <str name="Restriction">APRIBOJIMAS</str>
+  <str name="Warning">Įspėjimas</str>
+  <str name="Contents">Turinys</str>
+  <str name="Related concepts">Susijusios sąvokos</str>
+  <str name="Related tasks">Susijusios užduotys</str>
+  <str name="Related reference">Susijusi nuoroda</str>
+  <str name="Related information">Susijusi informacija</str>
+  <str name="Prerequisite">Nuoroda</str>
+  <str name="Prerequisites">Nuorodos</str>
+  <str name="or">arba</str>
+  <str name="task_context">Apie šią užduotį</str>
+  <str name="task_example">Pavyzdys</str>
+  <str name="task_postreq">Ką daryti toliau</str>
+  <str name="task_prereq">Prieš pradedant</str>
+  <str name="task_procedure">Procedūra</str>
+  <str name="task_procedure_unordered">Procedūra</str>
+  <str name="task_results">Rezultatai</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-lv-lv.xml
+++ b/src/main/xsl/common/strings-lv-lv.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="lv-lv">        <!-- Latvian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Attēls</str>
-<str name="Table">Tabula</str>
-<str name="Next topic">Nākamā tēma</str>
-<str name="Previous topic">Iepriekšējā tēma</str>
-<str name="Parent topic">Vecāktēma</str>
-<str name="Required cleanup">Nepieciešama tīrīšana</str>
-<str name="Draft comment">Komentārs melnrakstā</str>
-<str name="Option">Opcija</str>
-<str name="Description">Apraksts</str>
-<str name="Optional">Neobligāts</str>
-<str name="Required">Nepieciešams</str>
-<str name="Skip visual syntax diagram">Izlaist vizuālo sintakses diagrammu</str>
-<str name="Read syntax diagram">Lasīt sintakses diagrammu</str>
-<str name="Start of change">Izmaiņu sākums</str>
-<str name="End of change">Izmaiņu beigas</str>
-<str name="Index">Indekss</str>
-<str name="Special characters">Speciālās rakstzīmes</str>
-<str name="Numerics">Skaitļi</str>
-<str name="End notes">Beigu vēres</str>
-<str name="Artwork">Ilustrācija</str>
-<str name="Syntax">Sintakse</str>
-<str name="Type">Tips</str>
-<str name="Value">Vērtība</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Piezīme</str>
-<str name="Notes">Piezīmes</str>
-<str name="Tip">Padoms</str>
-<str name="Fastpath">Ātrais ceļš</str>
-<str name="Important">Svarīgi</str>
-<str name="Attention">Brīdinājums</str>
-<str name="Caution">UZMANĪBU</str>
-<str name="Danger">BĪSTAMI</str>
-<str name="Remember">Atcerieties</str>
-<str name="Restriction">Ierobežojums</str>
-<str name="Warning">Brīdinājums</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Saturs</str>
-<str name="Related concepts">Saistītās koncepcijas</str>
-<str name="Related tasks">Saistītie uzdevumi</str>
-<str name="Related reference">Saistītā atsauce</str>
-<str name="Related information">Saistītā informācija</str>
-
-<str name="Prerequisite">Priekšnoteikums</str>
-<str name="Prerequisites">Priekšnoteikumi</str>
-<str name="or">vai</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Par šo uzdevumu</str>
-<str name="task_example">Piemērs</str>
-<str name="task_postreq">Kā rīkoties tālāk</str>
-<str name="task_prereq">Pirms sākt darbu</str>
-<str name="task_procedure">Procedūra</str>
-<str name="task_procedure_unordered">Procedūra</str>
-<str name="task_results">Rezultāti</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Attēls</str>
+  <str name="Table">Tabula</str>
+  <str name="Next topic">Nākamā tēma</str>
+  <str name="Previous topic">Iepriekšējā tēma</str>
+  <str name="Parent topic">Vecāktēma</str>
+  <str name="Required cleanup">Nepieciešama tīrīšana</str>
+  <str name="Draft comment">Komentārs melnrakstā</str>
+  <str name="Option">Opcija</str>
+  <str name="Description">Apraksts</str>
+  <str name="Optional">Neobligāts</str>
+  <str name="Required">Nepieciešams</str>
+  <str name="Skip visual syntax diagram">Izlaist vizuālo sintakses diagrammu</str>
+  <str name="Read syntax diagram">Lasīt sintakses diagrammu</str>
+  <str name="Start of change">Izmaiņu sākums</str>
+  <str name="End of change">Izmaiņu beigas</str>
+  <str name="Index">Indekss</str>
+  <str name="Special characters">Speciālās rakstzīmes</str>
+  <str name="Numerics">Skaitļi</str>
+  <str name="End notes">Beigu vēres</str>
+  <str name="Artwork">Ilustrācija</str>
+  <str name="Syntax">Sintakse</str>
+  <str name="Type">Tips</str>
+  <str name="Value">Vērtība</str>
+  <str name="Note">Piezīme</str>
+  <str name="Notes">Piezīmes</str>
+  <str name="Tip">Padoms</str>
+  <str name="Fastpath">Ātrais ceļš</str>
+  <str name="Important">Svarīgi</str>
+  <str name="Attention">Brīdinājums</str>
+  <str name="Caution">UZMANĪBU</str>
+  <str name="Danger">BĪSTAMI</str>
+  <str name="Remember">Atcerieties</str>
+  <str name="Restriction">Ierobežojums</str>
+  <str name="Warning">Brīdinājums</str>
+  <str name="Contents">Saturs</str>
+  <str name="Related concepts">Saistītās koncepcijas</str>
+  <str name="Related tasks">Saistītie uzdevumi</str>
+  <str name="Related reference">Saistītā atsauce</str>
+  <str name="Related information">Saistītā informācija</str>
+  <str name="Prerequisite">Priekšnoteikums</str>
+  <str name="Prerequisites">Priekšnoteikumi</str>
+  <str name="or">vai</str>
+  <str name="task_context">Par šo uzdevumu</str>
+  <str name="task_example">Piemērs</str>
+  <str name="task_postreq">Kā rīkoties tālāk</str>
+  <str name="task_prereq">Pirms sākt darbu</str>
+  <str name="task_procedure">Procedūra</str>
+  <str name="task_procedure_unordered">Procedūra</str>
+  <str name="task_results">Rezultāti</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-mk-mk.xml
+++ b/src/main/xsl/common/strings-mk-mk.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="mk-mk">        <!-- Macedonian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Слика</str>
-<str name="Table">Табела</str>
-<str name="Next topic">Следна тема</str>
-<str name="Previous topic">Претходна тема</str>
-<str name="Parent topic">Матична тема</str>
-<str name="Required cleanup">Потребно средување</str>
-<str name="Draft comment">Прелиминарен коментар</str>
-<str name="Option">Избор</str>
-<str name="Description">Опис</str>
-<str name="Optional">Изборен</str>
-<str name="Required">Потребен</str>
-<str name="Skip visual syntax diagram">Прескокнете го визуелниот синтаксички дијаграм</str>
-<str name="Read syntax diagram">Прочитајте го синтаксичкиот дијаграм</str>
-<str name="Start of change">Почеток на промена</str>
-<str name="End of change">Крај на промена</str>
-<str name="Index">Индекс</str>
-<str name="Special characters">Специјални знаци</str>
-<str name="Numerics">Нумерици</str>
-<str name="End notes">Крајни забелешки</str>
-<str name="Artwork">Цртежи</str>
-<str name="Syntax">Синтакса</str>
-<str name="Type">Тип</str>
-<str name="Value">Вредност</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Забелешка</str>
-<str name="Notes">Забелешки</str>
-<str name="Tip">Помошна информација</str>
-<str name="Fastpath">Прекутрупа</str>
-<str name="Important">Важно</str>
-<str name="Attention">Внимание</str>
-<str name="Caution">ПРЕДУПРЕДУВАЊЕ</str>
-<str name="Danger">ОПАСНОСТ</str>
-<str name="Remember">Запаметете</str>
-<str name="Restriction">Ограничување</str>
-<str name="Warning">Предупредување</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Содржина</str>
-<str name="Related concepts">Сродни концепти</str>
-<str name="Related tasks">Сродни задачи</str>
-<str name="Related reference">Сродни референци</str>
-<str name="Related information">Сродни информации</str>
-
-<str name="Prerequisite">Потребно предзнаење</str>
-<str name="Prerequisites">Потребни предзнаења</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">За оваа активност</str>
-<str name="task_example">Пример</str>
-<str name="task_postreq">Што да направите следно</str>
-<str name="task_prereq">Пред да започнете</str>
-<str name="task_procedure">Процедура</str>
-<str name="task_procedure_unordered">Процедура</str>
-<str name="task_results">Резултати</str>
-
-<str name="Copyright">Авторски права</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Слика</str>
+  <str name="Table">Табела</str>
+  <str name="Next topic">Следна тема</str>
+  <str name="Previous topic">Претходна тема</str>
+  <str name="Parent topic">Матична тема</str>
+  <str name="Required cleanup">Потребно средување</str>
+  <str name="Draft comment">Прелиминарен коментар</str>
+  <str name="Option">Избор</str>
+  <str name="Description">Опис</str>
+  <str name="Optional">Изборен</str>
+  <str name="Required">Потребен</str>
+  <str name="Skip visual syntax diagram">Прескокнете го визуелниот синтаксички дијаграм</str>
+  <str name="Read syntax diagram">Прочитајте го синтаксичкиот дијаграм</str>
+  <str name="Start of change">Почеток на промена</str>
+  <str name="End of change">Крај на промена</str>
+  <str name="Index">Индекс</str>
+  <str name="Special characters">Специјални знаци</str>
+  <str name="Numerics">Нумерици</str>
+  <str name="End notes">Крајни забелешки</str>
+  <str name="Artwork">Цртежи</str>
+  <str name="Syntax">Синтакса</str>
+  <str name="Type">Тип</str>
+  <str name="Value">Вредност</str>
+  <str name="Note">Забелешка</str>
+  <str name="Notes">Забелешки</str>
+  <str name="Tip">Помошна информација</str>
+  <str name="Fastpath">Прекутрупа</str>
+  <str name="Important">Важно</str>
+  <str name="Attention">Внимание</str>
+  <str name="Caution">ПРЕДУПРЕДУВАЊЕ</str>
+  <str name="Danger">ОПАСНОСТ</str>
+  <str name="Remember">Запаметете</str>
+  <str name="Restriction">Ограничување</str>
+  <str name="Warning">Предупредување</str>
+  <str name="Contents">Содржина</str>
+  <str name="Related concepts">Сродни концепти</str>
+  <str name="Related tasks">Сродни задачи</str>
+  <str name="Related reference">Сродни референци</str>
+  <str name="Related information">Сродни информации</str>
+  <str name="Prerequisite">Потребно предзнаење</str>
+  <str name="Prerequisites">Потребни предзнаења</str>
+  <str name="or">or</str>
+  <str name="task_context">За оваа активност</str>
+  <str name="task_example">Пример</str>
+  <str name="task_postreq">Што да направите следно</str>
+  <str name="task_prereq">Пред да започнете</str>
+  <str name="task_procedure">Процедура</str>
+  <str name="task_procedure_unordered">Процедура</str>
+  <str name="task_results">Резултати</str>
+  <str name="Copyright">Авторски права</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ms-my.xml
+++ b/src/main/xsl/common/strings-ms-my.xml
@@ -1,74 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2004, 2005 IBM Corporation
+
+See the accompanying LICENSE file for applicable license.
+-->
 <strings xml:lang="ms-my">        <!-- Malay -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Rajah</str>
-<str name="Table">Jadual</str>
-<str name="Next topic">Tajuk seterusnya</str>
-<str name="Previous topic">Tajuk sebelumnya</str>
-<str name="Parent topic">Tajuk induk</str>
-<str name="Required cleanup">Pembersihan diperlukan</str>
-<str name="Draft comment">Komen draf</str>
-<str name="Option">Opsyen</str>
-<str name="Description">Deskripsi</str>
-<str name="Optional">Opsyenal</str>
-<str name="Required">Diperlukan</str>
-<str name="Skip visual syntax diagram">Langkau rajah sintaks visual</str>
-<str name="Read syntax diagram">Baca rajah sintaks</str>
-<str name="Start of change">Mula perubahan</str>
-<str name="End of change">Hujung perubahan</str>
-<str name="Index">Indeks</str>
-<str name="Special characters">Aksara khas</str>
-<str name="Numerics">Angka</str>
-<str name="End notes">Nota akhir</str>
-<str name="Artwork">Kerja seni</str>
-<str name="Syntax">Sintaks</str>
-<str name="Type">Jenis</str>
-<str name="Value">Nilai</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Nota</str>
-<str name="Tip">Petua</str>
-<str name="Fastpath">Laluan pantas</str>
-<str name="Important">Penting</str>
-<str name="Attention">Perhatian</str>
-<str name="Caution">AWAS</str>
-<str name="Danger">BAHAYA</str>
-<str name="Remember">Ingat</str>
-<str name="Warning">Amaran</str>
-<str name="Restriction">Sekatan</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Kandungan</str>
-<str name="Related concepts">Konsep berkaitan</str>
-<str name="Related tasks">Tugas berkaitan</str>
-<str name="Related reference">Rujukan berkaitan</str>
-<str name="Related information">Maklumat berkaitan</str>
-
-<str name="Prerequisite">Prasyarat</str>
-<str name="Prerequisites">Prasyarat</str>
-<str name="or">atau</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Mengenai tugas ini</str>
-<str name="task_example">Contoh</str>
-<str name="task_postreq">Apa perlu dilakukan seterusnya</str>
-<str name="task_prereq">Sebelum anda bermula</str>
-<str name="task_procedure">Prosedur</str>
-<str name="task_procedure_unordered">Prosedur</str>
-<str name="task_results">Hasil</str>
-
-<str name="Copyright">Hak Cipta</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Rajah</str>
+  <str name="Table">Jadual</str>
+  <str name="Next topic">Tajuk seterusnya</str>
+  <str name="Previous topic">Tajuk sebelumnya</str>
+  <str name="Parent topic">Tajuk induk</str>
+  <str name="Required cleanup">Pembersihan diperlukan</str>
+  <str name="Draft comment">Komen draf</str>
+  <str name="Option">Opsyen</str>
+  <str name="Description">Deskripsi</str>
+  <str name="Optional">Opsyenal</str>
+  <str name="Required">Diperlukan</str>
+  <str name="Skip visual syntax diagram">Langkau rajah sintaks visual</str>
+  <str name="Read syntax diagram">Baca rajah sintaks</str>
+  <str name="Start of change">Mula perubahan</str>
+  <str name="End of change">Hujung perubahan</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Aksara khas</str>
+  <str name="Numerics">Angka</str>
+  <str name="End notes">Nota akhir</str>
+  <str name="Artwork">Kerja seni</str>
+  <str name="Syntax">Sintaks</str>
+  <str name="Type">Jenis</str>
+  <str name="Value">Nilai</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Nota</str>
+  <str name="Tip">Petua</str>
+  <str name="Fastpath">Laluan pantas</str>
+  <str name="Important">Penting</str>
+  <str name="Attention">Perhatian</str>
+  <str name="Caution">AWAS</str>
+  <str name="Danger">BAHAYA</str>
+  <str name="Remember">Ingat</str>
+  <str name="Warning">Amaran</str>
+  <str name="Restriction">Sekatan</str>
+  <str name="Contents">Kandungan</str>
+  <str name="Related concepts">Konsep berkaitan</str>
+  <str name="Related tasks">Tugas berkaitan</str>
+  <str name="Related reference">Rujukan berkaitan</str>
+  <str name="Related information">Maklumat berkaitan</str>
+  <str name="Prerequisite">Prasyarat</str>
+  <str name="Prerequisites">Prasyarat</str>
+  <str name="or">atau</str>
+  <str name="task_context">Mengenai tugas ini</str>
+  <str name="task_example">Contoh</str>
+  <str name="task_postreq">Apa perlu dilakukan seterusnya</str>
+  <str name="task_prereq">Sebelum anda bermula</str>
+  <str name="task_procedure">Prosedur</str>
+  <str name="task_procedure_unordered">Prosedur</str>
+  <str name="task_results">Hasil</str>
+  <str name="Copyright">Hak Cipta</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-nl-be.xml
+++ b/src/main/xsl/common/strings-nl-be.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="nl-be">        <!-- Belgian Dutch -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figuur</str>
-<str name="Table">Tabel</str>
-<str name="Next topic">Volgend onderwerp</str>
-<str name="Previous topic">Vorig onderwerp</str>
-<str name="Parent topic">Hoofdonderwerp</str>
-<str name="Required cleanup">Opschonen vereist</str>
-<str name="Draft comment">Opmerking over concept</str>
-<str name="Option">Optie</str>
-<str name="Description">Beschrijving</str>
-<str name="Optional">Optioneel</str>
-<str name="Required">Vereist</str>
-<str name="Skip visual syntax diagram">Syntaxisdiagram overslaan</str>
-<str name="Read syntax diagram">Syntaxisdiagram lezen</str>
-<str name="Start of change">Begin wijziging</str>
-<str name="End of change">Einde wijziging</str>
-<str name="Index">Index</str>
-<str name="Special characters">Speciale tekens</str>
-<str name="Numerics">Numerieke tekens</str>
-<str name="End notes">Eindnoten</str>
-<str name="Artwork">Artwork</str>
-<str name="Syntax">Syntaxis</str>
-<str name="Type">Type</str>
-<str name="Value">Waarde</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Opmerking</str>
-<str name="Notes">Opmerkingen</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Versnelde keuze</str>
-<str name="Important">Belangrijk</str>
-<str name="Attention">Waarschuwing</str>
-<str name="Caution">LET OP!</str>
-<str name="Danger">GEVAAR!</str>
-<str name="Remember">Let op</str>
-<str name="Restriction">Beperking</str>
-<str name="Warning">Waarschuwing</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Inhoudsopgave</str>
-<str name="Related concepts">Verwante concepten</str>
-<str name="Related tasks">Verwante taken</str>
-<str name="Related reference">Verwante verwijzing</str>
-<str name="Related information">Verwante informatie</str>
-
-<str name="Prerequisite">Vereiste</str>
-<str name="Prerequisites">Vereisten</str>
-<str name="or">of</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Over deze taak</str>
-<str name="task_example">Voorbeeld</str>
-<str name="task_postreq">Volgende stappen</str>
-<str name="task_prereq">Voordat u begint</str>
-<str name="task_procedure">Procedure</str>
-<str name="task_procedure_unordered">Procedure</str>
-<str name="task_results">Resultaten</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figuur</str>
+  <str name="Table">Tabel</str>
+  <str name="Next topic">Volgend onderwerp</str>
+  <str name="Previous topic">Vorig onderwerp</str>
+  <str name="Parent topic">Hoofdonderwerp</str>
+  <str name="Required cleanup">Opschonen vereist</str>
+  <str name="Draft comment">Opmerking over concept</str>
+  <str name="Option">Optie</str>
+  <str name="Description">Beschrijving</str>
+  <str name="Optional">Optioneel</str>
+  <str name="Required">Vereist</str>
+  <str name="Skip visual syntax diagram">Syntaxisdiagram overslaan</str>
+  <str name="Read syntax diagram">Syntaxisdiagram lezen</str>
+  <str name="Start of change">Begin wijziging</str>
+  <str name="End of change">Einde wijziging</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Speciale tekens</str>
+  <str name="Numerics">Numerieke tekens</str>
+  <str name="End notes">Eindnoten</str>
+  <str name="Artwork">Artwork</str>
+  <str name="Syntax">Syntaxis</str>
+  <str name="Type">Type</str>
+  <str name="Value">Waarde</str>
+  <str name="Note">Opmerking</str>
+  <str name="Notes">Opmerkingen</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Versnelde keuze</str>
+  <str name="Important">Belangrijk</str>
+  <str name="Attention">Waarschuwing</str>
+  <str name="Caution">LET OP!</str>
+  <str name="Danger">GEVAAR!</str>
+  <str name="Remember">Let op</str>
+  <str name="Restriction">Beperking</str>
+  <str name="Warning">Waarschuwing</str>
+  <str name="Contents">Inhoudsopgave</str>
+  <str name="Related concepts">Verwante concepten</str>
+  <str name="Related tasks">Verwante taken</str>
+  <str name="Related reference">Verwante verwijzing</str>
+  <str name="Related information">Verwante informatie</str>
+  <str name="Prerequisite">Vereiste</str>
+  <str name="Prerequisites">Vereisten</str>
+  <str name="or">of</str>
+  <str name="task_context">Over deze taak</str>
+  <str name="task_example">Voorbeeld</str>
+  <str name="task_postreq">Volgende stappen</str>
+  <str name="task_prereq">Voordat u begint</str>
+  <str name="task_procedure">Procedure</str>
+  <str name="task_procedure_unordered">Procedure</str>
+  <str name="task_results">Resultaten</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-nl-nl.xml
+++ b/src/main/xsl/common/strings-nl-nl.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="nl-nl">        <!-- Dutch -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figuur</str>
-<str name="Table">Tabel</str>
-<str name="Next topic">Volgend onderwerp</str>
-<str name="Previous topic">Vorig onderwerp</str>
-<str name="Parent topic">Hoofdonderwerp</str>
-<str name="Required cleanup">Opschonen vereist</str>
-<str name="Draft comment">Opmerking over concept</str>
-<str name="Option">Optie</str>
-<str name="Description">Beschrijving</str>
-<str name="Optional">Optioneel</str>
-<str name="Required">Vereist</str>
-<str name="Skip visual syntax diagram">Syntaxisdiagram overslaan</str>
-<str name="Read syntax diagram">Syntaxisdiagram lezen</str>
-<str name="Start of change">Begin wijziging</str>
-<str name="End of change">Einde wijziging</str>
-<str name="Index">Trefwoordenregister</str>
-<str name="Special characters">Speciale tekens</str>
-<str name="Numerics">Numerieke tekens</str>
-<str name="End notes">Eindnoten</str>
-<str name="Artwork">Artwork</str>
-<str name="Syntax">Syntaxis</str>
-<str name="Type">Type</str>
-<str name="Value">Waarde</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Opmerking</str>
-<str name="Notes">Opmerkingen</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Versnelde keuze</str>
-<str name="Important">Belangrijk</str>
-<str name="Attention">Waarschuwing</str>
-<str name="Caution">Let op!</str>
-<str name="Danger">Gevaar!</str>
-<str name="Remember">Let op</str>
-<str name="Restriction">Beperking</str>
-<str name="Warning">Attentie</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Inhoudsopgave</str>
-<str name="Related concepts">Verwante onderwerpen</str>
-<str name="Related tasks">Verwante taken</str>
-<str name="Related reference">Verwante verwijzing</str>
-<str name="Related information">Verwante informatie</str>
-
-<str name="Prerequisite">Vereiste</str>
-<str name="Prerequisites">Vereisten</str>
-<str name="or">of</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Over deze taak</str>
-<str name="task_example">Voorbeeld</str>
-<str name="task_postreq">Volgende stappen</str>
-<str name="task_prereq">Voordat u begint</str>
-<str name="task_procedure">Procedure</str>
-<str name="task_procedure_unordered">Procedure</str>
-<str name="task_results">Resultaten</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figuur</str>
+  <str name="Table">Tabel</str>
+  <str name="Next topic">Volgend onderwerp</str>
+  <str name="Previous topic">Vorig onderwerp</str>
+  <str name="Parent topic">Hoofdonderwerp</str>
+  <str name="Required cleanup">Opschonen vereist</str>
+  <str name="Draft comment">Opmerking over concept</str>
+  <str name="Option">Optie</str>
+  <str name="Description">Beschrijving</str>
+  <str name="Optional">Optioneel</str>
+  <str name="Required">Vereist</str>
+  <str name="Skip visual syntax diagram">Syntaxisdiagram overslaan</str>
+  <str name="Read syntax diagram">Syntaxisdiagram lezen</str>
+  <str name="Start of change">Begin wijziging</str>
+  <str name="End of change">Einde wijziging</str>
+  <str name="Index">Trefwoordenregister</str>
+  <str name="Special characters">Speciale tekens</str>
+  <str name="Numerics">Numerieke tekens</str>
+  <str name="End notes">Eindnoten</str>
+  <str name="Artwork">Artwork</str>
+  <str name="Syntax">Syntaxis</str>
+  <str name="Type">Type</str>
+  <str name="Value">Waarde</str>
+  <str name="Note">Opmerking</str>
+  <str name="Notes">Opmerkingen</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Versnelde keuze</str>
+  <str name="Important">Belangrijk</str>
+  <str name="Attention">Waarschuwing</str>
+  <str name="Caution">Let op!</str>
+  <str name="Danger">Gevaar!</str>
+  <str name="Remember">Let op</str>
+  <str name="Restriction">Beperking</str>
+  <str name="Warning">Attentie</str>
+  <str name="Contents">Inhoudsopgave</str>
+  <str name="Related concepts">Verwante onderwerpen</str>
+  <str name="Related tasks">Verwante taken</str>
+  <str name="Related reference">Verwante verwijzing</str>
+  <str name="Related information">Verwante informatie</str>
+  <str name="Prerequisite">Vereiste</str>
+  <str name="Prerequisites">Vereisten</str>
+  <str name="or">of</str>
+  <str name="task_context">Over deze taak</str>
+  <str name="task_example">Voorbeeld</str>
+  <str name="task_postreq">Volgende stappen</str>
+  <str name="task_prereq">Voordat u begint</str>
+  <str name="task_procedure">Procedure</str>
+  <str name="task_procedure_unordered">Procedure</str>
+  <str name="task_results">Resultaten</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-no-no.xml
+++ b/src/main/xsl/common/strings-no-no.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="no-no">        <!-- Norwegian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figur</str>
-<str name="Table">Tabell</str>
-<str name="Next topic">Neste emne</str>
-<str name="Previous topic">Forrige emne</str>
-<str name="Parent topic">Overordnet emne</str>
-<str name="Required cleanup">Opprydning nødvendig</str>
-<str name="Draft comment">Kommentar om utkast</str>
-<str name="Option">Alternativ</str>
-<str name="Description">Beskrivelse</str>
-<str name="Optional">Valgfritt</str>
-<str name="Required">Nødvendig</str>
-<str name="Skip visual syntax diagram">Hopp over syntaksdiagram</str>
-<str name="Read syntax diagram">Les syntaksdiagram</str>
-<str name="Start of change">Start på endring</str>
-<str name="End of change">Slutt på endring</str>
-<str name="Index">Stikkordregister</str>
-<str name="Special characters">Spesialtegn</str>
-<str name="Numerics">Numerisk</str>
-<str name="End notes">Sluttnoter</str>
-<str name="Artwork">Grafikk</str>
-<str name="Syntax">Syntaks</str>
-<str name="Type">Type</str>
-<str name="Value">Verdi</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Merk</str>
-<str name="Notes">Merknader</str>
-<str name="Tip">Tips</str>
-<str name="Fastpath">Snarvei</str>
-<str name="Important">Viktig</str>
-<str name="Attention">ADVARSEL</str>
-<str name="Caution">ADVARSEL</str>
-<str name="Danger">FARE!</str>
-<str name="Remember">Husk</str>
-<str name="Restriction">Begrensning</str>
-<str name="Warning">ADVARSEL</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Innhold</str>
-<str name="Related concepts">Beslektede begreper</str>
-<str name="Related tasks">Beslektede oppgaver</str>
-<str name="Related reference">Beslektet referanse</str>
-<str name="Related information">Beslektet informasjon</str>
-
-<str name="Prerequisite">Krav</str>
-<str name="Prerequisites">Krav</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Om denne oppgaven</str>
-<str name="task_example">Eksempel</str>
-<str name="task_postreq">Neste oppgave</str>
-<str name="task_prereq">Før du begynner</str>
-<str name="task_procedure">Prosedyre</str>
-<str name="task_procedure_unordered">Prosedyre</str>
-<str name="task_results">Resultater</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figur</str>
+  <str name="Table">Tabell</str>
+  <str name="Next topic">Neste emne</str>
+  <str name="Previous topic">Forrige emne</str>
+  <str name="Parent topic">Overordnet emne</str>
+  <str name="Required cleanup">Opprydning nødvendig</str>
+  <str name="Draft comment">Kommentar om utkast</str>
+  <str name="Option">Alternativ</str>
+  <str name="Description">Beskrivelse</str>
+  <str name="Optional">Valgfritt</str>
+  <str name="Required">Nødvendig</str>
+  <str name="Skip visual syntax diagram">Hopp over syntaksdiagram</str>
+  <str name="Read syntax diagram">Les syntaksdiagram</str>
+  <str name="Start of change">Start på endring</str>
+  <str name="End of change">Slutt på endring</str>
+  <str name="Index">Stikkordregister</str>
+  <str name="Special characters">Spesialtegn</str>
+  <str name="Numerics">Numerisk</str>
+  <str name="End notes">Sluttnoter</str>
+  <str name="Artwork">Grafikk</str>
+  <str name="Syntax">Syntaks</str>
+  <str name="Type">Type</str>
+  <str name="Value">Verdi</str>
+  <str name="Note">Merk</str>
+  <str name="Notes">Merknader</str>
+  <str name="Tip">Tips</str>
+  <str name="Fastpath">Snarvei</str>
+  <str name="Important">Viktig</str>
+  <str name="Attention">ADVARSEL</str>
+  <str name="Caution">ADVARSEL</str>
+  <str name="Danger">FARE!</str>
+  <str name="Remember">Husk</str>
+  <str name="Restriction">Begrensning</str>
+  <str name="Warning">ADVARSEL</str>
+  <str name="Contents">Innhold</str>
+  <str name="Related concepts">Beslektede begreper</str>
+  <str name="Related tasks">Beslektede oppgaver</str>
+  <str name="Related reference">Beslektet referanse</str>
+  <str name="Related information">Beslektet informasjon</str>
+  <str name="Prerequisite">Krav</str>
+  <str name="Prerequisites">Krav</str>
+  <str name="or">or</str>
+  <str name="task_context">Om denne oppgaven</str>
+  <str name="task_example">Eksempel</str>
+  <str name="task_postreq">Neste oppgave</str>
+  <str name="task_prereq">Før du begynner</str>
+  <str name="task_procedure">Prosedyre</str>
+  <str name="task_procedure_unordered">Prosedyre</str>
+  <str name="task_results">Resultater</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-pl-pl.xml
+++ b/src/main/xsl/common/strings-pl-pl.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="pl-pl">        <!-- Polish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Rysunek</str>
-<str name="Table">Tabela</str>
-<str name="Next topic">Następny temat</str>
-<str name="Previous topic">Poprzedni temat</str>
-<str name="Parent topic">Temat nadrzędny</str>
-<str name="Required cleanup">Wymagana korekta</str>
-<str name="Draft comment">Komentarz roboczy</str>
-<str name="Option">Opcja</str>
-<str name="Description">Opis</str>
-<str name="Optional">Opcjonalne</str>
-<str name="Required">Wymagane</str>
-<str name="Skip visual syntax diagram">Pomiń diagram składni</str>
-<str name="Read syntax diagram">Czytaj diagram składni</str>
-<str name="Start of change">Początek zmiany</str>
-<str name="End of change">Koniec zmiany</str>
-<str name="Index">Indeks</str>
-<str name="Special characters">Znaki specjalne</str>
-<str name="Numerics">Symbole</str>
-<str name="End notes">Przypisy końcowe</str>
-<str name="Artwork">Ilustracja</str>
-<str name="Syntax">Składnia</str>
-<str name="Type">Typ</str>
-<str name="Value">Wartość</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Uwaga</str>
-<str name="Notes">Uwagi</str>
-<str name="Tip">Wskazówka</str>
-<str name="Fastpath">Krótka ścieżka</str>
-<str name="Important">Ważne</str>
-<str name="Attention">Ostrzeżenie</str>
-<str name="Caution">UWAGA</str>
-<str name="Danger">NIEBEZPIECZEŃSTWO</str>
-<str name="Remember">Zapamiętaj</str>
-<str name="Restriction">Ograniczenie</str>
-<str name="Warning">Ostrzeżenie</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Spis treści</str>
-<str name="Related concepts">Pojęcia pokrewne</str>
-<str name="Related tasks">Zadania pokrewne</str>
-<str name="Related reference">Odsyłacze pokrewne</str>
-<str name="Related information">Informacje pokrewne</str>
-
-<str name="Prerequisite">Wymaganie wstępne</str>
-<str name="Prerequisites">Wymagania wstępne</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">O tym zadaniu</str>
-<str name="task_example">Przykład</str>
-<str name="task_postreq">Co dalej</str>
-<str name="task_prereq">Zanim rozpoczniesz</str>
-<str name="task_procedure">Procedura</str>
-<str name="task_procedure_unordered">Procedura</str>
-<str name="task_results">Wyniki</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Rysunek</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Następny temat</str>
+  <str name="Previous topic">Poprzedni temat</str>
+  <str name="Parent topic">Temat nadrzędny</str>
+  <str name="Required cleanup">Wymagana korekta</str>
+  <str name="Draft comment">Komentarz roboczy</str>
+  <str name="Option">Opcja</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Opcjonalne</str>
+  <str name="Required">Wymagane</str>
+  <str name="Skip visual syntax diagram">Pomiń diagram składni</str>
+  <str name="Read syntax diagram">Czytaj diagram składni</str>
+  <str name="Start of change">Początek zmiany</str>
+  <str name="End of change">Koniec zmiany</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Znaki specjalne</str>
+  <str name="Numerics">Symbole</str>
+  <str name="End notes">Przypisy końcowe</str>
+  <str name="Artwork">Ilustracja</str>
+  <str name="Syntax">Składnia</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Wartość</str>
+  <str name="Note">Uwaga</str>
+  <str name="Notes">Uwagi</str>
+  <str name="Tip">Wskazówka</str>
+  <str name="Fastpath">Krótka ścieżka</str>
+  <str name="Important">Ważne</str>
+  <str name="Attention">Ostrzeżenie</str>
+  <str name="Caution">UWAGA</str>
+  <str name="Danger">NIEBEZPIECZEŃSTWO</str>
+  <str name="Remember">Zapamiętaj</str>
+  <str name="Restriction">Ograniczenie</str>
+  <str name="Warning">Ostrzeżenie</str>
+  <str name="Contents">Spis treści</str>
+  <str name="Related concepts">Pojęcia pokrewne</str>
+  <str name="Related tasks">Zadania pokrewne</str>
+  <str name="Related reference">Odsyłacze pokrewne</str>
+  <str name="Related information">Informacje pokrewne</str>
+  <str name="Prerequisite">Wymaganie wstępne</str>
+  <str name="Prerequisites">Wymagania wstępne</str>
+  <str name="or">or</str>
+  <str name="task_context">O tym zadaniu</str>
+  <str name="task_example">Przykład</str>
+  <str name="task_postreq">Co dalej</str>
+  <str name="task_prereq">Zanim rozpoczniesz</str>
+  <str name="task_procedure">Procedura</str>
+  <str name="task_procedure_unordered">Procedura</str>
+  <str name="task_results">Wyniki</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-pt-br.xml
+++ b/src/main/xsl/common/strings-pt-br.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="pt-br">        <!-- Brazilian Portuguese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Tabela</str>
-<str name="Next topic">Próximo tópico</str>
-<str name="Previous topic">Tópico anterior</str>
-<str name="Parent topic">Tópico pai</str>
-<str name="Required cleanup">Limpeza necessária</str>
-<str name="Draft comment">Comentário rascunho</str>
-<str name="Option">Opção</str>
-<str name="Description">Descrição</str>
-<str name="Optional">Opcional</str>
-<str name="Required">Necessário</str>
-<str name="Skip visual syntax diagram">Manter visual do diagrama de sintaxe</str>
-<str name="Read syntax diagram">Ler diagrama de sintaxe</str>
-<str name="Start of change">Início da mudança</str>
-<str name="End of change">Fim da mudança</str>
-<str name="Index">Índice Remissivo</str>
-<str name="Special characters">Caracteres Especiais</str>
-<str name="Numerics">Numéricos</str>
-<str name="End notes">Avisos Finais</str>
-<str name="Artwork">Ilustração</str>
-<str name="Syntax">Sintaxe</str>
-<str name="Type">Tipo</str>
-<str name="Value">Valor</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Notas</str>
-<str name="Tip">Dica</str>
-<str name="Fastpath">Atalho</str>
-<str name="Important">Importante</str>
-<str name="Attention">Atenção</str>
-<str name="Caution">CUIDADO</str>
-<str name="Danger">PERIGO</str>
-<str name="Remember">Lembre-se</str>
-<str name="Restriction">Restrição</str>
-<str name="Warning">Aviso</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Conteúdo</str>
-<str name="Related concepts">Conceitos relacionados</str>
-<str name="Related tasks">Tarefas relacionadas</str>
-<str name="Related reference">Referências relacionadas</str>
-<str name="Related information">Informações relacionadas</str>
-
-<str name="Prerequisite">Prerequisite</str>
-<str name="Prerequisites">Prerequisites</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Por Que e Quando Desempenhar Esta Tarefa</str>
-<str name="task_example">Exemplo</str>
-<str name="task_prereq">Antes de Iniciar</str>
-<str name="task_postreq">O que Fazer Depois</str>
-<str name="task_procedure">Procedimento</str>
-<str name="task_procedure_unordered">Procedimento</str>
-<str name="task_results">Resultados</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Próximo tópico</str>
+  <str name="Previous topic">Tópico anterior</str>
+  <str name="Parent topic">Tópico pai</str>
+  <str name="Required cleanup">Limpeza necessária</str>
+  <str name="Draft comment">Comentário rascunho</str>
+  <str name="Option">Opção</str>
+  <str name="Description">Descrição</str>
+  <str name="Optional">Opcional</str>
+  <str name="Required">Necessário</str>
+  <str name="Skip visual syntax diagram">Manter visual do diagrama de sintaxe</str>
+  <str name="Read syntax diagram">Ler diagrama de sintaxe</str>
+  <str name="Start of change">Início da mudança</str>
+  <str name="End of change">Fim da mudança</str>
+  <str name="Index">Índice Remissivo</str>
+  <str name="Special characters">Caracteres Especiais</str>
+  <str name="Numerics">Numéricos</str>
+  <str name="End notes">Avisos Finais</str>
+  <str name="Artwork">Ilustração</str>
+  <str name="Syntax">Sintaxe</str>
+  <str name="Type">Tipo</str>
+  <str name="Value">Valor</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Notas</str>
+  <str name="Tip">Dica</str>
+  <str name="Fastpath">Atalho</str>
+  <str name="Important">Importante</str>
+  <str name="Attention">Atenção</str>
+  <str name="Caution">CUIDADO</str>
+  <str name="Danger">PERIGO</str>
+  <str name="Remember">Lembre-se</str>
+  <str name="Restriction">Restrição</str>
+  <str name="Warning">Aviso</str>
+  <str name="Contents">Conteúdo</str>
+  <str name="Related concepts">Conceitos relacionados</str>
+  <str name="Related tasks">Tarefas relacionadas</str>
+  <str name="Related reference">Referências relacionadas</str>
+  <str name="Related information">Informações relacionadas</str>
+  <str name="Prerequisite">Prerequisite</str>
+  <str name="Prerequisites">Prerequisites</str>
+  <str name="or">or</str>
+  <str name="task_context">Por Que e Quando Desempenhar Esta Tarefa</str>
+  <str name="task_example">Exemplo</str>
+  <str name="task_prereq">Antes de Iniciar</str>
+  <str name="task_postreq">O que Fazer Depois</str>
+  <str name="task_procedure">Procedimento</str>
+  <str name="task_procedure_unordered">Procedimento</str>
+  <str name="task_results">Resultados</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-pt-pt.xml
+++ b/src/main/xsl/common/strings-pt-pt.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="pt-pt">        <!-- Portuguese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figura</str>
-<str name="Table">Tabela</str>
-<str name="Next topic">Tópico seguinte</str>
-<str name="Previous topic">Tópico anterior</str>
-<str name="Parent topic">Tópico ascendente</str>
-<str name="Required cleanup">Limpeza necessária</str>
-<str name="Draft comment">Comentário rascunho</str>
-<str name="Option">Opção</str>
-<str name="Description">Descrição</str>
-<str name="Optional">Opcional</str>
-<str name="Required">Necessário</str>
-<str name="Skip visual syntax diagram">Manter visual do diagrama de sintaxe</str>
-<str name="Read syntax diagram">Ler diagrama de sintaxe</str>
-<str name="Start of change">Início de alteração</str>
-<str name="End of change">Fim de alteração</str>
-<str name="Index">Índice remissivo</str>
-<str name="Special characters">Caracteres especiais</str>
-<str name="Numerics">Numérico</str>
-<str name="End notes">Notas finais</str>
-<str name="Artwork">Gráficos</str>
-<str name="Syntax">Sintaxe</str>
-<str name="Type">Tipo</str>
-<str name="Value">Valor</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Nota</str>
-<str name="Notes">Notas</str>
-<str name="Tip">Dica</str>
-<str name="Fastpath">Atalho</str>
-<str name="Important">Importante</str>
-<str name="Attention">Atenção</str>
-<str name="Caution">CUIDADO</str>
-<str name="Danger">PERIGO</str>
-<str name="Remember">Lembre-se</str>
-<str name="Restriction">Restrição</str>
-<str name="Warning">Aviso</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Índice</str>
-<str name="Related concepts">Conceitos relacionados</str>
-<str name="Related tasks">Tarefas relacionadas</str>
-<str name="Related reference">Referências relacionadas</str>
-<str name="Related information">Informações relacionadas</str>
-
-<str name="Prerequisite">Pré-requisito</str>
-<str name="Prerequisites">Pré-requisitos</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Sobre esta tarefa</str>
-<str name="task_example">Exemplo</str>
-<str name="task_postreq">Como proceder a seguir</str>
-<str name="task_prereq">Antes de começar</str>
-<str name="task_procedure">Procedimento</str>
-<str name="task_procedure_unordered">Procedimento</str>
-<str name="task_results">Resultados</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Tópico seguinte</str>
+  <str name="Previous topic">Tópico anterior</str>
+  <str name="Parent topic">Tópico ascendente</str>
+  <str name="Required cleanup">Limpeza necessária</str>
+  <str name="Draft comment">Comentário rascunho</str>
+  <str name="Option">Opção</str>
+  <str name="Description">Descrição</str>
+  <str name="Optional">Opcional</str>
+  <str name="Required">Necessário</str>
+  <str name="Skip visual syntax diagram">Manter visual do diagrama de sintaxe</str>
+  <str name="Read syntax diagram">Ler diagrama de sintaxe</str>
+  <str name="Start of change">Início de alteração</str>
+  <str name="End of change">Fim de alteração</str>
+  <str name="Index">Índice remissivo</str>
+  <str name="Special characters">Caracteres especiais</str>
+  <str name="Numerics">Numérico</str>
+  <str name="End notes">Notas finais</str>
+  <str name="Artwork">Gráficos</str>
+  <str name="Syntax">Sintaxe</str>
+  <str name="Type">Tipo</str>
+  <str name="Value">Valor</str>
+  <str name="Note">Nota</str>
+  <str name="Notes">Notas</str>
+  <str name="Tip">Dica</str>
+  <str name="Fastpath">Atalho</str>
+  <str name="Important">Importante</str>
+  <str name="Attention">Atenção</str>
+  <str name="Caution">CUIDADO</str>
+  <str name="Danger">PERIGO</str>
+  <str name="Remember">Lembre-se</str>
+  <str name="Restriction">Restrição</str>
+  <str name="Warning">Aviso</str>
+  <str name="Contents">Índice</str>
+  <str name="Related concepts">Conceitos relacionados</str>
+  <str name="Related tasks">Tarefas relacionadas</str>
+  <str name="Related reference">Referências relacionadas</str>
+  <str name="Related information">Informações relacionadas</str>
+  <str name="Prerequisite">Pré-requisito</str>
+  <str name="Prerequisites">Pré-requisitos</str>
+  <str name="or">or</str>
+  <str name="task_context">Sobre esta tarefa</str>
+  <str name="task_example">Exemplo</str>
+  <str name="task_postreq">Como proceder a seguir</str>
+  <str name="task_prereq">Antes de começar</str>
+  <str name="task_procedure">Procedimento</str>
+  <str name="task_procedure_unordered">Procedimento</str>
+  <str name="task_results">Resultados</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ro-ro.xml
+++ b/src/main/xsl/common/strings-ro-ro.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="ro-ro">
-   <!-- Romanian -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Figura</str>
-   <str name="Table">Tabela</str>
-   <str name="Next topic">Subiect următor</str>
-   <str name="Previous topic">Subiect anterior</str>
-   <str name="Parent topic">Subiect părinte</str>
-   <str name="Required cleanup">Curăţare necesară</str>
-   <str name="Draft comment">Comentariu ciornă</str>
-   <str name="Option">Opţiune</str>
-   <str name="Description">Descriere</str>
-   <str name="Optional">Opţional</str>
-   <str name="Required">Necesar</str>
-   <str name="Skip visual syntax diagram">Salt diagramă sintaxă </str>
-   <str name="Read syntax diagram">Citire diagramă sintaxă</str>
-   <str name="Start of change">Început modificare</str>
-   <str name="End of change">Sfârşit modificare</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Caractere speciale</str>
-   <str name="Numerics">Numerice</str>
-   <str name="End notes">Note de sfârşit</str>
-   <str name="Artwork">Ilustraţie</str>
-   <str name="Syntax">Sintaxă</str>
-   <str name="Type">Tip</str>
-   <str name="Value">Valoare</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Notă</str>
-   <str name="Notes">Note</str>
-   <str name="Tip">Indiciu</str>
-   <str name="Fastpath">Cale rapidă</str>
-   <str name="Important">Important</str>
-   <str name="Attention">Atenţie</str>
-   <str name="Caution">ATENŢIE</str>
-   <str name="Danger">PERICOL</str>
-   <str name="Remember">De reţinut</str>
-   <str name="Restriction">Restricţie</str>
-   <str name="Warning">Avertisment</str>
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Cuprins</str>
-   <str name="Related concepts">Concepte înrudite</str>
-   <str name="Related tasks">Operaţii înrudite</str>
-   <str name="Related reference">Referinţe înrudite</str>
-   <str name="Related information">Informaţii înrudite</str>
-
-   <str name="Prerequisite">Cerinţă</str>
-   <str name="Prerequisites">Cerinţe</str>
-   <str name="or">or</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Despre acest task</str>
-   <str name="task_example">Exemplu</str>
-   <str name="task_postreq">Ce se face în continuare</str>
-   <str name="task_prereq">Înainte de a începe</str>
-   <str name="task_procedure">Procedură</str>
-   <str name="task_procedure_unordered">Procedură</str>
-   <str name="task_results">Rezultate</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">„</str>
-   <str name="CloseQuote">”</str>
-   <str name="ColonSymbol">:</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
-
+<strings xml:lang="ro-ro">      <!-- Romanian -->
+  <str name="Figure">Figura</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Subiect următor</str>
+  <str name="Previous topic">Subiect anterior</str>
+  <str name="Parent topic">Subiect părinte</str>
+  <str name="Required cleanup">Curăţare necesară</str>
+  <str name="Draft comment">Comentariu ciornă</str>
+  <str name="Option">Opţiune</str>
+  <str name="Description">Descriere</str>
+  <str name="Optional">Opţional</str>
+  <str name="Required">Necesar</str>
+  <str name="Skip visual syntax diagram">Salt diagramă sintaxă </str>
+  <str name="Read syntax diagram">Citire diagramă sintaxă</str>
+  <str name="Start of change">Început modificare</str>
+  <str name="End of change">Sfârşit modificare</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Caractere speciale</str>
+  <str name="Numerics">Numerice</str>
+  <str name="End notes">Note de sfârşit</str>
+  <str name="Artwork">Ilustraţie</str>
+  <str name="Syntax">Sintaxă</str>
+  <str name="Type">Tip</str>
+  <str name="Value">Valoare</str>
+  <str name="Note">Notă</str>
+  <str name="Notes">Note</str>
+  <str name="Tip">Indiciu</str>
+  <str name="Fastpath">Cale rapidă</str>
+  <str name="Important">Important</str>
+  <str name="Attention">Atenţie</str>
+  <str name="Caution">ATENŢIE</str>
+  <str name="Danger">PERICOL</str>
+  <str name="Remember">De reţinut</str>
+  <str name="Restriction">Restricţie</str>
+  <str name="Warning">Avertisment</str>
+  <str name="Contents">Cuprins</str>
+  <str name="Related concepts">Concepte înrudite</str>
+  <str name="Related tasks">Operaţii înrudite</str>
+  <str name="Related reference">Referinţe înrudite</str>
+  <str name="Related information">Informaţii înrudite</str>
+  <str name="Prerequisite">Cerinţă</str>
+  <str name="Prerequisites">Cerinţe</str>
+  <str name="or">or</str>
+  <str name="task_context">Despre acest task</str>
+  <str name="task_example">Exemplu</str>
+  <str name="task_postreq">Ce se face în continuare</str>
+  <str name="task_prereq">Înainte de a începe</str>
+  <str name="task_procedure">Procedură</str>
+  <str name="task_procedure_unordered">Procedură</str>
+  <str name="task_results">Rezultate</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">„</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ru-ru.xml
+++ b/src/main/xsl/common/strings-ru-ru.xml
@@ -6,77 +6,58 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="ru-ru">        <!-- Russian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Рис.</str>
-<str name="Table">Табл.</str>
-<str name="Next topic">Следующая тема</str>
-<str name="Previous topic">Предыдущая тема</str>
-<str name="Parent topic">На уровень выше</str>
-<str name="Required cleanup">Требуется исправление</str>
-<str name="Draft comment">Замечание в черновой версии</str>
-<str name="Option">Опция</str>
-<str name="Description">Описание</str>
-<str name="Optional">Необязательно</str>
-<str name="Required">Обязательно</str>
-<str name="Skip visual syntax diagram">Пропуск синтаксической диаграммы</str>
-<str name="Read syntax diagram">Чтение синтаксической диаграммы</str>
-<str name="Start of change">Изменено</str>
-<str name="End of change">Конец изменений</str>
-<str name="Index">Индекс</str>
-<str name="Special characters">Спец. символы</str>
-<str name="Numerics">Числа</str>
-<str name="End notes">Сноски</str>
-<str name="Artwork">Иллюстрация</str>
-<str name="Syntax">Синтаксис</str>
-<str name="Type">Тип</str>
-<str name="Value">Значение</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Прим.</str>
-<str name="Notes">Прим.</str>
-<str name="Tip">Совет</str>
-<str name="Fastpath">Быстрый путь</str>
-<str name="Important">Важное замечание</str>
-<str name="Attention">Внимание</str>
-<str name="Caution">ОСТОРОЖНО</str>
-<str name="Danger">ОПАСНО</str>
-<str name="Remember">Напоминание</str>
-<str name="Restriction">Ограничение</str>
-<str name="Warning">Внимание</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Содержание</str>
-<str name="Related concepts">Понятия, связанные с данным</str>
-<str name="Related tasks">Задачи, связанные с данной</str>
-<str name="Related reference">Ссылки, связанные с данной</str>
-<str name="Related information">Информация, связанная с данной</str>
-
-<str name="Prerequisite">Предварительное условие</str>
-<str name="Prerequisites">Предварительные условия</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Об этой задаче</str>
-<str name="task_example">Пример</str>
-<str name="task_postreq">Дальнейшие действия</str>
-<str name="task_prereq">Подготовка</str>
-<str name="task_procedure">Процедура</str>
-<str name="task_procedure_unordered">Процедура</str>
-<str name="task_results">Результат</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">«</str>
-<str name="CloseQuote">»</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Рис.</str>
+  <str name="Table">Табл.</str>
+  <str name="Next topic">Следующая тема</str>
+  <str name="Previous topic">Предыдущая тема</str>
+  <str name="Parent topic">На уровень выше</str>
+  <str name="Required cleanup">Требуется исправление</str>
+  <str name="Draft comment">Замечание в черновой версии</str>
+  <str name="Option">Опция</str>
+  <str name="Description">Описание</str>
+  <str name="Optional">Необязательно</str>
+  <str name="Required">Обязательно</str>
+  <str name="Skip visual syntax diagram">Пропуск синтаксической диаграммы</str>
+  <str name="Read syntax diagram">Чтение синтаксической диаграммы</str>
+  <str name="Start of change">Изменено</str>
+  <str name="End of change">Конец изменений</str>
+  <str name="Index">Индекс</str>
+  <str name="Special characters">Спец. символы</str>
+  <str name="Numerics">Числа</str>
+  <str name="End notes">Сноски</str>
+  <str name="Artwork">Иллюстрация</str>
+  <str name="Syntax">Синтаксис</str>
+  <str name="Type">Тип</str>
+  <str name="Value">Значение</str>
+  <str name="Note">Прим.</str>
+  <str name="Notes">Прим.</str>
+  <str name="Tip">Совет</str>
+  <str name="Fastpath">Быстрый путь</str>
+  <str name="Important">Важное замечание</str>
+  <str name="Attention">Внимание</str>
+  <str name="Caution">ОСТОРОЖНО</str>
+  <str name="Danger">ОПАСНО</str>
+  <str name="Remember">Напоминание</str>
+  <str name="Restriction">Ограничение</str>
+  <str name="Warning">Внимание</str>
+  <str name="Contents">Содержание</str>
+  <str name="Related concepts">Понятия, связанные с данным</str>
+  <str name="Related tasks">Задачи, связанные с данной</str>
+  <str name="Related reference">Ссылки, связанные с данной</str>
+  <str name="Related information">Информация, связанная с данной</str>
+  <str name="Prerequisite">Предварительное условие</str>
+  <str name="Prerequisites">Предварительные условия</str>
+  <str name="or">or</str>
+  <str name="task_context">Об этой задаче</str>
+  <str name="task_example">Пример</str>
+  <str name="task_postreq">Дальнейшие действия</str>
+  <str name="task_prereq">Подготовка</str>
+  <str name="task_procedure">Процедура</str>
+  <str name="task_procedure_unordered">Процедура</str>
+  <str name="task_results">Результат</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">«</str>
+  <str name="CloseQuote">»</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sk-sk.xml
+++ b/src/main/xsl/common/strings-sk-sk.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="sk-sk">
-   <!-- Slovak -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Obrázok</str>
-   <str name="Table">Tabuľka</str>
-   <str name="Next topic">Nasledujúca téma</str>
-   <str name="Previous topic">Predchádzajúca téma</str>
-   <str name="Parent topic">Nadradená téma</str>
-   <str name="Required cleanup">Požadované čistenie</str>
-   <str name="Draft comment">Poznámka v koncepte</str>
-   <str name="Option">Voľba</str>
-   <str name="Description">Opis</str>
-   <str name="Optional">Voliteľný</str>
-   <str name="Required">Požadovaný</str>
-   <str name="Skip visual syntax diagram">Preskočiť vizuálny diagram syntaxe</str>
-   <str name="Read syntax diagram">Čítať diagram syntaxe</str>
-   <str name="Start of change">Začiatok zmeny</str>
-   <str name="End of change">Koniec zmeny</str>
-   <str name="Index">Index</str>
-   <str name="Special characters">Špeciálne znaky</str>
-   <str name="Numerics">Numerický</str>
-   <str name="End notes">Záverečné poznámky</str>
-   <str name="Artwork">Obrázok</str>
-   <str name="Syntax">Syntax</str>
-   <str name="Type">Typ</str>
-   <str name="Value">Hodnota</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Poznámka</str>
-   <str name="Notes">Poznámky</str>
-   <str name="Tip">Tip</str>
-   <str name="Fastpath">Rýchla cesta</str>
-   <str name="Important">Dôležité</str>
-   <str name="Attention">Varovanie</str>
-   <str name="Caution">POZOR</str>
-   <str name="Danger">NEBEZPEČENSTVO</str>
-   <str name="Remember">Zapamätajte si</str>
-   <str name="Restriction">Obmedzenie</str>
-   <str name="Warning">Varovanie</str>
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Obsah</str>
-   <str name="Related concepts">Súvisiace koncepty</str>
-   <str name="Related tasks">Súvisiace úlohy</str>
-   <str name="Related reference">Súvisiaci odkaz</str>
-   <str name="Related information">Súvisiace informácie</str>
-
-   <str name="Prerequisite">Požiadavka</str>
-   <str name="Prerequisites">Požiadavky</str>
-   <str name="or">or</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">Informácie o úlohe</str>
-   <str name="task_example">Príklad</str>
-   <str name="task_postreq">Ako ďalej</str>
-   <str name="task_prereq">Skôr ako začnete</str>
-   <str name="task_procedure">Procedúra</str>
-   <str name="task_procedure_unordered">Procedúra</str>
-   <str name="task_results">Výsledky</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">“</str>
-   <str name="CloseQuote">”</str>
-   <str name="ColonSymbol">:</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
-
+<strings xml:lang="sk-sk">       <!-- Slovak -->
+  <str name="Figure">Obrázok</str>
+  <str name="Table">Tabuľka</str>
+  <str name="Next topic">Nasledujúca téma</str>
+  <str name="Previous topic">Predchádzajúca téma</str>
+  <str name="Parent topic">Nadradená téma</str>
+  <str name="Required cleanup">Požadované čistenie</str>
+  <str name="Draft comment">Poznámka v koncepte</str>
+  <str name="Option">Voľba</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Voliteľný</str>
+  <str name="Required">Požadovaný</str>
+  <str name="Skip visual syntax diagram">Preskočiť vizuálny diagram syntaxe</str>
+  <str name="Read syntax diagram">Čítať diagram syntaxe</str>
+  <str name="Start of change">Začiatok zmeny</str>
+  <str name="End of change">Koniec zmeny</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Špeciálne znaky</str>
+  <str name="Numerics">Numerický</str>
+  <str name="End notes">Záverečné poznámky</str>
+  <str name="Artwork">Obrázok</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Hodnota</str>
+  <str name="Note">Poznámka</str>
+  <str name="Notes">Poznámky</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Rýchla cesta</str>
+  <str name="Important">Dôležité</str>
+  <str name="Attention">Varovanie</str>
+  <str name="Caution">POZOR</str>
+  <str name="Danger">NEBEZPEČENSTVO</str>
+  <str name="Remember">Zapamätajte si</str>
+  <str name="Restriction">Obmedzenie</str>
+  <str name="Warning">Varovanie</str>
+  <str name="Contents">Obsah</str>
+  <str name="Related concepts">Súvisiace koncepty</str>
+  <str name="Related tasks">Súvisiace úlohy</str>
+  <str name="Related reference">Súvisiaci odkaz</str>
+  <str name="Related information">Súvisiace informácie</str>
+  <str name="Prerequisite">Požiadavka</str>
+  <str name="Prerequisites">Požiadavky</str>
+  <str name="or">or</str>
+  <str name="task_context">Informácie o úlohe</str>
+  <str name="task_example">Príklad</str>
+  <str name="task_postreq">Ako ďalej</str>
+  <str name="task_prereq">Skôr ako začnete</str>
+  <str name="task_procedure">Procedúra</str>
+  <str name="task_procedure_unordered">Procedúra</str>
+  <str name="task_results">Výsledky</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sl-si.xml
+++ b/src/main/xsl/common/strings-sl-si.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
-<strings xml:lang="sl-si">
-   <!-- Slovenian -->
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Slika</str>
-   <str name="Table">Tabela</str>
-   <str name="Next topic">Naslednja tema</str>
-   <str name="Previous topic">Prejšnja tema</str>
-   <str name="Parent topic">Nadrejena tema</str>
-   <str name="Required cleanup">Potrebno očiščenje</str>
-   <str name="Draft comment">Komentar osnutka</str>
-   <str name="Option">Možnost</str>
-   <str name="Description">Opis</str>
-   <str name="Optional">Izbirno</str>
-   <str name="Required">Zahtevano</str>
-   <str name="Skip visual syntax diagram">Preskoči vizualni skladenjski diagram</str>
-   <str name="Read syntax diagram">Preberi skladenjski diagram</str>
-   <str name="Start of change">Začetek spremembe</str>
-   <str name="End of change">Konec spremembe</str>
-   <str name="Index">Stvarno Kazalo</str>
-   <str name="Special characters">Posebni znaki</str>
-   <str name="Numerics">Številke</str>
-   <str name="End notes">Končne opombe</str>
-   <str name="Artwork">Sličice</str>
-   <str name="Syntax">Skladnja</str>
-   <str name="Type">Tip</str>
-   <str name="Value">Vrednost</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Opomba</str>
-   <str name="Notes">Opombe</str>
-   <str name="Tip">Nasvet</str>
-   <str name="Fastpath">Bližnjica</str>
-   <str name="Important">Pomembno</str>
-   <str name="Attention">Opozorilo</str>
-   <str name="Caution">POZOR</str>
-   <str name="Danger">NEVARNOST</str>
-   <str name="Remember">Pomnite</str>
-   <str name="Restriction">Omejitev</str>
-   <str name="Warning">Opozorilo</str>
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Kazalo</str>
-   <str name="Related concepts">S tem povezani pojmi</str>
-   <str name="Related tasks">S tem povezana opravila</str>
-   <str name="Related reference">S tem povezane povezave</str>
-   <str name="Related information">S tem povezane informacije</str>
-
-   <str name="Prerequisite">Predpogoj</str>
-   <str name="Prerequisites">Predpogoji</str>
-   <str name="or">or</str>
-   <str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">O tej nalogi</str>
-   <str name="task_example">Zgled</str>
-   <str name="task_postreq">Kako naprej?</str>
-   <str name="task_prereq">Preden začnete</str>
-   <str name="task_procedure">Postopek</str>
-   <str name="task_procedure_unordered">Postopek</str>
-   <str name="task_results">Rezultati</str>
-
-   <str name="Copyright">Copyright</str>
-
-   <!-- Symbols -->
-   <str name="OpenQuote">“</str>
-   <str name="CloseQuote">”</str>
-   <str name="ColonSymbol">:</str>
-   <str name="#menucascade-separator"> &gt; </str>
-   <str name="a11y.and-then"></str>
-
+<strings xml:lang="sl-si">      <!-- Slovenian -->
+  <str name="Figure">Slika</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Naslednja tema</str>
+  <str name="Previous topic">Prejšnja tema</str>
+  <str name="Parent topic">Nadrejena tema</str>
+  <str name="Required cleanup">Potrebno očiščenje</str>
+  <str name="Draft comment">Komentar osnutka</str>
+  <str name="Option">Možnost</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Izbirno</str>
+  <str name="Required">Zahtevano</str>
+  <str name="Skip visual syntax diagram">Preskoči vizualni skladenjski diagram</str>
+  <str name="Read syntax diagram">Preberi skladenjski diagram</str>
+  <str name="Start of change">Začetek spremembe</str>
+  <str name="End of change">Konec spremembe</str>
+  <str name="Index">Stvarno Kazalo</str>
+  <str name="Special characters">Posebni znaki</str>
+  <str name="Numerics">Številke</str>
+  <str name="End notes">Končne opombe</str>
+  <str name="Artwork">Sličice</str>
+  <str name="Syntax">Skladnja</str>
+  <str name="Type">Tip</str>
+  <str name="Value">Vrednost</str>
+  <str name="Note">Opomba</str>
+  <str name="Notes">Opombe</str>
+  <str name="Tip">Nasvet</str>
+  <str name="Fastpath">Bližnjica</str>
+  <str name="Important">Pomembno</str>
+  <str name="Attention">Opozorilo</str>
+  <str name="Caution">POZOR</str>
+  <str name="Danger">NEVARNOST</str>
+  <str name="Remember">Pomnite</str>
+  <str name="Restriction">Omejitev</str>
+  <str name="Warning">Opozorilo</str>
+  <str name="Contents">Kazalo</str>
+  <str name="Related concepts">S tem povezani pojmi</str>
+  <str name="Related tasks">S tem povezana opravila</str>
+  <str name="Related reference">S tem povezane povezave</str>
+  <str name="Related information">S tem povezane informacije</str>
+  <str name="Prerequisite">Predpogoj</str>
+  <str name="Prerequisites">Predpogoji</str>
+  <str name="or">or</str>
+  <str name="task_context">O tej nalogi</str>
+  <str name="task_example">Zgled</str>
+  <str name="task_postreq">Kako naprej?</str>
+  <str name="task_prereq">Preden začnete</str>
+  <str name="task_procedure">Postopek</str>
+  <str name="task_procedure_unordered">Postopek</str>
+  <str name="task_results">Rezultati</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sr-latn-me.xml
+++ b/src/main/xsl/common/strings-sr-latn-me.xml
@@ -6,78 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="sr-latn-me">        <!-- Montenegrin -->
-
-   <!-- various labels (not author controlled) -->
-   <str name="Figure">Slika</str>
-   <str name="Table">Tabela</str>
-   <str name="Next topic">Slijedeće poglavlje</str>
-   <str name="Previous topic">Prethodno poglavlje</str>
-   <str name="Parent topic">Nadređeno poglavlje</str>
-   <str name="Required cleanup">Potrebno čišćenje</str>
-   <str name="Draft comment">Komentar nacrta</str>
-   <str name="Option">Opcija</str>
-   <str name="Description">Opis</str>
-   <str name="Optional">Opcionalno</str>
-   <str name="Required">Potrebno</str>
-   <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
-   <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
-   <str name="Start of change">Početak promijene</str>
-   <str name="End of change">Kraj promijene</str>
-   <str name="Index">Indeks</str>
-   <str name="Special characters">Posebni znakovi</str>
-   <str name="Numerics">Brojevi</str>
-   <str name="End notes">Završne napomene</str>
-   <str name="Artwork">Ilustracija</str>
-   <str name="Syntax">Sintaksa</str>
-   <str name="Type">Tip</str>
-   <str name="Value">Vrijednost</str>
-   <!-- Text that goes before a link to a topic -->
-   <str name="intro-to-topic-link"></str>
-
-   <!-- peril notice labels -->
-   <str name="Note">Zabilješka</str>
-   <str name="Notes">Zabilješke</str>
-   <str name="Tip">Savjet</str>
-   <str name="Fastpath">Brza staza</str>
-   <str name="Important">Važno</str>
-   <str name="Attention">Pažnja</str>
-   <str name="Caution">Oprez</str>
-   <str name="Danger">OPASNOST</str>
-   <str name="Remember">Zapamtite</str>
-   <str name="Restriction">Ograničenje</str>
-   <str name="Warning">Upozorenje</str>
-   <str name="Trouble">Trouble</str>  <!-- MISSING -->
-
-   <!-- default title text for section level generated sections -->
-   <str name="Contents">Sadržaj</str>
-   <str name="Related concepts">Srodni koncepti</str>
-   <str name="Related tasks">Srodni zadaci</str>
-   <str name="Related reference">Srodne reference</str>
-   <str name="Related information">Srodne informacije</str>
-
-   <str name="Prerequisite">Preduslov</str>
-   <str name="Prerequisites">Preduslovi</str>
-   <str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-   <!--Task section labels -->
-   <str name="task_context">O ovom zadatku</str>
-   <str name="task_example">Primjer</str>
-   <str name="task_postreq">Šta uraditi sljedeće</str>
-   <str name="task_prereq">Prije nego što počnete</str>
-   <str name="task_procedure">Postupak</str>
-   <str name="task_procedure_unordered">Postupak</str>
-   <str name="task_results">Rezultati</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Slika</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Slijedeće poglavlje</str>
+  <str name="Previous topic">Prethodno poglavlje</str>
+  <str name="Parent topic">Nadređeno poglavlje</str>
+  <str name="Required cleanup">Potrebno čišćenje</str>
+  <str name="Draft comment">Komentar nacrta</str>
+  <str name="Option">Opcija</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Opcionalno</str>
+  <str name="Required">Potrebno</str>
+  <str name="Skip visual syntax diagram">Preskočiti vizualni sintatički dijagram</str>
+  <str name="Read syntax diagram">Pročitati sintatički dijagram</str>
+  <str name="Start of change">Početak promijene</str>
+  <str name="End of change">Kraj promijene</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Posebni znakovi</str>
+  <str name="Numerics">Brojevi</str>
+  <str name="End notes">Završne napomene</str>
+  <str name="Artwork">Ilustracija</str>
+  <str name="Syntax">Sintaksa</str>
+  <str name="Type">Tip</str>
+  <str name="Value">Vrijednost</str>
+  <str name="Note">Zabilješka</str>
+  <str name="Notes">Zabilješke</str>
+  <str name="Tip">Savjet</str>
+  <str name="Fastpath">Brza staza</str>
+  <str name="Important">Važno</str>
+  <str name="Attention">Pažnja</str>
+  <str name="Caution">Oprez</str>
+  <str name="Danger">OPASNOST</str>
+  <str name="Remember">Zapamtite</str>
+  <str name="Restriction">Ograničenje</str>
+  <str name="Warning">Upozorenje</str>
+  <str name="Trouble">Trouble</str>  <!-- TODO:Trouble -->
+  <str name="Contents">Sadržaj</str>
+  <str name="Related concepts">Srodni koncepti</str>
+  <str name="Related tasks">Srodni zadaci</str>
+  <str name="Related reference">Srodne reference</str>
+  <str name="Related information">Srodne informacije</str>
+  <str name="Prerequisite">Preduslov</str>
+  <str name="Prerequisites">Preduslovi</str>
+  <str name="or">or</str>
+  <str name="task_context">O ovom zadatku</str>
+  <str name="task_example">Primjer</str>
+  <str name="task_postreq">Šta uraditi sljedeće</str>
+  <str name="task_prereq">Prije nego što počnete</str>
+  <str name="task_procedure">Postupak</str>
+  <str name="task_procedure_unordered">Postupak</str>
+  <str name="task_results">Rezultati</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sr-latn-rs.xml
+++ b/src/main/xsl/common/strings-sr-latn-rs.xml
@@ -7,75 +7,55 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <strings xml:lang="sr-Latn-RS">        <!-- Serbian Latin -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Ilustracija</str>
-<str name="Table">Tabela</str>
-<str name="Next topic">Sledeća tema</str>
-<str name="Previous topic">Prethodna tema</str>
-<str name="Parent topic">Nadređena tema</str>
-<str name="Required cleanup">Neophodno čišćenje</str>
-<str name="Draft comment">Komentar na koncept</str>
-<str name="Option">Izbor</str>
-<str name="Description">Opis</str>
-<str name="Optional">Neobavezno</str>
-<str name="Required">Neophodno</str>
-<str name="Skip visual syntax diagram">Preskočite vizualni sintaksni dijagram</str>
-<str name="Read syntax diagram">Pročitajte vizualni sintaksni dijagram</str>
-<str name="Start of change">Početak promene</str>
-<str name="End of change">Kraj promene</str>
-<str name="Index">Indeks</str>
-<str name="Special characters">Posebni Znaci</str>
-<str name="Numerics">Numerici</str>
-<str name="End notes">Završne primedbe</str>
-<str name="Artwork">Ilustracije</str>
-<str name="Syntax">Sintaksa</str>
-<str name="Type">Vrsta</str>
-<str name="Value">Vrednost</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Napomena</str>
-<str name="Notes">Napomene</str>
-<str name="Tip">Savet</str>
-<str name="Fastpath">Prečica</str>
-<str name="Important">Važno</str>
-<str name="Attention">Pažnja</str>
-<str name="Caution">UPOZORENJE</str>
-<str name="Danger">OPASNOST</str>
-<str name="Remember">Zapamtite</str>
-<str name="Restriction">Ograničenje</str>
-<str name="Warning">Upozorenje</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Sadržaj</str>
-<str name="Related concepts">Srodni koncepti</str>
-<str name="Related tasks">Srodni zadaci</str>
-<str name="Related reference">Srodna referenca</str>
-<str name="Related information">Srodna informacija</str>
-
-<str name="Prerequisite">Preduslov</str>
-<str name="Prerequisites">Preduslovi</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">O ovom zadatku</str>
-<str name="task_example">Primer</str>
-<str name="task_postreq">Šta uraditi sledeće</str>
-<str name="task_prereq">Pre nego što počnete</str>
-<str name="task_procedure">Postupak</str>
-<str name="task_procedure_unordered">Postupak</str>
-<str name="task_results">Rezultat</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Ilustracija</str>
+  <str name="Table">Tabela</str>
+  <str name="Next topic">Sledeća tema</str>
+  <str name="Previous topic">Prethodna tema</str>
+  <str name="Parent topic">Nadređena tema</str>
+  <str name="Required cleanup">Neophodno čišćenje</str>
+  <str name="Draft comment">Komentar na koncept</str>
+  <str name="Option">Izbor</str>
+  <str name="Description">Opis</str>
+  <str name="Optional">Neobavezno</str>
+  <str name="Required">Neophodno</str>
+  <str name="Skip visual syntax diagram">Preskočite vizualni sintaksni dijagram</str>
+  <str name="Read syntax diagram">Pročitajte vizualni sintaksni dijagram</str>
+  <str name="Start of change">Početak promene</str>
+  <str name="End of change">Kraj promene</str>
+  <str name="Index">Indeks</str>
+  <str name="Special characters">Posebni Znaci</str>
+  <str name="Numerics">Numerici</str>
+  <str name="End notes">Završne primedbe</str>
+  <str name="Artwork">Ilustracije</str>
+  <str name="Syntax">Sintaksa</str>
+  <str name="Type">Vrsta</str>
+  <str name="Value">Vrednost</str>
+  <str name="Note">Napomena</str>
+  <str name="Notes">Napomene</str>
+  <str name="Tip">Savet</str>
+  <str name="Fastpath">Prečica</str>
+  <str name="Important">Važno</str>
+  <str name="Attention">Pažnja</str>
+  <str name="Caution">UPOZORENJE</str>
+  <str name="Danger">OPASNOST</str>
+  <str name="Remember">Zapamtite</str>
+  <str name="Restriction">Ograničenje</str>
+  <str name="Warning">Upozorenje</str>
+  <str name="Contents">Sadržaj</str>
+  <str name="Related concepts">Srodni koncepti</str>
+  <str name="Related tasks">Srodni zadaci</str>
+  <str name="Related reference">Srodna referenca</str>
+  <str name="Related information">Srodna informacija</str>
+  <str name="Prerequisite">Preduslov</str>
+  <str name="Prerequisites">Preduslovi</str>
+  <str name="or">or</str>
+  <str name="task_context">O ovom zadatku</str>
+  <str name="task_example">Primer</str>
+  <str name="task_postreq">Šta uraditi sledeće</str>
+  <str name="task_prereq">Pre nego što počnete</str>
+  <str name="task_procedure">Postupak</str>
+  <str name="task_procedure_unordered">Postupak</str>
+  <str name="task_results">Rezultat</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sr-sp.xml
+++ b/src/main/xsl/common/strings-sr-sp.xml
@@ -8,77 +8,56 @@ See the accompanying LICENSE file for applicable license.
 -->
 <!-- Note that this file is used when the toolkit encounters
      xml:lang="sr-sp" as well as xml:lang="sr-rs" -->
-
 <strings xml:lang="sr">        <!-- Serbian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Илустрација</str>
-<str name="Table">Табела</str>
-<str name="Next topic">Следећа тема</str>
-<str name="Previous topic">Претходна тема</str>
-<str name="Parent topic">Надређена тема</str>
-<str name="Required cleanup">Неопходно чишћење</str>
-<str name="Draft comment">Коментар на концепт</str>
-<str name="Option">Избор</str>
-<str name="Description">Опис</str>
-<str name="Optional">Необавезно</str>
-<str name="Required">Неопходно</str>
-<str name="Skip visual syntax diagram">Прескочите визуални синтаксни дијаграм</str>
-<str name="Read syntax diagram">Прочитајте визуални синтаксни дијаграм</str>
-<str name="Start of change">Почетак промене</str>
-<str name="End of change">Крај промене</str>
-<str name="Index">Индекс</str>
-<str name="Special characters">Посебни Знаци</str>
-<str name="Numerics">Нумерици</str>
-<str name="End notes">Завршне примедбе</str>
-<str name="Artwork">Илустрације</str>
-<str name="Syntax">Синтакса</str>
-<str name="Type">Врста</str>
-<str name="Value">Вредност</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Напомена</str>
-<str name="Notes">Напомене</str>
-<str name="Tip">Савет</str>
-<str name="Fastpath">Пречица</str>
-<str name="Important">Важно</str>
-<str name="Attention">Пажња</str>
-<str name="Caution">УПОЗОРЕЊЕ</str>
-<str name="Danger">ОПАСНОСТ</str>
-<str name="Remember">Запамтите</str>
-<str name="Restriction">Ограничење</str>
-<str name="Warning">Упозорење</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Садржај</str>
-<str name="Related concepts">Сродни концепти</str>
-<str name="Related tasks">Сродни задаци</str>
-<str name="Related reference">Сродна референца</str>
-<str name="Related information">Сродна информација</str>
-
-<str name="Prerequisite">Предуслов</str>
-<str name="Prerequisites">Предуслови</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">О овом задатку</str>
-<str name="task_example">Пример</str>
-<str name="task_postreq">Шта урадити следеће</str>
-<str name="task_prereq">Пре него што почнете</str>
-<str name="task_procedure">Поступак</str>
-<str name="task_procedure_unordered">Поступак</str>
-<str name="task_results">Резултат</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Илустрација</str>
+  <str name="Table">Табела</str>
+  <str name="Next topic">Следећа тема</str>
+  <str name="Previous topic">Претходна тема</str>
+  <str name="Parent topic">Надређена тема</str>
+  <str name="Required cleanup">Неопходно чишћење</str>
+  <str name="Draft comment">Коментар на концепт</str>
+  <str name="Option">Избор</str>
+  <str name="Description">Опис</str>
+  <str name="Optional">Необавезно</str>
+  <str name="Required">Неопходно</str>
+  <str name="Skip visual syntax diagram">Прескочите визуални синтаксни дијаграм</str>
+  <str name="Read syntax diagram">Прочитајте визуални синтаксни дијаграм</str>
+  <str name="Start of change">Почетак промене</str>
+  <str name="End of change">Крај промене</str>
+  <str name="Index">Индекс</str>
+  <str name="Special characters">Посебни Знаци</str>
+  <str name="Numerics">Нумерици</str>
+  <str name="End notes">Завршне примедбе</str>
+  <str name="Artwork">Илустрације</str>
+  <str name="Syntax">Синтакса</str>
+  <str name="Type">Врста</str>
+  <str name="Value">Вредност</str>
+  <str name="Note">Напомена</str>
+  <str name="Notes">Напомене</str>
+  <str name="Tip">Савет</str>
+  <str name="Fastpath">Пречица</str>
+  <str name="Important">Важно</str>
+  <str name="Attention">Пажња</str>
+  <str name="Caution">УПОЗОРЕЊЕ</str>
+  <str name="Danger">ОПАСНОСТ</str>
+  <str name="Remember">Запамтите</str>
+  <str name="Restriction">Ограничење</str>
+  <str name="Warning">Упозорење</str>
+  <str name="Contents">Садржај</str>
+  <str name="Related concepts">Сродни концепти</str>
+  <str name="Related tasks">Сродни задаци</str>
+  <str name="Related reference">Сродна референца</str>
+  <str name="Related information">Сродна информација</str>
+  <str name="Prerequisite">Предуслов</str>
+  <str name="Prerequisites">Предуслови</str>
+  <str name="or">or</str>
+  <str name="task_context">О овом задатку</str>
+  <str name="task_example">Пример</str>
+  <str name="task_postreq">Шта урадити следеће</str>
+  <str name="task_prereq">Пре него што почнете</str>
+  <str name="task_procedure">Поступак</str>
+  <str name="task_procedure_unordered">Поступак</str>
+  <str name="task_results">Резултат</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-sv-se.xml
+++ b/src/main/xsl/common/strings-sv-se.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="sv-se">        <!-- Swedish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Figur</str>
-<str name="Table">Tabell</str>
-<str name="Next topic">Nästa avsnitt</str>
-<str name="Previous topic">Föregående avsnitt</str>
-<str name="Parent topic">Överordnat ämne</str>
-<str name="Required cleanup">Korrigering krävs</str>
-<str name="Draft comment">Kommentar till utkast</str>
-<str name="Option">Alternativ</str>
-<str name="Description">Beskrivning</str>
-<str name="Optional">Valfritt</str>
-<str name="Required">Krävs</str>
-<str name="Skip visual syntax diagram">Hoppa över syntaxdiagram</str>
-<str name="Read syntax diagram">Läs syntaxdiagram</str>
-<str name="Start of change">Ändring startar</str>
-<str name="End of change">Ändring slutar</str>
-<str name="Index">Index</str>
-<str name="Special characters">Specialtecken</str>
-<str name="Numerics">Siffror</str>
-<str name="End notes">Noter</str>
-<str name="Artwork">Bild</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">Typ</str>
-<str name="Value">Värde</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Anm</str>
-<str name="Notes">Anm</str>
-<str name="Tip">Tips</str>
-<str name="Fastpath">Genväg</str>
-<str name="Important">Viktigt</str>
-<str name="Attention">Varning</str>
-<str name="Caution">Varning - risk för personskada</str>
-<str name="Danger">Varning - livsfara</str>
-<str name="Remember">Glöm inte</str>
-<str name="Restriction">Begränsning</str>
-<str name="Warning">Varning - risk för maskinskada</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Innehåll</str>
-<str name="Related concepts">Närliggande begrepp</str>
-<str name="Related tasks">Närliggande uppgifter</str>
-<str name="Related reference">Närliggande referens</str>
-<str name="Related information">Närliggande information</str>
-
-<str name="Prerequisite">Läs detta först</str>
-<str name="Prerequisites">Läs detta först</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Den här uppgiften</str>
-<str name="task_example">Exempel</str>
-<str name="task_postreq">Och sedan då?</str>
-<str name="task_prereq">Innan du börjar</str>
-<str name="task_procedure">Arbetsordning</str>
-<str name="task_procedure_unordered">Arbetsordning</str>
-<str name="task_results">Resultat</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">”</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Figur</str>
+  <str name="Table">Tabell</str>
+  <str name="Next topic">Nästa avsnitt</str>
+  <str name="Previous topic">Föregående avsnitt</str>
+  <str name="Parent topic">Överordnat ämne</str>
+  <str name="Required cleanup">Korrigering krävs</str>
+  <str name="Draft comment">Kommentar till utkast</str>
+  <str name="Option">Alternativ</str>
+  <str name="Description">Beskrivning</str>
+  <str name="Optional">Valfritt</str>
+  <str name="Required">Krävs</str>
+  <str name="Skip visual syntax diagram">Hoppa över syntaxdiagram</str>
+  <str name="Read syntax diagram">Läs syntaxdiagram</str>
+  <str name="Start of change">Ändring startar</str>
+  <str name="End of change">Ändring slutar</str>
+  <str name="Index">Index</str>
+  <str name="Special characters">Specialtecken</str>
+  <str name="Numerics">Siffror</str>
+  <str name="End notes">Noter</str>
+  <str name="Artwork">Bild</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">Typ</str>
+  <str name="Value">Värde</str>
+  <str name="Note">Anm</str>
+  <str name="Notes">Anm</str>
+  <str name="Tip">Tips</str>
+  <str name="Fastpath">Genväg</str>
+  <str name="Important">Viktigt</str>
+  <str name="Attention">Varning</str>
+  <str name="Caution">Varning - risk för personskada</str>
+  <str name="Danger">Varning - livsfara</str>
+  <str name="Remember">Glöm inte</str>
+  <str name="Restriction">Begränsning</str>
+  <str name="Warning">Varning - risk för maskinskada</str>
+  <str name="Contents">Innehåll</str>
+  <str name="Related concepts">Närliggande begrepp</str>
+  <str name="Related tasks">Närliggande uppgifter</str>
+  <str name="Related reference">Närliggande referens</str>
+  <str name="Related information">Närliggande information</str>
+  <str name="Prerequisite">Läs detta först</str>
+  <str name="Prerequisites">Läs detta först</str>
+  <str name="or">or</str>
+  <str name="task_context">Den här uppgiften</str>
+  <str name="task_example">Exempel</str>
+  <str name="task_postreq">Och sedan då?</str>
+  <str name="task_prereq">Innan du börjar</str>
+  <str name="task_procedure">Arbetsordning</str>
+  <str name="task_procedure_unordered">Arbetsordning</str>
+  <str name="task_results">Resultat</str>
+  <str name="Copyright">Copyright</str>
+  <str name="OpenQuote">”</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-th-th.xml
+++ b/src/main/xsl/common/strings-th-th.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="th-th">        <!-- Thai -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">รูปที่</str>
-<str name="Table">ตารางที่</str>
-<str name="Next topic">หัวข้อถัดไป</str>
-<str name="Previous topic">หัวข้อก่อนหน้า</str>
-<str name="Parent topic">หัวข้อต้นทาง</str>
-<str name="Required cleanup">การแก้ไขที่ต้องการ</str>
-<str name="Draft comment">ข้อคิดเห็นฉบับร่าง</str>
-<str name="Option">ทางเลือก</str>
-<str name="Description">คำอธิบาย</str>
-<str name="Optional">ทางเลือก</str>
-<str name="Required">บังคับ</str>
-<str name="Skip visual syntax diagram">ข้ามการดู syntax diagram</str>
-<str name="Read syntax diagram">อ่าน syntax diagram</str>
-<str name="Start of change">เริ่มต้นของการเปลี่ยนแปลง</str>
-<str name="End of change">สิ้นสุดของการเปลี่ยนแปลง</str>
-<str name="Index">ดัชนี</str>
-<str name="Special characters">อักขระพิเศษ</str>
-<str name="Numerics">ตัวเลข</str>
-<str name="End notes">หมายเหตุท้าย</str>
-<str name="Artwork">อาร์ตเวิร์ก</str>
-<str name="Syntax">Syntax</str>
-<str name="Type">ประเภท</str>
-<str name="Value">ค่า</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">หมายเหตุ</str>
-<str name="Notes">หมายเหตุ</str>
-<str name="Tip">คำแนะนำ</str>
-<str name="Fastpath">ทางด่วน</str>
-<str name="Important">สำคัญ</str>
-<str name="Attention">ข้อควรสนใจ</str>
-<str name="Caution">ข้อควรระวัง</str>
-<str name="Danger">อันตราย</str>
-<str name="Remember">เตือนความจำ</str>
-<str name="Restriction">ข้อจำกัด</str>
-<str name="Warning">คำเตือน</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">สารบัญ</str>
-<str name="Related concepts">หลักการที่เกี่ยวข้อง</str>
-<str name="Related tasks">งานที่เกี่ยวข้อง</str>
-<str name="Related reference">สิ่งอ้างอิงที่เกี่ยวข้อง</str>
-<str name="Related information">ข้อมูลที่เกี่ยวข้อง</str>
-
-<str name="Prerequisite">สิ่งที่ต้องทำก่อน</str>
-<str name="Prerequisites">สิ่งที่ต้องทำก่อน</str>
-<str name="or">หรือ</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">เกี่ยวกับภารกิจนี้</str>
-<str name="task_example">ตัวอย่าง</str>
-<str name="task_postreq">สิ่งที่ต้องทำต่อไป</str>
-<str name="task_prereq">ก่อนเริ่มต้นภารกิจ</str>
-<str name="task_procedure">กระบวนการ</str>
-<str name="task_procedure_unordered">กระบวนการ</str>
-<str name="task_results">ผลลัพธ์</str>
-
-<str name="Copyright">ลิขสิทธิ์ของ</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">รูปที่</str>
+  <str name="Table">ตารางที่</str>
+  <str name="Next topic">หัวข้อถัดไป</str>
+  <str name="Previous topic">หัวข้อก่อนหน้า</str>
+  <str name="Parent topic">หัวข้อต้นทาง</str>
+  <str name="Required cleanup">การแก้ไขที่ต้องการ</str>
+  <str name="Draft comment">ข้อคิดเห็นฉบับร่าง</str>
+  <str name="Option">ทางเลือก</str>
+  <str name="Description">คำอธิบาย</str>
+  <str name="Optional">ทางเลือก</str>
+  <str name="Required">บังคับ</str>
+  <str name="Skip visual syntax diagram">ข้ามการดู syntax diagram</str>
+  <str name="Read syntax diagram">อ่าน syntax diagram</str>
+  <str name="Start of change">เริ่มต้นของการเปลี่ยนแปลง</str>
+  <str name="End of change">สิ้นสุดของการเปลี่ยนแปลง</str>
+  <str name="Index">ดัชนี</str>
+  <str name="Special characters">อักขระพิเศษ</str>
+  <str name="Numerics">ตัวเลข</str>
+  <str name="End notes">หมายเหตุท้าย</str>
+  <str name="Artwork">อาร์ตเวิร์ก</str>
+  <str name="Syntax">Syntax</str>
+  <str name="Type">ประเภท</str>
+  <str name="Value">ค่า</str>
+  <str name="Note">หมายเหตุ</str>
+  <str name="Notes">หมายเหตุ</str>
+  <str name="Tip">คำแนะนำ</str>
+  <str name="Fastpath">ทางด่วน</str>
+  <str name="Important">สำคัญ</str>
+  <str name="Attention">ข้อควรสนใจ</str>
+  <str name="Caution">ข้อควรระวัง</str>
+  <str name="Danger">อันตราย</str>
+  <str name="Remember">เตือนความจำ</str>
+  <str name="Restriction">ข้อจำกัด</str>
+  <str name="Warning">คำเตือน</str>
+  <str name="Contents">สารบัญ</str>
+  <str name="Related concepts">หลักการที่เกี่ยวข้อง</str>
+  <str name="Related tasks">งานที่เกี่ยวข้อง</str>
+  <str name="Related reference">สิ่งอ้างอิงที่เกี่ยวข้อง</str>
+  <str name="Related information">ข้อมูลที่เกี่ยวข้อง</str>
+  <str name="Prerequisite">สิ่งที่ต้องทำก่อน</str>
+  <str name="Prerequisites">สิ่งที่ต้องทำก่อน</str>
+  <str name="or">หรือ</str>
+  <str name="task_context">เกี่ยวกับภารกิจนี้</str>
+  <str name="task_example">ตัวอย่าง</str>
+  <str name="task_postreq">สิ่งที่ต้องทำต่อไป</str>
+  <str name="task_prereq">ก่อนเริ่มต้นภารกิจ</str>
+  <str name="task_procedure">กระบวนการ</str>
+  <str name="task_procedure_unordered">กระบวนการ</str>
+  <str name="task_results">ผลลัพธ์</str>
+  <str name="Copyright">ลิขสิทธิ์ของ</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-tr-tr.xml
+++ b/src/main/xsl/common/strings-tr-tr.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="tr-tr">        <!-- Turkish -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Şekil</str>
-<str name="Table">Çizelge</str>
-<str name="Next topic">Sonraki</str>
-<str name="Previous topic">Önceki</str>
-<str name="Parent topic">Ana başlık</str>
-<str name="Required cleanup">Düzeltilmeli</str>
-<str name="Draft comment">Draft comment</str>
-<str name="Option">Seçenek</str>
-<str name="Description">Tanımlama</str>
-<str name="Optional">İsteğe bağlı</str>
-<str name="Required">Gerekli</str>
-<str name="Skip visual syntax diagram">Görsel sözdizim çizgesini atla</str>
-<str name="Read syntax diagram">Sözdizim çizgesini oku</str>
-<str name="Start of change">Değişikliklerin başlangıcı</str>
-<str name="End of change">Değişikliklerin bitişi</str>
-<str name="Index">Dizin</str>
-<str name="Special characters">Özel karakterler</str>
-<str name="Numerics">Sayısallar</str>
-<str name="End notes">Notların sonu</str>
-<str name="Artwork">Şekil</str>
-<str name="Syntax">Sözdizim</str>
-<str name="Type">İpucu</str>
-<str name="Value">Değer</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Not</str>
-<str name="Notes">Notlar</str>
-<str name="Tip">Tip</str>
-<str name="Fastpath">Kısa yol</str>
-<str name="Important">Önemli</str>
-<str name="Attention">Uyarı</str>
-<str name="Caution">DİKKAT</str>
-<str name="Danger">TEHLİKE</str>
-<str name="Remember">Unutmayın</str>
-<str name="Restriction">Sınırlama</str>
-<str name="Warning">Uyarı</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">İçindekiler</str>
-<str name="Related concepts">İlgili kavramlar</str>
-<str name="Related tasks">İlgili görevler</str>
-<str name="Related reference">İlgili başvurular</str>
-<str name="Related information">İlgili bilgiler</str>
-
-<str name="Prerequisite">Okunması Gerekenler</str>
-<str name="Prerequisites">Okunması Gerekenler</str>
-<str name="or">or</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Bu görev hakkında</str>
-<str name="task_example">Örnek</str>
-<str name="task_postreq">Sonraki adım</str>
-<str name="task_prereq">Başlamadan önce</str>
-<str name="task_procedure">Yordam</str>
-<str name="task_procedure_unordered">Yordam</str>
-<str name="task_results">Sonuçlar</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Şekil</str>
+  <str name="Table">Çizelge</str>
+  <str name="Next topic">Sonraki</str>
+  <str name="Previous topic">Önceki</str>
+  <str name="Parent topic">Ana başlık</str>
+  <str name="Required cleanup">Düzeltilmeli</str>
+  <str name="Draft comment">Draft comment</str>
+  <str name="Option">Seçenek</str>
+  <str name="Description">Tanımlama</str>
+  <str name="Optional">İsteğe bağlı</str>
+  <str name="Required">Gerekli</str>
+  <str name="Skip visual syntax diagram">Görsel sözdizim çizgesini atla</str>
+  <str name="Read syntax diagram">Sözdizim çizgesini oku</str>
+  <str name="Start of change">Değişikliklerin başlangıcı</str>
+  <str name="End of change">Değişikliklerin bitişi</str>
+  <str name="Index">Dizin</str>
+  <str name="Special characters">Özel karakterler</str>
+  <str name="Numerics">Sayısallar</str>
+  <str name="End notes">Notların sonu</str>
+  <str name="Artwork">Şekil</str>
+  <str name="Syntax">Sözdizim</str>
+  <str name="Type">İpucu</str>
+  <str name="Value">Değer</str>
+  <str name="Note">Not</str>
+  <str name="Notes">Notlar</str>
+  <str name="Tip">Tip</str>
+  <str name="Fastpath">Kısa yol</str>
+  <str name="Important">Önemli</str>
+  <str name="Attention">Uyarı</str>
+  <str name="Caution">DİKKAT</str>
+  <str name="Danger">TEHLİKE</str>
+  <str name="Remember">Unutmayın</str>
+  <str name="Restriction">Sınırlama</str>
+  <str name="Warning">Uyarı</str>
+  <str name="Contents">İçindekiler</str>
+  <str name="Related concepts">İlgili kavramlar</str>
+  <str name="Related tasks">İlgili görevler</str>
+  <str name="Related reference">İlgili başvurular</str>
+  <str name="Related information">İlgili bilgiler</str>
+  <str name="Prerequisite">Okunması Gerekenler</str>
+  <str name="Prerequisites">Okunması Gerekenler</str>
+  <str name="or">or</str>
+  <str name="task_context">Bu görev hakkında</str>
+  <str name="task_example">Örnek</str>
+  <str name="task_postreq">Sonraki adım</str>
+  <str name="task_prereq">Başlamadan önce</str>
+  <str name="task_procedure">Yordam</str>
+  <str name="task_procedure_unordered">Yordam</str>
+  <str name="task_results">Sonuçlar</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-uk-ua.xml
+++ b/src/main/xsl/common/strings-uk-ua.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="uk-ua">        <!-- Ukrainian -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Мал.</str>
-<str name="Table">Табл.</str>
-<str name="Next topic">Наступна тема</str>
-<str name="Previous topic">Попередня тема</str>
-<str name="Parent topic">На рівень догори</str>
-<str name="Required cleanup">Необхідна чистка</str>
-<str name="Draft comment">Зауваження у чорновому варіанті</str>
-<str name="Option">Опція</str>
-<str name="Description">Опис</str>
-<str name="Optional">За бажанням</str>
-<str name="Required">Обов'язково</str>
-<str name="Skip visual syntax diagram">Пропустити візуальну синтаксичну діаграму</str>
-<str name="Read syntax diagram">Прочитати синтаксичну діаграму</str>
-<str name="Start of change">Початок зміни</str>
-<str name="End of change">Кінець зміни</str>
-<str name="Index">Покажчик</str>
-<str name="Special characters">Спеціальні символи</str>
-<str name="Numerics">Числа</str>
-<str name="End notes">Кінцеві примітки</str>
-<str name="Artwork">Оформлення</str>
-<str name="Syntax">Синтаксис</str>
-<str name="Type">Тип</str>
-<str name="Value">Значення</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Примітка</str>
-<str name="Notes">Примітки</str>
-<str name="Tip">Порада</str>
-<str name="Fastpath">Короткий шлях</str>
-<str name="Important">Важливо</str>
-<str name="Attention">Увага</str>
-<str name="Caution">ОБЕРЕЖНО</str>
-<str name="Danger">НЕБЕЗПЕЧНО</str>
-<str name="Remember">Запам'ятайте</str>
-<str name="Restriction">Обмеження</str>
-<str name="Warning">Попередження</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Зміст</str>
-<str name="Related concepts">Споріднені ідеї</str>
-<str name="Related tasks">Пов'язані задачі</str>
-<str name="Related reference">Відповідні посилання</str>
-<str name="Related information">Інформація з пов'язаних питань</str>
-
-<str name="Prerequisite">Необхідна вимога</str>
-<str name="Prerequisites">Необхідні вимоги</str>
-<str name="or">або</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">Інформація про завдання</str>
-<str name="task_example">Приклад</str>
-<str name="task_postreq">Подальші дії</str>
-<str name="task_prereq">Підготовчі дії</str>
-<str name="task_procedure">Процедура</str>
-<str name="task_procedure_unordered">Процедура</str>
-<str name="task_results">Результати</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Мал.</str>
+  <str name="Table">Табл.</str>
+  <str name="Next topic">Наступна тема</str>
+  <str name="Previous topic">Попередня тема</str>
+  <str name="Parent topic">На рівень догори</str>
+  <str name="Required cleanup">Необхідна чистка</str>
+  <str name="Draft comment">Зауваження у чорновому варіанті</str>
+  <str name="Option">Опція</str>
+  <str name="Description">Опис</str>
+  <str name="Optional">За бажанням</str>
+  <str name="Required">Обов'язково</str>
+  <str name="Skip visual syntax diagram">Пропустити візуальну синтаксичну діаграму</str>
+  <str name="Read syntax diagram">Прочитати синтаксичну діаграму</str>
+  <str name="Start of change">Початок зміни</str>
+  <str name="End of change">Кінець зміни</str>
+  <str name="Index">Покажчик</str>
+  <str name="Special characters">Спеціальні символи</str>
+  <str name="Numerics">Числа</str>
+  <str name="End notes">Кінцеві примітки</str>
+  <str name="Artwork">Оформлення</str>
+  <str name="Syntax">Синтаксис</str>
+  <str name="Type">Тип</str>
+  <str name="Value">Значення</str>
+  <str name="Note">Примітка</str>
+  <str name="Notes">Примітки</str>
+  <str name="Tip">Порада</str>
+  <str name="Fastpath">Короткий шлях</str>
+  <str name="Important">Важливо</str>
+  <str name="Attention">Увага</str>
+  <str name="Caution">ОБЕРЕЖНО</str>
+  <str name="Danger">НЕБЕЗПЕЧНО</str>
+  <str name="Remember">Запам'ятайте</str>
+  <str name="Restriction">Обмеження</str>
+  <str name="Warning">Попередження</str>
+  <str name="Contents">Зміст</str>
+  <str name="Related concepts">Споріднені ідеї</str>
+  <str name="Related tasks">Пов'язані задачі</str>
+  <str name="Related reference">Відповідні посилання</str>
+  <str name="Related information">Інформація з пов'язаних питань</str>
+  <str name="Prerequisite">Необхідна вимога</str>
+  <str name="Prerequisites">Необхідні вимоги</str>
+  <str name="or">або</str>
+  <str name="task_context">Інформація про завдання</str>
+  <str name="task_example">Приклад</str>
+  <str name="task_postreq">Подальші дії</str>
+  <str name="task_prereq">Підготовчі дії</str>
+  <str name="task_procedure">Процедура</str>
+  <str name="task_procedure_unordered">Процедура</str>
+  <str name="task_results">Результати</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-ur-pk.xml
+++ b/src/main/xsl/common/strings-ur-pk.xml
@@ -7,75 +7,55 @@ Copyright 2009 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <strings xml:lang="ur-pk">        <!-- Urdu -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">تصویر</str>
-<str name="Table">جدول</str>
-<str name="Next topic">اگلا موضوع</str>
-<str name="Previous topic">سابقہ موضوع</str>
-<str name="Parent topic">مادر موضوع</str>
-<str name="Required cleanup">مطلوبہ صفائی</str>
-<str name="Draft comment">تبصرے کا مسودہ</str>
-<str name="Option">اختیار</str>
-<str name="Description">وضاحت</str>
-<str name="Optional">اختیاری</str>
-<str name="Required">ضروری</str>
-<str name="Skip visual syntax diagram">وژوئل سنٹیکس کی شکل چھوڑ دیں</str>
-<str name="Read syntax diagram">وژوئل سنٹیکس کی شکل پڑھیں</str>
-<str name="Start of change">تبدیلی کی شروعات</str>
-<str name="End of change">تبدیلی کی کا اختتام</str>
-<str name="Index">انڈکس</str>
-<str name="Special characters">خاص حروف</str>
-<str name="Numerics">نمبر</str>
-<str name="End notes">اختتامی نوٹس</str>
-<str name="Artwork">آرٹ ورک</str>
-<str name="Syntax">سنٹیکس</str>
-<str name="Type">قسم</str>
-<str name="Value">قدر</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">نوٹ</str>
-<str name="Notes">نوٹس</str>
-<str name="Tip">مشورہ</str>
-<str name="Fastpath">تیز طریقہ</str>
-<str name="Important">اہم</str>
-<str name="Attention">براۓ توجہ</str>
-<str name="Caution">احتیاط</str>
-<str name="Danger">خطرناک</str>
-<str name="Remember">یاد رکھیں</str>
-<str name="Restriction">پابندی</str>
-<str name="Warning">انتباہ</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">فہرست</str>
-<str name="Related concepts">متعلقہ خیالات</str>
-<str name="Related tasks">متعلقہ کام</str>
-<str name="Related reference">متعلقہ حوالہ</str>
-<str name="Related information">متعلقہ معلومات</str>
-
-<str name="Prerequisite">شرط اول</str>
-<str name="Prerequisites">اولین شرطیں</str>
-<str name="or">یا</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">اس کام کے متعلق</str>
-<str name="task_example">مثال</str>
-<str name="task_postreq">آکے کیا کرنا ہے</str>
-<str name="task_prereq">قبل اس کے کہ آپ شروع کریں</str>
-<str name="task_procedure">طریق عمل</str>
-<str name="task_procedure_unordered">طریق عمل</str>
-<str name="task_results">نتائج</str>
-
-<str name="Copyright">حقوق</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">تصویر</str>
+  <str name="Table">جدول</str>
+  <str name="Next topic">اگلا موضوع</str>
+  <str name="Previous topic">سابقہ موضوع</str>
+  <str name="Parent topic">مادر موضوع</str>
+  <str name="Required cleanup">مطلوبہ صفائی</str>
+  <str name="Draft comment">تبصرے کا مسودہ</str>
+  <str name="Option">اختیار</str>
+  <str name="Description">وضاحت</str>
+  <str name="Optional">اختیاری</str>
+  <str name="Required">ضروری</str>
+  <str name="Skip visual syntax diagram">وژوئل سنٹیکس کی شکل چھوڑ دیں</str>
+  <str name="Read syntax diagram">وژوئل سنٹیکس کی شکل پڑھیں</str>
+  <str name="Start of change">تبدیلی کی شروعات</str>
+  <str name="End of change">تبدیلی کی کا اختتام</str>
+  <str name="Index">انڈکس</str>
+  <str name="Special characters">خاص حروف</str>
+  <str name="Numerics">نمبر</str>
+  <str name="End notes">اختتامی نوٹس</str>
+  <str name="Artwork">آرٹ ورک</str>
+  <str name="Syntax">سنٹیکس</str>
+  <str name="Type">قسم</str>
+  <str name="Value">قدر</str>
+  <str name="Note">نوٹ</str>
+  <str name="Notes">نوٹس</str>
+  <str name="Tip">مشورہ</str>
+  <str name="Fastpath">تیز طریقہ</str>
+  <str name="Important">اہم</str>
+  <str name="Attention">براۓ توجہ</str>
+  <str name="Caution">احتیاط</str>
+  <str name="Danger">خطرناک</str>
+  <str name="Remember">یاد رکھیں</str>
+  <str name="Restriction">پابندی</str>
+  <str name="Warning">انتباہ</str>
+  <str name="Contents">فہرست</str>
+  <str name="Related concepts">متعلقہ خیالات</str>
+  <str name="Related tasks">متعلقہ کام</str>
+  <str name="Related reference">متعلقہ حوالہ</str>
+  <str name="Related information">متعلقہ معلومات</str>
+  <str name="Prerequisite">شرط اول</str>
+  <str name="Prerequisites">اولین شرطیں</str>
+  <str name="or">یا</str>
+  <str name="task_context">اس کام کے متعلق</str>
+  <str name="task_example">مثال</str>
+  <str name="task_postreq">آکے کیا کرنا ہے</str>
+  <str name="task_prereq">قبل اس کے کہ آپ شروع کریں</str>
+  <str name="task_procedure">طریق عمل</str>
+  <str name="task_procedure_unordered">طریق عمل</str>
+  <str name="task_results">نتائج</str>
+  <str name="Copyright">حقوق</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-vi-vn.xml
+++ b/src/main/xsl/common/strings-vi-vn.xml
@@ -69,6 +69,7 @@ This file is part of the DITA Open Toolkit project.
 <str name="task_postreq">Điều cần làm tiếp theo</str>
 <str name="task_prereq">Trước khi bạn bắt đầu</str>
 <str name="task_procedure">Quy trình</str>
+<str name="task_procedure_unordered">Quy trình</str>
 <str name="task_results">Kết quả</str>
 
 <str name="Copyright">Bản quyền</str>

--- a/src/main/xsl/common/strings-vi-vn.xml
+++ b/src/main/xsl/common/strings-vi-vn.xml
@@ -4,81 +4,60 @@ This file is part of the DITA Open Toolkit project.
  See the accompanying LICENSE file for
  applicable licenses.-->
 <strings xml:lang="vi-vn">        <!-- Vietnamese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">Hình</str>
-<str name="Table">Bảng</str>
-<str name="Next topic">Chủ đề tiếp theo</str>
-<str name="Previous topic">Chủ đề trước</str>
-<str name="Parent topic">Chủ đề chính</str>
-<str name="Required cleanup">Yêu cầu dọn dẹp</str>
-<str name="Draft comment">Đánh giá nháp</str>
-<str name="Option">Tùy chọn</str>
-<str name="Description">Mô tả</str>
-<str name="Optional">Tùy chọn</str>
-<str name="Required">Yêu cầu</str>
-<str name="Skip visual syntax diagram">Bỏ qua sơ đồ cú pháp bằng hình ảnh</str>
-<str name="Read syntax diagram">Đọc sơ đồ cú pháp</str>
-<str name="Text version of syntax diagram">Phiên bản bằng văn bản của sơ đồ cú pháp</str>
-<str name="Start of change">Bắt đầu thay đổi</str>
-<str name="End of change">Kết thúc thay đổi</str>
-<str name="Index">Chỉ mục</str>
-<str name="Special characters">Ký tự đặc biệt</str>
-<str name="Numerics">Số</str>
-<str name="End notes">Ghi chú cuối trang</str>
-<str name="Artwork">Ảnh bìa</str>
-<str name="Syntax">Cú pháp</str>
-<str name="Type">Loại</str>
-<str name="Value">Giá trị</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">Ghi chú</str>
-<str name="Notes">Các ghi chú</str>
-<str name="Tip">Mẹo</str>
-<str name="Fastpath">Đường dẫn nhanh</str>
-<str name="Important">Quan trọng</str>
-<str name="Attention">Chú ý</str>
-<str name="Caution">THẬN TRỌNG</str>
-<str name="Danger">NGUY HIỂM</str>
-<str name="Remember">Ghi nhớ</str>
-<str name="Warning">Cảnh báo</str>
-<str name="Restriction">Hạn chế</str>
-<str name="Trouble">Trouble</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">Nội dung</str>
-<str name="Related concepts">Các khái niệm liên quan</str>
-<str name="Related tasks">Các tác vụ liên quan</str>
-<str name="Related reference">Tham chiếu liên quan</str>
-<str name="Related information">Thông tin liên quan</str>
-
-<str name="Prerequisite">Điều kiện tiên quyết</str>
-<str name="Prerequisites">Các điều kiện tiên quyết</str>
-<str name="or">hoặc</str>
-<str name="figure-number-separator"> </str>
-
-<str name="Prerequisite">Prerequisite</str>
-<str name="Prerequisites">Prerequisites</str>
-<str name="or">or</str>
-
-<!--Task section labels -->
-<str name="task_context">Thông tin về tác vụ này</str>
-<str name="task_example">Ví dụ</str>
-<str name="task_postreq">Điều cần làm tiếp theo</str>
-<str name="task_prereq">Trước khi bạn bắt đầu</str>
-<str name="task_procedure">Quy trình</str>
-<str name="task_procedure_unordered">Quy trình</str>
-<str name="task_results">Kết quả</str>
-
-<str name="Copyright">Bản quyền</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">Hình</str>
+  <str name="Table">Bảng</str>
+  <str name="Next topic">Chủ đề tiếp theo</str>
+  <str name="Previous topic">Chủ đề trước</str>
+  <str name="Parent topic">Chủ đề chính</str>
+  <str name="Required cleanup">Yêu cầu dọn dẹp</str>
+  <str name="Draft comment">Đánh giá nháp</str>
+  <str name="Option">Tùy chọn</str>
+  <str name="Description">Mô tả</str>
+  <str name="Optional">Tùy chọn</str>
+  <str name="Required">Yêu cầu</str>
+  <str name="Skip visual syntax diagram">Bỏ qua sơ đồ cú pháp bằng hình ảnh</str>
+  <str name="Read syntax diagram">Đọc sơ đồ cú pháp</str>
+  <str name="Text version of syntax diagram">Phiên bản bằng văn bản của sơ đồ cú pháp</str>
+  <str name="Start of change">Bắt đầu thay đổi</str>
+  <str name="End of change">Kết thúc thay đổi</str>
+  <str name="Index">Chỉ mục</str>
+  <str name="Special characters">Ký tự đặc biệt</str>
+  <str name="Numerics">Số</str>
+  <str name="End notes">Ghi chú cuối trang</str>
+  <str name="Artwork">Ảnh bìa</str>
+  <str name="Syntax">Cú pháp</str>
+  <str name="Type">Loại</str>
+  <str name="Value">Giá trị</str>
+  <str name="Note">Ghi chú</str>
+  <str name="Notes">Các ghi chú</str>
+  <str name="Tip">Mẹo</str>
+  <str name="Fastpath">Đường dẫn nhanh</str>
+  <str name="Important">Quan trọng</str>
+  <str name="Attention">Chú ý</str>
+  <str name="Caution">THẬN TRỌNG</str>
+  <str name="Danger">NGUY HIỂM</str>
+  <str name="Remember">Ghi nhớ</str>
+  <str name="Warning">Cảnh báo</str>
+  <str name="Restriction">Hạn chế</str>
+  <str name="Trouble">Trouble</str>
+  <str name="Contents">Nội dung</str>
+  <str name="Related concepts">Các khái niệm liên quan</str>
+  <str name="Related tasks">Các tác vụ liên quan</str>
+  <str name="Related reference">Tham chiếu liên quan</str>
+  <str name="Related information">Thông tin liên quan</str>
+  <str name="Prerequisite">Điều kiện tiên quyết</str>
+  <str name="Prerequisites">Các điều kiện tiên quyết</str>
+  <str name="or">hoặc</str>
+  <str name="Prerequisite">Prerequisite</str>
+  <str name="Prerequisites">Prerequisites</str>
+  <str name="or">or</str>
+  <str name="task_context">Thông tin về tác vụ này</str>
+  <str name="task_example">Ví dụ</str>
+  <str name="task_postreq">Điều cần làm tiếp theo</str>
+  <str name="task_prereq">Trước khi bạn bắt đầu</str>
+  <str name="task_procedure">Quy trình</str>
+  <str name="task_procedure_unordered">Quy trình</str>
+  <str name="task_results">Kết quả</str>
+  <str name="Copyright">Bản quyền</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-zh-cn.xml
+++ b/src/main/xsl/common/strings-zh-cn.xml
@@ -6,77 +6,57 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="zh-cn">        <!-- Simplified Chinese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">图</str>
-<str name="Table">表</str>
-<str name="Next topic">下一主题</str>
-<str name="Previous topic">上一主题</str>
-<str name="Parent topic">父主题</str>
-<str name="Required cleanup">需要修正</str>
-<str name="Draft comment">非正式版注释</str>
-<str name="Option">选项</str>
-<str name="Description">描述</str>
-<str name="Optional">可选</str>
-<str name="Required">必需</str>
-<str name="Skip visual syntax diagram">跳过直观语法图</str>
-<str name="Read syntax diagram">阅读语法图</str>
-<str name="Start of change">更新开始</str>
-<str name="End of change">更新结束</str>
-<str name="Index">索引</str>
-<str name="Special characters">特别字符</str>
-<str name="Numerics">数字</str>
-<str name="End notes">结尾注释</str>
-<str name="Artwork">图片</str>
-<str name="Syntax">语法</str>
-<str name="Type">类型</str>
-<str name="Value">值</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">注</str>
-<str name="Notes">注</str>
-<str name="Tip">提示</str>
-<str name="Fastpath">捷径</str>
-<str name="Important">重要</str>
-<str name="Attention">注意</str>
-<str name="Caution">警告</str>
-<str name="Danger">危险</str>
-<str name="Remember">切记</str>
-<str name="Restriction">限制</str>
-<str name="Warning">警告</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">内容</str>
-<str name="Related concepts">相关概念</str>
-<str name="Related tasks">相关任务</str>
-<str name="Related reference">相关参考</str>
-<str name="Related information">相关信息</str>
-
-<str name="Prerequisite">先决条件</str>
-<str name="Prerequisites">先决条件</str>
-<str name="or">或</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">关于此任务</str>
-<str name="task_example">示例</str>
-<str name="task_postreq">下一步做什么</str>
-<str name="task_prereq">开始之前</str>
-<str name="task_procedure">过程</str>
-<str name="task_procedure_unordered">过程</str>
-<str name="task_results">结果</str>
-
-<str name="Copyright">版权</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">：</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">图</str>
+  <str name="Table">表</str>
+  <str name="Next topic">下一主题</str>
+  <str name="Previous topic">上一主题</str>
+  <str name="Parent topic">父主题</str>
+  <str name="Required cleanup">需要修正</str>
+  <str name="Draft comment">非正式版注释</str>
+  <str name="Option">选项</str>
+  <str name="Description">描述</str>
+  <str name="Optional">可选</str>
+  <str name="Required">必需</str>
+  <str name="Skip visual syntax diagram">跳过直观语法图</str>
+  <str name="Read syntax diagram">阅读语法图</str>
+  <str name="Start of change">更新开始</str>
+  <str name="End of change">更新结束</str>
+  <str name="Index">索引</str>
+  <str name="Special characters">特别字符</str>
+  <str name="Numerics">数字</str>
+  <str name="End notes">结尾注释</str>
+  <str name="Artwork">图片</str>
+  <str name="Syntax">语法</str>
+  <str name="Type">类型</str>
+  <str name="Value">值</str>
+  <str name="Note">注</str>
+  <str name="Notes">注</str>
+  <str name="Tip">提示</str>
+  <str name="Fastpath">捷径</str>
+  <str name="Important">重要</str>
+  <str name="Attention">注意</str>
+  <str name="Caution">警告</str>
+  <str name="Danger">危险</str>
+  <str name="Remember">切记</str>
+  <str name="Restriction">限制</str>
+  <str name="Warning">警告</str>
+  <str name="Contents">内容</str>
+  <str name="Related concepts">相关概念</str>
+  <str name="Related tasks">相关任务</str>
+  <str name="Related reference">相关参考</str>
+  <str name="Related information">相关信息</str>
+  <str name="Prerequisite">先决条件</str>
+  <str name="Prerequisites">先决条件</str>
+  <str name="or">或</str>
+  <str name="task_context">关于此任务</str>
+  <str name="task_example">示例</str>
+  <str name="task_postreq">下一步做什么</str>
+  <str name="task_prereq">开始之前</str>
+  <str name="task_procedure">过程</str>
+  <str name="task_procedure_unordered">过程</str>
+  <str name="task_results">结果</str>
+  <str name="Copyright">版权</str>
+  <str name="ColonSymbol">：</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-zh-tw.xml
+++ b/src/main/xsl/common/strings-zh-tw.xml
@@ -6,77 +6,56 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-
 <strings xml:lang="zh-tw">        <!-- Traditional Chinese -->
-
-<!-- various labels (not author controlled) -->
-<str name="Figure">圖</str>
-<str name="Table">表</str>
-<str name="Next topic">下一個主題</str>
-<str name="Previous topic">前一個主題</str>
-<str name="Parent topic">上層主題</str>
-<str name="Required cleanup">必要修正</str>
-<str name="Draft comment">草稿註解</str>
-<str name="Option">選項</str>
-<str name="Description">敘述</str>
-<str name="Optional">選擇性的</str>
-<str name="Required">必要性的</str>
-<str name="Skip visual syntax diagram">略過語法圖表</str>
-<str name="Read syntax diagram">讀取語法圖表</str>
-<str name="Start of change">蜊曹羲宎</str>
-<str name="End of change">蜊曹賦旰</str>
-<str name="Index">索引</str>
-<str name="Special characters">特殊字元</str>
-<str name="Numerics">數字</str>
-<str name="End notes">結尾附註</str>
-<str name="Artwork">插圖</str>
-<str name="Syntax">語法</str>
-<str name="Type">類型</str>
-<str name="Value">值</str>
-<!-- Text that goes before a link to a topic -->
-<str name="intro-to-topic-link"></str>
-
-<!-- peril notice labels -->
-<str name="Note">註</str>
-<str name="Notes">註</str>
-<str name="Tip">提示</str>
-<str name="Fastpath">捷徑</str>
-<str name="Important">重要</str>
-<str name="Attention">小心</str>
-<str name="Caution">注意</str>
-<str name="Danger">危險</str>
-<str name="Remember">記住</str>
-<str name="Restriction">限制</str>
-<str name="Warning">警告</str>
-
-<!-- default title text for section level generated sections -->
-<str name="Contents">目錄</str>
-<str name="Related concepts">相關概念</str>
-<str name="Related tasks">相關工作</str>
-<str name="Related reference">相關參考</str>
-<str name="Related information">相關資訊</str>
-
-<str name="Prerequisite">必讀</str>
-<str name="Prerequisites">必讀</str>
-<str name="or">或</str>
-<str name="figure-number-separator"> </str>
-
-<!--Task section labels -->
-<str name="task_context">執行這項作業的原因和時機</str>
-<str name="task_example">範例</str>
-<str name="task_prereq">開始之前</str>
-<str name="task_postreq">下一步</str>
-<str name="task_procedure">程序</str>
-<str name="task_procedure_unordered">程序</str>
-<str name="task_results">結果</str>
-
-<str name="Copyright">Copyright</str>
-
-<!-- Symbols -->
-<str name="OpenQuote">“</str>
-<str name="CloseQuote">”</str>
-<str name="ColonSymbol">:</str>
-<str name="#menucascade-separator"> &gt; </str>
-<str name="a11y.and-then"></str>
-
+  <str name="Figure">圖</str>
+  <str name="Table">表</str>
+  <str name="Next topic">下一個主題</str>
+  <str name="Previous topic">前一個主題</str>
+  <str name="Parent topic">上層主題</str>
+  <str name="Required cleanup">必要修正</str>
+  <str name="Draft comment">草稿註解</str>
+  <str name="Option">選項</str>
+  <str name="Description">敘述</str>
+  <str name="Optional">選擇性的</str>
+  <str name="Required">必要性的</str>
+  <str name="Skip visual syntax diagram">略過語法圖表</str>
+  <str name="Read syntax diagram">讀取語法圖表</str>
+  <str name="Start of change">蜊曹羲宎</str>
+  <str name="End of change">蜊曹賦旰</str>
+  <str name="Index">索引</str>
+  <str name="Special characters">特殊字元</str>
+  <str name="Numerics">數字</str>
+  <str name="End notes">結尾附註</str>
+  <str name="Artwork">插圖</str>
+  <str name="Syntax">語法</str>
+  <str name="Type">類型</str>
+  <str name="Value">值</str>
+  <str name="Note">註</str>
+  <str name="Notes">註</str>
+  <str name="Tip">提示</str>
+  <str name="Fastpath">捷徑</str>
+  <str name="Important">重要</str>
+  <str name="Attention">小心</str>
+  <str name="Caution">注意</str>
+  <str name="Danger">危險</str>
+  <str name="Remember">記住</str>
+  <str name="Restriction">限制</str>
+  <str name="Warning">警告</str>
+  <str name="Contents">目錄</str>
+  <str name="Related concepts">相關概念</str>
+  <str name="Related tasks">相關工作</str>
+  <str name="Related reference">相關參考</str>
+  <str name="Related information">相關資訊</str>
+  <str name="Prerequisite">必讀</str>
+  <str name="Prerequisites">必讀</str>
+  <str name="or">或</str>
+  <str name="task_context">執行這項作業的原因和時機</str>
+  <str name="task_example">範例</str>
+  <str name="task_prereq">開始之前</str>
+  <str name="task_postreq">下一步</str>
+  <str name="task_procedure">程序</str>
+  <str name="task_procedure_unordered">程序</str>
+  <str name="task_results">結果</str>
+  <str name="Copyright">Copyright</str>
+  <str name="a11y.and-then"></str>
 </strings>

--- a/src/main/xsl/common/strings-zh-tw.xml
+++ b/src/main/xsl/common/strings-zh-tw.xml
@@ -57,5 +57,6 @@ See the accompanying LICENSE file for applicable license.
   <str name="task_procedure_unordered">程序</str>
   <str name="task_results">結果</str>
   <str name="Copyright">Copyright</str>
+  <str name="ColonSymbol">：</str>
   <str name="a11y.and-then"></str>
 </strings>

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -70,25 +70,25 @@
 </table>
 </div>
 
-<div class="note note"><span class="notetitle">註:</span> note</div>
+<div class="note note"><span class="notetitle">註：</span> note</div>
 
-<div class="note attention"><span class="attentiontitle">小心:</span> attention</div>
+<div class="note attention"><span class="attentiontitle">小心：</span> attention</div>
 
-<div class="cautiontitle">注意:</div><div class="note caution">CAUTION</div>
+<div class="cautiontitle">注意：</div><div class="note caution">CAUTION</div>
 
 <div class="dangertitle">危險</div><div class="note danger">DANGER</div>
 
-<div class="note fastpath"><span class="fastpathtitle">捷徑:</span> fastpath</div>
+<div class="note fastpath"><span class="fastpathtitle">捷徑：</span> fastpath</div>
 
-<div class="note important"><span class="importanttitle">重要:</span> important</div>
+<div class="note important"><span class="importanttitle">重要：</span> important</div>
 
-<div class="note remember"><span class="remembertitle">記住:</span> remember</div>
+<div class="note remember"><span class="remembertitle">記住：</span> remember</div>
 
-<div class="note restriction"><span class="restrictiontitle">限制:</span> restriction</div>
+<div class="note restriction"><span class="restrictiontitle">限制：</span> restriction</div>
 
-<div class="note tip"><span class="tiptitle">提示:</span> tip</div>
+<div class="note tip"><span class="tiptitle">提示：</span> tip</div>
 
-<div class="note note"><span class="notetitle">註:</span> <ol class="ol">
+<div class="note note"><span class="notetitle">註：</span> <ol class="ol">
 <li class="li">This is a list in a note</li>
 
 <li class="li">This is still a list in a note</li>
@@ -112,9 +112,9 @@
 
 <div class="related-links">
 <div class="familylinks">
-<div class="parentlink"><strong>上層主題:</strong> <a class="link" href="lang-parent.html" title="This is the parent topic for generated text tests">Parent topic for linking</a></div>
-<div class="previouslink"><strong>前一個主題:</strong> <a class="link" href="lang-previous.html" title="This is the previous topic for language tests">Previous topic link</a></div>
-<div class="nextlink"><strong>下一個主題:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
+<div class="parentlink"><strong>上層主題：</strong> <a class="link" href="lang-parent.html" title="This is the parent topic for generated text tests">Parent topic for linking</a></div>
+<div class="previouslink"><strong>前一個主題：</strong> <a class="link" href="lang-previous.html" title="This is the previous topic for language tests">Previous topic link</a></div>
+<div class="nextlink"><strong>下一個主題：</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>相關概念</strong><br />
@@ -154,8 +154,8 @@
 <div class="section context">context</div>
 
 <ol class="ol steps"><li class="li step"><span class="ph cmd">step 1</span></li>
-<li class="li step"><strong>選擇性的: </strong><span class="ph cmd">step 2 (optional)</span></li>
-<li class="li step"><strong>必要性的: </strong><span class="ph cmd">step 3 (required)</span></li>
+<li class="li step"><strong>選擇性的： </strong><span class="ph cmd">step 2 (optional)</span></li>
+<li class="li step"><strong>必要性的： </strong><span class="ph cmd">step 3 (required)</span></li>
 <li class="li step"><span class="ph cmd">step 4</span>
 
 <table border="1" frame="hsides" rules="rows" cellpadding="4" cellspacing="0" summary="" class="simpletable choicetable choicetableborder">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description
Adds support for no-language / language-independent variable files. Intent is to use this for variables that do not actually use any localized text. This can be either:

- variables that are empty by default (such as the current `Glossary odd footer`, empty in all 48 default string files in the PDF dir)
- variables that are common to all languages, where the default variable does not actually contain localized text (such as `Step Number`, which defaults to `<param ref-name="number"/>. `, or `Glossary odd header`, which has 3 parameters separated by `|`)

The current design uses all of the current logic, which will look for more specific languages, falling back to more general (`fr-ca` falls back to `fr`), then to the configured default, and only then will look for a "null language" string. 

## Motivation and Context

- Today, we ship 48 variable files in the PDF directory, 55 in `xsl/common` (the same 48 plus slight variants). For common variables, we're maintaining 48 or 55 copies of the same thing. With this change, we only maintain one.
- Locally, across the default + my 4 custom PDF styles, I have 165 definitions of `<variable id="Glossary odd footer">` (and most other common variables). Within each style, these are common, so I really only need 5 definitions - one per style, in the empty-language set. This enhancement would significantly ease the pain of adding / modifying common variables.
- I've also added my own common variables, such as `<variable id="Chapter number with title">`, which just lay out passed-in variables. It would be much simpler if I could do this by adding one common variable.
- Some common variables have been overlooked in the core. For example, we actually maintain 47 copies of `Step Number`, because it was somehow lost from Serbian, which means Serbian tasks will warn you that they're falling back to English. Making these common variables truly common ensures that doesn't happen. For strings that actually need text, any missing variable still falls back to the default and generates a "using default language" error, as it should.

There are a few open questions with this design that I'd like to address before I go any further.

1. Current design expects that the no-language elements are identified with `xml:lang=""`. It could instead look for `empty(@xml:lang)`, or for both. I'm not sure which approach is best; I'd probably do both because people will try both, except that I generally don't like defining 2 ways to do something.
1. If we have a string that is common to 46 languages - maybe all LTR languages - but differs for 2 others, is it best to define in the null space + the 2 exceptions? Pro: only 3 total definitions. Con: if another exception comes along, it _might_ be missed because having the null value means you won't get a warning. (Note: I expected to find some of these in our default PDF2 strings but have not yet.)
1. Overall goal is to move existing common strings like `Step Number` to a common set of variables, but I'm holding off until I get feedback. Is that a wise goal? It has all the advantages above. But, it at least opens the possibility that you won't notice those common strings when it's time to localize. That is, if you always saw `Index even header` in the existing files, and updated it, you may no longer even notice that it exists. But ... I don't think this is a problem, because for strings like that, you probably have your own matching copies just like DITA-OT does, so should "localize" the null set as well.

## How Has This Been Tested?
No impact on current tests / integration tests because the null space is only checked _after_ all currently working strings are tested.

Tested locally by defining a string set with an empty language. Added the following to `xsl/common/common-strings.xml`:
`<lang xml:lang="" filename="strings-emptylang.xml"/>`

In that file, defined a variable:
```
<?xml version="1.0" encoding="utf-8"?>
<strings xml:lang="">
<str name="test-emptylang">Test if I can get a string with an empty xml:lang</str>
</strings>
```

And successfully retrieved that variable as part of an HTML build with:
```
<div>
<xsl:call-template name="getVariable">
<xsl:with-param name="id" select="'test-emptylang'"/>
</xsl:call-template>
</div>
```

Similarly, I tested adding a new variable set to the common PDF strings, with `xml:lang=""`, and in that set defined:
`<variable id="emptyvar">[EMPTY]<param ref-name="stringy"/>[EMPTY]</variable>`

I successfully retrieved that variable using:
```
<xsl:call-template name="getVariable">
  <xsl:with-param name="id" select="'emptyvar'"/>
  <xsl:with-param name="params" as="element()*">
    <stringy>This is a test of the string</stringy>
  </xsl:with-param>
</xsl:call-template>
```

## Type of Changes

This is a new enhancement to the variable localization code.

Existing custom code and existing variables will work without modification. (Edge case - anyone who overrides `getVariable` will need to update, but hopefully that is not done today.)

Those adjusting variable files will need to be aware that common variables have been consolidated.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
- I have updated the unit tests to reflect the changes in my code.

## Still to do

Pending feedback - next step is to consolidate common PDF strings. I'm not sure exactly how many of these exist (guessing 20 or 30). In the `xsl/common/` string files, we only have a few common values, but they should probably be consolidated. Some depend on the answer to question 2 above ("ColonSymbol" is common to 52 string files, but 3 French variants differ).

Also need to verify whether existing tests catch one or more of the variables that move to the consolidated file; if not, one should be added.