### PR TITLE
Fatal message should terminate XSL

### DIFF
--- a/src/main/xsl/common/output-message.xsl
+++ b/src/main/xsl/common/output-message.xsl
@@ -47,16 +47,26 @@ See the accompanying LICENSE file for applicable license.
       <xsl:value-of select="concat($msgcat, $msgnum, $msgsev)"/>
     </xsl:param>
     
+    <xsl:variable name="msgdoc" select="document('plugin:org.dita.base:config/messages.xml')" as="document-node()?"/>
     <xsl:variable name="msgcontent" as="xs:string*">
       <xsl:choose>
         <xsl:when test="$msg != '***'">
           <xsl:value-of select="$msg"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:variable name="msgdoc" select="document('plugin:org.dita.base:config/messages.xml')"/>
           <xsl:apply-templates select="$msgdoc/messages/message[@id = $id]" mode="get-message-content">    
             <xsl:with-param name="params" select="$msgparams"/>    
           </xsl:apply-templates>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="msgseverity" as="xs:string*">
+      <xsl:choose>
+        <xsl:when test="$msgsev != 'I'">
+          <xsl:value-of select="$msg"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$msgdoc/messages/message[@id = $id]/@type"/>    
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
@@ -84,7 +94,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:sequence select="$msgcontent"/>
     </xsl:variable>
     <xsl:choose>
-      <xsl:when test="$msgsev = 'F'">
+      <xsl:when test="$msgsev = 'F' or $msgseverity='FATAL'">
         <xsl:message terminate="yes">
           <xsl:value-of select="$m" separator=""/>
         </xsl:message>


### PR DESCRIPTION
## Description

Updates the `output-message` routine so that if a message is defined with `type="FATAL"`, the XSL will terminate.

## Motivation and Context

I was trying to add a fatal-severity message to a custom XSL file, and noticed that it was generated (with `[FATAL]` in the message) but that the build continued to the normal end. A few years back, this would have stopped the build

Cause: messages used to be generated by passing in a message ID, a message, and a severity, which were combined with a hard-coded prefix. If the severity was `F`, the message was generated in a way that terminated the process. 

This method of calling messages was deprecated some releases ago; now you just pass in the ID and optional parameters. When a message is fatal, the message definition should specify `type="FATAL"`. We do not ship any fatal messages intended for XSL but it should be possible to create them; here's the syntax of another fatal message:
`<message id="DOTA001F" type="FATAL">`

This code update fixes the code so that in addition to checking the old param for `$msgsev='F'`, it reads the message and checks for `@type='FATAL'`.

## How Has This Been Tested?

1. Created a section with two `<title>` elements
1. Verify it generates the message `DOTX041W`
1. Change the message definition to fatal: `<message id="DOTX041W" type="FATAL">`
1. Rebuild, and processing of that topic now quits with:
```
     [xslt] file:/C:/Users/IBM_ADMIN/github/robander/dita-ot/src/main/docsrc/samples/concepts/lawnmower.xml:14:10: [DOTX041W][FATAL]: Found more than one title element in a section element. Using the first one for the section's title.
     [xslt] Failed to transform document: Processing terminated by xsl:message at line 99 in output-message.xsl
```

## Type of Changes

Bug fix - restores a simple feature that was broken / unavailable unless using deprecated code.