### PR TITLE
Remove leading spaces in coderefs #2907

### DIFF
--- a/src/main/java/org/dita/dost/util/SaxCache.java
+++ b/src/main/java/org/dita/dost/util/SaxCache.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+public class SaxCache {
+
+    public interface SaxEvent {
+        void write(ContentHandler handler) throws SAXException;
+    }
+
+    public static class StartPrefixMappingEvent implements SaxEvent {
+        public final String prefix;
+        public final String uri;
+
+        public StartPrefixMappingEvent(String prefix, String uri) {
+            this.prefix = prefix;
+            this.uri = uri;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.startPrefixMapping(prefix, uri);
+        }
+    }
+
+    public static class EndPrefixMappingEvent implements SaxEvent {
+        public final String prefix;
+
+        public EndPrefixMappingEvent(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.endPrefixMapping(prefix);
+        }
+    }
+
+    public static class StartElementEvent implements SaxEvent {
+        public final String uri;
+        public final String localName;
+        public final String qName;
+        public final Attributes atts;
+
+        public StartElementEvent(String uri, String localName, String qName, Attributes atts) {
+            this.uri = uri;
+            this.localName = localName;
+            this.qName = qName;
+            this.atts = atts;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.startElement(uri, localName, qName, atts);
+        }
+    }
+
+    public static class EndElementEvent implements SaxEvent {
+        public final String uri;
+        public final String localName;
+        public final String qName;
+
+        public EndElementEvent(String uri, String localName, String qName) {
+            this.uri = uri;
+            this.localName = localName;
+            this.qName = qName;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.endElement(uri, localName, qName);
+        }
+    }
+
+    public static class CharactersEvent implements SaxEvent {
+        public final char[] ch;
+        public final int start;
+        public final int length;
+
+        public CharactersEvent(char ch[], int start, int length) {
+            this.ch = ch;
+            this.start = start;
+            this.length = length;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.characters(ch, start, length);
+        }
+    }
+
+    public static class IgnorableWhitespaceEvent implements SaxEvent {
+        public final char[] ch;
+        public final int start;
+        public final int length;
+
+        public IgnorableWhitespaceEvent(char ch[], int start, int length) {
+            this.ch = ch;
+            this.start = start;
+            this.length = length;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.ignorableWhitespace(ch, start, length);
+        }
+    }
+
+    public static class ProcessingInstructionEvent implements SaxEvent {
+        public final String target;
+        public final String data;
+
+        public ProcessingInstructionEvent(String target, String data) {
+            this.target = target;
+            this.data = data;
+        }
+
+        @Override
+        public void write(ContentHandler handler) throws SAXException {
+            handler.processingInstruction(target, data);
+        }
+    }
+}

