### PR TITLE
Chunk=by-topic gives NPE on topicgroup

### DIFF
--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -351,7 +351,9 @@ public final class ChunkMapReader extends AbstractDomFilter {
             processChildTopicref(topicref);
             processNavitation(topicref);
         } else if (chunkByToken.equals(CHUNK_BY_TOPIC)) {
-            processSeparateChunk(topicref);
+            if (href != null) {
+                processSeparateChunk(topicref);
+            }
             processChildTopicref(topicref);
         } else { // chunkByToken.equals(CHUNK_BY_DOCUMENT)
             URI currentPath = null;

--- a/src/test/resources/ChunkMapReaderTest/src/gen.ditamap
+++ b/src/test/resources/ChunkMapReaderTest/src/gen.ditamap
@@ -241,4 +241,5 @@
   <topicref chunk="to-content" class="- map/topicref " href="../topics/222.dita">
     <topicref class="- map/topicref " href="../topics/223.dita"/>
   </topicref>
+  <topicref chunk="by-topic" class="- map/topicref "> </topicref>
 </map>


### PR DESCRIPTION
## Description

Fix for the following condition, which currently results in a null pointer error:
```
<map>
  <topicref chunk="by-topic">
    <topicref href="sample.dita"/>
  </topicref>
</map>
```

## Motivation and Context

Actual use case where this came up was a `<mapref>` element where the nested map used `chunk="by-topic"`. The resolved `<submap>` element has no `@href` but retains the chunk token. From that, I generalized the issue to any `<topicref>` that 1) has no `@href` and 2) has `chunk="by-topic"`.

This comes from the chunking code, which checks for `null` href values for other chunk tokens but does not check for `by-topic`, and tries to generate chunks regardless. The fix skips the "generate chunks" step and continues to children.

This issue has existed for a long time for `topicgroup` style elements, but is likely to come up more now that `chunk` values from submaps are preserved (that was added not too long ago).

## How Has This Been Tested?

Fixes the original test case, and the more general case. There is no failure, and child topicrefs are processed as expected.

Also added the following element to the existing `ChunkMapReaderTest`, which resulted in a NPE from `gradlew test`:
`<topicref chunk="by-topic" class="- map/topicref "> </topicref>`

This fix corrects the null pointer error.

## Type of Changes

Bug fix

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
