### PR TITLE
Use xmlcatalog element instead of xml.catalog.files property

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -105,7 +105,16 @@ with those set forth herein.
       <not><isset property="file.protocol.prefix"/></not>
     </condition>
     
-    <property name="xml.catalog.files" value="${customization.dir}/catalog.xml;${dita.plugin.org.dita.pdf2.dir}/cfg/catalog.xml;${dita.dir}/catalog-dita.xml"/>
+    <path id="xml.catalog.path">
+      <pathelement location="${customization.dir}/catalog.xml"/>
+      <pathelement location="${dita.plugin.org.dita.pdf2.dir}/cfg/catalog.xml"/>
+      <pathelement location="${dita.dir}/catalog-dita.xml"/>
+    </path>
+    <xmlcatalog id="xml.catalog">
+      <catalogpath refid="xml.catalog.path"/>
+    </xmlcatalog>
+    <!-- Deprecated since 3.1 -->
+    <pathconvert property="xml.catalog.files" refid="xml.catalog.path"/>
     
     <property name="xsl.dir" value="${dita.plugin.org.dita.pdf2.dir}/xsl"/>
     <property name="xsl.fo.dir" value="${dita.plugin.org.dita.pdf2.dir}/xsl/fo"/>
@@ -289,8 +298,9 @@ with those set forth herein.
     </condition>
 
     <index-preprocess input="${inputFile.url}" output="${dita.temp.dir}/stage1.xml"
-                      indexConfig="${index.config.file}" locale="${document.locale}"
-                      catalogs="${xml.catalog.files}"/> 
+                      indexConfig="${index.config.file}" locale="${document.locale}">
+      <xmlcatalog refid="xml.catalog"/>
+    </index-preprocess> 
   </target>
   
   <target name="transform.topic2fo.main">
@@ -326,9 +336,7 @@ with those set forth herein.
       <param name="variableFiles.url" expression="${variable.file.url}" if:set="variable.file.exists"/>
       <param name="defaultLanguage" expression="${default.language}"/>
       <dita:extension id="dita.conductor.pdf2.param" behavior="org.dita.dost.platform.InsertAction"/>
-      <xmlcatalog>
-        <catalogpath path="${xml.catalog.files}"/>
-      </xmlcatalog>
+      <xmlcatalog refid="xml.catalog"/>
     </xslt>
     </pipeline>
   </target>
@@ -371,9 +379,7 @@ with those set forth herein.
     <i18n-preprocess input="${dita.temp.dir}/stage2.fo" output="${pdf2.temp.dir}/topic.fo"
                      config="${i18n.config.file}"
                      style="${xsl.fo.dir}/i18n-postprocess.xsl">
-      <xmlcatalog>
-        <catalogpath path="${xml.catalog.files}"/>
-      </xmlcatalog>
+      <xmlcatalog refid="xml.catalog"/>
     </i18n-preprocess>
   </target>
   <target name="transform.topic2fo.i18n.no-filter" if="pdf2.i18n.skip">

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
@@ -1,19 +1,15 @@
 package com.idiominc.ws.opentopic.fo.index2;
 
-import static org.dita.dost.util.Constants.*;
-
 import com.idiominc.ws.opentopic.fo.index2.configuration.IndexConfiguration;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.Project;
-import org.apache.xml.resolver.tools.CatalogResolver;
+import org.apache.tools.ant.types.XMLCatalog;
 import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -57,7 +53,7 @@ extends Task {
     //    private String input = null;
     private String input = "";
     private String output = "";
-    private String catalogs = null;
+    private XMLCatalog xmlcatalog;
     private String locale = "ja";
     private String indexConfig = "";
     public static boolean failOnError = false;
@@ -72,25 +68,10 @@ extends Task {
     public void execute()
             throws BuildException {
         checkParameters();
-        if (this.catalogs != null) {
-            System.setProperty("xml.catalog.files", this.catalogs);
-        }
 
         try {
             final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
-            documentBuilder.setEntityResolver(new CatalogResolver() {
-                @Override
-                public InputSource resolveEntity(final String publicId, String systemId) {
-                    // strip path from DTD location
-                    final int slashIdx = systemId.lastIndexOf("/");
-                    if (slashIdx >= 0) {
-                        systemId = systemId.substring(slashIdx + 1);
-                    }
-
-                    // resolve real location with XMLCatalogResolver
-                    return super.resolveEntity(publicId, systemId);
-                }
-            });
+            documentBuilder.setEntityResolver(xmlcatalog);
 
             final Document doc = documentBuilder.parse(input);
             final IndexPreprocessor preprocessor = new IndexPreprocessor(this.prefix, this.namespace_url);
@@ -162,11 +143,9 @@ extends Task {
         this.output = theOutput;
     }
 
-
-    public void setCatalogs(final String theCatalogs) {
-        this.catalogs = theCatalogs;
+    public void addConfiguredXmlcatalog(final XMLCatalog xmlcatalog) {
+        this.xmlcatalog = xmlcatalog;
     }
-
 
     public void setLocale(final String theLocale) {
         this.locale = theLocale;


### PR DESCRIPTION
Use `<xmlcatalog>` element instead of `xml.catalog.files` property.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>
