### PR TITLE
Remove obsolete code to fix fragref error

### DIFF
--- a/src/main/xsl/preprocess/topicpull-pr-d.xsl
+++ b/src/main/xsl/preprocess/topicpull-pr-d.xsl
@@ -12,131 +12,14 @@ See the accompanying LICENSE file for applicable license.
   xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
   exclude-result-prefixes="topicpull ditamsg">
   
-  <xsl:template match="*[contains(@class, ' pr-d/fragref ')]">
-    <xsl:if test="@href=''">
-      <xsl:apply-templates select="." mode="ditamsg:empty-href"/>
-    </xsl:if>
-    <xsl:choose>
-      <!-- fragref cannot allow desc, so no need to check for it -->
-      <xsl:when test="text()|*">
-        <xsl:copy>
-          <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()"/>
-        </xsl:copy>
-      </xsl:when>
-      <xsl:when test="@href and not(@href='')">
-        <xsl:copy>
-          <xsl:apply-templates select="@*"/>
-          <!--create variables for attributes that will be passed by parameter to the getstuff template (which is shared with link, which needs the attributes in variables to save doing inheritance checks for each one)-->
-          <xsl:variable name="type">
-            <xsl:choose>
-              <xsl:when test="@type">
-                <xsl:value-of select="@type"/>
-              </xsl:when>
-              <xsl:otherwise>#none#</xsl:otherwise>
-            </xsl:choose>
-          </xsl:variable>
-          <xsl:variable name="format">
-            <xsl:choose>
-              <xsl:when test="@format">
-                <xsl:value-of select="@format"/>
-              </xsl:when>
-              <xsl:otherwise>#none#</xsl:otherwise>
-            </xsl:choose>
-          </xsl:variable>
-          <xsl:variable name="scope">
-            <xsl:choose>
-              <xsl:when test="@scope">
-                <xsl:value-of select="@scope"/>
-              </xsl:when>
-              <xsl:otherwise>#none#</xsl:otherwise>
-            </xsl:choose>
-          </xsl:variable>
-          <!--grab type, text and metadata, as long there's an href to grab from, otherwise error-->
-          <xsl:apply-templates select="." mode="topicpull:get-stuff">
-            <xsl:with-param name="localtype" select="$type"/>
-            <xsl:with-param name="scope" select="$scope"/>
-            <xsl:with-param name="format" select="$format"/>
-          </xsl:apply-templates>
-        </xsl:copy>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:apply-templates select="." mode="ditamsg:missing-href"/>
-      </xsl:otherwise>
-    </xsl:choose>
+  <!-- Allow fragref without href as long as it has content. -->
+  <xsl:template match="*[contains(@class, ' pr-d/fragref ')][not(@href)][text()|*]">
+    <xsl:copy>
+      <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()"/>
+    </xsl:copy>
   </xsl:template>
