### PR TITLE
Generate list of links as list rather than div #2447

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_links.scss
+++ b/src/main/plugins/org.dita.html5/sass/_links.scss
@@ -26,6 +26,17 @@
   margin-bottom: 1em;
 }
 
+ul.linklist {
+  margin-top: 0;
+  list-style-type: none;
+  padding-left: 0;
+}
+
+li.linklist {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .linklistwithchild {
   margin-bottom: 1em;
   margin-left: 1.5em;

--- a/src/main/plugins/org.dita.html5/sass/commonrtl.scss
+++ b/src/main/plugins/org.dita.html5/sass/commonrtl.scss
@@ -15,6 +15,12 @@
   margin-bottom: 1em;
 }
 
+ul.linklist {
+  margin-top: 0;
+  list-style-type: none;
+  padding-right: 0;
+}
+
 .linklistwithchild {
   margin-right: 1.5em;
   margin-top: 1em;

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -428,14 +428,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--basic child processing-->
   <xsl:template match="*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="2" name="topic.link_child">
-    <xsl:variable name="el-name">
-      <xsl:choose>
-        <xsl:when test="contains(../@class, ' topic/linklist ')">div</xsl:when>
-        <xsl:otherwise>li</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:element name="{$el-name}">
-      <xsl:attribute name="class">ulchildlink</xsl:attribute>
+    <li class="ulchildlink">
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'ulchildlink'"/>
       </xsl:call-template>
@@ -466,19 +459,12 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <br/>
       <!--add the description on the next line, like a summary-->
       <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    </xsl:element>
+    </li>
   </xsl:template>
 
   <!--ordered child processing-->
   <xsl:template match="*[@collection-type = 'sequence']/*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="3" name="topic.link_orderedchild">
-    <xsl:variable name="el-name" as="xs:string">
-      <xsl:choose>
-        <xsl:when test="contains(../@class, ' topic/linklist ')">div</xsl:when>
-        <xsl:otherwise>li</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:element name="{$el-name}">
-      <xsl:attribute name="class">olchildlink</xsl:attribute>
+    <li class="olchildlink">
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'olchildlink'"/>
       </xsl:call-template>
@@ -507,7 +493,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <br/>
       <!--add the description on a new line, unlike an info, to avoid issues with punctuation (adding a period)-->
       <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    </xsl:element>
+    </li>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/link ')]" name="topic.link">
@@ -516,7 +502,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <xsl:choose>
         <!-- Linklist links put out <br/> in "processlinklist" -->
         <xsl:when test="ancestor::*[contains(@class, ' topic/linklist ')]">
-          <xsl:call-template name="makelink"/>
+          <li class="linklist"><xsl:call-template name="makelink"/></li>
         </xsl:when>
         <!-- Ancestor links go in the breadcrumb trail, and should not get a <br/> -->
         <xsl:when test="@role = 'ancestor'">
@@ -624,22 +610,24 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
     <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    <xsl:for-each select="*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')]">
-      <xsl:choose>
-        <!-- for children, div wrapper is created in main template -->
-        <xsl:when test="contains(@class, ' topic/link ') and (@role = ('child', 'descendant'))">
-          <xsl:apply-templates select="."/>
-        </xsl:when>
-        <xsl:when test="contains(@class, ' topic/link ')">
-          <div>
-            <xsl:apply-templates select="."/>
-          </div>
-        </xsl:when>
-        <xsl:otherwise><!-- nested linklist -->
-          <xsl:apply-templates select="."/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:for-each>
+    <xsl:if test="exists(*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')])">
+      <ul class="linklist">
+        <xsl:for-each select="*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')]">
+          <xsl:choose>
+            <!-- for children, li wrapper is created in main template -->
+            <xsl:when test="contains(@class, ' topic/link ') and (@role = ('child', 'descendant'))">
+              <xsl:apply-templates select="."/>
+            </xsl:when>
+            <xsl:when test="contains(@class, ' topic/link ')">
+              <xsl:apply-templates select="."/>
+            </xsl:when>
+            <xsl:otherwise><!-- nested linklist -->
+              <li class="sublinklist"><xsl:apply-templates select="."/></li>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+        </ul>
+    </xsl:if>
     <xsl:apply-templates select="*[contains(@class, ' topic/linkinfo ')]"/>
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
   </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/resource/commonltr.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonltr.css
@@ -76,6 +76,15 @@
 .linklist {
   margin-bottom: 1em;
 }
+ul.linklist {
+  margin-top: 0;
+  list-style-type: none;
+  padding-left: 0;
+}
+li.linklist {
+  margin-top: 0;
+  margin-bottom: 0;
+}
 .linklistwithchild {
   margin-left: 1.5em;
   margin-bottom: 1em;

--- a/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
@@ -77,6 +77,16 @@
   margin-top: 1em;
   margin-bottom: 1em;
 }
+ul.linklist {
+  margin-top: 0;
+  list-style-type: none;
+  padding-right: 0;
+}
+
+li.linklist {
+  margin-top: 0;
+  margin-bottom: 0;
+}
 .linklistwithchild {
   margin-top: 1em;
   margin-right: 1.5em;

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -447,14 +447,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--basic child processing-->
   <xsl:template match="*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="2" name="topic.link_child">
-    <xsl:variable name="el-name">
-      <xsl:choose>
-        <xsl:when test="contains(../@class, ' topic/linklist ')">div</xsl:when>
-        <xsl:otherwise>li</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:element name="{$el-name}">
-      <xsl:attribute name="class">ulchildlink</xsl:attribute>
+    <li class="ulchildlink">
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'ulchildlink'"/>
       </xsl:call-template>
@@ -486,20 +479,13 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <xsl:value-of select="$newline"/>
       <!--add the description on the next line, like a summary-->
       <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    </xsl:element>
+    </li>
     <xsl:value-of select="$newline"/>
   </xsl:template>
 
   <!--ordered child processing-->
   <xsl:template match="*[@collection-type = 'sequence']/*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="3" name="topic.link_orderedchild">
-    <xsl:variable name="el-name" as="xs:string">
-      <xsl:choose>
-        <xsl:when test="contains(../@class, ' topic/linklist ')">div</xsl:when>
-        <xsl:otherwise>li</xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:element name="{$el-name}">
-      <xsl:attribute name="class">olchildlink</xsl:attribute>
+    <li class="olchildlink">
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'olchildlink'"/>
       </xsl:call-template>
@@ -529,7 +515,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <xsl:value-of select="$newline"/>
       <!--add the description on a new line, unlike an info, to avoid issues with punctuation (adding a period)-->
       <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    </xsl:element>
+    </li>
     <xsl:value-of select="$newline"/>
   </xsl:template>
 
@@ -539,7 +525,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <xsl:choose>
         <!-- Linklist links put out <br/> in "processlinklist" -->
         <xsl:when test="ancestor::*[contains(@class, ' topic/linklist ')]">
-          <xsl:call-template name="makelink"/>
+          <li class="linklist"><xsl:call-template name="makelink"/></li>
         </xsl:when>
         <!-- Ancestor links go in the breadcrumb trail, and should not get a <br/> -->
         <xsl:when test="@role = 'ancestor'">
@@ -652,24 +638,27 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
     <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
-    <xsl:for-each select="*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')]">
-      <xsl:choose>
-        <!-- for children, div wrapper is created in main template -->
-        <xsl:when test="contains(@class, ' topic/link ') and (@role = ('child', 'descendant'))">
-          <xsl:value-of select="$newline"/>
-          <xsl:apply-templates select="."/>
-        </xsl:when>
-        <xsl:when test="contains(@class, ' topic/link ')">
-          <xsl:value-of select="$newline"/>
-          <div>
-            <xsl:apply-templates select="."/>
-          </div>
-        </xsl:when>
-        <xsl:otherwise><!-- nested linklist -->
-          <xsl:apply-templates select="."/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:for-each>
+    <xsl:if test="exists(*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')])">
+      <ul class="linklist">
+        <xsl:for-each select="*[contains(@class, ' topic/linklist ')] | *[contains(@class, ' topic/link ')]">
+          <xsl:choose>
+            <!-- for children, li wrapper is created in main template -->
+            <xsl:when test="contains(@class, ' topic/link ') and (@role = ('child', 'descendant'))">
+              <xsl:value-of select="$newline"/>
+              <xsl:apply-templates select="."/>
+            </xsl:when>
+            <xsl:when test="contains(@class, ' topic/link ')">
+              <xsl:value-of select="$newline"/>
+              <xsl:apply-templates select="."/>
+            </xsl:when>
+            <xsl:otherwise><!-- nested linklist -->
+              <xsl:value-of select="$newline"/>
+              <li class="sublinklist"><xsl:apply-templates select="."/></li>
+            </xsl:otherwise>
+          </xsl:choose>
+          </xsl:for-each>
+        </ul>
+    </xsl:if>
     <xsl:apply-templates select="*[contains(@class, ' topic/linkinfo ')]"/>
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
   </xsl:template>

--- a/src/test/resources/keyref_All_tags/exp/xhtml/c.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/c.html
@@ -182,12 +182,14 @@
     <div class="related-links">
 <div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
 
-<div><a class="link" href="abs.html">Anti-lock Braking System</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="abs.html">Anti-lock Braking System</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
 
-<div><a class="link" href="dita1.html">DITA1</a></div>
-<div><a class="link" href="a1.html" title="Learn how to care for your new pet bat.">topic a1</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="dita1.html">DITA1</a></li>
+<li class="linklist"><a class="link" href="a1.html" title="Learn how to care for your new pet bat.">topic a1</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita2.html
@@ -23,8 +23,8 @@
     
     <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="dita1.html">DITA1</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="dita1.html">DITA1</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita2.html
@@ -23,8 +23,8 @@
     
     <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="dita3.html" title="When the author2 build, the &#34;dita2.dita&#34; will resolve to this dita. Dita3.dita">DITA3</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="dita3.html" title="When the author2 build, the &#34;dita2.dita&#34; will resolve to this dita. Dita3.dita">DITA3</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita2.html
@@ -23,8 +23,8 @@
     
     <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="http://www.ibm.com" target="_blank">this is link to external website</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com" target="_blank">this is link to external website</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita2.html
@@ -23,8 +23,8 @@
     
     <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="dita0.html">Dita0 as the fallback.</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="dita0.html">Dita0 as the fallback.</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/keyref_modify/exp/xhtml/c.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/c.html
@@ -181,13 +181,13 @@
 
     <div class="related-links">
 <div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
-
-<div><a class="link" href="abs.html">Anti-lock Braking System</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="abs.html">Anti-lock Braking System</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="dita1.html">DITA1</a></div>
-<div><a class="link" href="a1.html" title="Learn how to care for your new pet bat.">topic a1</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="dita1.html">DITA1</a></li>
+<li class="linklist"><a class="link" href="a1.html" title="Learn how to care for your new pet bat.">topic a1</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/lang/exp/xhtml/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-areg.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>المفاهيم المتعلقة</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>المهام المتعلقة</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>المرجع المتعلق</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>المعلومات المتعلقة</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml/lang-beby.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Адпаведныя канцэпцыі</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Адпаведныя задачы</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Адпаведная спасылка</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Адпаведная інфармацыя</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-bgbg.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Свързани понятия</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Свързани дейности</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Свързани справки</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Свързана информация</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml/lang-caes.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Conceptes relacionats</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tasques relacionades</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Referència relacionada</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informació relacionada</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml/lang-cscz.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Související pojmy</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Související úlohy</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Související odkazy</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Související informace</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dadk.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Beslægtede begreber</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Beslægtede opgaver</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Beslægtet reference</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Beslægtede oplysninger</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-elgr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Συναφείς έννοιες</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Συναφείς εργασίες</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Συναφής αναφορά</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Συναφείς πληροφορίες</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enca.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml/lang-engb.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enus.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml/lang-eses.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Conceptos relacionados</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tareas relacionadas</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Referencia relacionada</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Información relacionada</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml/lang-etee.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Seostuvad mõisted</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Seostuvad tegevused</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Seostuv viide</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Seostuv teave</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-fifi.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Aiheeseen liittyviä käsitteitä</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Aiheeseen liittyviä tehtäviä</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Aiheeseen liittyviä tietolähteitä</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Aiheeseen liittyviä tietoja</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frbe.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frca.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frch.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frfr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Information associée</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml/lang-heil.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>מושגים קשורים</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>משימות קשורות</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>תיעוד קשור</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>מידע קשור</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hiin.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>संबंधित अवधारणाए</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>संबंधित कार्य</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>संबंधित संदर्भ</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>संबंधित जानकारी</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hrhr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Srodni koncepti</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Srodni zadaci</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Srodne reference</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Srodne informacije</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml/lang-huhu.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Kapcsolódó fogalmak</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Kapcsolódó feladatok</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Kapcsolódó hivatkozás</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Kapcsolódó tájékoztatás</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml/lang-isis.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Skyld hugtök</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Skyld verkefni</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Skyld tilvísun</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Skyldar upplýsingar</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itch.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itit.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-jajp.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>関連概念</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>関連タスク</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>関連資料</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>関連情報</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-kokr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>관련 개념</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>관련 태스크</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>관련 참조</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>관련 정보</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ltlt.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Susijusios sąvokos</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Susijusios užduotys</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Susijusi nuoroda</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Susijusi informacija</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml/lang-lvlv.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Saistītās koncepcijas</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Saistītie uzdevumi</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Saistītā atsauce</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Saistītā informācija</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-mkmk.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Сродни задачи</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Сродни референци</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Сродни информации</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlbe.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlnl.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nono.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Beslektede begreper</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Beslektede oppgaver</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Beslektet referanse</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Beslektet informasjon</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-plpl.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Pojęcia pokrewne</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Zadania pokrewne</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Odsyłacze pokrewne</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informacje pokrewne</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptbr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptpt.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml/lang-roro.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Concepte înrudite</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Operaţii înrudite</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Referinţe înrudite</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Informaţii înrudite</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ruru.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Понятия, связанные с данным</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Задачи, связанные с данной</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Ссылки, связанные с данной</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Информация, связанная с данной</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-sksk.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Súvisiace koncepty</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Súvisiace úlohy</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Súvisiaci odkaz</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Súvisiace informácie</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-slsi.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>S tem povezani pojmi</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>S tem povezana opravila</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>S tem povezane povezave</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>S tem povezane informacije</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-srsp.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Сродни задаци</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Сродна референца</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Сродна информација</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml/lang-svse.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Närliggande begrepp</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Närliggande uppgifter</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Närliggande referens</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Närliggande information</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml/lang-thth.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>หลักการที่เกี่ยวข้อง</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>งานที่เกี่ยวข้อง</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>สิ่งอ้างอิงที่เกี่ยวข้อง</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>ข้อมูลที่เกี่ยวข้อง</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-trtr.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>İlgili kavramlar</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>İlgili görevler</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>İlgili başvurular</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>İlgili bilgiler</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ukua.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>Споріднені ідеї</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>Пов'язані задачі</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>Відповідні посилання</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>Інформація з пов'язаних питань</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-urpk.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>متعلقہ خیالات</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>متعلقہ کام</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>متعلقہ حوالہ</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>متعلقہ معلومات</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhcn.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>相关概念</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>相关任务</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>相关参考</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>相关信息</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -118,20 +118,20 @@
 </div>
 
 <div class="linklist linklist relinfo relconcepts"><strong>相關概念</strong><br />
-
-<div><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo reltasks"><strong>相關工作</strong><br />
-
-<div><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
 <div class="linklist linklist relinfo relref"><strong>相關參考</strong><br />
-
-<div><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
 <div class="linklist linklist relinfo"><strong>相關資訊</strong><br />
-
-<div><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>
 </div>
 

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
@@ -40,12 +40,12 @@
 
 <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></div>
-<div><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></div>
-<div><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></div>
-<div><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></div>
-<div><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></li>
+<li class="linklist"><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></li>
+<li class="linklist"><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></li>
+<li class="linklist"><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></li>
+<li class="linklist"><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
@@ -40,12 +40,12 @@
 
 <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></div>
-<div><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></div>
-<div><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></div>
-<div><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></div>
-<div><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="localditalink.html">Local DITA link, evaluate but do not generate</a></li>
+<li class="linklist"><a class="link" href="peerditalink.html">Peer topic link, do not get it</a></li>
+<li class="linklist"><a class="link" href="externalditalink.dita" target="_blank">External topic link, do not get it</a></li>
+<li class="linklist"><a class="link" href="peerhtmllink.html">Peer html link, do not get it</a></li>
+<li class="linklist"><a class="link" href="externalhtmllink.html" target="_blank">External html link, do not get it</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/a.html
+++ b/src/test/resources/uplevels1/exp/xhtml/a.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="b.html">b</a></div>
-<div><a class="link" href="topics/c.html">c</a></div>
-<div><a class="link" href="maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="b.html">b</a></li>
+<li class="linklist"><a class="link" href="topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/b.html
+++ b/src/test/resources/uplevels1/exp/xhtml/b.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="a.html">a</a></div>
-<div><a class="link" href="topics/c.html">c</a></div>
-<div><a class="link" href="maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="a.html">a</a></li>
+<li class="linklist"><a class="link" href="topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/maps/e.html
+++ b/src/test/resources/uplevels1/exp/xhtml/maps/e.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="../topics/c.html">c</a></div>
-<div><a class="link" href="f.html">f</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="../topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="f.html">f</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/maps/f.html
+++ b/src/test/resources/uplevels1/exp/xhtml/maps/f.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="../topics/d.html">d</a></div>
-<div><a class="link" href="e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="../topics/d.html">d</a></li>
+<li class="linklist"><a class="link" href="e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/topics/c.html
+++ b/src/test/resources/uplevels1/exp/xhtml/topics/c.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="c.html">c</a></div>
-<div><a class="link" href="../maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="c.html">c</a></li>
+<li class="linklist"><a class="link" href="../maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels1/exp/xhtml/topics/d.html
+++ b/src/test/resources/uplevels1/exp/xhtml/topics/d.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="d.html">d</a></div>
-<div><a class="link" href="../maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="d.html">d</a></li>
+<li class="linklist"><a class="link" href="../maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/a.html
+++ b/src/test/resources/uplevels3/exp/xhtml/a.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="b.html">b</a></div>
-<div><a class="link" href="topics/c.html">c</a></div>
-<div><a class="link" href="maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="b.html">b</a></li>
+<li class="linklist"><a class="link" href="topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/b.html
+++ b/src/test/resources/uplevels3/exp/xhtml/b.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="a.html">a</a></div>
-<div><a class="link" href="topics/c.html">c</a></div>
-<div><a class="link" href="maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="a.html">a</a></li>
+<li class="linklist"><a class="link" href="topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/maps/e.html
+++ b/src/test/resources/uplevels3/exp/xhtml/maps/e.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="../topics/c.html">c</a></div>
-<div><a class="link" href="f.html">f</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="../topics/c.html">c</a></li>
+<li class="linklist"><a class="link" href="f.html">f</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/maps/f.html
+++ b/src/test/resources/uplevels3/exp/xhtml/maps/f.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="../topics/d.html">d</a></div>
-<div><a class="link" href="e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="../topics/d.html">d</a></li>
+<li class="linklist"><a class="link" href="e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/topics/c.html
+++ b/src/test/resources/uplevels3/exp/xhtml/topics/c.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="c.html">c</a></div>
-<div><a class="link" href="../maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="c.html">c</a></li>
+<li class="linklist"><a class="link" href="../maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>

--- a/src/test/resources/uplevels3/exp/xhtml/topics/d.html
+++ b/src/test/resources/uplevels3/exp/xhtml/topics/d.html
@@ -32,10 +32,10 @@
 
   <div class="related-links">
 <div class="linklist linklist relinfo"><strong>Related information</strong><br />
-
-<div><a class="link" href="../a.html">a</a></div>
-<div><a class="link" href="d.html">d</a></div>
-<div><a class="link" href="../maps/e.html">e</a></div></div>
+<ul class="linklist">
+<li class="linklist"><a class="link" href="../a.html">a</a></li>
+<li class="linklist"><a class="link" href="d.html">d</a></li>
+<li class="linklist"><a class="link" href="../maps/e.html">e</a></li></ul></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description
Converts lists of links from `<div>` markup to actual list markup for more accessible output, as described in #2447 

First commit only covers HTML5, which doesn't have a big hit on integration tests. I made the equivalent change in XHTML, but ... not surprisingly ... it hits a ton of integration tests, and I haven't had a chance to update them all.

In both cases, I've updated the CSS / SASS files so that generated link lists retain the same formatting in browsers.

## Motivation and Context

The web content accessibility guidelines from w3 state that groups of links should be encoded using list markup: https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H48.html

We already present generated links as lists under "Related concepts" and similar headings; manually grouped `<linklist>` contents are also presented as lists. The markup should match. I've encountered accessibility tools that flag the current output as incompatible with WCAG 2.0, and screen readers will perform better with the new markup.

## How Has This Been Tested?

Tested initially with a set of topics designed to generate links + include linklists, then against integration tests.

## Type of Changes

Somewhere between a bug fix / enhancement, improves output that doesn't pass WCAG validation today.

## Checklist

I haven't yet updated the integration tests so XHTML will pass. There's a lot to update, so if further changes are requested, I'd like to make those first before updating all of the `exp/` directories for XHTML.