### PR TITLE
Fix broken CHM compile

### DIFF
--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -18,8 +18,6 @@ See the accompanying LICENSE file for applicable license.
                    htmlhelp.copy-image,
                    copy-css">
     <antcall target="dita.map.htmlhelp"/>
-    <antcall target="dita.htmlhelp.convertlang"/>
-    <antcall target="compile.HTML.Help"/>
   </target>
 
   <target name="dita2htmlhelp.init">
@@ -65,7 +63,9 @@ See the accompanying LICENSE file for applicable license.
           depends="dita.map.htmlhelp.init,
                    dita.map.htmlhelp.hhp,
                    dita.map.htmlhelp.hhc,
-                   dita.map.htmlhelp.hhk"/> 
+                   dita.map.htmlhelp.hhk,
+                   dita.htmlhelp.convertlang,
+                   compile.HTML.Help"/> 
 
   <target name="dita.map.htmlhelp.init" description="Init properties for HTMLHelp">
     <condition property="out.ext" value=".html">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

HTML Help with 3.0 produces all relevant files in the temp directory, and only returns a CHM.

The support for new property `args.output.base` initializes that property to the map name and uses it for the HHP, HHC, and HHK names. That part works well.

Because the last steps of the compiler use `<antcall>` (as they long have), the `args.output.base` initialization done in the first call are lost with the last call to generate the CHM. As a result, when the compiler is found on a Windows system, it is unable to run; nothing is generated in the output directory, and the build ends with a message like this:
```
compile.HTML.Help:
     [exec] Unable to open C:\DCS\2.5.3\test\yacute\tempdev\temp_chm_dir\${args.output.base}.hhp.
```

The fix merges the final 3 `<antcall>` instances into a single one that uses dependencies, so that properties are initialized in the first HTML Help project section remain available.

## How Has This Been Tested?

Tested on my windows machine with a variety of maps built to HTML Help; the CHM is now returned properly.

Note -- the `args.output.base` property is *not* working, either with 3.0 or with this fix. That's a separate (lower priority) issue that should be addressed later -- the project files all respect that property (they're generated using that name), but the HHP project itself still uses the map name to reference TOC and index.

## Type of Changes

Bug fix.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
