### PR TITLE
Support incorrectly defined absolute external links

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -358,6 +358,16 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <message id="DOTJ075W" type="WARN">
+    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
+    <response>Using 'scope' attribute value 'external'.</response>
+  </message>
+
+  <message id="DOTJ076W" type="WARN">
+    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -567,8 +567,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
         // external resource is filtered here.
         if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope) || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
-                // FIXME: testing for :// here is incorrect, rely on source scope instead
-                || attrValue.toString().contains(COLON_DOUBLE_SLASH) || attrValue.toString().startsWith(SHARP)) {
+                || attrValue.toString().startsWith(SHARP)) {
             return;
         }
 

--- a/src/test/resources/conref/exp/preprocess/lang-common0.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common0.dita
@@ -79,12 +79,12 @@
           class="- topic/xref " type="table"><?ditaot gentext?>Table 1</xref>. Now do it again,
           <xref href="#topic/table" class="- topic/xref " type="table"><?ditaot usertext?>with link
           text</xref>.</p>
-      <p class="- topic/p ">Xref to an external website: <xref href="http://www.ibm.com"
-          format="html" class="- topic/xref "/>. Now do it again, <xref href="http://www.ibm.com"
+      <p class="- topic/p ">Xref to an external website: <xref scope="external" href="http://www.ibm.com"
+          format="html" class="- topic/xref "/>. Now do it again, <xref scope="external" href="http://www.ibm.com"
           format="html" class="- topic/xref "><?ditaot usertext?>with link text</xref>.</p>
       <p class="- topic/p ">Xref to an external website with an anchor: <xref
-          href="http://www.ibm.com/index.html#anchor" format="html" class="- topic/xref "/>. Now do
-        it again, <xref href="http://www.ibm.com/index.html#anchor" format="html"
+          scope="external" href="http://www.ibm.com/index.html#anchor" format="html" class="- topic/xref "/>. Now do
+        it again, <xref scope="external" href="http://www.ibm.com/index.html#anchor" format="html"
           class="- topic/xref "><?ditaot usertext?>with link text</xref>.</p>
       <fig id="fig" class="- topic/fig ">
         <title class="- topic/title ">figure title</title>

--- a/src/test/resources/conref/exp/preprocess/lang-common1.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common1.dita
@@ -79,11 +79,11 @@
           class="- topic/xref " href="#topic/d7e179" type="table"><?ditaot usertext?>with link
           text</xref>.</p>
       <p class="- topic/p ">Xref to an external website: <xref class="- topic/xref " format="html"
-          href="http://www.ibm.com"/>. Now do it again, <xref class="- topic/xref " format="html"
-          href="http://www.ibm.com"><?ditaot usertext?>with link text</xref>.</p>
+          scope="external" href="http://www.ibm.com"/>. Now do it again, <xref class="- topic/xref " format="html"
+          scope="external" href="http://www.ibm.com"><?ditaot usertext?>with link text</xref>.</p>
       <p class="- topic/p ">Xref to an external website with an anchor: <xref class="- topic/xref "
-          format="html" href="http://www.ibm.com/index.html#anchor"/>. Now do it again, <xref
-          class="- topic/xref " format="html" href="http://www.ibm.com/index.html#anchor"
+          format="html" scope="external" href="http://www.ibm.com/index.html#anchor"/>. Now do it again, <xref
+          class="- topic/xref " format="html" scope="external" href="http://www.ibm.com/index.html#anchor"
           ><?ditaot usertext?>with link text</xref>.</p>
       <fig class="- topic/fig " id="d7e168">
         <title class="- topic/title ">figure title</title>

--- a/src/test/resources/conref/src/lang-common0.dita
+++ b/src/test/resources/conref/src/lang-common0.dita
@@ -63,11 +63,11 @@
           href="#topic/table"/>. Now do it again, <xref class="- topic/xref " href="#topic/table"
           >with link text</xref>.</p>
       <p class="- topic/p ">Xref to an external website: <xref class="- topic/xref " format="html"
