### PR TITLE
Remove variables deprecated in 2.3

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ar.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">اختياري:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/be.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Неабавазкова:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bg.xml
@@ -174,12 +174,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -196,7 +190,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -260,91 +253,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Избираем:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcionalno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ca.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/cs.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Volitelné:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -172,12 +172,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -194,7 +188,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -258,91 +251,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Valgfrit:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -189,12 +189,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Inhaltsverweis auf: </variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Unbenannter Abschnitt.</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -211,7 +205,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Suchtitel</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -275,62 +268,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- The title of the links to Related references -->
     <variable id="Related references"/>
-
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Inhalt</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">Index</variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Suche</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Zurück</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Vorwärts</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Hauptseite</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Vorige Seite</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Folgende Seite</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">On-line-Hilfe</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Suche nach dem Schlüsselwort:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">Sehen Sie</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Suchhilfe für:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Suche</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/el.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Προαιρετικά:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -193,12 +193,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -215,7 +209,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -281,91 +274,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- The title of the links to Related references -->
     <variable id="Related references">Related References</variable>
-
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Contents</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">Index</variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Search</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Back</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Forward</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Home</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Previous Topic</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Next Topic</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">Online Help</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Search for the keyword:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">View</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Search help for:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Search</variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field">Search method</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or">or</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And">and</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch">Highlight text in search results</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title">Show Next</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch">Find whole words only</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch">Match case</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message">The search was stopped after 50 hits.</variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message">"The following words were excluded from the search: "+<param ref-name="stop-words-list"/></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message">Search in progress...</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message">No matches were found.</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Optional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/es.xml
@@ -186,12 +186,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Referencia de contenido a: </variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Sección sin título.</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -208,7 +202,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Buscar título</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -267,62 +260,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- Image path to use for a note of "other" type. -->
     <variable id="other Note Image Path"></variable>
 
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Contenido</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">Índice</variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Búsqueda</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Detrás</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Adelante</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Página Principal</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Página Anterior</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Página Siguiente</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">Ayuda En línea</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Búsqueda para la palabra clave:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">Visión</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Ayuda de la búsqueda para:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Búsqueda</variable>
-    
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>
     <variable id="Required Step">Necesario:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/et.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Mittenõutav:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fi.xml
@@ -66,8 +66,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -95,8 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Aiheeseen liittyviä tietolähteitä</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Valinnainen:</variable>
   <variable id="Required Step">Pakollinen:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/fr.xml
@@ -186,12 +186,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Référence de contenu vers :</variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Section sans titre.</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -208,7 +202,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Titre de recherche</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -267,62 +260,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- Image path to use for a note of "other" type. -->
     <variable id="other Note Image Path"></variable>
 
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Sommaire</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">Index</variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Recherche</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Retournez</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Allez En avant</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Page Principale</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Page Précédente</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Prochaine Page</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">Aide En ligne</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Recherche du mot-clé :</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">Regardez</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Aide de recherche pour :</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Recherche</variable>
-    
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Facultatif :</variable>
     <variable id="Required Step">Obligatoire :</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/he.xml
@@ -66,8 +66,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -95,8 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">תיעוד קשור</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">אופציונלי:</variable>
   <variable id="Required Step">דרוש:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hi.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!--    Label for a step with importance="optional"-->
     <variable id="Optional Step">वैकल्पिक:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hr.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcijsko:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/hu.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Választható:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/id.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opsional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/is.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Valfrjáls:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/it.xml
@@ -186,12 +186,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Riferimento di contenuto a: </variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Sezione senza titolo.</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -208,7 +202,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Titolo di ricerca</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -267,62 +260,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- Image path to use for a note of "other" type. -->
     <variable id="other Note Image Path"></variable>
 
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Sommario</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">Indice</variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Ricerca</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Indietro</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Avanti</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Pagina Principale</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Pagina Precedente</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Pagina Seguente</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">Aiuto In linea</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Ricerca della parola chiave:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">Osservi</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Aiuto di ricerca per:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Ricerca</variable>
-    
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Opzionale:</variable>
     <variable id="Optional Step">Richiesto:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ja.xml
