### PR TITLE
Let processing continue when map references bookmap

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -222,9 +222,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="processTopicChapter">
         <xsl:variable name="expectedChapterContext" as="xs:boolean">
             <xsl:choose>
-                <xsl:when test="empty(parent::*[contains(@class,' topic/topic ')])"><xsl:value-of select="true()"/></xsl:when>
+                <xsl:when test="empty(parent::*[contains(@class,' topic/topic ')])"><xsl:sequence select="true()"/></xsl:when>
                 <xsl:when test="count(ancestor::*[contains(@class,' topic/topic ')]) = 1 and 
-                    contains((key('map-id',parent::*/@id)[1])/@class,' bookmap/part ')"><xsl:value-of select="true()"/></xsl:when>
+                    contains((key('map-id',parent::*/@id)[1])/@class,' bookmap/part ')"><xsl:sequence select="true()"/></xsl:when>
                 <xsl:otherwise><xsl:sequence select="false()"/></xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
@@ -361,7 +361,7 @@ See the accompanying LICENSE file for applicable license.
   <!--  Bookmap appendices processing  -->
   <xsl:template name="processTopicAppendices">
       <xsl:variable name="expectedAppsContext" as="xs:boolean" 
-          select="if (empty(parent::*[contains(@class,' topic/topic ')])) then (true()) else (false())"/>
+          select="empty(parent::*[contains(@class,' topic/topic ')])"/>
       <xsl:choose>
           <xsl:when test="$expectedAppsContext">
               <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.appendix">
@@ -437,7 +437,7 @@ See the accompanying LICENSE file for applicable license.
     <!--  Bookmap Part processing  -->
     <xsl:template name="processTopicPart">
         <xsl:variable name="expectedPartContext" as="xs:boolean" 
-            select="if (empty(parent::*[contains(@class,' topic/topic ')])) then (true()) else (false())"/>
+            select="empty(parent::*[contains(@class,' topic/topic ')])"/>
         <xsl:choose>
             <xsl:when test="$expectedPartContext">
                 <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.part">
@@ -572,7 +572,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- Deprecated in 3.0: use mode="insertChapterFirstpageStaticContent" -->
     <xsl:template name="processFrontMatterTopic">
         <xsl:variable name="expectedFMContext" as="xs:boolean" 
-            select="if (empty(parent::*[contains(@class,' topic/topic ')])) then (true()) else (false())"/>
+            select="empty(parent::*[contains(@class,' topic/topic ')])"/>
         <xsl:choose>
             <xsl:when test="$expectedFMContext">
                 <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.frontmatter">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -244,49 +244,48 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
     </xsl:template>
     <xsl:template match="*" mode="processTopicChapterInsideFlow">
-                <fo:block xsl:use-attribute-sets="topic">
-                    <xsl:call-template name="commonattributes"/>
-                    <xsl:variable name="level" as="xs:integer">
-                      <xsl:apply-templates select="." mode="get-topic-level"/>
-                    </xsl:variable>
-                    <xsl:if test="$level eq 1">
-                        <fo:marker marker-class-name="current-topic-number">
-                          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
-                          <xsl:for-each select="$topicref">
-                            <xsl:apply-templates select="." mode="topicTitleNumber"/>
-                          </xsl:for-each>
-                        </fo:marker>
-                        <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
-                    </xsl:if>
+        <fo:block xsl:use-attribute-sets="topic">
+            <xsl:call-template name="commonattributes"/>
+            <xsl:variable name="level" as="xs:integer">
+              <xsl:apply-templates select="." mode="get-topic-level"/>
+            </xsl:variable>
+            <xsl:if test="$level eq 1">
+                <fo:marker marker-class-name="current-topic-number">
+                  <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                  <xsl:for-each select="$topicref">
+                    <xsl:apply-templates select="." mode="topicTitleNumber"/>
+                  </xsl:for-each>
+                </fo:marker>
+                <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+            </xsl:if>
 
-                    <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+            <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
-                        <xsl:with-param name="type" select="'chapter'"/>
-                    </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+                <xsl:with-param name="type" select="'chapter'"/>
+            </xsl:apply-templates>
 