--- a/src/main/java/org/dita/dost/util/SaxCache.java
+++ b/src/main/java/org/dita/dost/util/SaxCache.java
@@ -11,6 +11,7 @@ package org.dita.dost.util;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 public class SaxCache {
 
@@ -56,7 +57,7 @@ public class SaxCache {
             this.uri = uri;
             this.localName = localName;
             this.qName = qName;
-            this.atts = atts;
+            this.atts = new AttributesImpl(atts);
         }
 
         @Override
@@ -88,8 +89,10 @@ public class SaxCache {
         public final int length;
 
         public CharactersEvent(char ch[], int start, int length) {
-            this.ch = ch;
-            this.start = start;
+            final char[] copy = new char[length];
+            System.arraycopy(ch, start, copy, 0, length);
+            this.ch = copy;
+            this.start = 0;
             this.length = length;
         }
 
@@ -105,8 +108,10 @@ public class SaxCache {
         public final int length;
 
         public IgnorableWhitespaceEvent(char ch[], int start, int length) {
-            this.ch = ch;
-            this.start = start;
+            final char[] copy = new char[length];
+            System.arraycopy(ch, start, copy, 0, length);
+            this.ch = copy;
+            this.start = 0;
             this.length = length;
         }
 

--- a/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
@@ -10,11 +10,9 @@ package org.dita.dost.writer;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_OUTPUTCLASS;
 import static org.dita.dost.util.Constants.PR_D_CODEBLOCK;
 
 /**
@@ -24,6 +22,7 @@ import static org.dita.dost.util.Constants.PR_D_CODEBLOCK;
  */
 public final class NormalizeCodeblock extends AbstractXMLFilter {
 
+    private Set<String> outputClass = new HashSet(Arrays.asList("normalize-space"));
     private int depth = 0;
     private Collection<SAXEvent> buf = new ArrayList<>();
 
@@ -58,8 +57,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
 //            contentHandler.endPrefixMapping(prefix);
 //        }
 //    }
-
-
+    
     @Override
     public void startElement(String uri, String localName, String qName,
                              Attributes atts)
@@ -67,12 +65,16 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
         if (depth > 0) {
             depth++;
             buf.add(new StartElementEvent(uri, localName, qName, atts));
-        } else if (PR_D_CODEBLOCK.matches(atts)) {
+        } else if (PR_D_CODEBLOCK.matches(atts) && hasStripWhitespace(atts.getValue(ATTRIBUTE_NAME_OUTPUTCLASS))) {
             depth = 1;
             super.startElement(uri, localName, qName, atts);
         } else {
             super.startElement(uri, localName, qName, atts);
         }
+    }
+
+    private boolean hasStripWhitespace(String value) {
+        return value != null && Arrays.stream(value.split("\\s+")).anyMatch(cls -> outputClass.contains(cls));
     }
 
     @Override

--- a/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.writer;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.dita.dost.util.Constants.PR_D_CODEBLOCK;
+
+/**
+ * Trim whitespace in codeblock elements.
+ *
+ * @since 3.1
+ */
+public final class NormalizeCodeblock extends AbstractXMLFilter {
+
+    private int depth = 0;
+    private Collection<SAXEvent> buf = new ArrayList<>();
+
+//    /**
+//     * Filter a start Namespace prefix mapping event.
+//     *
+//     * @param prefix The Namespace prefix.
+//     * @param uri The Namespace URI.
+//     * @exception org.xml.sax.SAXException The client may throw
+//     *            an exception during processing.
+//     */
+//    public void startPrefixMapping (String prefix, String uri)
+//            throws SAXException
+//    {
+//        if (contentHandler != null) {
+//            contentHandler.startPrefixMapping(prefix, uri);
+//        }
+//    }
+//
+//
+//    /**
+//     * Filter an end Namespace prefix mapping event.
+//     *
+//     * @param prefix The Namespace prefix.
+//     * @exception org.xml.sax.SAXException The client may throw
+//     *            an exception during processing.
+//     */
+//    public void endPrefixMapping (String prefix)
+//            throws SAXException
+//    {
+//        if (contentHandler != null) {
+//            contentHandler.endPrefixMapping(prefix);
+//        }
+//    }
+
+
+    @Override
+    public void startElement(String uri, String localName, String qName,
+                             Attributes atts)
+            throws SAXException {
+        if (depth > 0) {
+            depth++;
+            buf.add(new StartElementEvent(uri, localName, qName, atts));
+        } else if (PR_D_CODEBLOCK.matches(atts)) {
+            depth = 1;
+            super.startElement(uri, localName, qName, atts);
+        } else {
+            super.startElement(uri, localName, qName, atts);
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName)
+            throws SAXException {
+        if (depth > 0) {
+            depth--;
+            if (depth == 0) {
+                for (final SAXEvent event : buf) {
+                    if (event instanceof StartElementEvent) {
+                        final StartElementEvent e = (StartElementEvent) event;
+                        super.startElement(e.uri, e.localName, e.qName, e.atts);
+                    } else if (event instanceof EndElementEvent) {
+                        final EndElementEvent e = (EndElementEvent) event;
+                        super.endElement(e.uri, e.localName, e.qName);
+                    } else if (event instanceof CharactersEvent) {
+                        final CharactersEvent e = (CharactersEvent) event;
+                        super.characters(e.ch, e.start, e.length);
+                    } else if (event instanceof ProcessingInstructionEvent) {
+                        final ProcessingInstructionEvent e = (ProcessingInstructionEvent) event;
+                        super.processingInstruction(e.target, e.data);
+                    } else {
+                        throw new IllegalArgumentException(event.getClass().getCanonicalName());
+                    }
+                }
+                buf.clear();
+                super.endElement(uri, localName, qName);
+            } else {
+                buf.add(new EndElementEvent(uri, localName, qName));
+            }
+        } else {
+            super.endElement(uri, localName, qName);
+        }
+    }
+
+    @Override
+    public void characters(char ch[], int start, int length)
+            throws SAXException {
+        if (depth > 0) {
+            buf.add(new CharactersEvent(ch, start, length));
+        } else {
+            super.characters(ch, start, length);
+        }
+    }
+
+    @Override
+    public void ignorableWhitespace(char ch[], int start, int length)
+            throws SAXException {
+        if (depth > 0) {
+            buf.add(new CharactersEvent(ch, start, length));
+        } else {
+            super.ignorableWhitespace(ch, start, length);
+        }
+    }
+
+    @Override
+    public void processingInstruction(String target, String data)
+            throws SAXException {
+        if (depth > 0) {
+            buf.add(new ProcessingInstructionEvent(target, data));
+        } else {
+            super.processingInstruction(target, data);
+        }
+    }
+
+    interface SAXEvent {
+    }
+
+    static class StartElementEvent implements SAXEvent {
+        final String uri;
+        final String localName;
+        final String qName;
+        final Attributes atts;
+
+        StartElementEvent(String uri, String localName, String qName, Attributes atts) {
+            this.uri = uri;
+            this.localName = localName;
+            this.qName = qName;
+            this.atts = atts;
+        }
+    }
+
+    static class EndElementEvent implements SAXEvent {
+        final String uri;
+        final String localName;
+        final String qName;
+
+        EndElementEvent(String uri, String localName, String qName) {
+            this.uri = uri;
+            this.localName = localName;
+            this.qName = qName;
+        }
+    }
+
+    static class CharactersEvent implements SAXEvent {
+        final char[] ch;
+        final int start;
+        final int length;
+
+        CharactersEvent(char ch[], int start, int length) {
+            this.ch = ch;
+            this.start = start;
+            this.length = length;
+        }
+    }
+
+    static class ProcessingInstructionEvent implements SAXEvent {
+        final String target;
+        final String data;
+
+        ProcessingInstructionEvent(String target, String data) {
+            this.target = target;
+            this.data = data;
+        }
+    }
+
+}

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -354,7 +354,7 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
-        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.codeblock.skip"/>
+        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -354,6 +354,7 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
+        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.codeblock.skip"/>
       </sax>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -303,6 +303,7 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
+        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.codeblock.skip"/>
       </sax>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -303,7 +303,7 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
-        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.codeblock.skip"/>
+        <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>
     </pipeline>
   </target>

--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -72,6 +72,13 @@ public class NormalizeCodeblockTest {
     }
 
     @Test
+    public void testNestedElementWithIndentAndNewline() throws Exception {
+        final Document act = filter(new File(srcDir, "nestedElementWithIndentAndNewline.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "nestedElementWithIndentAndNewline.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    @Test
     public void testCountLeadingSpace() {
         final NormalizeCodeblock filter = new NormalizeCodeblock();
         assertEquals(0, filter.countLeadingSpace("foo"));

--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.writer;
+
+import org.dita.dost.TestUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import java.io.File;
+
+import static org.dita.dost.TestUtils.assertXMLEqual;
+
+public class NormalizeCodeblockTest {
+
+    private static final File resourceDir = TestUtils.getResourceDir(NormalizeCodeblockTest.class);
+    private static final File srcDir = new File(resourceDir, "src");
+    private static final File expDir = new File(resourceDir, "exp");
+
+    private final DocumentBuilder documentBuilder;
+    private final SAXTransformerFactory transformerFactory;
+
+    public NormalizeCodeblockTest() throws ParserConfigurationException {
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        transformerFactory = ((SAXTransformerFactory) TransformerFactory.newInstance());
+    }
+
+    @Test
+    public void testOnlyText() throws Exception {
+        final Document act = filter(new File(srcDir, "onlyText.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "onlyText.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    @Test
+    public void testNestedElement() throws Exception {
+        final Document act = filter(new File(srcDir, "nestedElement.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "nestedElement.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    private Document filter(final File file) throws Exception {
+        final DOMResult result = new DOMResult(documentBuilder.newDocument());
+
+        final TransformerHandler serializer = transformerFactory.newTransformerHandler();
+        serializer.setResult(result);
+
+        final NormalizeCodeblock filter = new NormalizeCodeblock();
+        filter.setContentHandler(serializer);
+
+        final XMLReader parser = XMLReaderFactory.createXMLReader();
+        parser.setContentHandler(filter);
+        parser.parse(file.toURI().toString());
+
+        return (Document) result.getNode();
+    }
+
+}

--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -78,7 +78,6 @@ public class NormalizeCodeblockTest {
         assertEquals(2, filter.countLeadingSpace("  foo"));
         assertEquals(0, filter.countLeadingSpace(""));
         assertEquals(2, filter.countLeadingSpace("  "));
-
     }
 
     private void assertXMLEqual(Document exp, Document act) {

--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -23,7 +25,7 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import java.io.File;
 
-import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
 
 public class NormalizeCodeblockTest {
 
@@ -49,10 +51,44 @@ public class NormalizeCodeblockTest {
     }
 
     @Test
+    public void testOnlyTextWithIndent() throws Exception {
+        final Document act = filter(new File(srcDir, "onlyTextWithIndent.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "onlyTextWithIndent.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    @Test
     public void testNestedElement() throws Exception {
         final Document act = filter(new File(srcDir, "nestedElement.xml"));
         final Document exp = documentBuilder.parse(new File(expDir, "nestedElement.xml"));
         assertXMLEqual(exp, act);
+    }
+
+    @Test
+    public void testNestedElementWithIndent() throws Exception {
+        final Document act = filter(new File(srcDir, "nestedElementWithIndent.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "nestedElementWithIndent.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    @Test
+    public void testCountLeadingSpace() {
+        final NormalizeCodeblock filter = new NormalizeCodeblock();
+        assertEquals(0, filter.countLeadingSpace("foo"));
+        assertEquals(2, filter.countLeadingSpace("  foo"));
+        assertEquals(0, filter.countLeadingSpace(""));
+        assertEquals(2, filter.countLeadingSpace("  "));
+
+    }
+
+    private void assertXMLEqual(Document exp, Document act) {
+        final Diff d = DiffBuilder
+                .compare(exp)
+                .withTest(act)
+                .build();
+        if (d.hasDifferences()) {
+            throw new AssertionError(d.toString());
+        }
     }
 
     private Document filter(final File file) throws Exception {

--- a/src/test/resources/NormalizeCodeblockTest/exp/nestedElement.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/nestedElement.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  <b class="+ topic/ph hi-d/b ">bar</b>
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndent.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  <b class="+ topic/ph hi-d/b ">bar</b>
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndent.xml
@@ -1,6 +1,6 @@
 <topic class="- topic/topic ">
   <body class="- topic/body ">
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">foo
   <b class="+ topic/ph hi-d/b ">bar</b>
 baz</codeblock>
   </body>

--- a/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndentAndNewline.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/nestedElementWithIndentAndNewline.xml
@@ -1,0 +1,8 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">foo
+  <b class="+ topic/ph hi-d/b ">bar
+  baz</b>
+qux</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/exp/onlyText.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/onlyText.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  bar
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithIndent.xml
@@ -1,6 +1,6 @@
 <topic class="- topic/topic ">
   <body class="- topic/body ">
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">foo
   bar
 
 baz</codeblock>

--- a/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithIndent.xml
@@ -1,0 +1,8 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  bar
+
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/nestedElement.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/nestedElement.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  <b class="+ topic/ph hi-d/b ">bar</b>
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndent.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">  foo
+    <b class="+ topic/ph hi-d/b ">bar</b>
+  baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndent.xml
@@ -1,6 +1,6 @@
 <topic class="- topic/topic ">
   <body class="- topic/body ">
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">  foo
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">  foo
     <b class="+ topic/ph hi-d/b ">bar</b>
   baz</codeblock>
   </body>

--- a/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndentAndNewline.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/nestedElementWithIndentAndNewline.xml
@@ -1,0 +1,8 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">  foo
+    <b class="+ topic/ph hi-d/b ">bar
+    baz</b>
+  qux</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/onlyText.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/onlyText.xml
@@ -1,0 +1,7 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">foo
+  bar
+baz</codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithIndent.xml
@@ -1,6 +1,6 @@
 <topic class="- topic/topic ">
   <body class="- topic/body ">
-    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">  foo
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">  foo
     bar
 
   baz</codeblock>

--- a/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithIndent.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithIndent.xml
@@ -1,0 +1,8 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve">  foo
+    bar
+
+  baz</codeblock>
+  </body>
+</topic>


### PR DESCRIPTION
Add filter to remove leading whitespace from `codeblock` elements. Implements #2907.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>

