### PR TITLE
Update grammar files for coming DITA 1.3 errata

### DIFF
--- a/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/dtd/tblDecl.mod
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/dtd/tblDecl.mod
@@ -322,7 +322,7 @@
                            headers |
                            norowheader |
                            -dita-use-conref-target)
-                                    'headers'
+                                    #IMPLIED
                %tbl.colspec.att;
                %dita.colspec.attributes;"
 >

--- a/src/main/plugins/org.oasis-open.dita.v1_3/rng/base/rng/tblDeclMod.rng
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/rng/base/rng/tblDeclMod.rng
@@ -439,8 +439,7 @@ For <entry>, add:
       </attribute>
     </optional>
     <optional>
-      <attribute name="rowheader" dita:since="1.3"
-        a:defaultValue="headers">
+      <attribute name="rowheader" dita:since="1.3">
         <choice>
           <value>firstcol</value>
           <value dita:since="1.3">headers</value>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclMod.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclMod.xsd
@@ -350,7 +350,7 @@
       </xs:attribute>
       <xs:attribute name="char" type="xs:string"/>
       <xs:attribute name="charoff" type="xs:NMTOKEN"/>
-      <xs:attribute name="rowheader" default="headers">
+      <xs:attribute name="rowheader">
          <xs:simpleType>
             <xs:restriction base="xs:string">
                <xs:enumeration value="firstcol"/>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema/base/xsd/tblDeclMod.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema/base/xsd/tblDeclMod.xsd
@@ -350,7 +350,7 @@
       </xs:attribute>
       <xs:attribute name="char" type="xs:string"/>
       <xs:attribute name="charoff" type="xs:NMTOKEN"/>
-      <xs:attribute name="rowheader" default="headers">
+      <xs:attribute name="rowheader">
          <xs:simpleType>
             <xs:restriction base="xs:string">
                <xs:enumeration value="firstcol"/>

--- a/src/test/resources/table_colwidth/exp/preprocess/test.dita
+++ b/src/test/resources/table_colwidth/exp/preprocess/test.dita
@@ -13,8 +13,8 @@
     </table>
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="2">
-        <colspec class="- topic/colspec " colname="col1" colnum="1" colwidth="1*" rowheader="headers"/>
-        <colspec class="- topic/colspec " colname="col2" colnum="2" colwidth="3*" rowheader="headers"/>
+        <colspec class="- topic/colspec " colname="col1" colnum="1" colwidth="1*"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2" colwidth="3*"/>
         <tbody class="- topic/tbody ">
           <row class="- topic/row ">
             <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">1</entry>
@@ -25,8 +25,8 @@
     </table>
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="2">
-        <colspec class="- topic/colspec " colname="col1" colnum="1" colwidth="1cm" rowheader="headers"/>
-        <colspec class="- topic/colspec " colname="col2" colnum="2" colwidth="3cm" rowheader="headers"/>
+        <colspec class="- topic/colspec " colname="col1" colnum="1" colwidth="1cm"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2" colwidth="3cm"/>
         <tbody class="- topic/tbody ">
           <row class="- topic/row ">
             <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">1</entry>


### PR DESCRIPTION
The DITA 1.3 grammar files ship support for the `colspec/@rowheader` attribute. They mistakenly set a default of `rowheader="headers"`, which would designate every cell in every column as a header (for those tables which use `<colspec>` elements).

This was discussed on the OASIS list 2 weeks ago, and at the meeting this week the TC agreed to treat it as an errata, to be updated in the second DITA 1.3 errata.

This pull request makes the relevant changes (removing the default), and updates the only test case where expected output included that default value. With this change, we will be able to implement #1779 (currently blocked by the default value).