### PR TITLE
Fix for #2795 missing external link

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -520,8 +520,11 @@ See the accompanying LICENSE file for applicable license.
                       <xsl:with-param name="element" select="$element"/>
                     </xsl:call-template>
                   </xsl:when>
-                  <xsl:otherwise>
+                  <xsl:when test="*[contains(@class, ' topic/linktext ')]">
                     <xsl:apply-templates select="*[contains(@class, ' topic/linktext ')]"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="@href"/>
                   </xsl:otherwise>
                 </xsl:choose>
             </fo:basic-link>


### PR DESCRIPTION
Bug fix for #2795 missing external links in PDF `<related-links>` section.

Current processing tries to determine a link text based on the DITA target; if that cannot be found, it uses the `<linktext>` element. 

For `<xref>` when the target is external / non-dita or cannot be accessed, link text is set using text/element content (if available), otherwise it uses `@href`.

This fix updates `<link>` processing to match that -- using `<linktext>` _if available_, otherwise using `@href`. This means links where text could not be retrieved still show up, using the supplied link text. (Note that the link was already there in the FO / PDF -- it just had no text).