### PR TITLE
Update Saxon from 9.8.0-5 to 9.8.0-7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile group: 'xerces', name: 'xercesImpl', version:'2.11.0'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     compile group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
-    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.8.0-5'
+    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.8.0-7'
     compile group: 'com.ibm.icu', name: 'icu4j', version:'57.1'
     compile group: 'org.apache.ant', name: 'ant', version:'1.10.1'
     compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.10.1'


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Updates the bundled version of Saxon to get latest fixes.

## Motivation and Context

As reported in #2887, the latest Saxon update restores the ability to run XSLT 1.0 based stylesheets, which would allow many existing plugins from older toolkit releases to work in 3.0 without migration.

## How Has This Been Tested?

Ran our tests locally and on Travis with the updated version, all passed.

## Type of Changes

Bug fix / enhancement -- updates our bundled version of Saxon to latest in order to get latest Saxon fixes and enhancements.

## Checklist

X I have signed-off my commits per http://www.dita-ot.org/DCO.
X Builds & tests completed successfully (`./gradlew test integrationTest`).
X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