@@ -193,12 +193,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">コンテンツ参照 : </variable>
 
-    <!-- Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">無題のセクション</variable>
-
     <!-- Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -215,7 +209,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">検索タイトル</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -279,91 +272,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- The title of the links to Related references -->
     <variable id="Related references">関連参照</variable>
-
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">目次</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">索引</variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">、 </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">検索</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">戻る</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">進む</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">ホーム</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">前のトピック</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">次のトピック</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">オンライン ヘルプ</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">次のキーワードを検索します:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">表示</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">ヘルプで次の文字列を検索します:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">検索</variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field">検索方法</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or">または</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And">および</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch">検索結果でテキストを強調表示する</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title">次を表示</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch">単語単位で探す</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch">大文字と小文字を区別する</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message">50 件ヒットしたので、検索は停止しました。</variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message">"次の単語は検索から除外されました: "+<param ref-name="stop-words-list"/></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message">検索中...</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message">一致は見つかりませんでした。</variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">オプション:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/kk.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Қосымша:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ko.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">옵션:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lt.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">Nebūtina:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/lv.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Neobligāts:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/mk.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Изборен:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ms.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opsyenal:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/nl.xml
@@ -65,12 +65,9 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links">Verwante onderwerpen</variable>
   <variable id="Cross-Reference">Verwijzing naar:</variable>
   <variable id="Content-Reference">Verwijzing naar:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section">Naamloze sectie.</variable>
   <variable id="List item">Lijst onderdeel.</variable>
   <variable id="Foot note">Voetnoot.</variable>
   <variable id="Navigation title">Navigatietitel</variable>
-  <!-- Deprecated since 2.3 -->
   <variable id="Search title">Zoektitel</variable>
   <variable id="Chapter with number">Hoofdstuk <param ref-name="number"/></variable>
   <variable id="Appendix with number">Appendix <param ref-name="number"/></variable>
@@ -96,56 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Verwante verwijzingen</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Contents button title">Inhoud</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index button title">Index</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search button title">Zoek</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Back button title">Terug</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Forward button title">Vooruit</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Main page button title">Hoofdpagina</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Previous page button title">Vorig onderwerp</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Next page button title">Volgend onderwerp</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online help prefix">Online Help</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index field title">Zoek op het trefwoord:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index button title">Zie</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search text field title">Zoek help voor:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search text button title">Zoek</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field">Zoek methode</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or">of</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And">en</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch">Markeer tekst in zoekresultaten</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title">Toon volgende</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch">Zoek alleen hele woorden</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch">Hoofdlettergevoelig</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message">De zoekactie is gestopt na 50 treffers.</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message">"De volgende woorden worden uitgesloten van de zoekactie: "+<param ref-name="stop-words-list"/></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message">De zoekactie loopt...</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message">Geen treffers gevonden.</variable>
   <variable id="Optional Step">Optioneel:</variable>
   <variable id="Required Step">Vereist:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/no.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Valgfritt:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pl.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcjonalne:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/pt_BR.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcional:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ro.xml
@@ -66,8 +66,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -95,8 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Referinţe înrudite</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Opţional:</variable>
   <variable id="Required Step">Necesar:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ru.xml
@@ -66,8 +66,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -95,8 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Ссылки, связанные с данной</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Необязательно:</variable>
   <variable id="Required Step">Обязательно:</variable>
   <!-- Task strings now reused from common -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sk.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Voliteľný:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sl.xml
@@ -66,12 +66,9 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links">Sorodne povezave</variable>
   <variable id="Cross-Reference">Križni sklic na:</variable>
   <variable id="Content-Reference">Navzkrižni sklic na:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section">Neimenovan odsek.</variable>
   <variable id="List item">Točka seznama.</variable>
   <variable id="Foot note">Opomba v nogi.</variable>
   <variable id="Navigation title">Poimenovanje krmarjenja</variable>
