### PR TITLE
Place PDF in output directory regardless of uplevels

### DIFF
--- a/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
@@ -187,10 +187,10 @@ See the accompanying LICENSE file for applicable license.
       </condition>
     </fail>
     
-    <condition property="outputFile" value="${dita.map.output.dir}/${outputFile.base}${xsl.formatter.ext}">
+    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
       <not><isset property="outputFile"/></not>
     </condition>
-    <mkdir dir="${dita.map.output.dir}"/>
+    <mkdir dir="${dita.output.dir}"/>
     
     <antcall target="transform.fo2pdf.ah.nooption"/>
     <antcall target="transform.fo2pdf.ah.hasoption"/>

--- a/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
@@ -141,10 +141,10 @@ See the accompanying LICENSE file for applicable license.
   <target name="transform.fo2pdf.fop" if="use.fop.pdf.formatter">
     <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop" classpathref="dost.class.path"/>
     
-    <condition property="outputFile" value="${dita.map.output.dir}/${outputFile.base}${xsl.formatter.ext}">
+    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
       <not><isset property="outputFile"/></not>
     </condition>
-    <mkdir dir="${dita.map.output.dir}"/>
+    <mkdir dir="${dita.output.dir}"/>
     
     <fop format="${fop.formatter.output-format}" fofile="${pdf2.temp.dir}/topic.fo" basedir="${pdf2.temp.dir}"
          outfile="${outputFile}" messagelevel="info" relativebase="true" force="true"

--- a/src/main/plugins/org.dita.pdf2.xep/build_xep.xml
+++ b/src/main/plugins/org.dita.pdf2.xep/build_xep.xml
@@ -184,10 +184,10 @@ See the accompanying LICENSE file for applicable license.
       <not><isset property="xep.failOnError"/></not>
     </condition>
     
-    <condition property="outputFile" value="${dita.map.output.dir}/${outputFile.base}${xsl.formatter.ext}">
+    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
       <not><isset property="outputFile"/></not>
     </condition>
-    <mkdir dir="${dita.map.output.dir}"/>
+    <mkdir dir="${dita.output.dir}"/>
     
     <echo level="info" taskname="xep">Processing ${pdf2.temp.dir}/topic.fo to ${outputFile}</echo>
     <java classname="com.idiominc.ws.opentopic.fo.xep.Runner" resultproperty="errCode"


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

PDF builds currently uses `${dita.map.output.dir}` when writing the actual PDF file. This variable uses the calculated map directory + `uplevels`, so in the temp directory this would be the common directory at the root of all content. For formats like CHM and Eclipse, where we write map-based files that will be zipped or compiled, `uplevels` ensures they are written at the top level of the zip, and the zip contains everything.

For PDF there is no reason to use this variable, because only one file is generated, and it should be placed in `dita.output.dir` regardless of whether content above the level of the map was used.

## Motivation and Context

I noticed this while testing an obsolete issue with flags on content above the map directory. My simple samples have a map with topic content one level up, same level as map, and one level down.
[uplevelpdf.zip](https://github.com/dita-ot/dita-ot/files/1835886/uplevelpdf.zip)

Looking for related issues I'm pretty sure this will also fix #2910.

## How Has This Been Tested?

With the attached samples that include uplevel content.

## Type of Changes

Bug fix.

## Checklist

X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- No unit tests applicable for PDF
