### PR TITLE
Support alt text for images in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic2fo_shell_axf_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic2fo_shell_axf_template.xsl
@@ -16,6 +16,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="../../cfg/fo/attrs/index-attr_axf.xsl" />
   <xsl:import href="root-processing_axf.xsl"/>
   <xsl:import href="index_axf.xsl"/>
+  <xsl:import href="topic_axf.xsl"/>
   
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic_axf.xsl
+++ b/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic_axf.xsl
@@ -1,0 +1,21 @@
+<?xml version='1.0'?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2018 IBM
+
+See the accompanying LICENSE file for applicable license.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    exclude-result-prefixes="dita-ot xs"
+    version="2.0">
+
+    <xsl:template match="*|@alt" mode="graphicAlternateText">
+        <xsl:attribute name="axf:alttext"><xsl:apply-templates select="." mode="text-only"/></xsl:attribute>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
@@ -18,6 +18,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="tables_fop.xsl"/>
   <xsl:import href="index_fop.xsl"/>
   <xsl:import href="flagging_fop.xsl"/>
+  <xsl:import href="topic_fop.xsl"/>
 
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic_fop.xsl
@@ -1,0 +1,21 @@
+<?xml version='1.0'?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2018 IBM
+
+See the accompanying LICENSE file for applicable license.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    exclude-result-prefixes="dita-ot xs"
+    version="2.0">
+
+    <xsl:template match="*|@alt" mode="graphicAlternateText">
+        <xsl:attribute name="fox:alt-text"><xsl:apply-templates select="." mode="text-only"/></xsl:attribute>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic2fo_shell_xep_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic2fo_shell_xep_template.xsl
@@ -16,6 +16,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="root-processing_xep.xsl"/>
   <xsl:import href="../../cfg/fo/attrs/index-attr_xep.xsl"/>
   <xsl:import href="index_xep.xsl"/>
+  <xsl:import href="topic_xep.xsl"/>
 
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic_xep.xsl
@@ -1,0 +1,21 @@
+<?xml version='1.0'?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2018 IBM
+
+See the accompanying LICENSE file for applicable license.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:rx="http://www.renderx.com/XSL/Extensions"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    exclude-result-prefixes="dita-ot xs"
+    version="2.0">
+
+    <xsl:template match="*|@alt" mode="graphicAlternateText">
+        <xsl:attribute name="rx:alt-description"><xsl:apply-templates select="." mode="text-only"/></xsl:attribute>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -1318,12 +1318,22 @@ See the accompanying LICENSE file for applicable license.
             <xsl:attribute name="content-height">scale-to-fit</xsl:attribute>
             <xsl:attribute name="scaling">uniform</xsl:attribute>
           </xsl:if>
+          <xsl:choose>
+            <xsl:when test="*[contains(@class,' topic/alt ')]">
+              <xsl:apply-templates select="*[contains(@class,' topic/alt ')]" mode="graphicAlternateText"/>
+            </xsl:when>
+            <xsl:when test="@alt">
+              <xsl:apply-templates select="@alt" mode="graphicAlternateText"/>
+            </xsl:when>
+          </xsl:choose>
+          
           <xsl:apply-templates select="node() except (text(),
                                                       *[contains(@class, ' topic/alt ') or
                                                         contains(@class, ' topic/longdescref ')])"/>
         </fo:external-graphic>
     </xsl:template>
 
+    <xsl:template match="*|@alt" mode="graphicAlternateText"/>
 
     <xsl:template match="*[contains(@class,' topic/alt ')]">
         <fo:block xsl:use-attribute-sets="alt">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

FOP, Antenna House, and XEP all have extensions to support alternate text in images. The alternate text is embedded with the image when formatters are produce Tagged PDF output (producing tagged output may be a configuration option on the formatter).

Today, for all FO output, the alternate text is discarded. This update ensures that the alternate text is passed to the FO file using the appropriate extension for each formatter; when the formatter produces tagged / accessible PDF, the alternate text will be used automatically without the need for additional plugins or customizations.

## Motivation and Context

In chatting with @xephon2 he mentioned the FOP extension for alternate text. This also came up as a question for some of my customers recently.

Even though the tagged PDF output is off by default in FOP, we should include the alternate text so that it is already there when somebody turns on tagging. (In general, we should preserve all possible content, and let the rendering step determine whether it is discarded.)

AH and XEP each have their own extensions to support this text, so I've added the update for all three formatters.

## How Has This Been Tested?

- Added alternate text to an image
- Tested to ensure the expected attribute is present in all three copies of `topic.fo`
- Ensured that when tagging is _off_, the alt text does not show up unexpectedly (tested for FOP and AH; I don't have a working copy of XEP to try out, so I've just tested that the attribute matches the one in an [XEP white paper](http://www.renderx.com/Images/Section_508_Showcase.pdf))

## Type of Changes

Sort of a bug fix (we should not have discarded the text), more of an enhancement (improving image processing by supporting alt-text).