### PR TITLE
Removes the redundant map2html5Impl.xsl import

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -13,8 +13,6 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot ditamsg">
   
-  <xsl:import href="plugin:org.dita.html5:xsl/map2html5Impl.xsl"/>
-  
   <xsl:param name="nav-toc" as="xs:string?"/>
   <xsl:param name="FILEDIR" as="xs:string?"/>
   <xsl:param name="FILENAME" as="xs:string?"/>


### PR DESCRIPTION
## Description
The nav.xsl file is used only as a part of map2html5-coverImpl[_template].xsl which already imports map2html5Impl.xsl.

## Motivation and Context
Let's avoid the annoying Saxon message about multiple imports.

## How Has This Been Tested?
gradlew test

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>