### PR TITLE
Strip redundant whitespace from domains attribute

### DIFF
--- a/src/main/java/org/dita/dost/writer/NormalizeFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeFilter.java
@@ -13,6 +13,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
+import java.util.regex.Pattern;
+
 import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.*;
 
@@ -21,12 +23,13 @@ import static org.dita.dost.util.Constants.*;
  * 
  * <ul>
  *   <li>Add default metadata {@code cascade} attribute value.</li>
+ *   <li>Strip redundant whitespace from {@code domains} attribute value.</li>
  * </ul>
  */
 public final class NormalizeFilter extends AbstractXMLFilter {
 
+    private final Pattern whitespace = Pattern.compile("\\s+");
     private Configuration.Mode processingMode;
-
     private int depth;
 
     public NormalizeFilter() {
@@ -48,16 +51,29 @@ public final class NormalizeFilter extends AbstractXMLFilter {
             super.startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
         }
 
-        final AttributesImpl res = new AttributesImpl(atts);
+        AttributesImpl res = null;
         final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
         if (MAP_MAP.matches(cls)) {
-            if (res.getIndex(ATTRIBUTE_NAME_CASCADE) == -1) {
+            if (atts.getIndex(ATTRIBUTE_NAME_CASCADE) == -1) {
+                if (res == null) {
+                    res = new AttributesImpl(atts);
+                }
                 XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_CASCADE,
                         configuration.getOrDefault("default.cascade", ATTRIBUTE_CASCADE_VALUE_MERGE));
             }
         }
+        if (MAP_MAP.matches(cls) || TOPIC_TOPIC.matches(cls)) {
+            final String domains = atts.getValue(ATTRIBUTE_NAME_DOMAINS);
+            if (domains != null) {
+                final String normalized = whitespace.matcher(domains.trim()).replaceAll(" ");
+                if (res == null) {
+                    res = new AttributesImpl(atts);
+                }
+                XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_DOMAINS, normalized);
+            }
+        }
 
-        getContentHandler().startElement(uri, localName, qName, res);
+        getContentHandler().startElement(uri, localName, qName, res != null ? res : atts);
     }
 
     @Override

--- a/src/test/java/org/dita/dost/writer/NormalizeFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeFilterTest.java
@@ -16,7 +16,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import static javax.xml.XMLConstants.NULL_NS_URI;
 import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class NormalizeFilterTest {
 
@@ -33,6 +33,24 @@ public class NormalizeFilterTest {
         });
         f.startElement(NULL_NS_URI, MAP_MAP.localName, MAP_MAP.localName, new XMLUtils.AttributesBuilder()
                 .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString()).build());
+    }
+
+    @Test
+    public void testDomains() throws Exception {
+        final NormalizeFilter f = new NormalizeFilter();
+        f.setLogger(new TestUtils.TestLogger());
+        f.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(String uri, String localName,
+                                     String qName, Attributes attributes) throws SAXException {
+                assertEquals("(topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)",
+                        attributes.getValue(ATTRIBUTE_NAME_DOMAINS));
+            }
+        });
+        f.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new XMLUtils.AttributesBuilder()
+                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                .add(ATTRIBUTE_NAME_DOMAINS, "(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    ")
+                .build());
     }
 
     @Test


### PR DESCRIPTION
Strip redundant whitespace from `@domains` attribute. This improves readability of the temporary topics and maps.

Use lazy initialization for result `AttributesImpl` to reduce object creation as a performance optimization.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>
