### PR TITLE
PDF should respect scaling for fig content

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -997,6 +997,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setExpanse"/>
+            <xsl:call-template name="setScale"/>
             <xsl:if test="not(@id)">
               <xsl:attribute name="id">
                 <xsl:call-template name="get-id"/>
@@ -1249,6 +1250,12 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="href"/>
         <xsl:param name="height" as="xs:string?"/>
         <xsl:param name="width" as="xs:string?"/>
+        <xsl:param name="scale" as="xs:string?">
+            <xsl:choose>
+                <xsl:when test="@scale"><xsl:value-of select="@scale"/></xsl:when>
+                <xsl:when test="ancestor::*[@scale]"><xsl:value-of select="ancestor::*[@scale][1]/@scale"/></xsl:when>
+            </xsl:choose>
+        </xsl:param>
 <!--Using align attribute set according to image @align attribute-->
         <xsl:call-template name="processAttrSetReflection">
                 <xsl:with-param name="attrSet" select="concat('__align__', $imageAlign)"/>
@@ -1291,12 +1298,12 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:choose>
                 </xsl:attribute>
             </xsl:if>
-            <xsl:if test="not($width) and not($height) and @scale">
+            <xsl:if test="not($width) and not($height) and $scale">
                 <xsl:attribute name="content-width">
-                    <xsl:value-of select="concat(@scale,'%')"/>
+                    <xsl:value-of select="concat($scale,'%')"/>
                 </xsl:attribute>
             </xsl:if>
-          <xsl:if test="@scalefit = 'yes' and not($width) and not($height) and not(@scale)">            
+          <xsl:if test="@scalefit = 'yes' and not($width) and not($height) and not($scale)">            
             <xsl:attribute name="width">100%</xsl:attribute>
             <xsl:attribute name="height">100%</xsl:attribute>
             <xsl:attribute name="content-width">scale-to-fit</xsl:attribute>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Updates PDF to process the `@scale` attribute on the `<fig>` element.

## Motivation and Context

Discovered that setting `@scale` on figures made no change to the default PDF output (customers were trying this as a way to get a set of code blocks to fit better). We already have a named template that processes `@scale` correctly for other elements; calling that from the figure context fixes the issue for text content.

Images within figures need a bit of additional processing; because the standard scaling only works with text (by setting `@font-size`), any images within the text will not be scaled even after the initial fix.

This update also tweaks normal image processing for scale. That processing currently has a series of fallback processes (look for height/width, then scale, then scalefit). I've updated it so that the check for scale will first look on `<image>` itself, but look at ancestors and respect any `@scale` value on the closest ancestor.

## How Has This Been Tested?

Tested with:

* Figures that include text content
* Figures with inline images inside the text
* Figures with block images
* Images that set their own `@scale` value within the figure

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- No changes to test cases, as we do not currently validate the FO output
