### PR TITLE
Show whitespace characters in codeblock in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/pr-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/pr-domain-attr.xsl
@@ -64,6 +64,10 @@ See the accompanying LICENSE file for applicable license.
       <xsl:attribute name="color">gray</xsl:attribute>
       <xsl:attribute name="padding-end">1em</xsl:attribute>
     </xsl:attribute-set>
+    
+  <xsl:attribute-set name="codeblock.whitespace">
+    <xsl:attribute name="color">#C0C0C0</xsl:attribute>
+  </xsl:attribute-set>
 
     <xsl:attribute-set name="option">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -47,7 +47,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:variable name="codeblock.wrap" select="false()"/>
   <xsl:variable name="codeblock.tab-width" as="xs:integer" select="4"/>
   <xsl:template match="node()" mode="codeblock.generate-line-number" as="xs:boolean">
-    <xsl:sequence select="false()"/>
+    <xsl:sequence select="tokenize(@outputclass, '\s+') = 'show-line-numbers'"/>
   </xsl:template>
   <xsl:template match="node()" mode="codeblock.show-whitespace" as="xs:boolean">
     <xsl:sequence select="tokenize(@outputclass, '\s+') = 'show-whitespace'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -45,9 +45,22 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
   <xsl:variable name="codeblock.wrap" select="false()"/>
+  <xsl:variable name="codeblock.tab-width" as="xs:integer" select="4"/>
   <xsl:template match="node()" mode="codeblock.generate-line-number" as="xs:boolean">
     <xsl:sequence select="false()"/>
   </xsl:template>
+  <xsl:template match="node()" mode="codeblock.show-whitespace" as="xs:boolean">
+    <xsl:sequence select="tokenize(@outputclass, '\s+') = 'show-whitespace'"/>
+  </xsl:template>
+  <xsl:template match="node()" mode="codeblock.whitespace-character.space" as="item()">
+    <xsl:text>&#xB7;</xsl:text>
+  </xsl:template>
+  <xsl:template match="node()" mode="codeblock.whitespace-character.tab" as="item()">
+    <xsl:value-of>
+      <xsl:text>&#x2192;</xsl:text>
+      <xsl:for-each select="2 to $codeblock.tab-width">&#xA0;</xsl:for-each>
+    </xsl:value-of>
+  </xsl:template>  
 
     <xsl:template match="*[contains(@class,' pr-d/codeblock ')]">
         <xsl:call-template name="generateAttrLabel"/>
@@ -59,8 +72,17 @@ See the accompanying LICENSE file for applicable license.
             <xsl:variable name="codeblock.line-number" as="xs:boolean">
               <xsl:apply-templates select="." mode="codeblock.generate-line-number"/>
             </xsl:variable>
+            <xsl:variable name="codeblock.show-whitespace" as="xs:boolean">
+              <xsl:apply-templates select="." mode="codeblock.show-whitespace"/>
+            </xsl:variable>
+            <xsl:variable name="codeblock.whitespace-character.space" as="item()">
+              <xsl:apply-templates select="." mode="codeblock.whitespace-character.space"/>
+            </xsl:variable>
+            <xsl:variable name="codeblock.whitespace-character.tab" as="item()">
+              <xsl:apply-templates select="." mode="codeblock.whitespace-character.tab"/>
+            </xsl:variable>
             <xsl:choose>
-              <xsl:when test="$codeblock.wrap or $codeblock.line-number">
+              <xsl:when test="$codeblock.wrap or $codeblock.line-number or $codeblock.show-whitespace">
                 <xsl:variable name="content" as="node()*">
                   <xsl:apply-templates/>
                 </xsl:variable>
@@ -75,10 +97,17 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:variable name="line-count" select="count($buf/descendant::processing-instruction('line-number'))"/>
                     <xsl:apply-templates select="$buf" mode="codeblock">
                       <xsl:with-param name="line-count" select="$line-count" tunnel="yes"/>
