### PR TITLE
Use linktext as fallback title for peer content

### DIFF
--- a/src/main/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/xsl/preprocess/mappullImpl.xsl
@@ -620,6 +620,9 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="@navtitle">
             <xsl:value-of select="@navtitle"/>
           </xsl:when>
+          <xsl:when test="*/*[contains(@class,' map/linktext ')]">
+            <xsl:value-of select="*/*[contains(@class,' map/linktext ')]"/>
+          </xsl:when>
           <xsl:otherwise>
             <xsl:text>#none#</xsl:text>
             <xsl:apply-templates select="." mode="ditamsg:missing-navtitle-peer"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Updates navigation title processing in `mappull` so that if no other fallback is available for `peer` content, we use the `linktext` element and do not issue a warning.

## Motivation and Context

We have a bunch of key definitions marked with `scope="peer"`. Many of these are to HTML topics, many others are to DITA topics. All specify `<linktext>`. Today, the links to DITA topics generate a warning ("Missing navigation title"), but the HTML topics do not.

We already use `<linktext>` as a fallback for navigation titles when the content is non-DITA (even if local), or when the content has `scope="external"`. We know that topics labeled `scope="peer"` are not available for processing, so we should use the same fallback used for non-DITA content.

## How Has This Been Tested?

Test files with `resource-only` key definitions that specify `scope="peer"`, provide `<linktext>`, and reference DITA topics. Any process that uses these today already falls back to `linktext` at a later point, or use the `@href` value. This fix ensures `linktext` is used consistently, and avoids the warning message.

Passes all unit / integration tests.

## Type of Changes

Bug fix: remove an unnecessary error that results in unstable builds, and use link text in situations that end up with only a file name today.
