### PR TITLE
Use implicit @tempdir attribute in pipeline task

### DIFF
--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -142,7 +142,6 @@ See the accompanying LICENSE file for applicable license.
             description="Build Eclipse Help index file">
         <echo level="info"> args.eclipsehelp.indexsee = ${args.eclipsehelp.indexsee} </echo>
         <pipeline message="Extract index term."
-            tempdir="${dita.temp.dir}"
             inputmap="${user.input.file}">
           <module class="org.dita.dost.module.IndexTermExtractModule">
             <param name="output" location="${dita.output.dir}/${user.input.file}"/>
@@ -163,7 +162,6 @@ See the accompanying LICENSE file for applicable license.
         description="Build Eclipse Help index file">
         <echo level="info"> args.eclipsehelp.indexsee = ${args.eclipsehelp.indexsee} </echo>
         <pipeline message="Extract index term."
-            tempdir="${dita.temp.dir}"
             inputmap="${user.input.file}">
           <module class="org.dita.dost.module.IndexTermExtractModule">
             <param name="output" location="${dita.output.dir}/index.xml"/>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -135,7 +135,7 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="html5.image-metadata"
           unless="html5.image-metadata.skip" description="Read image metadata">
-    <pipeline message="Read image metadata." taskname="image-metadata" tempdir="${dita.temp.dir}">
+    <pipeline message="Read image metadata." taskname="image-metadata">
       <module class="org.dita.dost.module.ImageMetadataModule">
         <param name="outputdir" location="${dita.output.dir}"/>
       </module>

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -123,7 +123,7 @@ See the accompanying LICENSE file for applicable license.
     <condition property="htmlhelp.hhk.output.dir" value="${dita.output.dir}" else="${_dita.map.output.dir}">
       <isset property="inner.transform"/>
     </condition>
-    <pipeline message="Extract index term." tempdir="${dita.temp.dir}" inputmap="${user.input.file}">
+    <pipeline message="Extract index term." inputmap="${user.input.file}">
       <module class="org.dita.dost.module.IndexTermExtractModule">
         <param name="output" location="${htmlhelp.hhk.output.dir}/${args.output.base}.hhk"/>
         <param name="targetext" value="${out.ext}"/>

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -144,8 +144,7 @@ with those set forth herein.
   <target name="map2pdf2" unless="noMap">
     <dirname property="dita.temp.dir.fullpath" file="${dita.temp.dir}${file.separator}dummy.file"/>
     <pipeline message="topicmerge" taskname="topic-merge"
-              inputmap="${dita.temp.dir.fullpath}${file.separator}${user.input.file}"
-              tempdir="${dita.temp.dir.fullpath}">
+              inputmap="${dita.temp.dir.fullpath}${file.separator}${user.input.file}">
       <module class="org.dita.dost.module.TopicMergeModule">
         <param name="output" location="${dita.temp.dir.fullpath}${file.separator}${dita.map.filename.root}_MERGED.xml"/>
         <param name="style" location="${dita.plugin.org.dita.pdf2.dir}/xsl/common/topicmerge.xsl"/>

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -124,7 +124,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="xhtml.image-metadata"
           unless="xhtml.image-metadata.skip"
           description="Read image metadata">
-    <pipeline message="Read image metadata." taskname="image-metadata" tempdir="${dita.temp.dir}">
+    <pipeline message="Read image metadata." taskname="image-metadata">
       <module class="org.dita.dost.module.ImageMetadataModule">
         <param name="outputdir" location="${dita.output.dir}"/>
       </module>


### PR DESCRIPTION
## Description
Use implicit temporary directory instead of explicitly setting it with `@tempdir` attribute in `pipeline` task.

## Motivation and Context
The temporary directory is always same as `dita.temp.dir` property and when `@tempdir` is omitted the value is read directly from that property. Explicitly setting the attribute value may cause bugs and forces setting a value that effectively is always the same.

