### PR TITLE
Generate revprop when changebar specified in ditaval

### DIFF
--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -799,14 +799,18 @@ public final class FilterUtils {
             if (style != null) {
                 propAtts.add("style", Stream.of(style).collect(Collectors.joining(" ")));
             }
-            contentHandler.startElement(NULL_NS_URI, "prop", "prop", propAtts.build());
+            if (changebar != null) {
+                propAtts.add("changebar", Stream.of(changebar).collect(Collectors.joining(" ")));
+            }
+            String tagname = null != changebar ? "revprop" : "prop"; 
+            contentHandler.startElement(NULL_NS_URI, tagname, tagname, propAtts.build());
             if (isStart && startflag != null) {
                 startflag.writeFlag(contentHandler, "startflag");
             }
             if (!isStart && endflag != null) {
                 endflag.writeFlag(contentHandler, "endflag");
             }
-            contentHandler.endElement(NULL_NS_URI, "prop", "prop");
+            contentHandler.endElement(NULL_NS_URI, tagname, tagname);
         }
 
         public Element getStartFlag() {

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -131,30 +131,22 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop" mode="changebar">
-      <xsl:param name="changebar-id"/>
-      <xsl:param name="changebar-style">
-        <xsl:choose>
-          <xsl:when test="@changebar = ('none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove', 'ridge', 'inset', 'outset')">
-            <xsl:value-of select="@changebar"/>
-          </xsl:when>
-          <xsl:otherwise>groove</xsl:otherwise>
-        </xsl:choose>
-      </xsl:param>
-      <xsl:param name="changebar-color">
-        <!-- Could take color from @changebar, but for now take from @color to allow @changebar to set style; bar color matches text -->
-        <xsl:choose>
-          <xsl:when test="@color"><xsl:value-of select="@color"/></xsl:when>
-          <xsl:otherwise>black</xsl:otherwise>
-        </xsl:choose>
-      </xsl:param>
-      <fo:change-bar-begin 
-        change-bar-class="{$changebar-id}" 
-        change-bar-style="{$changebar-style}" 
-        change-bar-color="{$changebar-color}" 
-        change-bar-offset="2mm"/>
-    </xsl:template>
-    <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop" mode="changebar">
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop" mode="changebar">
+    <xsl:param name="changebar-id"/>
+    
+    <xsl:variable name="change-bar-style-atts" as="attribute()*">
+      <xsl:call-template name="parseChangeBarStyle">
+        <xsl:with-param name="value" select="string(@changebar)"/>
+      </xsl:call-template>                
+    </xsl:variable>
+    
+    <fo:change-bar-begin 
+      change-bar-class="{$changebar-id}">
+      <xsl:sequence select="$change-bar-style-atts"/>
+    </fo:change-bar-begin>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop" mode="changebar">
       <xsl:param name="changebar-id"/>
       <fo:change-bar-end change-bar-class="{$changebar-id}"/>
     </xsl:template>


### PR DESCRIPTION
Handle suitesol-style changebar values for preprocessing-produced flagging markup

## Description

Updated XSLT to use the same code as suite-sol flagging markup for flagging markup created during preprocessing so that the change bar attributes are handled consistently and per current OT documentation.

Extended FilterUtils to generate <revprop> instead of <prop> when changebar is present on incoming ditaval data.

## Motivation and Context

Fixes broken flagging preprocessing (change bar data was not being passed through).

Fixes styling of change bars for PDF output (if passed through, XSLT was not using change bar style values).

## How Has This Been Tested?

Created small test document set that exercises revprop with change bars and prop with action="flag". Formatted using AHF and verified that flagging and rev bars were produced as expected.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have not updated the unit tests to reflect the changes in my code.
  Not clear how to test this particular behavior. Didn't see any comparable tests for existing functionality.