### PR TITLE
Support nested UL past level 4 #2824

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -68,7 +68,7 @@ See the accompanying LICENSE file for applicable license.
             <fo:list-item-label xsl:use-attribute-sets="ul.li__label">
                 <fo:block xsl:use-attribute-sets="ul.li__label__content">
                     <xsl:call-template name="getVariable">
-                        <xsl:with-param name="id" select="concat('Unordered List bullet ', $depth)"/>
+                        <xsl:with-param name="id" select="concat('Unordered List bullet ', (($depth - 1) mod 4) + 1)"/>
                     </xsl:call-template>
                 </fo:block>
             </fo:list-item-label>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This avoids the "missing variable" error and the bad "Undefined variable" generated text when UL is nested past the 4th level in PDF.

Fix uses the code update @jelovirt suggested in #2824.

Tested with the following list nested to 9 levels, all of which now work (no errors, no bad text in place of the bullet):
```
<ul>
<li>here's a list<ul>
<li>second level<ul>
<li>third level<ul>
<li>fourth level<ul>
<li>fifth<ul>
<li>six<ul>
<li>seven<ul>
<li>eight<ul>
<li>nine!!!!</li>
</ul></li>
</ul></li>
</ul></li>
</ul></li>
</ul></li>
</ul></li>
</ul></li>
</ul></li>
<li>well that was exhausting</li>
</ul>
```