+                      <xsl:with-param name="codeblock.show-whitespace" select="$codeblock.show-whitespace" tunnel="yes"/>
+                      <xsl:with-param name="codeblock.whitespace-character.space" select="$codeblock.whitespace-character.space" tunnel="yes"/>
+                      <xsl:with-param name="codeblock.whitespace-character.tab" select="$codeblock.whitespace-character.tab" tunnel="yes"/>
                     </xsl:apply-templates>    
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:apply-templates select="$content" mode="codeblock"/>
+                    <xsl:apply-templates select="$content" mode="codeblock">
+                      <xsl:with-param name="codeblock.show-whitespace" select="$codeblock.show-whitespace" tunnel="yes"/>
+                      <xsl:with-param name="codeblock.whitespace-character.space" select="$codeblock.whitespace-character.space" tunnel="yes"/>
+                      <xsl:with-param name="codeblock.whitespace-character.tab" select="$codeblock.whitespace-character.tab" tunnel="yes"/>
+                    </xsl:apply-templates>
                   </xsl:otherwise>
                 </xsl:choose>                
               </xsl:when>
@@ -132,11 +161,47 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="text()" mode="codeblock"
                 name="codeblock.text" priority="10">
     <xsl:param name="text" select="."/>
+    <xsl:param name="codeblock.show-whitespace" as="xs:boolean" select="false()" tunnel="yes"/>
+    <xsl:param name="codeblock.whitespace-character.space" as="item()" select="' '" tunnel="yes"/>
+    <xsl:param name="codeblock.whitespace-character.tab" as="item()" select="'&#x09;'" tunnel="yes"/>
     <xsl:variable name="head" select="substring($text, 1, 1)"/>
     <xsl:variable name="tail" select="substring($text, 2)"/>
     <xsl:choose>
-      <xsl:when test="$codeblock.wrap and $head = (' ', '&#xA0;')">
-        <xsl:text>&#xA0;&#xAD;</xsl:text>
+      <xsl:when test="$head = (' ', '&#xA0;')">
+        <xsl:choose>
+          <xsl:when test="$codeblock.show-whitespace">
+            <fo:inline xsl:use-attribute-sets="codeblock.whitespace">
+              <xsl:copy-of select="$codeblock.whitespace-character.space"/>
+            </fo:inline>
+          </xsl:when>
+          <xsl:when test="$codeblock.wrap">
+            <xsl:text>&#xA0;</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$head"/>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:if test="$codeblock.wrap">
+          <xsl:text>&#xAD;</xsl:text>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="$head = ('&#x9;')">
+        <xsl:choose>
+          <xsl:when test="$codeblock.show-whitespace">
+            <fo:inline xsl:use-attribute-sets="codeblock.whitespace">
+              <xsl:copy-of select="$codeblock.whitespace-character.tab"/>
+            </fo:inline>
+          </xsl:when>
+          <xsl:when test="$codeblock.wrap">
+            <xsl:text>&#xA0;</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$head"/>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:if test="$codeblock.wrap">
+          <xsl:text>&#xAD;</xsl:text>
+        </xsl:if>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$head"/>


### PR DESCRIPTION
Add support for showing invisible whitespace characters and defining tab character width in `codeblock` elements in PDF. Add outputclass based trigger for line numbering.

![test](https://user-images.githubusercontent.com/52934/40574478-2acb1182-60db-11e8-8901-3ea26e3f9c98.png)

New variables and template modes:

* `codeblock.tab-width` variable to define width of tab characters. Defaults to `4`.
* `codeblock.show-whitespace` template mode to define whether whitespace characters are made visible. Default is to check `show-whitespace` in `@outputclass`.
* `codeblock.whitespace-character.space` template mode to output a visible space character. Defaults to `·`.
* `codeblock.whitespace-character.tab` template mode to output a visible tab character. Defaults to `→   `.

New attribute sets:
* `codeblock.whitespace` to define visible whitespace styling.

Changed defaults:
* `codeblock.generate-line-number` template mode default has been changed to check `show-line-numbers` in `@outputclass`.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>