### PR TITLE
Refactor HTML5 simpletable accessibility for modern approach

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/choicetable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/choicetable.xsl
@@ -20,33 +20,13 @@ See the accompanying LICENSE file for applicable license.
   ">
     <chhead class="- topic/sthead task/chhead ">
       <choptionhd class="- topic/stentry task/choptionhd ">
-        <xsl:attribute name="id" select="simpletable:generate-headers(., 'option')"/>
         <xsl:sequence select="dita-ot:get-variable(., 'Option')"/>
       </choptionhd>
 
       <chdeschd class="- topic/stentry task/chdeschd ">
-        <xsl:attribute name="id" select="simpletable:generate-headers(., 'desc')"/>
         <xsl:sequence select="dita-ot:get-variable(., 'Description')"/>
       </chdeschd>
     </chhead>
-  </xsl:template>
-
-  <xsl:template mode="headers" match="
-    *[contains(@class,' task/choption ')]
-     [empty(simpletable:get-current-table(.)/*[contains(@class,' task/chhead ')])]
-  ">
-    <xsl:attribute name="headers" select="
-      simpletable:generate-headers(simpletable:get-current-table(.), 'option')
-    "/>
-  </xsl:template>
-
-  <xsl:template mode="headers" match="
-    *[contains(@class,' task/chdesc ')]
-     [empty(simpletable:get-current-table(.)/*[contains(@class,' task/chhead ')])]
-  ">
-    <xsl:attribute name="headers" select="
-      simpletable:generate-headers(simpletable:get-current-table(.), 'desc')
-    "/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/properties.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/properties.xsl
@@ -54,17 +54,14 @@ See the accompanying LICENSE file for applicable license.
   ">
     <prophead class="- topic/sthead reference/prophead ">
       <proptypehd class="- topic/stentry task/proptypehd ">
-        <xsl:attribute name="id" select="simpletable:generate-headers(., 'type')"/>
         <xsl:sequence select="dita-ot:get-variable(., 'Type')"/>
       </proptypehd>
 
       <propvaluehd class="- topic/stentry task/propvaluehd ">
-        <xsl:attribute name="id" select="simpletable:generate-headers(., 'value')"/>
         <xsl:sequence select="dita-ot:get-variable(., 'Value')"/>
       </propvaluehd>
 
       <propdeschd class="- topic/stentry task/propdeschd ">
-        <xsl:attribute name="id" select="simpletable:generate-headers(., 'desc')"/>
         <xsl:sequence select="dita-ot:get-variable(., 'Description')"/>
       </propdeschd>
     </prophead>

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -85,14 +85,14 @@ See the accompanying LICENSE file for applicable license.
       <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
       <prophead class="- topic/sthead reference/prophead ">
         <xsl:if test="$hasType">
-         <proptypehd class="- topic/stentry reference/proptypehd " id="{generate-id()}-type">
+         <proptypehd class="- topic/stentry reference/proptypehd ">
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Type'"/>
            </xsl:call-template>
          </proptypehd>
         </xsl:if>
         <xsl:if test="$hasValue">
-          <propvaluehd class="- topic/stentry reference/propvaluehd " id="{generate-id()}-value">
+          <propvaluehd class="- topic/stentry reference/propvaluehd ">
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Value'"/>
            </xsl:call-template>
@@ -107,7 +107,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template name="gen-propdeschd">
     <xsl:variable name="properties" select="ancestor-or-self::*[contains(@class,' reference/properties ')][1]"/>
-    <propdeschd class="- topic/stentry reference/propdeschd " id="{generate-id($properties)}-desc">
+    <propdeschd class="- topic/stentry reference/propdeschd ">
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'Description'"/>
       </xsl:call-template>
@@ -134,14 +134,13 @@ See the accompanying LICENSE file for applicable license.
            <xsl:apply-templates select="*[contains(@class,' reference/proptypehd ')]"/>
          </xsl:when>
          <xsl:when test="$hasType">
-           <th>
+           <th scope="col">
              <xsl:call-template name="style">
                <xsl:with-param name="contents">
                  <xsl:text>vertical-align:bottom;</xsl:text>
                  <xsl:call-template name="th-align"/>
                </xsl:with-param>
              </xsl:call-template>           
-             <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-type</xsl:attribute>
              <xsl:call-template name="getVariable">
                <xsl:with-param name="id" select="'Type'"/>
              </xsl:call-template>
@@ -153,14 +152,13 @@ See the accompanying LICENSE file for applicable license.
            <xsl:apply-templates select="*[contains(@class,' reference/propvaluehd ')]"/>
          </xsl:when>
          <xsl:when test="$hasValue">
-           <th>
+           <th scope="col">
              <xsl:call-template name="style">
                <xsl:with-param name="contents">
                  <xsl:text>vertical-align:bottom;</xsl:text>
                  <xsl:call-template name="th-align"/>
                </xsl:with-param>
              </xsl:call-template>
-             <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-value</xsl:attribute>
              <xsl:call-template name="getVariable">
                <xsl:with-param name="id" select="'Value'"/>
              </xsl:call-template>
@@ -175,14 +173,13 @@ See the accompanying LICENSE file for applicable license.
            <xsl:variable name="propdeschd" as="element()">
              <xsl:call-template name="gen-propdeschd"/>
            </xsl:variable>
-           <th>
+           <th scope="col">
              <xsl:call-template name="style">
                <xsl:with-param name="contents">
                  <xsl:text>vertical-align:bottom;</xsl:text>
                  <xsl:call-template name="th-align"/>
                </xsl:with-param>
              </xsl:call-template>           
-             <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-desc</xsl:attribute>
              <xsl:call-template name="getVariable">
                <xsl:with-param name="id" select="'Description'"/>
              </xsl:call-template>
@@ -256,15 +253,14 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:variable>
     <xsl:element name="{$element-name}">
+      <xsl:call-template name="setid"/>
+      <xsl:if test="$element-name='th'">
+        <xsl:attribute name="scope" select="'row'"/>
+      </xsl:if>
       <xsl:call-template name="style">
         <xsl:with-param name="contents">
-          <xsl:text>vertical-align:top;</xsl:text>     
+          <xsl:text>vertical-align:top;</xsl:text>
         </xsl:with-param>
-      </xsl:call-template>
-      <xsl:call-template name="output-stentry-id"/>
-      <xsl:call-template name="addPropertiesHeadersAttribute">
-        <xsl:with-param name="classVal"> reference/prop<xsl:value-of select="$elementType"/>hd<xsl:text> </xsl:text></xsl:with-param>
-        <xsl:with-param name="elementType" select="$elementType"/>
       </xsl:call-template>
       <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -66,6 +66,7 @@ See the accompanying LICENSE file for applicable license.
        attribute on <simpletable>
        NOTE: It references simpletable with parent::*/parent::* in order to avoid problems
        with nested simpletables. -->
+  <!-- Deprecated in 3.0 in favor of HTML5 @scope attribute. -->
   <xsl:template name="output-stentry-id">
     <!-- Find the position in this row -->
     <xsl:variable name="thiscolnum"><xsl:number level="single" count="*[contains(@class, ' topic/stentry ')]"/></xsl:variable>
@@ -88,6 +89,7 @@ See the accompanying LICENSE file for applicable license.
        Note: This function is not called within sthead, so sthead never gets headers.
        NOTE: I reference simpletable with parent::*/parent::* in order to avoid problems
        with nested simpletables. -->
+  <!-- Deprecated in 3.0 in favor of HTML5 @scope attribute -->
   <xsl:template name="set.stentry.headers">
     <xsl:variable name="keycol" select="parent::*/parent::*/@keycol"/>
     <xsl:if test="$keycol | parent::*/parent::*/*[contains(@class, ' topic/sthead ')]">
@@ -232,11 +234,13 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[simpletable:is-head-entry(.)]" mode="headers">
-    <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>
+    <xsl:attribute name="scope" select="'col'"/>
   </xsl:template>
 
   <xsl:template match="*[simpletable:is-body-entry(.)]" mode="headers">
-    <xsl:call-template name="set.stentry.headers"/>
+    <xsl:if test="simpletable:is-keycol-entry(.)">
+      <xsl:attribute name="scope" select="'row'"/>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-header" priority="10">

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -407,17 +407,16 @@ See the accompanying LICENSE file for applicable license.
    
     <!-- Generate default choicetable header -->
     <xsl:template name="gen-chhead" as="element(gen)?">
-      <xsl:variable name="choicetable" select="ancestor-or-self::*[contains(@class,' task/choicetable ')][1]" as="element()"/>
       <!-- Generated header needs to be wrapped in gen element to allow correct language detection -->
       <gen>
         <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <chhead class="- topic/sthead task/chhead ">
-         <choptionhd class="- topic/stentry task/choptionhd " id="{generate-id($choicetable)}">
+         <choptionhd class="- topic/stentry task/choptionhd ">
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Option'"/>
            </xsl:call-template>
          </choptionhd>  
-         <chdeschd class="- topic/stentry task/chdeschd " id="{generate-id($choicetable)}">
+         <chdeschd class="- topic/stentry task/chdeschd ">
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Description'"/>
            </xsl:call-template>
@@ -438,53 +437,29 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
     
   <xsl:template match="*[contains(@class,' task/choptionhd ')]">
-    <th>
+    <th scope="col">
       <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setid"/>
       <xsl:call-template name="style">
         <xsl:with-param name="contents">
           <xsl:text>vertical-align:bottom;</xsl:text>
           <xsl:call-template name="th-align"/>
         </xsl:with-param>
       </xsl:call-template>
-      <xsl:attribute name="id">
-        <xsl:choose>
-          <!-- if the option header has an ID, use that -->
-          <xsl:when test="@id">
-            <xsl:value-of select="@id"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <!-- output a default option header ID -->
-            <xsl:value-of select="generate-id(../..)"/>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>-option</xsl:text>
-      </xsl:attribute>
       <xsl:apply-templates select="." mode="chtabhdr"/>
     </th>
   </xsl:template>
     
   <xsl:template match="*[contains(@class,' task/chdeschd ')]">
-    <th>
+    <th scope="col">
       <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setid"/>
       <xsl:call-template name="style">
         <xsl:with-param name="contents">
           <xsl:text>vertical-align:bottom;</xsl:text>
           <xsl:call-template name="th-align"/>
         </xsl:with-param>
       </xsl:call-template>
-      <xsl:attribute name="id">
-        <xsl:choose>
-          <!-- if the description header has an ID, use that -->
-          <xsl:when test="@id">
-            <xsl:value-of select="@id"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <!-- output a default descr header ID -->
-            <xsl:value-of select="generate-id(../..)"/>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>-desc</xsl:text>
-      </xsl:attribute>
       <xsl:apply-templates select="." mode="chtabhdr"/>
     </th>
   </xsl:template>
@@ -524,37 +499,15 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>  
     <xsl:variable name="element-name" select="if ($localkeycol = 1) then 'th' else 'td'"/>
     <xsl:element name="{$element-name}">
+      <xsl:call-template name="setid"/>
       <xsl:call-template name="style">
         <xsl:with-param name="contents">
           <xsl:text>vertical-align:top;</xsl:text>     
         </xsl:with-param>
       </xsl:call-template>
-     <!-- Add header attr for column header -->
-     <xsl:attribute name="headers">
-      <xsl:choose>
-        <!-- First choice: if there is a user-specified header, and it has an ID -->
-        <xsl:when test="ancestor::*[contains(@class,' task/choicetable ')][1]/*[contains(@class,' task/chhead ')]/*[contains(@class,' task/choptionhd ')]/@id">
-          <xsl:value-of select="ancestor::*[contains(@class,' task/choicetable ')][1]/*[contains(@class,' task/chhead ')]/*[contains(@class,' task/choptionhd ')]/@id"/>
-        </xsl:when>
-        <!-- Second choice: no user-specified header for this column. ID is based on the table's generated ID. -->
-        <xsl:otherwise>
-          <xsl:value-of select="generate-id(ancestor::*[contains(@class,' task/choicetable ')][1])"/>
-        </xsl:otherwise>
-      </xsl:choose>
-       <xsl:text>-option</xsl:text>
-     </xsl:attribute>
-     <!-- Add header attr, column header then row header -->
-     <xsl:attribute name="id">
-      <!-- If there is a user-specified ID, use it -->
-      <xsl:choose>
-        <xsl:when test="@id">
-          <xsl:value-of select="@id"/>
-        </xsl:when>
-        <xsl:otherwise> <!-- generate one -->
-          <xsl:value-of select="generate-id(.)"/>
-        </xsl:otherwise>
-      </xsl:choose>
-     </xsl:attribute>
+      <xsl:if test="$localkeycol = 1">
+        <xsl:attribute name="scope">row</xsl:attribute>
+      </xsl:if>
       <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
       <xsl:call-template name="stentry-templates"/>
@@ -576,40 +529,16 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>  
     <xsl:variable name="element-name" select="if ($localkeycol = 2) then 'th' else 'td'"/>
     <xsl:element name="{$element-name}">
+      <xsl:call-template name="setid"/>
       <xsl:call-template name="style">
         <xsl:with-param name="contents">
           <xsl:text>vertical-align:top;</xsl:text>     
         </xsl:with-param>
       </xsl:call-template>
-     <!-- Add header attr, column header then option header -->
-     <xsl:attribute name="headers">
-      <xsl:choose>
-        <!-- First choice: if there is a user-specified header, and it has an ID-->
-        <xsl:when test="ancestor::*[contains(@class,' task/choicetable ')][1]/*[contains(@class,' task/chhead ')]/*[contains(@class,' task/chdeschd ')]/@id">
-         <!-- If there is a user-specified row ID -->
-          <xsl:value-of select="ancestor::*[contains(@class,' task/choicetable ')][1]/*[contains(@class,' task/chhead ')]/*[contains(@class,' task/chdeschd ')]/@id"/>
-        </xsl:when>
-        <!-- Second choice: no user-specified header for this column. ID is based on the table's generated ID. -->
-        <xsl:otherwise>
-          <xsl:value-of select="generate-id(ancestor::*[contains(@class,' task/choicetable ')][1])"/>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:text>-desc </xsl:text>
-       <!-- add CHOption ID -->
-      <xsl:choose>
-         <xsl:when test="../*[contains(@class,' task/choption ')]/@id">
-           <xsl:value-of select="../*[contains(@class,' task/choption ')]/@id"/>
-         </xsl:when>
-         <xsl:otherwise>
-           <xsl:value-of select="generate-id(../*[contains(@class,' task/choption ')])"/>
-         </xsl:otherwise>
-      </xsl:choose>
-     </xsl:attribute>
-     <!-- If there is a user-specified ID, add it -->
-     <xsl:if test="@id">
-      <xsl:attribute name="id" select="@id"/>
-     </xsl:if>
-     <xsl:call-template name="commonattributes"/>
+      <xsl:if test="$localkeycol = 2">
+        <xsl:attribute name="scope">row</xsl:attribute>
+      </xsl:if>
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
       <xsl:call-template name="stentry-templates"/>
       <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This pull request modifies the way simpletable headers are marked up for accessibility.

The original approach specified `@id` for every header cell, and used `@headers` on body cells to reference each header. This was the recommended approach when DITA-OT 1.0 came out and was used in XHTML.

There are a number of problems with this:

1. It used generated IDs, which are a problem for many systems that use diff to compare output
1. The output is extremely verbose, while many HTML5 developers prefer clean files / minimal noise
1. In our implementation, generated IDs for cells inside `sthead` often override specified IDs, so links to those entries do not resolve
1. Even when specified IDs are preserved today, the actual ID is used instead of `topic__id` - so again, links to those IDs do not resolve
1. In 2.5, when a header row is specified for `<choicetable>`, the same generated ID is used for each cell of the header, so those are broken today (it only works when the header row is generated, or when the header entries specify their own ID)

The updated code here switches to use the `@scope` attribute to mark header cells. It is always used for entries inside `sthead` (with `scope="col"`), and is also used for any designated key column (with `scope="row"`). The code to generate these values is much simpler, which makes it easy to fix items 3/4/5 above. By removing extra noise from the HTML5 output, we also move to the now-recommended approach for data tables. See: https://webaim.org/techniques/tables/data#headers

> The scope attribute tells the browser and screen reader that everything within a column that is associated to the header with scope="col" in that column, and that a cell with scope="row" is a header for all cells in that row.
> All <th> elements should generally always have a scope attribute. While screen readers may correctly guess whether a header is a column header or a row header based on the table layout, assigning a scope makes this unambiguous.
> ...
> Another way to associate data cells and headers is to use the headers and id attributes. This method is NOT generally recommended because scope is usually sufficient for most tables, even if the table is complex with multiple levels of headers.

A few notes / caveats:

- This update is straightforward for simpletables, where entries cannot span and headers are easy to calculate. I'd like to make the same update for complex tables but am not sure I'll have time before 3.0 is frozen. The updates for complex tables are closely related to #1779 so should probably be done together.
- I've only done this for HTML5. Given that the existing support is valid (although outdated), and given the churn this would cause for existing XHTML table overrides, I'd prefer to leave that alone (much higher cost for a lower return).
- The update here covers simpletables and OASIS specializations of simple tables (`<properties>`, `<choicetable>`).
- When integrated, this should close #2448 and #2449 that both suggest removing generated headers in simple tables

Tested using the following files, which cover simpletable (with / without headers and keycol), properties (with/without generated headers and keycol), and choice tables (with / without headers and keycol).
[1779.zip](https://github.com/dita-ot/dita-ot/files/1380262/1779.zip)