-                    <fo:block xsl:use-attribute-sets="topic.title">
-                        <xsl:call-template name="pullPrologIndexTerms"/>
-                        <xsl:for-each select="*[contains(@class,' topic/title ')]">
-                            <xsl:apply-templates select="." mode="getTitle"/>
-                        </xsl:for-each>
-                    </fo:block>
+            <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:for-each select="*[contains(@class,' topic/title ')]">
+                    <xsl:apply-templates select="." mode="getTitle"/>
+                </xsl:for-each>
+            </fo:block>
 
-                    <xsl:choose>
-                      <xsl:when test="$chapterLayout='BASIC'">
-                          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                             contains(@class, ' topic/prolog '))]"/>
-                          <!--xsl:apply-templates select="." mode="buildRelationships"/-->
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:apply-templates select="." mode="createMiniToc"/>
-                      </xsl:otherwise>
-                    </xsl:choose>
+            <xsl:choose>
+              <xsl:when test="$chapterLayout='BASIC'">
+                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
+                                                     contains(@class, ' topic/prolog '))]"/>
+                  <!--xsl:apply-templates select="." mode="buildRelationships"/-->
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:apply-templates select="." mode="createMiniToc"/>
+              </xsl:otherwise>
+            </xsl:choose>
 
-                    <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
-                    <xsl:call-template name="pullPrologIndexTerms.end-range"/>
-                </fo:block>
-
+            <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
+            <xsl:call-template name="pullPrologIndexTerms.end-range"/>
+        </fo:block>
     </xsl:template>
 
     <!--  Bookmap Appendix processing  -->
@@ -315,48 +314,48 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
     </xsl:template>
     <xsl:template match="*" mode="processTopicAppendixInsideFlow">
-                <fo:block xsl:use-attribute-sets="topic">
-                    <xsl:call-template name="commonattributes"/>
-                    <xsl:variable name="level" as="xs:integer">
-                      <xsl:apply-templates select="." mode="get-topic-level"/>
-                    </xsl:variable>
-                    <xsl:if test="$level eq 1">
-                        <fo:marker marker-class-name="current-topic-number">
-                            <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
-                            <xsl:for-each select="$topicref">
-                              <xsl:apply-templates select="." mode="topicTitleNumber"/>
-                            </xsl:for-each>
-                        </fo:marker>
-                        <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
-                    </xsl:if>
+        <fo:block xsl:use-attribute-sets="topic">
+            <xsl:call-template name="commonattributes"/>
+            <xsl:variable name="level" as="xs:integer">
+              <xsl:apply-templates select="." mode="get-topic-level"/>
+            </xsl:variable>
+            <xsl:if test="$level eq 1">
+                <fo:marker marker-class-name="current-topic-number">
+                    <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                    <xsl:for-each select="$topicref">
+                      <xsl:apply-templates select="." mode="topicTitleNumber"/>
+                    </xsl:for-each>
+                </fo:marker>
+                <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+            </xsl:if>
 
-                    <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+            <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
-                        <xsl:with-param name="type" select="'appendix'"/>
-                    </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+                <xsl:with-param name="type" select="'appendix'"/>
+            </xsl:apply-templates>
 
-                    <fo:block xsl:use-attribute-sets="topic.title">
-                        <xsl:call-template name="pullPrologIndexTerms"/>
-                        <xsl:for-each select="*[contains(@class,' topic/title ')]">
-                            <xsl:apply-templates select="." mode="getTitle"/>
-                        </xsl:for-each>
-                    </fo:block>
+            <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:for-each select="*[contains(@class,' topic/title ')]">
+                    <xsl:apply-templates select="." mode="getTitle"/>
+                </xsl:for-each>
+            </fo:block>
 
-                    <xsl:choose>
-                      <xsl:when test="$appendixLayout='BASIC'">
-                          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                             contains(@class, ' topic/prolog '))]"/>
-                          <!--xsl:apply-templates select="." mode="buildRelationships"/-->
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:apply-templates select="." mode="createMiniToc"/>
-                      </xsl:otherwise>
-                    </xsl:choose>
+            <xsl:choose>
+              <xsl:when test="$appendixLayout='BASIC'">
+                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
+                                                     contains(@class, ' topic/prolog '))]"/>
+                  <!--xsl:apply-templates select="." mode="buildRelationships"/-->
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:apply-templates select="." mode="createMiniToc"/>
+              </xsl:otherwise>
+            </xsl:choose>
 
-                    <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
-                    <xsl:call-template name="pullPrologIndexTerms.end-range"/>
-                </fo:block>
+            <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
+            <xsl:call-template name="pullPrologIndexTerms.end-range"/>
+        </fo:block>
     </xsl:template>
 
   <!--  Bookmap appendices processing  -->
