### PR TITLE
Add end to end tests for transtype regression test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 - git submodule update --init --recursive
 - "./gradlew"
 script:
-- "./gradlew check integrationTest --info --stacktrace --no-daemon"
+- "./gradlew check integrationTest e2eTest --info --stacktrace --no-daemon"
 after_success:
 - "./gradlew dist --stacktrace --no-daemon -Pcommit=${TRAVIS_COMMIT} -Ptag=${TRAVIS_TAG} -PskipGenerateDocs=${SKIP_GENERATE_DOCS}"
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ artifacts {
 
 test {
     exclude '**/IntegrationTest*.class'
+    exclude '**/EndToEndTest*.class'
 }
 
 // Integration test
@@ -88,6 +89,29 @@ task integrationTest(type: Test, dependsOn: 'buildLocal') {
     maxHeapSize = "1024m"
     systemProperties = integrationTestSystemProperties
     include '**/IntegrationTest*.class'
+}
+
+// End to end test
+
+dependencies {
+    testCompile project(':eclipsehelp')
+    testCompile project(':htmlhelp')
+}
+
+def e2eTestSystemProperties = [
+        temp_dir : "${buildDir}/tmp/e2eTest",
+        dita_dir : "${projectDir}/src/main",
+        basedir : "${projectDir}/src/test"
+]
+if (System.getProperty("log_level") != null) {
+    integrationTestSystemProperties["log_level"] = System.getProperty("log_level")
+}
+
+task e2eTest(type: Test, dependsOn: 'buildLocal') {
+    minHeapSize = "128m"
+    maxHeapSize = "1024m"
+    systemProperties = e2eTestSystemProperties
+    include '**/EndToEndTest*.class'
 }
 
 // Install

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ test {
     exclude '**/EndToEndTest*.class'
 }
 
+test.maxParallelForks = 4
+
 // Integration test
 
 def integrationTestSystemProperties = [

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -148,7 +148,7 @@ public class AbstractIntegrationTest {
     private static final File baseTempDir = new File(System.getProperty(TEMP_DIR) != null
             ? System.getProperty(TEMP_DIR)
             : "build" + File.separator + "tmp" + File.separator + "integrationTest");
-    private static final File resourceDir = new File(baseDir, "resources");
+    static final File resourceDir = new File(baseDir, "resources");
     private static DocumentBuilder db;
     private static HtmlDocumentBuilder htmlb;
     private static int level;

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -48,6 +48,8 @@ public class AbstractIntegrationTest {
     private String[] targets;
     private Path input;
     private Map<String, Object> args = new HashMap<>();
+    private List<TestListener.Message> log;
+    private File actDir;
     private int warnCount = 0;
     private int errorCount = 0;
 
@@ -99,6 +101,10 @@ public class AbstractIntegrationTest {
                 "build-init", "preprocess"),
         XHTML("xhtml", false,
                 "dita2xhtml"),
+        HTML5("html", false,
+                "dita2html5"),
+        PDF("pdf", false,
+                "dita2pdf2"),
         ECLIPSEHELP("eclipsehelp", false,
                 "dita2eclipsehelp"),
         HTMLHELP("htmlhelp", false,
@@ -178,9 +184,13 @@ public class AbstractIntegrationTest {
     }
 
     protected void test() throws Throwable {
+        run();
+        compare();
+    }
+
+    protected AbstractIntegrationTest run() throws Throwable {
         final File testDir = Paths.get("src", "test", "resources", name).toFile();
         final File srcDir = new File(testDir, SRC_DIR);
-        final File expDir = new File(testDir, EXP_DIR);
         final File outDir = new File(baseTempDir, testDir.getName() + File.separator + "out");
         final File tempDir = new File(baseTempDir, testDir.getName() + File.separator + "temp");
 
@@ -197,17 +207,16 @@ public class AbstractIntegrationTest {
         builder.put("args.input", new File(srcDir, input.toFile().toString()).getAbsolutePath());
         final Map<String, String> params = builder.build();
 
-        List<TestListener.Message> log = null;
         try {
-            log = runOt(testDir, transtype, tempDir, outDir, params, targets);
+            this.log = runOt(testDir, transtype, tempDir, outDir, params, targets);
             assertEquals("Warn message count does not match expected",
                     warnCount,
                     countMessages(log, Project.MSG_WARN));
             assertEquals("Error message count does not match expected",
                     errorCount,
                     countMessages(log, Project.MSG_ERR));
-            final File actDir = transtype.compareTemp ? tempDir : outDir;
-            compare(expDir, actDir);
+
+            this.actDir = transtype.compareTemp ? tempDir : outDir;
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Throwable e) {
@@ -216,6 +225,15 @@ public class AbstractIntegrationTest {
             }
             throw new Throwable("Case " + testDir.getName() + " failed: " + e.getMessage(), e);
         }
+        return this;
+    }
+
+    protected AbstractIntegrationTest compare() throws Throwable {
+        final File testDir = Paths.get("src", "test", "resources", name).toFile();
+        final File expDir = new File(testDir, EXP_DIR);
+
+        compare(expDir, actDir);
+        return this;
     }
 
     @Deprecated

--- a/src/test/java/org/dita/dost/EndToEndTest.java
+++ b/src/test/java/org/dita/dost/EndToEndTest.java
@@ -1,0 +1,52 @@
+package org.dita.dost;
+
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.dita.dost.AbstractIntegrationTest.Transtype.*;
+
+public class EndToEndTest extends AbstractIntegrationTest {
+
+    @Test
+    public void xhtml() throws Throwable {
+        builder().name("e2e")
+                .transtype(XHTML)
+                .input(Paths.get("root.ditamap"))
+                .run();
+    }
+
+    @Test
+    public void html5() throws Throwable {
+        builder().name("e2e")
+                .transtype(HTML5)
+                .input(Paths.get("root.ditamap"))
+                .run();
+    }
+
+    @Test
+    public void pdf() throws Throwable {
+        builder().name("e2e")
+                .transtype(PDF)
+                .input(Paths.get("root.ditamap"))
+                .warnCount(16)
+                .run();
+    }
+
+    @Test
+    public void eclipsehelp() throws Throwable {
+        builder().name("e2e")
+                .transtype(ECLIPSEHELP)
+                .input(Paths.get("root.ditamap"))
+                .run();
+    }
+
+    @Test
+    public void htmlhelp() throws Throwable {
+        builder().name("e2e")
+                .transtype(HTMLHELP)
+                .input(Paths.get("root.ditamap"))
+                .run();
+    }
+
+}

--- a/src/test/java/org/dita/dost/EndToEndTest.java
+++ b/src/test/java/org/dita/dost/EndToEndTest.java
@@ -2,6 +2,7 @@ package org.dita.dost;
 
 import org.junit.Test;
 
+import java.io.File;
 import java.nio.file.Paths;
 
 import static org.dita.dost.AbstractIntegrationTest.Transtype.*;
@@ -29,7 +30,8 @@ public class EndToEndTest extends AbstractIntegrationTest {
         builder().name("e2e")
                 .transtype(PDF)
                 .input(Paths.get("root.ditamap"))
-                .warnCount(16)
+                .put("args.fo.userconfig", new File(resourceDir, "e2e" + File.separator + "fop.xconf").getAbsolutePath())
+                .warnCount(10)
                 .run();
     }
 

--- a/src/test/resources/e2e/fop.xconf
+++ b/src/test/resources/e2e/fop.xconf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fop version="1.0">
+  <strict-validation>false</strict-validation>
+  <base>.</base>
+  <source-resolution>72</source-resolution>
+  <target-resolution>72</target-resolution>
+  <default-page-settings height="11.00in" width="8.50in"/>
+  <renderers>
+    <renderer mime="application/pdf">
+      <fonts>
+        <!--auto-detect/-->
+      </fonts>
+    </renderer>
+  </renderers>
+</fop>

--- a/src/test/resources/e2e/src/root.ditamap
+++ b/src/test/resources/e2e/src/root.ditamap
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map id="UC03TC" title="Test generated parent/child link">
+  <topicref href="t1.dita">
+    <topicref href="t2.dita"/>
+  </topicref>
+</map>

--- a/src/test/resources/e2e/src/t1.dita
+++ b/src/test/resources/e2e/src/t1.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="test1">
+  <title>test 1</title>
+  <body>
+    <p>content</p>
+  </body>
+</topic>

--- a/src/test/resources/e2e/src/t2.dita
+++ b/src/test/resources/e2e/src/t2.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="test2">
+  <title>test 2</title>
+  <body>
+    <p>content</p>
+  </body>
+</topic>


### PR DESCRIPTION
## Description
Add a new test to run DITA-OT transtypes to catch regression bugs. The test doesn't compare actual output with expected output, it only runs a transtype.

## Motivation and Context
The goal is to run every transtype during testing phase, even if the output cannot be verified to be correct. This allows us to catch regression bugs that break the whole transtype process.

