### PR TITLE
Resolve all coderef elements from source files #2901

### DIFF
--- a/src/main/java/org/dita/dost/writer/CoderefResolver.java
+++ b/src/main/java/org/dita/dost/writer/CoderefResolver.java
@@ -117,13 +117,13 @@ public final class CoderefResolver extends AbstractXMLFilter {
     }
 
     private File getFile(URI hrefValue) {
-        File tempFile = toFile(stripFragment(currentFile.resolve(hrefValue))).getAbsoluteFile();
+        final File tempFile = toFile(stripFragment(currentFile.resolve(hrefValue))).getAbsoluteFile();
         final URI rel = job.tempDirURI.relativize(tempFile.toURI());
         final Job.FileInfo fi = job.getFileInfo(rel);
 
-        if (tempFile.exists() && fi != null && PR_D_CODEREF.localName.equals(fi.format)) {
-            return tempFile;
-        }
+//        if (tempFile.exists() && fi != null && PR_D_CODEREF.localName.equals(fi.format)) {
+//            return tempFile;
+//        }
         if (fi != null && "file".equals(fi.src.getScheme())) {
             return new File(fi.src);
         }


### PR DESCRIPTION
Resolve all coderef elements from source files. Files in the temporary directory have been normalized and no longer reflect the original intended blockcode source.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>