### PR TITLE
Unused xref in referenced file breaks PDF with "null"

### DIFF
--- a/src/main/java/org/dita/dost/util/MergeUtils.java
+++ b/src/main/java/org/dita/dost/util/MergeUtils.java
@@ -10,6 +10,7 @@ package org.dita.dost.util;
 
 import static org.dita.dost.util.URLUtils.*;
 
+import java.io.File;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -134,6 +135,9 @@ public final class MergeUtils {
      */
     public String getFirstTopicId(final URI file, final boolean useCatalog) {
         assert file.isAbsolute();
+        if (!(new File(file).exists())) {
+            return null;
+        }
         final StringBuilder firstTopicId = new StringBuilder();
         final TopicIdParser parser = new TopicIdParser(firstTopicId);
         try {
@@ -147,7 +151,6 @@ public final class MergeUtils {
             logger.error(e.getMessage(), e) ;
         }
         return firstTopicId.toString();
-
     }
 
 }

--- a/src/test/java/org/dita/dost/util/TestMergeUtils.java
+++ b/src/test/java/org/dita/dost/util/TestMergeUtils.java
@@ -102,6 +102,7 @@ public class TestMergeUtils {
         //assertEquals("task",mergeUtils.getFirstTopicId("stub.xml", "TEST_STUB"));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), false));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), true));
+        assertNull(mergeUtils.getFirstTopicId(srcDir.toURI().resolve("filedoesnotexist.xml"), false));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

My map just has one topic, which uses `@conref` to pull in a simple `<p>` from another file `library.dita`. Elsewhere, `library.dita` has an `<xref>` to a topic that does not exist. When we run topicmerge, each topic (including `library.dita`) is processed in full. The library topic now has an `<xref>` like this in the temporary file:
`<xref href="88ed512971fcff0087bc3d77a59378489c764cdd.dita" class="- topic/xref "`

The topic merge process tries to [take the first ID from that topic](https://github.com/dita-ot/dita-ot/blob/develop/src/main/java/org/dita/dost/reader/MergeTopicParser.java#L152): 
`final String fileId = util.getFirstTopicId(absolutePath, false);`

That method tries to parse the topic without checking if it exists (it does not). When the parse fails, the Exception isn't handled in any useful way; the build crashes at this point, and stops writing out merged content: https://github.com/dita-ot/dita-ot/blob/develop/src/main/java/org/dita/dost/util/MergeUtils.java#L145

The only message on the console is `null`, followed by a Saxon crash because it can't parse the incomplete merged file:
```
[topic-merge] null
Error: Failed to run pipeline: Failed to process merged topics: Invalid elementname. Invalid QName {}
```

(Note: the `<xref>` that causes this problem will never be part of the PDF.)

## How Has This Been Tested?

Small sample of the original problem is here:
[npe.zip](https://github.com/dita-ot/dita-ot/files/1516465/npe.zip)

With the fix in place, the original map (several thousand topics) successfully builds a PDF.

I'm not sure if there is a more elegant way to handle this or a better place to put a fix, but this current fix seems appropriate (check if the file exists and avoid parsing it when it doesn't) -- the code that called this method already has recovery in place when a known topic ID is not returned.

## Type of Changes

Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