@@ -387,52 +386,52 @@ See the accompanying LICENSE file for applicable license.
       </xsl:for-each>
   </xsl:template>
   <xsl:template match="*" mode="processTopicAppendicesInsideFlow">
-        <fo:block xsl:use-attribute-sets="topic">
-          <xsl:call-template name="commonattributes"/>
-          <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
-            <fo:marker marker-class-name="current-topic-number">
-              <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
-              <xsl:for-each select="$topicref">
-                <xsl:apply-templates select="." mode="topicTitleNumber"/>
-              </xsl:for-each>
-            </fo:marker>
-            <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
-          </xsl:if>
-          
-          <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
-          
-          <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
-            <xsl:with-param name="type" select="'appendices'"/>
-          </xsl:apply-templates>
-          
-          <fo:block xsl:use-attribute-sets="topic.title">
-            <xsl:call-template name="pullPrologIndexTerms"/>
-            <xsl:for-each select="*[contains(@class,' topic/title ')]">
-              <xsl:apply-templates select="." mode="getTitle"/>
-            </xsl:for-each>
-          </fo:block>
-          
-          <xsl:choose>
-            <xsl:when test="$appendicesLayout='BASIC'">
-              <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                 contains(@class, ' topic/prolog '))]"/>
-              <!--xsl:apply-templates select="." mode="buildRelationships"/-->
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:apply-templates select="." mode="createMiniToc"/>
-            </xsl:otherwise>
-          </xsl:choose>
-                    
-          <xsl:for-each select="*[contains(@class,' topic/topic ')]">
-            <xsl:variable name="topicType" as="xs:string">
-              <xsl:call-template name="determineTopicType"/>
-            </xsl:variable>
-            <xsl:if test="$topicType = 'topicSimple'">
-              <xsl:apply-templates select="."/>
-            </xsl:if>
+    <fo:block xsl:use-attribute-sets="topic">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
+        <fo:marker marker-class-name="current-topic-number">
+          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+          <xsl:for-each select="$topicref">
+            <xsl:apply-templates select="." mode="topicTitleNumber"/>
           </xsl:for-each>
-          <xsl:call-template name="pullPrologIndexTerms.end-range"/>
-        </fo:block>
+        </fo:marker>
+        <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+      </xsl:if>
+          
+      <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+          
+      <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+        <xsl:with-param name="type" select="'appendices'"/>
+      </xsl:apply-templates>
+          
+      <fo:block xsl:use-attribute-sets="topic.title">
+        <xsl:call-template name="pullPrologIndexTerms"/>
+        <xsl:for-each select="*[contains(@class,' topic/title ')]">
+          <xsl:apply-templates select="." mode="getTitle"/>
+        </xsl:for-each>
+      </fo:block>
+          
+      <xsl:choose>
+        <xsl:when test="$appendicesLayout='BASIC'">
+          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
+                                             contains(@class, ' topic/prolog '))]"/>
+          <!--xsl:apply-templates select="." mode="buildRelationships"/-->
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="." mode="createMiniToc"/>
+        </xsl:otherwise>
+      </xsl:choose>
+                    
+      <xsl:for-each select="*[contains(@class,' topic/topic ')]">
+        <xsl:variable name="topicType" as="xs:string">
+          <xsl:call-template name="determineTopicType"/>
+        </xsl:variable>
+        <xsl:if test="$topicType = 'topicSimple'">
+          <xsl:apply-templates select="."/>
+        </xsl:if>
+      </xsl:for-each>
+      <xsl:call-template name="pullPrologIndexTerms.end-range"/>
+    </fo:block>
   </xsl:template>
 
     <!--  Bookmap Part processing  -->
@@ -463,51 +462,51 @@ See the accompanying LICENSE file for applicable license.
         </xsl:for-each>
     </xsl:template>
     <xsl:template match="*" mode="processTopicPartInsideFlow">
