### PR TITLE
Respect navtitle element inside topics for PDF TOC and bookmarks

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -444,6 +444,9 @@ See the accompanying LICENSE file for applicable license.
                             $topicref/@navtitle">
                 <xsl:value-of select="$topicref/@navtitle"/>
             </xsl:when>
+            <xsl:when test="*[contains(@class,' topic/titlealts ')]/*[contains(@class,' topic/navtitle ')]">
+                <xsl:apply-templates select="*[contains(@class,' topic/titlealts ')]/*[contains(@class,' topic/navtitle ')]/node()"/> 
+            </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="*[contains(@class,' topic/title ')]" mode="getTitle"/>
             </xsl:otherwise>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Builds on the fix in #2897 to support `<navtitle>` elements that are encoded within a topic, rather than a map. Those elements are currently ignored for PDF TOC and Bookmarks except when `@locktitle` is set on the reference to those topics, which is not the intent. (Our mappull process pulls the navigation title from the topic into the map, but PDF then ignores it unless `locktitle` is active and goes back to the topic title).

## Motivation and Context

Fixes #2904 which @infotexture encountered when trying to migrate our own DITA-OT documentation away from using deprecated `@navtitle` attributes.

## How Has This Been Tested?

Tested with the same set of tests in #2897, which tests all of the locktitle + navtitle combinations I could think of (locktitle not set, set to yes, set to no, with `@navtitle` in the map, `<navtitle>` in the map, and `<navtitle>` in the topic). Results now match the HTML TOC that resulted from that earlier fix. That test set was added to our integration test as part of the earlier pull request.

## Type of Changes

Bug fix.