### PR TITLE
Remove base catalog file from catalog defaults

### DIFF
--- a/src/main/config/CatalogManager.properties
+++ b/src/main/config/CatalogManager.properties
@@ -3,7 +3,7 @@
 # Copyright 2006 IBM Corporation
 #
 # See the accompanying LICENSE file for applicable license.
-catalogs=../catalog-dita.xml
+#catalogs=../catalog-dita.xml
 relative-catalogs=no
 prefer=public
 static-catalog=yes


### PR DESCRIPTION
Remove default catalog from the catalog configuration file and only use explicitly configured catalogs.  Fixes #2835.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>
