### PR TITLE
Key definitions with copy-to should resolve to the copy

### DIFF
--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -209,7 +209,7 @@ public final class KeyrefReader implements AbstractReader {
                     final Document d = builder.newDocument();
                     final Element copy = (Element) d.importNode(elem, true);
                     d.appendChild(copy);
-                    final String h = copy.getAttribute(ATTRIBUTE_NAME_HREF);
+                    final String h = copy.getAttribute(ATTRIBUTE_NAME_COPY_TO).isEmpty() ? copy.getAttribute(ATTRIBUTE_NAME_HREF) : copy.getAttribute(ATTRIBUTE_NAME_COPY_TO);
                     final URI href = h.isEmpty() ? null : toURI(h);
                     final String s = copy.getAttribute(ATTRIBUTE_NAME_SCOPE);
                     final String scope = s.isEmpty() ? null : s;

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -325,7 +325,7 @@ public class TestKeyrefReader {
         assertEquals("nested-three.dita", scope2.get("scope1.map.key3").href.toString());
     }
 
-    // DITA 1.3 specificiation examples
+    // DITA 1.3 specification examples
 
     @Test
     public void testExample7() throws DITAOTException {
@@ -513,6 +513,18 @@ public class TestKeyrefReader {
         assertEquals(2, d.keySet().size());
         assertEquals("def2", d.get("a").element.getAttribute("id"));
         assertEquals("def1", d.get("A.a").element.getAttribute("id"));
+    }
+    
+    @Test
+    public void testCopyto() throws DITAOTException {
+        final File filename = new File(srcDir, "copyto.ditamap");
+
+        final KeyrefReader keyrefreader = new KeyrefReader();
+        keyrefreader.read(filename.toURI(), readMap(filename));
+        final KeyScope root = keyrefreader.getKeyDefinition();
+
+        assertEquals("topic-original.dita", root.get("original").href.toString());
+        assertEquals("topic-copy.dita", root.get("copy").href.toString());
     }
 
     private void log(final KeyScope scope, final String indent) {

--- a/src/test/resources/TestKeyrefReader/src/copyto.ditamap
+++ b/src/test/resources/TestKeyrefReader/src/copyto.ditamap
@@ -1,0 +1,8 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)"
+  ditaarch:DITAArchVersion="1.3">
+  <keydef class="+ map/topicref mapgroup-d/keydef " href="topic-original.dita" keys="original" processing-role="resource-only"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " href="topic-original.dita" keys="copy" copy-to="topic-copy.dita" processing-role="resource-only"/>
+  <topicref class="- map/topicref " keyref="original"/>
+  <topicref class="- map/topicref " keyref="copy"/>
+</map>


### PR DESCRIPTION
## Description

If a key definition specifies both `@href` and `@copy-to`, references to that key should pick up the updated name from `@copy-to`.

## Motivation and Context

Fixes #2842.

As reported in that issue, if a key definition specifies `@copy-to`, references to that key will resolve to the original file name rather than to the updated name.  For example, with the following markup, references to both `originalkey` and `copykey` resolve to `topic-original.dita`, but the second one should resolve instead to `topic-copy.dita`:

```
<topicref href="topic-original.dita" keys="originalkey"/>
<topicref href="topic-original.dita" keys="copykey" copy-to="topic-copy.dita"/>
```

## How Has This Been Tested?

- Tested against the unit and integration tests
- Tested against the sample file in 2842
- Added failing JUnit test that reproduces the problem, now works with the fix

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
