### PR TITLE
Fix catalog configuration file to remove redundant error logging

### DIFF
--- a/src/main/config/CatalogManager.properties
+++ b/src/main/config/CatalogManager.properties
@@ -3,7 +3,7 @@
 # Copyright 2006 IBM Corporation
 #
 # See the accompanying LICENSE file for applicable license.
-#catalogs=../catalog-dita.xml
+catalogs=
 relative-catalogs=no
 prefer=public
 static-catalog=yes


### PR DESCRIPTION
Instead of removing `catalogs` entry from `CatalogManager.properties`, the `catalogs` entry should be left empty. Without the entry the catalog manager will throw an error message about missing configuration.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>