-                <fo:block xsl:use-attribute-sets="topic">
-                    <xsl:call-template name="commonattributes"/>
-                    <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
-                        <fo:marker marker-class-name="current-topic-number">
-                          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
-                          <xsl:for-each select="$topicref">
-                            <xsl:apply-templates select="." mode="topicTitleNumber"/>
-                          </xsl:for-each>
-                        </fo:marker>
-                        <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
-                    </xsl:if>
+        <fo:block xsl:use-attribute-sets="topic">
+            <xsl:call-template name="commonattributes"/>
+            <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
+                <fo:marker marker-class-name="current-topic-number">
+                  <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                  <xsl:for-each select="$topicref">
+                    <xsl:apply-templates select="." mode="topicTitleNumber"/>
+                  </xsl:for-each>
+                </fo:marker>
+                <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+            </xsl:if>
 
-                    <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+            <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
-                    <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
-                        <xsl:with-param name="type" select="'part'"/>
-                    </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+                <xsl:with-param name="type" select="'part'"/>
+            </xsl:apply-templates>
 
-                    <fo:block xsl:use-attribute-sets="topic.title">
-                        <xsl:call-template name="pullPrologIndexTerms"/>
-                        <xsl:for-each select="*[contains(@class,' topic/title ')]">
-                            <xsl:apply-templates select="." mode="getTitle"/>
-                        </xsl:for-each>
-                    </fo:block>
+            <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:for-each select="*[contains(@class,' topic/title ')]">
+                    <xsl:apply-templates select="." mode="getTitle"/>
+                </xsl:for-each>
+            </fo:block>
 
-                    <xsl:choose>
-                      <xsl:when test="$partLayout='BASIC'">
-                          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                             contains(@class, ' topic/prolog '))]"/>
-                          <!--xsl:apply-templates select="." mode="buildRelationships"/-->
-                      </xsl:when>
-                      <xsl:otherwise>
-                          <xsl:apply-templates select="." mode="createMiniToc"/>
-                      </xsl:otherwise>
-                    </xsl:choose>
-                    <xsl:for-each select="*[contains(@class,' topic/topic ')]">
-                        <xsl:variable name="topicType" as="xs:string">
-                            <xsl:call-template name="determineTopicType"/>
-                        </xsl:variable>
-                        <xsl:if test="$topicType = 'topicSimple'">
-                            <xsl:apply-templates select="."/>
-                        </xsl:if>
-                    </xsl:for-each>
-                    <xsl:call-template name="pullPrologIndexTerms.end-range"/>
-                </fo:block>
+            <xsl:choose>
+              <xsl:when test="$partLayout='BASIC'">
+                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
+                                                     contains(@class, ' topic/prolog '))]"/>
+                  <!--xsl:apply-templates select="." mode="buildRelationships"/-->
+              </xsl:when>
+              <xsl:otherwise>
+                  <xsl:apply-templates select="." mode="createMiniToc"/>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:for-each select="*[contains(@class,' topic/topic ')]">
+                <xsl:variable name="topicType" as="xs:string">
+                    <xsl:call-template name="determineTopicType"/>
+                </xsl:variable>
+                <xsl:if test="$topicType = 'topicSimple'">
+                    <xsl:apply-templates select="."/>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:call-template name="pullPrologIndexTerms.end-range"/>
+        </fo:block>
     </xsl:template>
 
     <xsl:template name="processTopicNotices">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -55,27 +55,27 @@ See the accompanying LICENSE file for applicable license.
              </xsl:otherwise>
          </xsl:choose>
      </xsl:template>
-    <xsl:template match="*" mode="processTopicPrefaceInsideFlow">
-                 <fo:block xsl:use-attribute-sets="topic">
-                     <xsl:call-template name="commonattributes"/>
-                     <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
-                         <fo:marker marker-class-name="current-topic-number">
-                             <xsl:number format="1"/>
-                         </fo:marker>
-                         <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
-                     </xsl:if>
-                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
-                     <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
-                         <xsl:with-param name="type" select="'preface'"/>
-                     </xsl:apply-templates>
-                     <fo:block xsl:use-attribute-sets="topic.title">
-                         <xsl:call-template name="pullPrologIndexTerms"/>
-                         <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
-                             <xsl:apply-templates select="." mode="getTitle"/>
-                         </xsl:for-each>
-                     </fo:block>
-                     <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
-                 </fo:block>
-    </xsl:template>
+     <xsl:template match="*" mode="processTopicPrefaceInsideFlow">
+         <fo:block xsl:use-attribute-sets="topic">
+             <xsl:call-template name="commonattributes"/>
+             <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
+                 <fo:marker marker-class-name="current-topic-number">
+                     <xsl:number format="1"/>
+                 </fo:marker>
+                 <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
+             </xsl:if>
+             <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
+             <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
+                 <xsl:with-param name="type" select="'preface'"/>
+             </xsl:apply-templates>
+             <fo:block xsl:use-attribute-sets="topic.title">
+                 <xsl:call-template name="pullPrologIndexTerms"/>
+                 <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
+                     <xsl:apply-templates select="." mode="getTitle"/>
+                 </xsl:for-each>
+             </fo:block>
+             <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
+         </fo:block>
+     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -33,14 +33,29 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:opentopic="http://www.idiominc.com/opentopic"
-    exclude-result-prefixes="opentopic"
+    exclude-result-prefixes="opentopic xs"
     version="2.0">
 
      <xsl:template name="processTopicPreface">
