### PR TITLE
Fix use of args.output.base with HHP file

### DIFF
--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -89,7 +89,7 @@ See the accompanying LICENSE file for applicable license.
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhp.xsl">
       <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
-      <param name="HHCNAME" expression="${dita.map.filename.root}.hhc"/>
+      <param name="HHCNAME" expression="${args.output.base}.hhc"/>
       <param name="INCLUDEFILE" expression="${args.htmlhelp.includefile}" if="args.htmlhelp.includefile"/>
       <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

As mentioned in #2851, the new `args.output.base` parameter is not working for HTML Help in 3.0.

The project files (HHP, HHC, HHK, and compiled CHM) are generated using that parameter. But the HHP file itself references the HHC, HHK, and CHM files using the original map name rather than the `args.output.base` name, so the compiled CHM with the new name doesn't actually find the TOC or index.

The parameter `HHCNAME` that is used when creating the project file needs to use the same `args.output.base` property that's used to generate the various files.