### PR TITLE
Add xml-model to all plugins

### DIFF
--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.eclipsehelp/plugin.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.htmlhelp/plugin.xml
+++ b/src/main/plugins/org.dita.htmlhelp/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.pdf2.axf/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.pdf2.fop/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.pdf2.xep/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.xep/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.specialization.dita11/plugin.xml
+++ b/src/main/plugins/org.dita.specialization.dita11/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
     | (C) Copyright IBM Corporation 2008. All Rights Reserved.
     *-->

--- a/src/main/plugins/org.dita.xhtml/plugin.xml
+++ b/src/main/plugins/org.dita.xhtml/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.oasis-open.dita.v1_2/plugin.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_2/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.

--- a/src/main/plugins/org.oasis-open.dita.v1_3/plugin.xml
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/plugin.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.


### PR DESCRIPTION
## Description
Add the `xml-model` to all plugins.

```xml
<?xml-model href="dita-ot/plugin.rnc" type="application/relax-ng-compact-syntax"?>
```

## Motivation and Context
Inform users about the existens of the `plugin.rnc`, as they might copy official `plugin.xml` files.

## How Has This Been Tested?
Validation locally tested with &lt;oXygen/&gt; XML.

## Type of Changes
- New feature

## Checklist

- [x] I have signed-off my commits per http://www.dita-ot.org/DCO.
- [x] Builds & tests completed successfully (`./gradlew test integrationTest`).
- [x] My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- [x] I have updated the unit tests to reflect the changes in my code.