-  <!-- Deprecated since 2.3 -->
   <variable id="Search title">Poimenovanje iskanja</variable>
   <variable id="Chapter with number">Poglavje <param ref-name="number"/></variable>
   <variable id="Appendix with number">Dodatek <param ref-name="number"/></variable>
@@ -97,56 +94,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Sorodne reference</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Contents button title">Vsebine</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index button title">Kazalo</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search button title">Iskanje</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Back button title">Nazaj</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Forward button title">Naprej</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Main page button title">Domov</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Previous page button title">Predhodnji</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Next page button title">Naslednji</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online help prefix">Sprotna pomoč</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index field title">Išči ključno besedo:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index button title">Poglej</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search text field title">Iskanje pomoči za:</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search text button title">Išči</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field">Način iskanja</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or">ali</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And">in</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch">Poudari besedilo v rezultatih iskanja</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title">Prikaži naslednjo</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch">Najdi samo cele besede</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch">Ujemanje velikosti</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message">Iskanje je bilo ustavljeno po 50 zadetkih.</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message">"Naslednje besede so izključene iz iskanja: "+<param ref-name="stop-words-list"/></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message">Iskanje v teku...</variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message">Ni ujemanj.</variable>
   <variable id="Optional Step">Izbiren:</variable>
   <variable id="Required Step">Zahtevano:</variable>
   <!-- Prereq was "Predzahteva", changing to common string, currently "Preden začnete" -->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Opcionalno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-rs.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Neobavezno:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">Необавезно:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sv.xml
@@ -66,8 +66,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Related Links"><!--TODO:Related Links--></variable>
   <variable id="Cross-Reference"><!--TODO:Cross-Reference to:--></variable>
   <variable id="Content-Reference"><!--TODO:Content-Reference to:--></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Untitled section"><!--TODO:Untitled section.--></variable>
   <variable id="List item"><!--TODO:List item.--></variable>
   <variable id="Foot note"><!--TODO:Footnote.--></variable>
   <variable id="Navigation title"><!--TODO:Navigation title--></variable>
@@ -95,8 +93,6 @@ See the accompanying LICENSE file for applicable license.
 
   <variable id="Related references">Närliggande referens</variable>
   
-  <!-- Deprecated since 2.3 -->
-  <variable id="Index multiple entries separator">, </variable>
   <variable id="Optional Step">Valfritt:</variable>
   <variable id="Required Step">Krävs:</variable>
   <!--Labels for task sections, now reused from common-->

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/th.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- UPDATE: Label for a step with importance="optional"-->
     <variable id="Optional Step">ทางเลือก:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/tr.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">İsteğe bağlı:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/uk.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">За бажанням:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/ur.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">اختیاری:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -172,12 +172,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -194,7 +188,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -258,91 +251,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">Tùy chọn:</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_CN.xml
@@ -189,12 +189,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -211,7 +205,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -270,62 +263,6 @@ See the accompanying LICENSE file for applicable license.
     <!-- Image path to use for a note of "other" type. -->
     <variable id="other Note Image Path"></variable>
 
-    <!--
-       Strings used in the online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title">Contents</variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title">索引</variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title">Search</variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title">Back</variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title">Forward</variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title">Main Page</variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title">Previous Page</variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title">Next Page</variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix">Online Help</variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title">Search for the keyword:</variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title">View</variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title">Search help for:</variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title">Search</variable>
-    
     <!--Label for a step with importance="optional"-->
     <variable id="Optional Step">可选：</variable>
     <variable id="Required Step">必需：</variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/zh_TW.xml
@@ -173,12 +173,6 @@ See the accompanying LICENSE file for applicable license.
          text in case target cannot be resolved. -->
     <variable id="Content-Reference">Unresolved content reference to:</variable>
 
-    <!-- UNUSED: Default title text for referenced section title. Used to generate 
-         reference text in case reference has no explicit content and
-         referenced section has no title. -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Untitled section">Untitled section.</variable>
-
     <!-- TODO: Default title text for referenced list item. Used to generate
          reference text in case reference has no explicit content and 
          reference target is a list item. -->
