### PR TITLE
Fix for #2752 pull alt text from key definition

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -82,7 +82,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         ki.add(new KeyrefInfo(TOPIC_AUTHOR, ATTRIBUTE_NAME_HREF, false, true));
         ki.add(new KeyrefInfo(TOPIC_DATA, ATTRIBUTE_NAME_HREF, false, true));
         ki.add(new KeyrefInfo(TOPIC_DATA_ABOUT, ATTRIBUTE_NAME_HREF, false, true));
-        ki.add(new KeyrefInfo(TOPIC_IMAGE, ATTRIBUTE_NAME_HREF, true, false));
+        ki.add(new KeyrefInfo(TOPIC_IMAGE, ATTRIBUTE_NAME_HREF, false, true));
         ki.add(new KeyrefInfo(TOPIC_LINK, ATTRIBUTE_NAME_HREF, false, true));
         ki.add(new KeyrefInfo(TOPIC_LQ, ATTRIBUTE_NAME_HREF, false, true));
         ki.add(new KeyrefInfo(MAP_NAVREF, "mapref", true, false));
@@ -280,6 +280,10 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                     final AttributesImpl atts = new AttributesImpl();
                                     XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, TOPIC_LINKTEXT.toString());
                                     getContentHandler().startElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName, atts);
+                                } else if (TOPIC_IMAGE.matches(currentElement.type)) {
+                                    final AttributesImpl atts = new AttributesImpl();
+                                    XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, TOPIC_ALT.toString());
+                                    getContentHandler().startElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName, atts);
                                 }
                                 if (!currentElement.isEmpty) {
                                     for (final Element onekeyword: keywordsInKeywords) {
@@ -288,11 +292,13 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 }
                                 if (TOPIC_LINK.matches(currentElement.type)) {
                                     getContentHandler().endElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName);
+                                } else if (TOPIC_IMAGE.matches(currentElement.type)) {
+                                    getContentHandler().endElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName);
                                 }
                             }
                         } else {
                             if (TOPIC_LINK.matches(currentElement.type)) {
-                                // If the key reference element is link or its specification,
+                                // If the key reference element is link or its specialization,
                                 // should pull in the linktext
                                 final NodeList linktext = elem.getElementsByTagName(TOPIC_LINKTEXT.localName);
                                 if (linktext.getLength() > 0) {
@@ -310,6 +316,23 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                             if (!hrefAtt.trim().isEmpty()) {
                                                 writeLinktext(hrefAtt);
                                             }
+                                        }
+                                    }
+                                }
+                            } else if (TOPIC_IMAGE.matches(currentElement.type)) {
+                                // If the key reference element is an image or its specialization,
+                                // should pull in the linktext
+                                final NodeList linktext = elem.getElementsByTagName(TOPIC_LINKTEXT.localName);
+                                 if (linktext.getLength() > 0) {
+                                    writeAlt((Element) linktext.item(0));
+                                } else if (fallbackToNavtitleOrHref(elem)) {
+                                    final NodeList navtitleElement = elem.getElementsByTagName(TOPIC_NAVTITLE.localName);
+                                    if (navtitleElement.getLength() > 0) {
+                                        writeAlt((Element) navtitleElement.item(0));
+                                    } else {
+                                        final String navtitle = elem.getAttribute(ATTRIBUTE_NAME_NAVTITLE);
+                                        if (!navtitle.trim().isEmpty()) {
+                                            writeAlt(navtitle);
                                         }
                                     }
                                 }
@@ -381,6 +404,33 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         final char[] ch = navtitle.toCharArray();
         getContentHandler().characters(ch, 0, ch.length);
         getContentHandler().endElement(NULL_NS_URI, TOPIC_LINKTEXT.localName, TOPIC_LINKTEXT.localName);
+    }
+    
+    /**
+     * Write alt element
+     *
+     * @param srcElem element content
+     */
+    private void writeAlt(Element srcElem) throws SAXException {
+        final AttributesImpl atts = new AttributesImpl();
+        XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, TOPIC_ALT.toString());
+        getContentHandler().startElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName, atts);
+        domToSax(srcElem, false);
+        getContentHandler().endElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName);
+    }
+
+    /**
+     * Write alt element
+     *
+     * @param navtitle element text content
+     */
+    private void writeAlt(final String navtitle) throws SAXException {
+        final AttributesImpl atts = new AttributesImpl();
+        XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, TOPIC_ALT.toString());
+        getContentHandler().startElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName, atts);
+        final char[] ch = navtitle.toCharArray();
+        getContentHandler().characters(ch, 0, ch.length);
+        getContentHandler().endElement(NULL_NS_URI, TOPIC_ALT.localName, TOPIC_ALT.localName);
     }
 
     @Override

--- a/src/test/resources/KeyrefPaserTest/exp/a.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/a.xml
@@ -42,7 +42,9 @@
       </data-about>
     </prolog>
     <body class="- topic/body ">
-      <image class="- topic/image " keyref="image" placement="inline"/>
+      <image class="- topic/image " keyref="image" placement="inline">
+        <alt class="- topic/alt "><keyword class="- topic/keyword ">image keyword</keyword></alt>
+      </image>
       <p class="- topic/p ">
         <xref class="- topic/xref " keyref="xref">
           <keyword class="- topic/keyword ">xref keyword</keyword>
