### PR TITLE
Fix XSLT error with non-specific glossary key

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1024,13 +1024,13 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="glossentries" select="$m_entry-file-contents/descendant-or-self::*[contains(@class, ' glossentry/glossentry ')]" as="element()*"/>
     <xsl:choose>
       <xsl:when test="$m_glossid = '' and $glossentries[lang($m_reflang)]">
-        <xsl:sequence select="$glossentries[lang($m_reflang)]"/>
+        <xsl:sequence select="$glossentries[lang($m_reflang)][1]"/>
       </xsl:when>
       <xsl:when test="not($m_glossid = '') and $glossentries[@id = $m_glossid][lang($m_reflang)]">
         <xsl:sequence select="$glossentries[@id = $m_glossid][lang($m_reflang)]"/>
       </xsl:when>
       <xsl:when test="$m_glossid = '' and $glossentries[lang($DEFAULTLANG)]">
-        <xsl:sequence select="$glossentries[lang($DEFAULTLANG)]"/>
+        <xsl:sequence select="$glossentries[lang($DEFAULTLANG)][1]"/>
       </xsl:when>
       <xsl:when test="not($m_glossid = '') and $glossentries[@id = $m_glossid][lang($DEFAULTLANG)]">
         <xsl:sequence select="$glossentries[@id = $m_glossid][lang($DEFAULTLANG)]"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1189,13 +1189,13 @@ See the accompanying LICENSE file for applicable license.
   <xsl:variable name="glossentries" select="$m_entry-file-contents/descendant-or-self::*[contains(@class, ' glossentry/glossentry ')]" as="element()*"/>
   <xsl:choose>
     <xsl:when test="$m_glossid = '' and $glossentries[lang($m_reflang)]">
-      <xsl:sequence select="$glossentries[lang($m_reflang)]"/>
+      <xsl:sequence select="$glossentries[lang($m_reflang)][1]"/>
     </xsl:when>
     <xsl:when test="not($m_glossid = '') and $glossentries[@id = $m_glossid][lang($m_reflang)]">
       <xsl:sequence select="$glossentries[@id = $m_glossid][lang($m_reflang)]"/>
     </xsl:when>
     <xsl:when test="$m_glossid = '' and $glossentries[lang($DEFAULTLANG)]">
-      <xsl:sequence select="$glossentries[lang($DEFAULTLANG)]"/>
+      <xsl:sequence select="$glossentries[lang($DEFAULTLANG)][1]"/>
     </xsl:when>
     <xsl:when test="not($m_glossid = '') and $glossentries[@id = $m_glossid][lang($DEFAULTLANG)]">
       <xsl:sequence select="$glossentries[@id = $m_glossid][lang($DEFAULTLANG)]"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Fixes a problem with keys that refer to a `glossgroup` topic (a collection of glossary entries) without specifying the ID of a specific entry.

Currently, when the the topic with glossary entries specifies a language, but the key resolves to a `glossgroup` parent, we end up grabbing all child `glossentry` elements and trying to use them where we should just be using the first. This results in an XSLT failure:
```
     [xslt] Failed to transform document: A sequence of more than one item is not allowed as the result of template getMatchingTarget
```

Oddly, when no language at all is specified, we already use `[1]` to ensure the first term is used (so that condition does not result in a build error).

## Motivation and Context

Ran into this problem with a map that used a `glossgroup` topic that had only a few entries; each entry had a key *but* none of the keys used a topic ID, so they all resolved to the group. Both XHTML and HTML5 failed with the message above.

## How Has This Been Tested?

Simplified version of the original map:
```
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
<map xml:lang="en-us"><title>test map</title>
<keydef keys="puffin" href="glossterms.dita"/>
<keydef keys="tern" href="glossterms.dita"/>
<topicref href="birds.dita"/>
<topicref href="glossterms.dita"/>
</map>
```

And the gloss terms topic:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE glossgroup PUBLIC "-//OASIS//DTD DITA Glossary Group//EN" "glossgroup.dtd">
<glossgroup id="glossterms" xml:lang="en-us">
<title>Glossary entry file containing multiple entries</title>
<glossentry id="puffin">
<glossterm>Puffin</glossterm>
<glossdef>A very nice bird</glossdef>
</glossentry>
<glossentry id="tern">
<glossterm>Arctic Tern</glossterm>
<glossdef>A very mean bird</glossdef>
</glossentry>
</glossgroup>
```

Using `<term keyref="puffin">` or `<term keyref="tern">` recreates the failure.
[termkey.zip](https://github.com/dita-ot/dita-ot/files/1749122/termkey.zip)

## Type of Changes

Bug fix.

The markup that results in this build failure is not optimal (keys for glossary entries like this will give better results when the key is associated with the individual entry). But using the first is better than an XSLT build failure.