-          href="http://www.ibm.com"/>. Now do it again, <xref class="- topic/xref " format="html"
-          href="http://www.ibm.com">with link text</xref>.</p>
+         scope="external" href="http://www.ibm.com"/>. Now do it again, <xref class="- topic/xref " format="html"
+         scope="external" href="http://www.ibm.com">with link text</xref>.</p>
       <p class="- topic/p ">Xref to an external website with an anchor: <xref class="- topic/xref "
-          format="html" href="http://www.ibm.com/index.html#anchor"/>. Now do it again, <xref
-          class="- topic/xref " format="html" href="http://www.ibm.com/index.html#anchor">with link
+          format="html" scope="external" href="http://www.ibm.com/index.html#anchor"/>. Now do it again, <xref
+          class="- topic/xref " format="html" scope="external" href="http://www.ibm.com/index.html#anchor">with link
           text</xref>.</p>
       <fig class="- topic/fig " id="fig">
         <title class="- topic/title ">figure title</title>

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -4,6 +4,7 @@ XXX234E=Error {0} reason {1}. Error {0} response {1}.
 PDFX008W=Font definition not found for the logical name or alias ''{0}''.
 DOTX064W=The copy-to attribute [copy-to\="{0}"] uses the name of a file that already exists, so this attribute is ignored.
 DOTX025E=Missing linktext and navtitle for non-DITA resource "{0}". References must provide a local navigation title when the target is not a local DITA resource.
+PDFX012E=Found a table row with more entries than allowed.
 DOTX005E=Unable to find navigation title for reference to ''{0}''. The build will use ''{0}'' as the title in the Eclipse Table of Contents.
 DOTJ043W=The conref push function is trying to replace an element that does not exist (element "{0}" in file "{1}").
 DOTX044E=The area element in an image map does not specify a link target. Please add an xref element with a link target to the area element.
@@ -46,8 +47,8 @@ DOTA067W=Ignoring index-see ''{0}'' inside parent index entry ''{1}'' because th
 DOTX061W=ID ''{0}'' was used in topicref tag but did not reference a topic element. The href attribute on a topicref element should only reference topic level elements.
 DOTJ041E=The attribute conref\="{0}" uses invalid syntax. The value should contain ''\#'' followed by a topic or map ID, optionally followed by ''/elemID'' for a sub-topic element.
 DOTX018I=The type attribute on a topicref was set to ''{0}'', but the topicref references a more specific ''{1}'' topic. Note that the type attribute cascades in maps, so the value ''{0}'' may come from an ancestor topicref.
-DOTX041W=Found more than one title element in a {0} element. Using the first one for the {0}''s title.
 XEPJ003E={0}
+DOTX041W=Found more than one title element in a {0} element. Using the first one for the {0}''s title.
 DOTJ057E=The id attribute value "{0}" is not unique within the topic that contains it.
 DOTA008E=Cannot find the running-header file "{0}". Please double check the value to ensure it is specified correctly.
 DOTX057W=The link or cross reference target ''{0}'' cannot be found, which may cause errors creating links or cross references in your output file.
@@ -67,6 +68,8 @@ DOTA007E=Cannot find the running-footer file "{0}". Please double check the valu
 DOTX056W=The file ''{0}'' is not available to resolve link information.
 DOTX017E=Found a link or cross reference with an empty href attribute (href\=""). Remove the empty href attribute or provide a value.
 PDFX004F=A topic reference was found with href\="". Please specify a target or remove the href attribute.
+DOTJ075W=Absolute link ''{0}'' without correct ''scope'' attribute. Using ''scope'' attribute value ''external''.
+DOTJ076W=Absolute link ''{0}'' without correct ''scope'' attribute.
 DOTA066F=Cannot find the user specified XSLT stylesheet ''{0}''.
 XEPJ001W={0}
 PDFJ003I=Index entry ''{0}'' will be sorted under the "Special characters" heading.