@@ -195,7 +189,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: Text to use for a generated label of search title. Renders 
          as part of <searchtitle> element. -->
-    <!-- Deprecated since 2.3 -->
     <variable id="Search title">Search title</variable>
 
     <!-- Text to use for chapter titles.-->
@@ -259,91 +252,6 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- UNUSED: The title of the links to Related references -->
     <variable id="Related references"></variable>
-
-    <!--
-       UNUSED IN PDF2: Strings for online-help publishing.
-    -->
-
-    <!-- The title of the "contents" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Contents button title"></variable>
-
-    <!-- The title of the "index" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index button title"></variable>
-
-    <!-- The separator of multiple index entries in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Index multiple entries separator">, </variable>
-
-    <!-- The title of the "search" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search button title"></variable>
-
-    <!-- The title of the "back" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Back button title"></variable>
-
-    <!-- The title of the "forward" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Forward button title"></variable>
-
-    <!-- The title of the "main page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Main page button title"></variable>
-
-    <!-- The title of the "previous page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Previous page button title"></variable>
-
-    <!-- The title of the "next page" button in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Next page button title"></variable>
-
-    <!-- The "online help" document title prefix in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Online help prefix"></variable>
-
-    <!-- The search by index field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index field title"></variable>
-
-    <!-- The search by index button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search index button title"></variable>
-
-    <!-- The search by text field title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text field title"></variable>
-
-    <!-- The search by text button title in online-help output -->
-    <!-- Deprecated since 2.3 -->
-    <variable id="Search text button title"></variable>
-
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Field"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method Or"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Online Help Search Method And"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Highlight Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search index next button title"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Whole Words Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Case Sensitive Switch"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Stopped Message"></variable>
-  <!--This one is a java script expression. So if the order of message should be another don't forget to add '+'
-  and quotes to the string expressions.-->
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Excluded Stop Words Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search in Progress Message"></variable>
-  <!-- Deprecated since 2.3 -->
-  <variable id="Search Search Give No Results Message"></variable>
 
     <!-- Label for a step with importance="optional"-->
     <variable id="Optional Step">選擇性的:</variable>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

We marked a bunch of variables in the PDF2 variable files as deprecated in 2.3. These should _mostly_ be removed.

- The `Search title` variable was mistakenly marked deprecated. This was search/replace mistake when adding the deprecated marker for many other variables that start with `Search `. This variable is actually used to generate a sort of heading for `<searchtitle>` contents when the `args.draft` parameter is active.
- The `Untitled section` variable has never been used and I can't see any use in a generic title that would apply to all generic sections.
- The remaining variables were all for some sort of online help system that has never been part of DITA-OT. They were in most, but not all, of the variable files, but usually untranslated. If anybody is using those to produce online help, the variables should move into the plugin that generates that online help. The remaining deprecated variables removed with this are
```
<variable id="Contents button title">
<variable id="Index button title">
<variable id="Index multiple entries separator">
<variable id="Search button title">
<variable id="Back button title">
<variable id="Forward button title">
<variable id="Main page button title">
<variable id="Previous page button title">
<variable id="Next page button title">
<variable id="Online help prefix">
<variable id="Search index field title">
<variable id="Search index button title">
<variable id="Search text field title">
<variable id="Search text button title">
<variable id="Online Help Search Method Field">
<variable id="Online Help Search Method Or">
<variable id="Online Help Search Method And">
<variable id="Search Highlight Switch">
<variable id="Search index next button title">
<variable id="Search Whole Words Switch">
<variable id="Search Case Sensitive Switch">
<variable id="Search Stopped Message">
<variable id="Search Excluded Stop Words Message">
<variable id="Search Search in Progress Message">
<variable id="Search Search Give No Results Message">
```

## How Has This Been Tested?
I've built a PDF with every test map in my NLS test set: https://github.com/robander/metadita.nlstest

These test files cover every supported language, and generate every string that is actually used. There are no new warnings or errors caused by removing these strings.
