### PR TITLE
In-topic links break when using onlytopic.in.map=true

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -405,7 +405,8 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
         final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
         final String scope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
-        if (href != null && !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
+        if (href != null && !href.toString().startsWith("#") &&
+                !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
             if (!(MAP_TOPICREF.matches(cls))) {
                 nonTopicrefReferenceSet.add(stripFragment(currentDir.resolve(href)));
             } else if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(processingRole)) {

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -405,7 +405,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
         final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
         final String scope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
-        if (href != null && !href.toString().startsWith("#") &&
+        if (href != null && href.getPath() != null &&
                 !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
             if (!(MAP_TOPICREF.matches(cls))) {
                 nonTopicrefReferenceSet.add(stripFragment(currentDir.resolve(href)));

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -405,7 +405,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
         final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
         final String scope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
-        if (href != null && href.getPath() != null &&
+        if (href != null && href.getPath() != null && !href.getPath().isEmpty() &&
                 !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
             if (!(MAP_TOPICREF.matches(cls))) {
                 nonTopicrefReferenceSet.add(stripFragment(currentDir.resolve(href)));

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
@@ -24,6 +24,8 @@
 
 <div class="body">
 <ul class="ul">
+<li class="li"><a class="xref" href="#Id1">Link to this topic</a></li>
+  
 <li class="li"><a class="xref" href="localditaxref.html">Local DITA xref, evaluate but do not generate</a></li>
 
 <li class="li"><a class="xref" href="peerditaxref.html">Peer topic, do not get it</a></li>

--- a/src/test/resources/onlytopic.in.map.false/src/generate.dita
+++ b/src/test/resources/onlytopic.in.map.false/src/generate.dita
@@ -4,6 +4,7 @@
 <title>Title</title>
 <body>
 <ul>
+<li><xref href="#Id1">Link to this topic</xref></li>
 <li><xref href="localditaxref.dita"/></li>
 <li><xref href="peerditaxref.dita" scope="peer">Peer topic, do not get it</xref></li>
 <li><xref href="externalditaxref.dita" scope="external">External topic, do not get it</xref></li>

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
@@ -24,6 +24,8 @@
 
 <div class="body">
 <ul class="ul">
+<li class="li"><a class="xref" href="#Id1">Link to this topic</a></li>
+  
 <li class="li"><a class="xref" href="localditaxref.html">Local DITA xref, evaluate but do not generate</a></li>
 
 <li class="li"><a class="xref" href="peerditaxref.html">Peer topic, do not get it</a></li>

--- a/src/test/resources/onlytopic.in.map/src/generate.dita
+++ b/src/test/resources/onlytopic.in.map/src/generate.dita
@@ -4,6 +4,7 @@
 <title>Title</title>
 <body>
 <ul>
+<li><xref href="#Id1">Link to this topic</xref></li>
 <li><xref href="localditaxref.dita"/></li>
 <li><xref href="peerditaxref.dita" scope="peer">Peer topic, do not get it</xref></li>
 <li><xref href="externalditaxref.dita" scope="external">External topic, do not get it</xref></li>


### PR DESCRIPTION
## Description

I've got in-topic links like the following:
`<xref href="#roottopic"/>`
or
`<xref href="#topic/niftyFigure"/>`

Our custom x/html transform types set `onlytopic.in.map=true` as a default. When that is set, these in-topic links are added to the list of "non topicref resources", which eventually ends up with the directory itself treated as a file reference, and the following series of errors from the build:
```
   [filter] C:\Users\IBM_AD~1\AppData\Local\Temp\temp20170928202410586 (Access is denied.)
[topic-fragment] Failed to process XML filter: Failed to transform C:\Users\IBM_AD~1\AppData\Local\Temp\temp20170928202410586: C:\Users\IBM_AD~1\AppData\Local\Temp\temp20170928202410586 (Access is denied.)
[topicpull] Failed to transform document: org.xml.sax.SAXParseException: Content is not allowed in prolog.
```

The fix ensures that any `@href` beginning with `#` is not added to any reference list (if we're in a topic, that topic is already in a list, and this self-reference does not represent a new type of reference for tracking).

## How Has This Been Tested?

I added an in-topic reference to our existing integration tests for `onlytopic.in.map`, which caused the build to fail; the fix restores a passing build, and also fixes the problem in the files that originally encountered the issue.

## Type of Changes

Bug fix.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
