### PR TITLE
Fix format tracking for non-DITA resources #2867

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -9,6 +9,8 @@
 package org.dita.dost.module.reader;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MultimapBuilder.SetMultimapBuilder;
+import com.google.common.collect.SetMultimap;
 import org.apache.commons.io.FileUtils;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.dita.dost.exception.DITAOTException;
@@ -71,7 +73,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     /** Set of all images used for flagging */
     private final Set<URI> flagImageSet = new LinkedHashSet<>(128);
     /** Set of all HTML and other non-DITA or non-image files */
-    final Set<URI> htmlSet = new HashSet<>(128);
+    final SetMultimap<String, URI> htmlSet = SetMultimapBuilder.hashKeys().hashSetValues().build();
     /** Set of all the href targets */
     private final Set<URI> hrefTargetSet = new HashSet<>(128);
     /** Set of all the conref targets */
@@ -628,8 +630,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             f.isFlagImage = true;
             f.format = ATTR_FORMAT_VALUE_IMAGE;
         }
-        for (final URI file: htmlSet) {
-            getOrCreateFileInfo(fileinfos, file).format = ATTR_FORMAT_VALUE_HTML;
+        for (final String format: htmlSet.keySet()) {
+            for (final URI file : htmlSet.get(format)) {
+                getOrCreateFileInfo(fileinfos, file).format = format;
+            }
         }
         for (final URI file: hrefTargetSet) {
             getOrCreateFileInfo(fileinfos, file).isTarget = true;

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -142,7 +142,7 @@ public final class MapReaderModule extends AbstractReaderModule {
             } else if (ATTR_FORMAT_VALUE_DITAVAL.equals(file.format)) {
                 formatSet.add(file);
             } else {
-                htmlSet.add(file.filename);
+                htmlSet.put(file.format, file.filename);
             }
         }
     }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -268,7 +268,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
                     logger.warn(MessageUtils.getMessage("DOTX008W", file.filename.toString()).toString());
                 }
             } else {
-                htmlSet.add(file.filename);
+                htmlSet.put(file.format, file.filename);
             }
         }
     }


### PR DESCRIPTION
Correct `@format` tracking for non-DITA resources. The previous code always assumes `html` format for non-DITA resources. LWDITA plugin adds HDITA processing, thus `html` cannot be used as a generic magic value for non-DITA resources. This change uses the actual `@format` value in the job configuration instead of `html`.