### PR TITLE
Switch error to warning for non-breaking source issue

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -62,6 +62,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
   
+  <message id="DOTJ007W" type="WARN">
+    <reason>Duplicate condition in filter file for rule '%1'.</reason>
+    <response>The first encountered condition will be used.</response>
+  </message>
+
   <message id="DOTJ007E" type="ERROR">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -387,7 +387,7 @@ public final class DitaValReader implements AbstractReader {
         if (filterMap.get(key) == null) {
             filterMap.put(key, action);
         } else {
-            logger.error(MessageUtils.getMessage("DOTJ007E", key.toString()).toString());
+            logger.warn(MessageUtils.getMessage("DOTJ007W", key.toString()).toString());
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

We currently generate an error message `DOTJ007E` when two rules are found in your DITAVAL(s) for the same condition. This request lowers the severity from `ERROR` to `WARNING`.

## Motivation and Context

One of my customers rightly complained that our severity level is too high for the message about duplicate DITAVAL conditions:
```
[gen-list] [DOTJ007E][ERROR] Duplicate condition in filter file for rule 'platform=abc'. The first encountered condition will be used.
[filter] [DOTJ007E][ERROR] Duplicate condition in filter file for rule 'platform=abc'. The first encountered condition will be used.
```

I've rarely (maybe never) seen this result in broken content -- it's usually just two copies of the same rule. According to our own docs, Error means:
> The toolkit encountered a more severe problem, and the output is affected. For example, some content is missing or invalid, or the content is not rendered in the output

This condition definitely _could_ result in broken content, which fits our definition of a warning: "Processing will continue, but the output might not be as expected."

## How Has This Been Tested?

Tested locally + passed unit and integration tests.

## Type of Changes

I'd call this a bug fix, but one that should go out in a release because we shouldn't change error numbers in a hotfix.

If this is merged to `develop`, then we also need to update a doc topic that mentions the message number: https://github.com/dita-ot/docs/blob/master/reference/implementation-dependent-features.dita#L46
