### PR TITLE
Use configured image extensions as fallback to image format #2917

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -439,7 +439,7 @@ public final class ExtensibleAntInvoker extends Task {
     }
 
     public static class FileInfoFilterElem extends ConfElem {
-        private Set<String> format = Collections.emptySet();
+        private Set<String> formats = Collections.emptySet();
         private Boolean hasConref;
         private Boolean isResourceOnly;
 
@@ -448,7 +448,7 @@ public final class ExtensibleAntInvoker extends Task {
             if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
                 supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
             }
-            this.format = builder.build();
+            this.formats = builder.build();
 
         }
 
@@ -461,7 +461,7 @@ public final class ExtensibleAntInvoker extends Task {
         }
 
         public Predicate<FileInfo> toFilter() {
-            return f -> (format.isEmpty() || format.contains(f.format)) &&
+            return f -> (formats.isEmpty() || formats.contains(f.format)) &&
                     (hasConref == null || f.hasConref == hasConref) &&
                     (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
         }

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -8,8 +8,11 @@
 package org.dita.dost.ant.types;
 
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
+import static org.dita.dost.util.FileUtils.supportedImageExtensions;
 import static org.dita.dost.util.URLUtils.*;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.AbstractFileSet;
 import org.apache.tools.ant.types.Resource;
@@ -24,16 +27,15 @@ import org.dita.dost.util.Job;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Resource collection that finds matching resources from job configuration.
  */
 public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
 
-    private String format;
+    private Set<String> format = Collections.emptySet();
     private Boolean hasConref;
     private Boolean isResourceOnly;
     private Collection<Resource> res;
@@ -47,7 +49,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (res == null) {
             final Job job = getJob();
             res = new ArrayList<>();
-            for (final Job.FileInfo f : job.getFileInfo(f -> (format == null || (format.equals(f.format)/* || (format.equals(ATTR_FORMAT_VALUE_DITA) && f.format == null)*/)) &&
+            for (final Job.FileInfo f : job.getFileInfo(f -> (format.isEmpty() || format.contains(f.format)) &&
                     (hasConref == null || f.hasConref == hasConref) &&
                     (isResourceOnly == null || f.isResourceOnly == isResourceOnly))) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
@@ -113,7 +115,11 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
     }
 
     public void setFormat(final String format) {
-        this.format = format;
+        final ImmutableSet.Builder<String> builder = ImmutableSet.<String>builder().add(format);
+        if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
+            supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
+        }
+        this.format = builder.build();
     }
 
     public void setConref(final boolean conref) {

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -28,14 +28,13 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Resource collection that finds matching resources from job configuration.
  */
 public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
 
-    private Set<String> format = Collections.emptySet();
+    private Set<String> formats = Collections.emptySet();
     private Boolean hasConref;
     private Boolean isResourceOnly;
     private Collection<Resource> res;
@@ -49,7 +48,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (res == null) {
             final Job job = getJob();
             res = new ArrayList<>();
-            for (final Job.FileInfo f : job.getFileInfo(f -> (format.isEmpty() || format.contains(f.format)) &&
+            for (final Job.FileInfo f : job.getFileInfo(f -> (formats.isEmpty() || formats.contains(f.format)) &&
                     (hasConref == null || f.hasConref == hasConref) &&
                     (isResourceOnly == null || f.isResourceOnly == isResourceOnly))) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
@@ -119,7 +118,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
             supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
         }
-        this.format = builder.build();
+        this.formats = builder.build();
     }
 
     public void setConref(final boolean conref) {

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -32,7 +32,7 @@ public final class FileUtils {
      * Supported image extensions. File extensions contain a leading dot.
      */
     @Deprecated
-    private final static List<String> supportedImageExtensions;
+    public final static List<String> supportedImageExtensions;
     static {
         final List<String> sie = new ArrayList<>();
         final String imageExtensions = Configuration.configuration.get(CONF_SUPPORTED_IMAGE_EXTENSIONS);


### PR DESCRIPTION
Use configured image extensions as fallback to `image` format, because correct `image` format is not populated until image metadata is read.

This is a workaround and should be replaced by moving image copy to transtype specific code.