### PR TITLE
Fix failing relative path test on Windows

### DIFF
--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -163,9 +163,12 @@ public final class FileUtils {
      * 
      * @param basePath base path
      * @param refPath reference path
-     * @return relative path
+     * @return relative path, or refPath if different root means no relative path is possible
      */
     public static File getRelativePath(final File basePath, final File refPath) {
+        if (!basePath.toPath().getRoot().equals(refPath.toPath().getRoot())) {
+            return refPath;
+        }
         return basePath.toPath().getParent().relativize(refPath.toPath()).toFile();
     }
     


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

With latest `develop` code, I'm getting 2 failing tests on my Windows machine. Still tracking down one of them, but the other comes from [this line](https://github.com/dita-ot/dita-ot/blob/develop/src/test/java/org/dita/dost/util/TestFileUtils.java#L77) in `public void testGetRelativePathFromMapFileFile`:

`assertEquals(new File("d:\\a.dita"), FileUtils.getRelativePath(new File("c:\\map.ditamap"), new File("d:\\a.dita")));`

The code fails in [FileUtils.java](https://github.com/dita-ot/dita-ot/blob/develop/src/main/java/org/dita/dost/util/FileUtils.java#L169) when trying to run `relativize()` between the two root drives:
`return basePath.toPath().getParent().relativize(refPath.toPath()).toFile();

The help for `relativize()` says
> A relative path cannot be constructed if only one of the paths have a root component. Where both paths have a root component then it is implementation dependent if a relative path can be constructed.

Not sure if this is the best fix but it corrects the problem on Windows. If it detects that the root drives are not equal, it returns the original reference path (which is what the tests currently expect, and is probably the best fallback). I think it's only possible to get to this function when we have two absolute paths ... if one or both does not, then a more complete solution probably needs to check if `getRoot()` is `null`?