-
-  <!-- Override the rule for fragref, so that it does not retrieve <desc> -->
-  <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="topicpull:get-stuff">
-    <xsl:param name="localtype">#none#</xsl:param>
-    <xsl:param name="scope">#none#</xsl:param>
-    <xsl:param name="format">#none#</xsl:param>
-    <!--the file name of the target, if any-->
-    <xsl:variable name="file"><xsl:apply-templates select="." mode="topicpull:get-stuff_file"/></xsl:variable>
-
-    <!--the position of the target topic relative to the current one: in the same file, referenced by id in another file, or referenced as the first topic in another file-->
-    <xsl:variable name="topicpos"><xsl:apply-templates select="." mode="topicpull:get-stuff_topicpos"/></xsl:variable>
-
-    <xsl:apply-templates select="." mode="topicpull:get-stuff_verify-target-present">
-      <xsl:with-param name="topicpos" select="$topicpos"/>
-      <xsl:with-param name="scope" select="$scope"/>
-      <xsl:with-param name="format" select="$format"/>
-      <xsl:with-param name="file" select="$file"/>
-    </xsl:apply-templates>
-
-    <!--the id of the target topic-->
-    <xsl:variable name="topicid">
-      <xsl:apply-templates select="." mode="topicpull:get-stuff_topicid"/>
-    </xsl:variable>
-    <!--the id of the target element, if any-->
-    <xsl:variable name="elemid">
-      <xsl:apply-templates select="." mode="topicpull:get-stuff_elemid"/>
-    </xsl:variable>
-    <!--type - grab type from target, if not defined locally -->
-    <xsl:variable name="type">
-      <xsl:apply-templates select="." mode="topicpull:get-stuff_get-type">
-        <xsl:with-param name="localtype" select="$localtype"/>
-        <xsl:with-param name="scope" select="$scope"/>
-        <xsl:with-param name="format" select="$format"/>
-        <xsl:with-param name="topicpos" select="$topicpos"/>
-        <xsl:with-param name="file" select="$file"/>
-        <xsl:with-param name="topicid" select="$topicid"/>
-        <xsl:with-param name="elemid" select="$elemid"/>
-      </xsl:apply-templates>
-    </xsl:variable>
-
-    <!--now, create the type attribute, if the type attribute didn't exist locally but was retrieved successfully-->
-    <xsl:if test="$localtype='#none#' and not($type='#none#')">
-      <xsl:attribute name="type"><xsl:value-of select="$type"/></xsl:attribute>
-    </xsl:if>
-
-    <!-- Verify that the type was correct, if specified locally, and DITA target is available -->
-    <xsl:apply-templates select="." mode="topicpull:get-stuff_verify-type">
-      <xsl:with-param name="localtype" select="$localtype"/>
-      <xsl:with-param name="scope" select="$scope"/>
-      <xsl:with-param name="format" select="$format"/>
-      <xsl:with-param name="topicpos" select="$topicpos"/>
-      <xsl:with-param name="file" select="$file"/>
-      <xsl:with-param name="topicid" select="$topicid"/>
-      <xsl:with-param name="elemid" select="$elemid"/>
-    </xsl:apply-templates>
-
-    <!--create class value string implied by the link's type, used for comparison with class strings in the target topic for validation-->
-    <xsl:variable name="classval">
-      <xsl:apply-templates select="." mode="topicpull:get-stuff_classval"><xsl:with-param name="type" select="$type"/></xsl:apply-templates>
-    </xsl:variable>
-
-    <!--linktext-->
-    <xsl:apply-templates select="." mode="topicpull:get-stuff_get-linktext">
-      <xsl:with-param name="type" select="$type"/>
-      <xsl:with-param name="scope" select="$scope"/>
-      <xsl:with-param name="format" select="$format"/>
-      <xsl:with-param name="topicpos" select="$topicpos"/>
-      <xsl:with-param name="file" select="$file"/>
-      <xsl:with-param name="topicid" select="$topicid"/>
-      <xsl:with-param name="elemid" select="$elemid"/>
-      <xsl:with-param name="classval" select="$classval"/>
-    </xsl:apply-templates>
-
-  </xsl:template>
-
+  
+  <!-- Ensure desc is not pulled into fragref, which does not allow it in base model -->
+  <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="topicpull:get-stuff_get-shortdesc"/>
+  
 </xsl:stylesheet>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Replaces a lot of obsolete overrides for `<fragref>` with a much simpler override using the latest designs from the `topicpull` module. This resolves a processing error that appears today when using `<fragref>` to reference a syntax diagram fragment:

```
[topicpull] Failed to transform document: A value must be supplied for parameter
 $targetElement because the default value is not a valid instance of the required type
```

## Motivation and Context

DITA-OT has had custom `topicpull` processing for the `<fragref>` element for as long as I can remember. The original purpose was to do two things:

1. Prevent processing from generating `<desc>` into the cross reference, which would never make sense if `<fragref>` was used as designed. Although the `<fragref>` element is specialized from `<xref>`, it specifically excludes `<desc>` as a child, and having that show up caused problems with some tools designed with that restriction in mind.
1. Avoid warning message for `<fragref>` elements without `@href`, as long as the element provided content.

The overall design for `topicpull` has been significantly improved since we created the override. The existing override for `fragref` uses over 100 lines to 1) override `fragref` matching to avoid the "missing `@href`" message, and 2) override `get-stuff` to avoid getting a description. The older code is still based on the original design, meaning that it passes parameters that do nothing and does not pass required parameters, resulting in the error above.

Replacing all of those overrides with two simple match statements simplifies the code, fulfills the original requirements, and fixes the error.

## How Has This Been Tested?

Passed all automated tests; also tested with original documents that resulted in this error, and with following test case that also resulted in the error:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
<topic id="frag" xml:lang="en-us">
 <title>test fragref</title>
 <body>
  <syntaxdiagram id="syntaxdiagram_w34_52d_rdb">
   <groupchoice><kwd>a</kwd>
    <fragref href="#frag/bees"/><fragref>B without href</fragref>
   <kwd>c</kwd></groupchoice>
   <fragment id="bees">
    <title>LOTS OF B OPTIONS</title>
    <groupseq><kwd>B</kwd><kwd>b</kwd><kwd>BB</kwd><kwd>bb</kwd><kwd>Βeta</kwd><kwd>β</kwd></groupseq>
   </fragment>
  </syntaxdiagram>
 </body>
</topic>
```

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_