@@ -117,7 +119,12 @@
       </data-about>
     </prolog>
     <body class="- topic/body ">
-      <image class="- topic/image " href="b.gif" keyref="image_link" placement="inline" scope="external"/>
+      <image class="- topic/image " href="b.gif" keyref="image_link" placement="inline" scope="external">
+        <alt class="- topic/alt "><keyword class="- topic/keyword ">image keyword</keyword></alt>
+      </image>
+      <image class="- topic/image " href="b.gif" keyref="image_link_common" placement="inline" scope="external">
+        <alt class="- topic/alt ">Normal practice: use linktext for alt text</alt>
+      </image>
       <p class="- topic/p ">
         <xref class="- topic/xref " href="a.xml" keyref="xref_link" type="dead">
           <keyword class="- topic/keyword ">xref keyword</keyword>

--- a/src/test/resources/KeyrefPaserTest/src/a.xml
+++ b/src/test/resources/KeyrefPaserTest/src/a.xml
@@ -93,6 +93,7 @@
     </prolog>
     <body class="- topic/body ">
       <image class="- topic/image " href="dead" keyref="image_link" placement="inline" scope="external"/>
+      <image class="- topic/image " href="dead" keyref="image_link_common" placement="inline" scope="external"/>
       <p class="- topic/p ">
         <xref class="- topic/xref " format="dead" href="dead" keyref="xref_link" scope="external" type="dead"/>
         <cite class="- topic/cite " keyref="cite_link"/>

--- a/src/test/resources/KeyrefPaserTest/src/keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/keys.ditamap
@@ -308,6 +308,11 @@
         </keywords>
       </topicmeta>
     </keydef>
+    <keydef class="+ map/topicref mapgroup-d/keydef " href="b.gif" keys="image_link_common" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <linktext class="- map/linktext ">Normal practice: use linktext for alt text</linktext>
+      </topicmeta>
+    </keydef>
     <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="link_link" processing-role="resource-only">
       <topicmeta class="- map/topicmeta ">
         <linktext class="- map/linktext ">link linktext</linktext>

--- a/src/test/resources/keyref/exp/preprocess/a.xml
+++ b/src/test/resources/keyref/exp/preprocess/a.xml
@@ -8,7 +8,7 @@
     <data-about keyref="data-about" class="- topic/data-about " href="b.xml" scope="peer"><data class="- topic/data ">data-about data-about</data></data-about>
   </prolog>
   <body class="- topic/body ">
-    <image keyref="image" alt="Alt attribute." placement="inline" class="- topic/image " href="delta.gif" format="gif"/>
+    <image keyref="image" alt="Alt attribute." placement="inline" class="- topic/image " href="delta.gif" format="gif"><alt class="- topic/alt "><keyword class="- topic/keyword ">image keyword</keyword></alt></image>
     <image keyref="image" placement="inline" class="- topic/image " href="delta.gif" format="gif"><alt class="- topic/alt ">Alt element.</alt></image>
     <p class="- topic/p ">
       <xref keyref="xref" class="- topic/xref " href="b.xml" scope="peer"><?ditaot usertext?><keyword class="- topic/keyword ">xref keyword</keyword></xref>

--- a/src/test/resources/keyref_All_tags/exp/xhtml/c.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/c.html
@@ -130,7 +130,7 @@
 
             <li class="li"><img class="image" src="abs.dita" /></li>
 
-            <li class="li"><img class="image" /></li>
+            <li class="li"><img class="image" alt="KEYWORD" /></li>
 
         </ol>
 

--- a/src/test/resources/keyref_modify/exp/xhtml/c.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/c.html
@@ -130,7 +130,7 @@
 
             <li class="li"><img class="image" src="abs.dita" /></li>
 
-            <li class="li"><img class="image" /></li>
+            <li class="li"><img class="image" alt="KEYWORD" /></li>
 
         </ol>
 


### PR DESCRIPTION
## Description

The DITA spec says that when a key reference is resolved on an `<image>`, what would normally be pulled as link text for that key should go into `<alt>`. This is required to make keys really work for images, because alt text is required for virtually every image, and is likely to change when the image changes with a key definition.

## Motivation and Context

As discussed in #2752 -- this updates key processing to put resolved key text into `<alt>`. It follows the same logic used elsewhere to put a `<linktext>` wrapper around key text resolved for a `<link>`. As part of this, it changes `<image>` designation from an empty element with no content, to an element that allows content -- which is true of the created `<alt>` element (in the same way that `<link>` allows content once we create `<linktext>`).

## How Has This Been Tested?

Tested with existing tests, which are extended to add the "normal" case of alternate text inside `<linktext>` inside the key definition.

Also tested with local key definition that gets alt text from each of:

- `<linktext>`
- `<navtitle>`
- `@navtitle`
- `<keyword>`
- no alt text

Repeated each of those cases for `<image>`, `<image>` with `<alt>` (use that), `image/@alt` (key text overrides the deprecated `@alt`), and image without `@href`.

## Type of Changes

Fix that follows the pattern of recent fix for other keys.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
