### PR TITLE
Fix DITA 1.2 XSDs to use version-specific ID #2874

### DIFF
--- a/src/main/plugins/org.oasis-open.dita.v1_2/schema/technicalContent/xsd/ditabase.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_2/schema/technicalContent/xsd/ditabase.xsd
@@ -179,7 +179,7 @@
 
   </xs:redefine>
   
-  <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd"/>  
+  <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:ditabaseMod.xsd:1.2"/>  
 
   <xs:group name="ditabase-info-types">
     <xs:choice>

--- a/src/main/plugins/org.oasis-open.dita.v1_2/schema/technicalContent/xsd/strictTaskbodyConstraintMod.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_2/schema/technicalContent/xsd/strictTaskbodyConstraintMod.xsd
@@ -16,7 +16,7 @@
     </xs:documentation>
   </xs:annotation>
   
-  <xs:redefine schemaLocation="urn:oasis:names:tc:dita:xsd:taskMod.xsd">
+  <xs:redefine schemaLocation="urn:oasis:names:tc:dita:xsd:taskMod.xsd:1.2">
 
     <xs:group name="taskPreStep" xmlns:xs="http://www.w3.org/2001/XMLSchema">  
       <xs:sequence>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

The DITA 1.2 Schemas were supposed to use version-specific identifiers in the `@schemaLocation` references. As noted in #2874, the version number is missing in two locations, which means the schemas do not work properly in environments where "latest module" inclusions resolve to DITA 1.3.

OASIS is not going to issue an errata for this, but could update the copy stored in SVN; either way, we should be able to fix the versions in DITA-OT so that toolkit users can use DITA 1.2 as intended.