### PR TITLE
Use more meaningful message for invalid DITAVAL

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -367,6 +367,11 @@ See the accompanying LICENSE file for applicable license.
     <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
     <response></response>
   </message>
+  
+  <message id="DOTJ077F" type="FATAL">
+    <reason>Invalid action attribute '%1' on DITAVAL property.</reason>
+    <response></response>
+  </message>
 
   <!-- End of Java Messages -->
     

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -193,7 +193,7 @@ public final class DitaValReader implements AbstractReader {
                 action = readFlag(elem);
                 break;
             default:
-                throw new IllegalArgumentException("Invalid action: " + attAction);
+                throw new IllegalArgumentException(MessageUtils.getMessage("DOTJ077F", attAction).toString());
         }
         if (action != null) {
             final QName attName;


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Adds an official error message for invalid DITAVAL actions, with a more meaningful message.

## Motivation and Context

One of my customers had a DITAVAL with a typo in the `@action` attribute. The current message is only meaningful if you know that a DITAVAL is being parsed (only clear if you turn on verbose logging), and also remember that is uses an `@action` attribute:
`Error: Failed to run pipeline: Invalid action: excluxde`

It's a bit worse if the typo is a space at the end of the action, in which case the message looks like it's reporting something valid:
`Error: Failed to run pipeline: Invalid action: exclude `

This update moves the invalid value into a clear (quoted) message:
```
 [gen-list] [DOTJ077F][FATAL] Invalid action attribute 'exclude ' on DITAVAL property.
Error: Failed to run pipeline: Invalid DITAVAL.
```

I wondered if in `lax` mode we should ignore the value and keep going, but then realized even in lax mode it's better to fail immediately on the invalid doc rather than running an entire build with incorrect filter conditions.

## How Has This Been Tested?

Tested with invalid DITAVAL actions, and with the default junit / integration tests.

## Type of Changes

Bug fix / doc fix to make a build failure easier to diagnose.