@@ -79,6 +82,7 @@ DOTX036E=Unable to generate link text for a cross reference to a dlentry (the dl
 DOTJ055E=Invalid key name "{0}".
 DOTX055W=Customized stylesheet uses deprecated template "flagit". Conditional processing is no longer supported using this template. Please update your stylesheet to use template "start-flagit" instead of deprecated template "flagit".
 DOTJ035F=The file "{0}" is outside the scope of the input dita/map directory. If you want to lower the severity level, please use the Ant parameter ''outer.control'', and set the value to "warn" or "quiet". Otherwise, move the referenced file "{0}" into the input dita/map directory.
+DOTJ074W=Rev attribute cannot be used with prop filter.
 PDFJ002E=The build failed due to problems encountered when sorting the PDF index. Please address any messages located earlier in the log.
 PDFX002W=There are multiple index terms specified with start\="{0}", but there is only one term to end this range, or the ranges for this term overlap. Ensure that each term with this start value has a matching end value, and that the specified ranges for this value do not overlap
 DOTX035E=Unable to generate the correct number for a cross reference to a footnote\: ''{0}''
@@ -91,6 +95,7 @@ DOTJ053W=Input file ''{0}'' is not valid DITA file name. Please check ''{0}'' to
 PDFJ001E=The PDF indexing process could not find the proper sort location for ''{0}'', so the term has been dropped from the index.
 PDFX001W=There is an index term specified with start\="{0}", but there is no matching end for this term. Add an index term in a valid location with end\="{0}".
 DOTJ049W=The attribute value {0}\="{2}" on element "{1}" does not comply with the specified subject scheme. According to the subject scheme map, the following values are valid for the {0} attribute\: {3}
+DOTJ073E=Email link without correct ''scope'' attribute. Using ''scope'' attribute value ''external''.
 DOTX034E=Unable to generate link text for a cross reference to an undered list item\: ''{0}''
 DOTA004F=Invalid DITA topic extension ''{0}''. Supported values are ''.dita'' and ''.xml''.
 DOTJ069E=Circular key definition {0}.
@@ -102,6 +107,7 @@ DOTJ029I=No ''domains'' attribute was found for element ''<{0}>''. This generall
 DOTJ013E=Failed to parse the referenced file ''{0}''.
 DOTX053E=A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to ''{0}''.
 DOTJ009E=Cannot overwrite file ''{0}'' with file ''{1}''. The modified result may not be consumed by the following steps in the transform pipeline. Check to see whether the file is locked by some other application during the transformation process.
+DOTJ072E=Email link without correct ''format'' attribute. Using ''format'' attribute value ''email''.
 DOTX009W=Could not retrieve a title from ''{0}''. Using ''{1}'' instead.
 DOTX049I=References to non-dita files will be ignored by the PDF, ODT, and RTF output transforms.
 DOTX033E=Unable to generate link text for a cross reference to a list item\: ''{0}''
@@ -118,7 +124,6 @@ DOTJ012F=Failed to parse the input file ''{0}''.
 DOTX012W=When you conref another topic or an item in another topic, the domains attribute of the target topic must be equal to or a subset of the current topic''s domains attribute. Put your target under an appropriate domain. You can see the messages guide for more help.
 DOTJ028E=No format attribute was found on a reference to file ''{0}'', which does not appear to be a DITA file. If this is not a DITA file, set the format attribute to an appropriate value, otherwise set the format attribute to "dita".
 DOTJ071E=Cannot find the specified DITAVAL ''{0}''.
-DOTJ074W=Rev attribute cannot be used with prop filter.
 DOTX048I=In order to include peer or external topic ''{0}'' in your help file, you may need to recompile the CHM file after making the file available.
 DOTX008W=File ''{0}'' cannot be loaded, and no navigation title is specified for the table of contents.
 DOTX071W=Parameter "{0}" on template "{1}" is deprecated. Use parameter "{2}" instead.


### PR DESCRIPTION
When a topic has an external link without external `@scope` attribute, current processing has special handling that results in incorrect output in preprocess2. For example:

```xml
<xref href="http://example.com/topic.html" format="html">topic</xref>
<xref href="http://example.com/topic.dita">topic</xref>
```

This PR changes the preprocess validation filter to fix these in lax processing mode to:

```xml
<xref href="http://example.com/topic.html" format="html" scope="external">topic</xref>
<xref href="http://example.com/topic.dita" scope="external">topic</xref>
```