### PR TITLE
Fix for #2833 unable to override common variables

### DIFF
--- a/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
@@ -39,6 +39,8 @@ import org.w3c.dom.NodeList;
  */
 public final class VariableFileTask extends Task {
 
+    public static final String COMMON_VARIABLE_FILENAME = "commonvariables.xml";
+    
     private List<FileSet> filesets = new ArrayList<FileSet>();
     private File file;
     
@@ -78,7 +80,11 @@ public final class VariableFileTask extends Task {
                 final Element lang = d.createElement("lang");
                 final String n = f.getName();
                 final int i = n.indexOf('.');
-                lang.setAttributeNS(XML_NS_URI, "xml:lang", n.substring(0, i).replace('_', '-'));
+                if (n.equals(COMMON_VARIABLE_FILENAME)) {
+                    lang.setAttributeNS(XML_NS_URI, "xml:lang", "");
+                } else {
+                    lang.setAttributeNS(XML_NS_URI, "xml:lang", n.substring(0, i).replace('_', '-'));
+                }
                 lang.setAttribute("filename", f.toURI().toString());
                 root.appendChild(lang);
             }


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

I'm not sure if this is the most elegant fix, but here goes ...

Long-standing design of PDF2 code allows you to override variables in your configuration directory simply by creating a matching file name. To override English variables, create `en.xml` in your configuration's variable directory, and it works.

Long-standing design also assumes that all variables in that directory must use the ISO language code in the file name - so that we can automatically set the appropriate `xml:lang` value based on the file name.

With 3.0 we introduced the `commonvariables.xml` file with no specified language. If you try to override those common variables in a configuration directory, the current code uses that file name to set `xml:lang="commonvariables"`, with the result that they are never actually used / there is no way to override those variables in a configuration directory. Originally reported in #2833.

The fix below hard-codes the file name of our shipped common variable file, which I'm not really fond of, but I'm not sure what would work better (and that effectively follows the older pattern of using matching file names in the config variables dir). When a file with that same name is found in the config dir, it is integrated for that PDF build with the expected `xml:lang=""` setting. That restores the ability for a config directory to override common strings as they could in earlier releases.