### PR TITLE
Allow variable contributions to use mixed case for locale

### DIFF
--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -94,7 +94,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="l" select="($ancestorlang, $defaultlang)[1]" as="xs:string?"/>
     <xsl:choose>
       <xsl:when test="exists($l)">
-        <xsl:variable name="stringfile" select="$stringFiles[@xml:lang = $l]/@filename" as="xs:string*"/>
+        <xsl:variable name="stringfile" select="$stringFiles[lower-case(@xml:lang) = lower-case($l)]/@filename" as="xs:string*"/>
         <xsl:variable name="str" as="element()*">
           <xsl:for-each select="$stringfile">
             <xsl:sequence select="document(., $stringFiles[1])/*/*[@name = $id or @id = $id]"/><!-- strings/str/@name opentopic-vars:vars/opentopic-vars:variable/@id -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Allows plugins to contribute variables using mixed case. With this change, either of these will work to contribute a plugin; currently, only the first will work:
```
<lang filename="pt_BR.xml" xml:lang="pt-br"/>
<lang filename="pt_BR.xml" xml:lang="pt-BR"/>
```

Any case is valid, and `xx-YY` is most common. We currently allow any case in the `@xml:lang` attribute in source files, but the variable lookup is broken for anything but lower-case in the string/variable files.

## Motivation and Context

I've created variable files that use mixed-case to contribute variables. This was how default contributions were done for PDF2 until I noticed they were broken for `pt-BR` and `zh-CN`; that was fixed by lower-casing the contributions with commit https://github.com/dita-ot/dita-ot/commit/500761b8a7e7a137be3a56d6ea34bdeb8d7a7cf7 

That does not address variables contributed by other plugins. We should expect mixed case because `pt-BR` style is the normal case for two-part locales; I've run into this, and it's been reported in #2226 and #2790.

This fix lower-cases both sides of the comparison. @robertnthomas also suggested using `matches(@xml:lang, $l, 'i')` in #2790 but I'm not sure if one or the other is preferred.

## How Has This Been Tested?

Started by changing the variable contributions for `pt-BR` for "Note" and "Figure" so that they no longer matched `pt. Then changed the plugin contribution files in in `xsl/common/` and `plugins/org.dita.pdf2/cfg/common/vars/` so that they contributed variables for `pt-BR` instead of `pt-br`, and confirmed that the variables were no longer found; instead, `pt` Portuguese variables were used in PDF and HTML5.

With this change, the `pt-BR'` contributions were restored in both PDF and HTML5 builds.

## Type of Changes

Bug fix - current code fails silently for `pt-BR` and you get `pt` strings without knowing it; it fails completely for `zh-CN` in PDF because there is no mapping for `zh` on its own.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
