### PR TITLE
Make import explicit to work around Saxon caching on Windows

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2742,6 +2742,6 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:include href="css-class.xsl"/>
-  <xsl:include href="functions.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/functions.xsl"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This is an odd one because it's a platform-specific workaround for Saxon that does not change any designs or add any new code, and is only relevant on Windows.

We have two different files in 3.0 named `functions.xsl`:
`xsl/common/functions.xsl`
and
`plugins/org.dita.html5/xsl/functions.xsl`

Our HTML5 code uses both of these, as might be expected. This works fine on Travis, and fine on Mac / Linux.

On my Windows machine (and on at least one other Windows machine, as reported in Slack) this causes build failures in some cases when building HTML5. Before the failure I get erroneous "duplicate import" messages from Saxon about `functions.xsl`. I eventually tracked it down to the include line in HTML5's `topic.xsl`, which should include a file from the HTML5 directory:
`<xsl:include href="functions.xsl"/>`

When that is evaluated on my machine - _in some cases but not all cases_ - Saxon pulls in a cached copy of `functions.xsl` from the common directory. This results in the "duplicate import" warning, and is followed by a build failure when functions called by the HTML5 code are not found. My build results in the following (followed by a lot more static errors about functions):
```
html5.map.toc:
     [xslt] Transforming into C:\DITA-OT\dita-ot-3.0.2\docsrc\out
     [xslt] Warning at xsl:stylesheet on line 15 column 40 of functions.xsl:
     [xslt]   Stylesheet module functions.xsl is included or imported more than once. This is permitted,
     [xslt]   but may lead to errors or unexpected behavior
     [xslt] Warning at xsl:stylesheet on line 12 column 59 of map2html5Impl.xsl:

     [xslt]   Stylesheet module plugin:org.dita.html5:xsl/map2html5Impl.xsl is included or imported more
     [xslt]   than once. This is permitted, but may lead to errors or unexpected behavior
     [xslt] Static error near {...dita-ot:get-element-id(@hre...} in expression in xsl:value-of/@select on line 321 column 113 of rel-links.xsl:
     [xslt]   XPST0017: Cannot find a 2-argument function named
     [xslt]   {http://dita-ot.sourceforge.net/ns/201007/dita-ot}generate-id()
```

This does not happen with every HTML5 build, but the failing builds always fail:

- On my machine, I cannot pass `gradlew test` because `testRun` fails during the simple HTML5 test. I worked around this locally for 3.0 through 3.0.2 with the commit in this pull request, thinking it was a local system issue and somehow only breaking that test.
- I've now realized it fails with our doc build on my machine. When running the `ant` build inside `docsrc/` I get the same failure, even though I can successfully build the same map (with same options) using the `dita` command.

After reproducing the error here (rather than just in the `gradlew test` command), I think this is more likely to come up on other Windows machines, so I'm suggesting the simple workaround for 3.0.3.

The workaround itself just changes the `xsl:include` to use a full path to the file (by way of our `plugin:` syntax). With the `plugin:org.dita.html5:` syntax that resolves to the correct path, the `xsl:include` statement is evaluated correctly and the cached `functions.xsl` from another directory is not loaded.