-         <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.preface">
-             <xsl:call-template name="insertPrefaceStaticContents"/>
-             <fo:flow flow-name="xsl-region-body">
+         <xsl:variable name="expectedPrefaceContext" as="xs:boolean" 
+             select="if (empty(parent::*[contains(@class,' topic/topic ')])) then (true()) else (false())"/>
+         <xsl:choose>
+             <xsl:when test="$expectedPrefaceContext">
+                 <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.preface">
+                     <xsl:call-template name="insertPrefaceStaticContents"/>
+                     <fo:flow flow-name="xsl-region-body">
+                         <xsl:apply-templates select="." mode="processTopicPrefaceInsideFlow"/>
+                     </fo:flow>
+                 </fo:page-sequence>
+             </xsl:when>
+             <xsl:otherwise>
+                 <xsl:apply-templates select="." mode="processTopicPrefaceInsideFlow"/>
+             </xsl:otherwise>
+         </xsl:choose>
+     </xsl:template>
+    <xsl:template match="*" mode="processTopicPrefaceInsideFlow">
                  <fo:block xsl:use-attribute-sets="topic">
                      <xsl:call-template name="commonattributes"/>
                      <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
@@ -61,8 +76,6 @@ See the accompanying LICENSE file for applicable license.
                      </fo:block>
                      <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
                  </fo:block>
-             </fo:flow>
-         </fo:page-sequence>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -40,7 +40,7 @@ See the accompanying LICENSE file for applicable license.
 
      <xsl:template name="processTopicPreface">
          <xsl:variable name="expectedPrefaceContext" as="xs:boolean" 
-             select="if (empty(parent::*[contains(@class,' topic/topic ')])) then (true()) else (false())"/>
+             select="empty(parent::*[contains(@class,' topic/topic ')])"/>
          <xsl:choose>
              <xsl:when test="$expectedPrefaceContext">
                  <fo:page-sequence master-reference="body-sequence" xsl:use-attribute-sets="page-sequence.preface">


### PR DESCRIPTION
If a bookmap is referenced from within another topic reference, FO processing today will crash because it results in an invalid `<fo:page-sequence>` within an `<fo:block>`. For example, as in #2596 :
```
<map>
    <title>Sample</title>
   <topicref href="first.dita">
       <topicref href="bookmap.ditamap" format="ditamap"/>
   </topicref>
```

This problem exists (in separate sections of the code) for `chapter`, `part`, `appendix`, `appendices`, `preface`, and topics as children of `frontmatter`.

This fix does the light-touch change of checking when those bookmap elements are at the root level (or in an otherwise expected context); if so, page sequence is generated, otherwise the content is processed without the page sequence and static content. This allows processing to complete without errors. 

The formatting is a bit odd because you can end up with "Chapter" headings in sub-topics this way, but I'm not sure what *good* formatting would be like in that situation. Another alternative might be to try and process them as simple topics; I'm not sure what the best default is in this case.

## How Has This Been Tested?

Tested by extending the original sample from @raducoravu to use each of the constructs mentioned above; each of those previously crashed, but now the PDF is created.

Also tested with my samples that attempt to use every bookmap construct, to ensure that current processing is not broken:
https://github.com/robander/metadita/tree/master/sampledocs/bookmap

## Type of Changes

Bug fix _(non-breaking change which fixes an issue)_

## Checklist

x I have signed-off my commits per http://www.dita-ot.org/DCO. (Note: I did it as 2 commits because the spacing in our FO code is inconsistent. First commit makes the change but leaves spacing alone, so it's easier to diff. Second commit just fixes indentation to match what came before.)
x Builds & tests completed successfully (`./gradlew test integrationTest`).
x My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
