### PR TITLE
Change label of note type 'danger' in German from 'Vorsicht' to 'Gefa…

### DIFF
--- a/src/main/xsl/common/strings-de-ch.xml
+++ b/src/main/xsl/common/strings-de-ch.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Important">Wichtig</str>
   <str name="Attention">Achtung</str>
   <str name="Caution">ACHTUNG</str>
-  <str name="Danger">VORSICHT</str>
+  <str name="Danger">GEFAHR</str>
   <str name="Remember">Hinweis</str>
   <str name="Restriction">Einschränkung</str>
   <str name="Warning">Warnung</str>

--- a/src/main/xsl/common/strings-de-de.xml
+++ b/src/main/xsl/common/strings-de-de.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Important">Wichtig</str>
   <str name="Attention">Achtung</str>
   <str name="Caution">ACHTUNG</str>
-  <str name="Danger">VORSICHT</str>
+  <str name="Danger">GEFAHR</str>
   <str name="Remember">Hinweis</str>
   <str name="Restriction">Einschränkung</str>
   <str name="Warning">Warnung</str>

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -76,7 +76,7 @@
 
 <div class="cautiontitle">ACHTUNG:</div><div class="note caution">CAUTION</div>
 
-<div class="dangertitle">VORSICHT</div><div class="note danger">DANGER</div>
+<div class="dangertitle">GEFAHR</div><div class="note danger">DANGER</div>
 
 <div class="note fastpath"><span class="fastpathtitle">Direktaufruf:</span> fastpath</div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -76,7 +76,7 @@
 
 <div class="cautiontitle">ACHTUNG:</div><div class="note caution">CAUTION</div>
 
-<div class="dangertitle">VORSICHT</div><div class="note danger">DANGER</div>
+<div class="dangertitle">GEFAHR</div><div class="note danger">DANGER</div>
 
 <div class="note fastpath"><span class="fastpathtitle">Direktaufruf:</span> fastpath</div>
 


### PR DESCRIPTION
Fixed German label for `<note type="danger">`. Changed from `VORSICHT` to `GEFAHR` as suggested by **ANSI Z535.4**, see [NORM 5 – Neue ANSI Z535 – vom vernünftigen Umgang mit Sicherheitshinweisen](http://www.schmeling-consultants.de/uploads/media/NORM_5_Schmeling_ANSI_Z535_neu.pdf), page **21**.