### PR TITLE
Use ditafileset for all XSLT processing

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -439,6 +439,7 @@ public final class ExtensibleAntInvoker extends Task {
     public static class FileInfoFilterElem extends ConfElem {
         private String format;
         private Boolean hasConref;
+        private Boolean isInput;
         private Boolean isResourceOnly;
 
         public void setFormat(final String format) {
@@ -449,6 +450,10 @@ public final class ExtensibleAntInvoker extends Task {
             this.hasConref = conref;
         }
 
+        public void setInput(final boolean isInput) {
+            this.isInput = isInput;
+        }
+
         public void setProcessingRole(final String processingRole) {
             this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
         }
@@ -456,6 +461,7 @@ public final class ExtensibleAntInvoker extends Task {
         public Predicate<FileInfo> toFilter() {
             return f -> (format == null || (format.equals(f.format)/* || (format.equals(ATTR_FORMAT_VALUE_DITA) && f.format == null)*/)) &&
                     (hasConref == null || f.hasConref == hasConref) &&
+                    (isInput == null || f.isInput == isInput) &&
                     (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
         }
     }

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -20,6 +20,7 @@ import org.dita.dost.ant.ExtensibleAntInvoker;
 import org.dita.dost.util.Constants;
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.Job.FileInfo;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -35,6 +36,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     private String format;
     private Boolean hasConref;
+    private Boolean isInput;
     private Boolean isResourceOnly;
     private Collection<Resource> res;
     private boolean isFilesystemOnly = true;
@@ -47,9 +49,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (res == null) {
             final Job job = getJob();
             res = new ArrayList<>();
-            for (final Job.FileInfo f : job.getFileInfo(f -> (format == null || (format.equals(f.format)/* || (format.equals(ATTR_FORMAT_VALUE_DITA) && f.format == null)*/)) &&
-                    (hasConref == null || f.hasConref == hasConref) &&
-                    (isResourceOnly == null || f.isResourceOnly == isResourceOnly))) {
+            for (final FileInfo f : job.getFileInfo(this::filter)) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
                 final File tempFile = new File(job.tempDir, f.file.getPath());
                 if (tempFile.exists()) {
@@ -120,8 +120,19 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         this.hasConref = conref;
     }
 
+    public void setInput(final boolean isInput) {
+        this.isInput = isInput;
+    }
+
     public void setProcessingRole(final String processingRole) {
         this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
+    }
+
+    private boolean filter(final FileInfo f) {
+        return (format == null || (format.equals(f.format)/* || (format.equals(ATTR_FORMAT_VALUE_DITA) && f.format == null)*/)) &&
+                (hasConref == null || f.hasConref == hasConref) &&
+                (isInput == null || f.isInput == isInput) &&
+                (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
     }
 
     private static class JobResource extends URLResource {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -790,6 +790,14 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             job.add(fi);
         }
 
+        final FileInfo root = job.getFileInfo(rootFile);
+        if (root == null) {
+            throw new RuntimeException("Unable to set input file to job configuration");
+        }
+        job.add(new FileInfo.Builder(root)
+                .isInput(true)
+                .build());
+
         try {
             logger.info("Serializing job specification");
             if (!job.tempDir.exists() && !job.tempDir.mkdirs()) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -687,6 +687,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             }
         }
 
+        final FileInfo root = job.getFileInfo(rootFile);
+        if (root == null) {
+            throw new RuntimeException("Unable to set input file to job configuration");
+        }
+        job.add(new FileInfo.Builder(root)
+                .isInput(true)
+                .build());
+
         try {
             logger.info("Serializing job specification");
             if (!job.tempDir.exists() && !job.tempDir.mkdirs()) {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -74,6 +74,7 @@ public final class Job {
     private static final String ATTRIBUTE_CONREF_PUSH = "conrefpush";
     private static final String ATTRIBUTE_SUBJECT_SCHEME = "subjectscheme";
     private static final String ATTRIBUTE_HAS_LINK = "has-link";
+    private static final String ATTRIBUTE_INPUT = "input";
     private static final String ATTRIBUTE_COPYTO_SOURCE_LIST = "copy-to-source";
     private static final String ATTRIBUTE_OUT_DITA_FILES_LIST = "out-dita";
     private static final String ATTRIBUTE_CHUNKED_DITAMAP_LIST = "chunked-ditamap";
@@ -102,6 +103,7 @@ public final class Job {
         try {
             attrToFieldMap.put(ATTRIBUTE_CHUNKED, FileInfo.class.getField("isChunked"));
             attrToFieldMap.put(ATTRIBUTE_HAS_LINK, FileInfo.class.getField("hasLink"));
+            attrToFieldMap.put(ATTRIBUTE_INPUT, FileInfo.class.getField("isInput"));
             attrToFieldMap.put(ATTRIBUTE_HAS_CONREF, FileInfo.class.getField("hasConref"));
             attrToFieldMap.put(ATTRIBUTE_HAS_KEYREF, FileInfo.class.getField("hasKeyref"));
             attrToFieldMap.put(ATTRIBUTE_HAS_CODEREF, FileInfo.class.getField("hasCoderef"));
@@ -609,6 +611,8 @@ public final class Job {
         public boolean isFlagImage;
         /** Source file is outside base directory. */
         public boolean isOutDita;
+        /** File is input document that is used as processing root. */
+        public boolean isInput;
 
         FileInfo(final URI src, final URI uri, final File file) {
             if (uri == null && file == null) throw new IllegalArgumentException(new NullPointerException());
@@ -639,6 +643,7 @@ public final class Job {
                     ", isResourceOnly=" + isResourceOnly +
                     ", isTarget=" + isTarget +
                     ", isConrefPush=" + isConrefPush +
+                    ", isInput=" + isInput +
                     ", hasKeyref=" + hasKeyref +
                     ", hasCoderef=" + hasCoderef +
                     ", isSubjectScheme=" + isSubjectScheme +
@@ -652,48 +657,31 @@ public final class Job {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             FileInfo fileInfo = (FileInfo) o;
-
-            if (hasConref != fileInfo.hasConref) return false;
-            if (isChunked != fileInfo.isChunked) return false;
-            if (hasLink != fileInfo.hasLink) return false;
-            if (isResourceOnly != fileInfo.isResourceOnly) return false;
-            if (isTarget != fileInfo.isTarget) return false;
-            if (isConrefPush != fileInfo.isConrefPush) return false;
-            if (hasKeyref != fileInfo.hasKeyref) return false;
-            if (hasCoderef != fileInfo.hasCoderef) return false;
-            if (isSubjectScheme != fileInfo.isSubjectScheme) return false;
-            if (isSubtarget != fileInfo.isSubtarget) return false;
-            if (isFlagImage != fileInfo.isFlagImage) return false;
-            if (isOutDita != fileInfo.isOutDita) return false;
-            if (src != null ? !src.equals(fileInfo.src) : fileInfo.src != null) return false;
-            if (!uri.equals(fileInfo.uri)) return false;
-            if (!file.equals(fileInfo.file)) return false;
-            if (result != null ? !result.equals(fileInfo.result) : fileInfo.result != null) return false;
-            return format != null ? format.equals(fileInfo.format) : fileInfo.format == null;
+            return hasConref == fileInfo.hasConref &&
+                    isChunked == fileInfo.isChunked &&
+                    hasLink == fileInfo.hasLink &&
+                    isResourceOnly == fileInfo.isResourceOnly &&
+                    isTarget == fileInfo.isTarget &&
+                    isConrefPush == fileInfo.isConrefPush &&
+                    hasKeyref == fileInfo.hasKeyref &&
+                    hasCoderef == fileInfo.hasCoderef &&
+                    isSubjectScheme == fileInfo.isSubjectScheme &&
+                    isSubtarget == fileInfo.isSubtarget &&
+                    isFlagImage == fileInfo.isFlagImage &&
+                    isOutDita == fileInfo.isOutDita &&
+                    isInput == fileInfo.isInput &&
+                    Objects.equals(src, fileInfo.src) &&
+                    Objects.equals(uri, fileInfo.uri) &&
+                    Objects.equals(file, fileInfo.file) &&
+                    Objects.equals(result, fileInfo.result) &&
+                    Objects.equals(format, fileInfo.format);
         }
 
         @Override
         public int hashCode() {
-            int result1 = src != null ? src.hashCode() : 0;
-            result1 = 31 * result1 + uri.hashCode();
-            result1 = 31 * result1 + file.hashCode();
-            result1 = 31 * result1 + (result != null ? result.hashCode() : 0);
-            result1 = 31 * result1 + (format != null ? format.hashCode() : 0);
-            result1 = 31 * result1 + (hasConref ? 1 : 0);
-            result1 = 31 * result1 + (isChunked ? 1 : 0);
-            result1 = 31 * result1 + (hasLink ? 1 : 0);
-            result1 = 31 * result1 + (isResourceOnly ? 1 : 0);
-            result1 = 31 * result1 + (isTarget ? 1 : 0);
-            result1 = 31 * result1 + (isConrefPush ? 1 : 0);
-            result1 = 31 * result1 + (hasKeyref ? 1 : 0);
-            result1 = 31 * result1 + (hasCoderef ? 1 : 0);
-            result1 = 31 * result1 + (isSubjectScheme ? 1 : 0);
-            result1 = 31 * result1 + (isSubtarget ? 1 : 0);
-            result1 = 31 * result1 + (isFlagImage ? 1 : 0);
-            result1 = 31 * result1 + (isOutDita ? 1 : 0);
-            return result1;
+            return Objects.hash(src, uri, file, result, format, hasConref, isChunked, hasLink, isResourceOnly, isTarget,
+                    isConrefPush, hasKeyref, hasCoderef, isSubjectScheme, isSubtarget, isFlagImage, isOutDita, isInput);
         }
 
         public static class Builder {
@@ -715,6 +703,7 @@ public final class Job {
             private boolean isSubtarget;
             private boolean isFlagImage;
             private boolean isOutDita;
+            private boolean isInput;
 
             public Builder() {}
             public Builder(final FileInfo orig) {
@@ -735,6 +724,7 @@ public final class Job {
                 isSubtarget = orig.isSubtarget;
                 isFlagImage = orig.isFlagImage;
                 isOutDita = orig.isOutDita;
+                isInput = orig.isInput;
             }
 
             /**
@@ -758,6 +748,7 @@ public final class Job {
                 if (orig.isSubtarget) isSubtarget = orig.isSubtarget;
                 if (orig.isFlagImage) isFlagImage = orig.isFlagImage;
                 if (orig.isOutDita) isOutDita = orig.isOutDita;
+                if (orig.isInput) isInput = orig.isInput;
                 return this;
             }
 
@@ -799,6 +790,7 @@ public final class Job {
             public Builder isSubtarget(final boolean isSubtarget) { this.isSubtarget = isSubtarget; return this; }
             public Builder isFlagImage(final boolean isFlagImage) { this.isFlagImage = isFlagImage; return this; }
             public Builder isOutDita(final boolean isOutDita) { this.isOutDita = isOutDita; return this; }
+            public Builder isInput(final boolean isInput) { this.isInput = isInput; return this; }
 
             public FileInfo build() {
                 if (uri == null && file == null) {
@@ -821,6 +813,7 @@ public final class Job {
                 fi.isSubtarget = isSubtarget;
                 fi.isFlagImage = isFlagImage;
                 fi.isOutDita = isOutDita;
+                fi.isInput = isInput;   
                 return fi;
             }
 

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -181,7 +181,7 @@ See the accompanying LICENSE file for applicable license.
     description="Resolve input map files keyref">
     <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.KeyrefModule">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
         <param name="transtype" value="${transtype}"/>
       </module>
     </pipeline>
@@ -199,7 +199,7 @@ See the accompanying LICENSE file for applicable license.
     description="Resolve input map files conref push">
     <pipeline message="Resolve conref push." taskname="conref-push">
       <module class="org.dita.dost.module.ConrefPushModule">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
       </module>
     </pipeline>  
   </target>
@@ -215,7 +215,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/map-conref.xsl" filenameparameter="file-being-processed">
-        <ditaFileset format="ditamap" conref="true"/>
+        <ditafileset format="ditamap" conref="true"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -229,7 +229,7 @@ See the accompanying LICENSE file for applicable license.
     description="Profile input map files">
     <pipeline message="Profile filtering." taskname="profile">
       <module class="org.dita.dost.module.FilterModule">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
         <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
         <param name="transtype" value="${transtype}"/>
       </module>
@@ -278,7 +278,7 @@ See the accompanying LICENSE file for applicable license.
           description="Resolve keyref">
     <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.KeyrefModule">
-        <ditaFileset format="dita"/>
+        <ditafileset format="dita"/>
         <param name="transtype" value="${transtype}"/>
       </module>
     </pipeline>
@@ -297,8 +297,8 @@ See the accompanying LICENSE file for applicable license.
           description="Resolve conref push">
     <pipeline message="Resolve conref push." taskname="conref-push">
       <module class="org.dita.dost.module.ConrefPushModule">
-        <ditaFileset format="dita"/>
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="dita"/>
+        <ditafileset format="ditamap"/>
       </module>
     </pipeline>
   </target>
@@ -314,8 +314,8 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl" filenameparameter="file-being-processed">
-        <ditaFileset conref="true" format="dita"/>
-        <ditaFileset conref="true" format="ditamap"/>
+        <ditafileset conref="true" format="dita"/>
+        <ditafileset conref="true" format="ditamap"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -329,7 +329,7 @@ See the accompanying LICENSE file for applicable license.
           description="Profile input files">
     <pipeline message="Profile filtering." taskname="profile">
       <module class="org.dita.dost.module.FilterModule">
-        <ditaFileset format="dita"/>
+        <ditafileset format="dita"/>
         <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
         <param name="transtype" value="${transtype}"/>
       </module>
@@ -346,7 +346,7 @@ See the accompanying LICENSE file for applicable license.
           description="Normalize same topic fragment identifiers and table column names, and resolve coderef">
     <pipeline message="Resolve topic fragment." taskname="topic-fragment">
       <sax>
-        <ditaFileset format="dita"/>
+        <ditafileset format="dita"/>
         <filter class="org.dita.dost.writer.TopicFragmentFilter">
           <param name="attributes" value="href"/>
         </filter>
@@ -406,7 +406,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl">
-        <ditaFileset format="dita"/>
+        <ditafileset format="dita"/>
         <param name="TABLELINK" expression="${args.tablelink.style}" if:set="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if:set="args.figurelink.style" />
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if:set="onlytopic.in.map"/>
@@ -427,7 +427,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.clean-map}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/clean-map.xsl">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
     </pipeline>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -190,8 +190,8 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Profile filtering." taskname="profile"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.FilterModule">
-        <ditaFileset format="dita"/>
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="dita"/>
+        <ditafileset format="ditamap"/>
         <!--param name="ditadir" location="${dita.dir}"/-->
         <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
         <!--param name="inputdir" location="${args.input.dir}" if:set="args.input.dir"/-->
@@ -236,8 +236,8 @@ See the accompanying LICENSE file for applicable license.
     description="Resolve conref push">
     <pipeline message="Resolve conref push." taskname="conref-push">
       <module class="org.dita.dost.module.ConrefPushModule">
-        <ditaFileset format="dita"/>
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="dita"/>
+        <ditafileset format="ditamap"/>
       </module>
     </pipeline>
     <job-helper file="conref.list" property="conreflist"/>
@@ -276,7 +276,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl" filenameparameter="file-being-processed">
-        <ditaFileset conref="true"/>
+        <ditafileset conref="true"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -358,7 +358,7 @@ See the accompanying LICENSE file for applicable license.
             reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"
             filenameparameter="file-being-processed">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
         <param name="TRANSTYPE" expression="${transtype}" />
         <param name="child-topicref-warning" expression="false"/>
         <param name="keep-submap-href" expression="false"/>
@@ -466,7 +466,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
         style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl">
-        <ditaFileset format="dita"/>
+        <ditafileset format="dita"/>
         <param name="TABLELINK" expression="${args.tablelink.style}" if:set="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if:set="args.figurelink.style" />
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if:set="onlytopic.in.map"/>
@@ -497,7 +497,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.clean-map}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/clean-map.xsl">
-        <ditaFileset format="ditamap"/>
+        <ditafileset format="ditamap"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
     </pipeline>

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -107,11 +107,10 @@ See the accompanying LICENSE file for applicable license.
         <xslt
               basedir="${dita.temp.dir}"
               destdir="${dita.output.dir}"
-              includesfile="${dita.temp.dir}/${fullditamapfile}"
               extension=".xml"
               classpathref="dost.class.path"
               style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
-          <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
+            <ditaFileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
             <param name="defaultLanguage" expression="${default.language}"/>
@@ -125,10 +124,9 @@ See the accompanying LICENSE file for applicable license.
         <xslt
             basedir="${dita.temp.dir}"
             destdir="${dita.output.dir}"
-            includesfile="${dita.temp.dir}/${fullditamapfile}"
             classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
-          <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
+            <ditaFileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
             <param name="defaultLanguage" expression="${default.language}"/>

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -104,11 +104,9 @@ See the accompanying LICENSE file for applicable license.
     <target name="dita.map.eclipse.toc" unless="noMap"
             depends="dita.map.eclipse.plugin.init" if="old.transform"
             description="Build EclipseHelp TOC file">
-        <xslt
-              basedir="${dita.temp.dir}"
-              destdir="${dita.output.dir}"
+      <pipeline>
+        <xslt destdir="${dita.output.dir}"
               extension=".xml"
-              classpathref="dost.class.path"
               style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
             <ditaFileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
@@ -116,15 +114,15 @@ See the accompanying LICENSE file for applicable license.
             <param name="defaultLanguage" expression="${default.language}"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
+      </pipeline>
     </target>
     
     <target name="dita.out.map.eclipse.toc" unless="noMap"
         depends="dita.map.eclipse.plugin.init" if="inner.transform"
         description="Build EclipseHelp TOC file">
+      <pipeline>
         <xslt
-            basedir="${dita.temp.dir}"
             destdir="${dita.output.dir}"
-            classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
             <ditaFileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
@@ -134,6 +132,7 @@ See the accompanying LICENSE file for applicable license.
             <mapper classname="org.dita.dost.ant.types.JobMapper" to=".xml"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
+      </pipeline>
     </target>
     
     <target name="dita.map.eclipse.index" unless="noMap"
@@ -182,10 +181,10 @@ See the accompanying LICENSE file for applicable license.
             unless="noPlugin"
             depends="dita.map.eclipse.plugin.init" if="old.transform"
             description="Build Eclipsehelp plugin file">
+      <pipeline>
         <xslt
               in="${dita.temp.dir}/${user.input.file}"
               out="${dita.map.output.dir}/plugin.xml"
-              classpathref="dost.class.path"
               style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
             <param name="TOCROOT" expression="${dita.map.filename.root}" />
             <param name="version"
@@ -202,16 +201,17 @@ See the accompanying LICENSE file for applicable license.
                   expression="dita.eclipse.plugin"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
+      </pipeline>
     </target>
     
     <target name="dita.out.map.eclipse.plugin"
         unless="noPlugin"
         depends="dita.map.eclipse.plugin.init" if="inner.transform"
         description="Build Eclipsehelp plugin file">
+      <pipeline>  
         <xslt
             in="${dita.temp.dir}/${user.input.file}"
             out="${dita.output.dir}/plugin.xml"
-            classpathref="dost.class.path"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
             <param name="TOCROOT" expression="${dita.map.filename.root}" />
             <param name="version"
@@ -228,6 +228,7 @@ See the accompanying LICENSE file for applicable license.
                   expression="dita.eclipse.plugin"/>
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
+      </pipeline>
     </target>
   
   <!-- New support for creating Eclipse fragments based on the similar map used to create a plug-in -->
@@ -238,10 +239,10 @@ See the accompanying LICENSE file for applicable license.
     unless="noPlugin"
     depends="dita.map.eclipse.plugin.init" if="old.transform"
     description="Build Eclipsehelp manifest.mf file">
+    <pipeline>
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
       out="${dita.map.output.dir}/META-INF/MANIFEST.MF"
-      classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <param name="version"
         expression="${args.eclipse.version}"
@@ -265,16 +266,17 @@ See the accompanying LICENSE file for applicable license.
         expression="dita.eclipse.manifest"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
+    </pipeline>
   </target>
   
   <target name="dita.out.map.eclipse.manifest.file"
     unless="noPlugin"
     depends="dita.map.eclipse.plugin.init" if="inner.transform"
     description="Build Eclipsehelp manifest.mf file">
+    <pipeline>
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
       out="${dita.map.output.dir}/META-INF/MANIFEST.MF"
-      classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <param name="version"
         expression="${args.eclipse.version}"
@@ -298,6 +300,7 @@ See the accompanying LICENSE file for applicable license.
         expression="dita.eclipse.manifest"/>
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
+    </pipeline>
   </target>
   
   
@@ -305,10 +308,10 @@ See the accompanying LICENSE file for applicable license.
     unless="noPlugin"
     depends="dita.map.eclipse.plugin.init" if="old.transform"
     description="Create eclipse plugin.properties file">
+    <pipeline>
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
       out="${dita.output.dir}/plugin.properties"
-      classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <outputproperty value="text" name="method"/>
       <param name="dita.plugin.output" 
@@ -321,16 +324,17 @@ See the accompanying LICENSE file for applicable license.
           if="args.eclipse.provider" />
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
+    </pipeline>
   </target>
   
   <target name="dita.out.map.eclipse.plugin.properties"
     unless="noPlugin"
     depends="dita.map.eclipse.plugin.init" if="inner.transform"
     description="Create eclipse plugin.properties file">
+    <pipeline>
     <xslt
       in="${dita.temp.dir}/${user.input.file}"
       out="${dita.output.dir}/plugin.properties"
-      classpathref="dost.class.path"
       style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2plugin.xsl">
       <outputproperty value="text" name="method"/>
       <param name="dita.plugin.output" expression="dita.eclipse.properties"/>
@@ -342,6 +346,7 @@ See the accompanying LICENSE file for applicable license.
           if="args.eclipse.provider" />
       <xmlcatalog refid="dita.catalog"/>
     </xslt>
+    </pipeline>
   </target>
   
   <target name="dita.map.eclipse.fragment.language.init" if="eclipse.fragment.language"

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -108,7 +108,7 @@ See the accompanying LICENSE file for applicable license.
         <xslt destdir="${dita.output.dir}"
               extension=".xml"
               style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
-            <ditaFileset format="ditamap" processingRole="normal"/>
+            <ditafileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
             <param name="defaultLanguage" expression="${default.language}"/>
@@ -124,7 +124,7 @@ See the accompanying LICENSE file for applicable license.
         <xslt
             destdir="${dita.output.dir}"
             style="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/map2eclipse.xsl">
-            <ditaFileset format="ditamap" processingRole="normal"/>
+            <ditafileset format="ditamap" processingRole="normal"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="WORKDIR" expression="${workdir}" if="workdir"/>
             <param name="defaultLanguage" expression="${default.language}"/>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -180,15 +180,13 @@ See the accompanying LICENSE file for applicable license.
     <element name="params" optional="true" implicit="true"/>
     <sequential>
       <pipeline message="Convert DITA topic to HTML5" taskname="xslt">
-      <xslt basedir="${dita.temp.dir}"
-            destdir="${dita.output.dir}"
+      <xslt destdir="${dita.output.dir}"
             reloadstylesheet="${dita.html5.reloadstylesheet}"
-            classpathref="dost.class.path"
             extension="${out.ext}"
             style="${args.xsl}"
             filenameparameter="FILENAME"
             filedirparameter="FILEDIR">
-        <ditaFileset format="dita" processingRole="normal"/>
+        <ditafileset format="dita" processingRole="normal"/>
         <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile"/>
         <param name="CSS" expression="${args.css.file}" if="args.css.file"/>
         <param name="CSSPATH" expression="${user.csspath}" if="user.csspath"/>
@@ -222,11 +220,9 @@ See the accompanying LICENSE file for applicable license.
         <isset property="inner.transform"/>
       </condition>
       <pipeline message="Convert DITA map to HTML5" taskname="xslt">
-      <xslt basedir="${dita.temp.dir}"
-            destdir="${html5.toc.output.dir}"
-            includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
-            classpathref="dost.class.path"
+      <xslt destdir="${html5.toc.output.dir}"
             style="${args.html5.toc.xsl}">
+        <ditafileset input="true"/>
         <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile"/>
         <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
         <param name="contenttarget" expression="${args.html5.contenttarget}" if="args.html5.contenttarget"/>

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -82,19 +82,18 @@ See the accompanying LICENSE file for applicable license.
     <condition property="htmlhelp.hhp.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
-    <xslt basedir="${dita.temp.dir}"
-          destdir="${htmlhelp.hhp.output.dir}"
-          includesfile="${dita.temp.dir}/${user.input.file.listfile}"
-          classpathref="dost.class.path"
+    <pipeline>
+    <xslt destdir="${htmlhelp.hhp.output.dir}"
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhp.xsl">
-      <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
+      <ditafileset input="true" processingRole="normal"/>
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
       <param name="HHCNAME" expression="${args.output.base}.hhc"/>
       <param name="INCLUDEFILE" expression="${args.htmlhelp.includefile}" if="args.htmlhelp.includefile"/>
       <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
-      <mergemapper to="${args.output.base}.hhp"/>
+      <mapper type="merge" to="${args.output.base}.hhp"/>
     </xslt>
+    </pipeline>
   </target>
 
   <target name="dita.map.htmlhelp.hhc" depends="dita.map.htmlhelp.init"
@@ -103,17 +102,16 @@ See the accompanying LICENSE file for applicable license.
     <condition property="htmlhelp.hhc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
-    <xslt basedir="${dita.temp.dir}"
-          destdir="${htmlhelp.hhc.output.dir}"
-          includesfile="${dita.temp.dir}/${user.input.file.listfile}"
-          classpathref="dost.class.path"
+    <pipeline>
+    <xslt destdir="${htmlhelp.hhc.output.dir}"
           style="${dita.plugin.org.dita.htmlhelp.dir}/xsl/map2hhc.xsl">
-      <excludesfile name="${dita.temp.dir}/${resourceonlyfile}" if="resourceonlyfile"/>
+      <ditafileset input="true" processingRole="normal"/>
       <param name="OUTEXT" expression="${out.ext}" if="out.ext"/>
       <param name="defaultLanguage" expression="${default.language}"/>
       <xmlcatalog refid="dita.catalog"/>
-      <mergemapper to="${args.output.base}.hhc"/>
+      <mapper type="merge" to="${args.output.base}.hhc"/>
     </xslt>
+    </pipeline>
   </target>
 
   <target name="dita.map.htmlhelp.hhk" depends="dita.map.htmlhelp.init"

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -300,6 +300,7 @@ with those set forth herein.
     <makeurl property="user.input.dir.url" file="${user.input.dir}" validate="no"/>    
     <makeurl property="variable.file.url" file="${variable.file}" validate="no"/>
 
+    <pipeline>
     <xslt style="${temp.transformation.file}"
           in="${dita.temp.dir}/stage1.xml"
           out="${dita.temp.dir}/stage2.fo">
@@ -327,6 +328,7 @@ with those set forth herein.
         <catalogpath path="${xml.catalog.files}"/>
       </xmlcatalog>
     </xslt>
+    </pipeline>
   </target>
 
   <target name="transform.topic2fo.i18n"

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
       <pipeline>
       <xslt destdir="${xhtml.toc.output.dir}"
             style="${args.xhtml.toc.xsl}">
-        <ditaFileset input="true"/>
+        <ditafileset input="true"/>
         <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
         <param name="contenttarget" expression="${args.xhtml.contenttarget}" if="args.xhtml.contenttarget"/>
         <param name="CSS" expression="${args.css.file}" if="args.css.file" />
@@ -79,7 +79,7 @@ See the accompanying LICENSE file for applicable license.
       <pipeline>
         <xslt destdir="${dita.output.dir}"
               style="${args.xhtml.toc.xsl}">
-            <ditaFileset input="true"/>
+            <ditafileset input="true"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="contenttarget" expression="${args.xhtml.contenttarget}" if="args.xhtml.contenttarget"/>
             <param name="CSS" expression="${args.css.file}" if="args.css.file" />

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -53,39 +53,33 @@ See the accompanying LICENSE file for applicable license.
       <local name="xhtml.toc.output.dir"/>
       <condition property="xhtml.toc.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
        <isset property="inner.transform"/>
-      </condition>      
-      <xslt
-        basedir="${dita.temp.dir}"
-        destdir="${xhtml.toc.output.dir}"
-        includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
-        classpathref="dost.class.path"
-        style="${args.xhtml.toc.xsl}">
-        <!--excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/-->
+      </condition>
+      <pipeline>
+      <xslt destdir="${xhtml.toc.output.dir}"
+            style="${args.xhtml.toc.xsl}">
+        <ditaFileset input="true"/>
         <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
         <param name="contenttarget" expression="${args.xhtml.contenttarget}" if="args.xhtml.contenttarget"/>
         <param name="CSS" expression="${args.css.file}" if="args.css.file" />
         <param name="CSSPATH" expression="${user.csspath}" if="user.csspath" />
         <param name="OUTPUTCLASS" expression="${args.xhtml.toc.class}" if="args.xhtml.toc.class" />
         <params/>
-        <mergemapper to="${args.xhtml.toc}${out.ext}"/>
+        <mapper type="merge" to="${args.xhtml.toc}${out.ext}"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
+      </pipeline>
     </sequential>
   </macrodef>
-    
 
     <!-- Deprecated since 2.1 -->
     <target name="dita.out.map.xhtml.toc"
             unless="noMap" if="inner.transform"
             description="Build HTML TOC file,which will adjust the directory">
         <dita-ot-echo id="DOTX070W"><param name="1" value="dita.out.map.xhtml.toc"/></dita-ot-echo>
-        <xslt
-              basedir="${dita.temp.dir}"
-              destdir="${dita.output.dir}"
-              includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
-              classpathref="dost.class.path"
+      <pipeline>
+        <xslt destdir="${dita.output.dir}"
               style="${args.xhtml.toc.xsl}">
-          <!--excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/-->
+            <ditaFileset input="true"/>
             <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
             <param name="contenttarget" expression="${args.xhtml.contenttarget}" if="args.xhtml.contenttarget"/>
             <param name="CSS" expression="${args.css.file}" if="args.css.file" />
@@ -97,6 +91,7 @@ See the accompanying LICENSE file for applicable license.
                     to="${args.xhtml.toc}${out.ext}" />
           <xmlcatalog refid="dita.catalog"/>
         </xslt>
+      </pipeline>
     </target>
     
   <target name="copy-revflag" if="dita.input.valfile">

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -141,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
         extension="${out.ext}" style="${args.xsl}"
         filenameparameter="FILENAME"
         filedirparameter="FILEDIR">
-        <ditaFileset format="dita" processingRole="normal"/>
+        <ditafileset format="dita" processingRole="normal"/>
         <param name="TRANSTYPE" expression="${transtype}" />
         <param name="FILTERFILE" expression="${dita.input.valfile.url}"
           if="dita.input.valfile" />


### PR DESCRIPTION
## Description
Use `<ditafileset>` custom [resource collection](https://ant.apache.org/manual/Types/resources.html#collection) in XSLT processing and replace built-in Ant `<xslt>` use with `<pipeline>` XSLT module.

## Motivation and Context
Using a custom task for XSLT processing will allow more control over XSLT, e.g. custom extension and using job configuration to select files.
