### PR TITLE
Allow DITA-OT to process DITAVAL documents that include a doctype

### DIFF
--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -48,6 +48,7 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     /** Absolute paths for filter files. */
     private final List<File> ditavalFiles = new LinkedList<>();
+    private File ditaDir = null;
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
@@ -71,6 +72,7 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     private void parseInputParameters(final AbstractPipelineInput input) {
         final File basedir = toFile(input.getAttribute(ANT_INVOKER_PARAM_BASEDIR));
+        ditaDir = toFile(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
         if (input.getAttribute(ANT_INVOKER_PARAM_DITAVAL) != null) {
             final String[] allDitavalFiles = input.getAttribute(ANT_INVOKER_PARAM_DITAVAL).split(File.pathSeparator);
             for (final String oneDitavalFile : allDitavalFiles) {
@@ -103,6 +105,8 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     private void writeMergedDitaval() throws DITAOTException {
         final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
+        CatalogUtils.setDitaDir(ditaDir);
+        ditavalbuilder.setEntityResolver(CatalogUtils.getCatalogResolver());
         XMLStreamWriter export = null;
         try (OutputStream exportStream = new FileOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL))) {
             export = XMLOutputFactory.newInstance().createXMLStreamWriter(exportStream, "UTF-8");

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -84,6 +84,7 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Preprocess and merge ditavals" taskname="ditaval-merge" if:set="args.filter">
       <module class="org.dita.dost.module.MergeDitavalModule">
         <param name="ditaval" value="${args.filter}"/>
+        <param name="ditadir" location="${dita.dir}"/>
       </module>
     </pipeline>
   </target>

--- a/src/test/resources/filterlist/src/subdir/filter2.ditaval
+++ b/src/test/resources/filterlist/src/subdir/filter2.ditaval
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE val PUBLIC "-//OASIS//DTD DITA DITAVAL//EN" "ditaval.dtd">
 <val>
     <prop action="include" att="otherprops" val="subinclude" />
     <prop action="exclude" att="otherprops" val="subexclude" />


### PR DESCRIPTION
## Description

Allows DITAVAL documents with standard doctype declarations to be processed.

## Motivation and Context

Fixes #2005. The `ditaval-merge` module has been added since the last comment on that report; the build still fails when a DITAVAL uses a doctype, but as of DITA-OT 3.0.3 the message is:
```
[ditaval-merge] Failed to close merged ditaval file: java.io.IOException: Stream Closed
Error: Failed to run pipeline: Failed to merge ditaval files: C:\DCS\test\sourcedir\ditaval.dtd (The system cannot find the file specified.)
```

The DITAVAL doctypes are already part of our standard catalog, so we should be able to use that catalog to parse the files.

## How Has This Been Tested?

Tested with a DITAVAL that uses the standard DTD Doctype.

We already have several integration tests that use DITAVAL filter conditions, including one test that uses multiple DITAVAL documents. I've updated one of the DITAVAL documents for the multiple condition, so that existing test now ensures that DITAVAL documents can be processed both with and without a doctype.

## Type of Changes

Bug fix; reuses the same entity resolver / catalog that is already used for DITA documents.

## Checklist

X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
