### PR TITLE
Use SLF4J with FOP

### DIFF
--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%level] %msg%n</pattern>
+      <!--pattern>
+        %d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n
+      </pattern-->
+    </encoder>
+  </appender>
+  <logger name="FOP" level="INFO"/>
+  <logger name="org.apache.fop" level="INFO"/>
+  <logger name="org.apache.fop.apps.FopConfParser" level="WARN"/>
+  <logger name="org.apache.xmlgraphics" level="INFO"/>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/plugins/org.dita.pdf2.fop/build.gradle
+++ b/src/main/plugins/org.dita.pdf2.fop/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     runtime group: 'org.apache.pdfbox', name: 'fontbox', version: '2.0.7'
     runtime group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.10'
     runtime group: 'xml-apis', name: 'xml-apis-ext', version: '1.3.04'
+    runtime group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
 }
 
 task copyInstall(type: Copy) {
@@ -47,6 +48,7 @@ task copyInstall(type: Copy) {
         exclude 'batik-util-*.jar'
         exclude 'batik-xml-*.jar'
         exclude 'commons-io-*.jar'
+        exclude 'commons-logging-*.jar'
         exclude 'xalan-*.jar'
         exclude 'xml-apis-2*.jar'
     }
@@ -85,6 +87,7 @@ task copyDistTemp(type: Copy) {
         exclude 'batik-util-*.jar'
         exclude 'batik-xml-*.jar'
         exclude 'commons-io-*.jar'
+        exclude 'commons-logging-*.jar'
         exclude 'xalan-*.jar'
         exclude 'xml-apis-2*.jar'
         into "plugins/org.dita.pdf2.fop/lib"

--- a/src/main/plugins/org.dita.pdf2.fop/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/plugin.xml
@@ -14,9 +14,9 @@ See the accompanying LICENSE file for applicable license.
   <feature extension="dita.conductor.lib.import" file="lib/avalon-framework-api-4.3.1.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/avalon-framework-impl-4.3.1.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/batik-all-1.10.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/commons-logging-1.2.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/fontbox-2.0.7.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/fop-2.3.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/jcl-over-slf4j-1.7.25.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xml-apis-ext-1.3.04.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xmlgraphics-commons-2.3.jar"/>
   <transtype name="pdf" desc="PDF">


### PR DESCRIPTION
FOP logging from PDF2 has used a custom log formatter where each log message takes two lines. This PR adds configuration to use SLF4J for FOP, thus allowing to configure the output format. The log messages are all at INFO level, because they are piped through STDERR.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>