### PR TITLE
Fix PDF rowheader when rows spanned #2942

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -439,7 +439,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="validate-entry-position"/>
         <xsl:choose>
             <xsl:when test="ancestor::*[contains(@class, ' topic/table ')][1]/@rowheader = 'firstcol'
-                        and empty(preceding-sibling::*[contains(@class, ' topic/entry ')])">
+                and @dita-ot:x = '1'">
                 <fo:table-cell xsl:use-attribute-sets="tbody.row.entry__firstcol">
                     <xsl:apply-templates select="." mode="processTableEntry"/>
                 </fo:table-cell>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Incorporates Radu's suggested fix in #2942 -- when checking whether to apply row-header formatting, check the existing attribute `@dita-ot:x` that gives the position within a row, rather than checking for preceding siblings which may give the wrong answer.

## Motivation and Context

When a cell in column 1 spans rows, entries in the next row will be the first `<entry>` but are not actually part of the first column. The current test for `@rowheader` assumes all entries that are first in the row are part of the first column.

Radu's fix, based on the same test in HTML5, resolves the problem.

## How Has This Been Tested?

Using the sample table provided in #2942 

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
