### PR TITLE
Fix specified Dublin Core format for HTML5

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -436,7 +436,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- this value is based on output format used for DC indexing, not source.
        Put in this odd template for easy overriding, if creating another output format. -->
   <xsl:template match="*" mode="gen-format-metadata">
-    <meta name="DC.Format" content="XHTML"/>
+    <meta name="DC.Format" content="HTML5"/>
   </xsl:template>
   
   <!-- INSTANTIATION: Identifier --> <!-- id is an attribute on Topic -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Default HTML5 output generates Dublin Core metadata with the format as:
`<meta name="DC.Format" content="XHTML">`

That's left over from the code split between XHTML and HTML5. As long as we're specifying the default content format, HTML5 output should specify that it's HTML5.
