### PR TITLE
Support frame attribute on choice table

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -929,37 +929,20 @@ See the accompanying LICENSE file for applicable license.
           <xsl:for-each select="$current">
             <fo:table-cell xsl:use-attribute-sets="strow.stentry">
                 <xsl:call-template name="commonattributes"/>
-                <xsl:variable name="frame" as="xs:string">
-                    <xsl:choose>
-                        <xsl:when test="../@frame">
-                            <xsl:value-of select="../@frame"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="$table.frame-default"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
+                <xsl:variable name="frame" as="xs:string" select="if (../@frame)
+                    then (../@frame)
+                    else ($table.frame-default)"/>
                 <xsl:if test="following-sibling::*[contains(@class, ' topic/strow ')]">
-                    <xsl:call-template name="generateSimpleTableHorizontalBorders">
-                        <xsl:with-param name="frame" select="$frame"/>
-                    </xsl:call-template>
+                    <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
+                        <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                    </xsl:apply-templates>
                 </xsl:if>
-                <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
-                    <xsl:call-template name="processAttrSetReflection">
-                        <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-                        <xsl:with-param name="path" select="$tableAttrs"/>
-                    </xsl:call-template>
-                </xsl:if>
-                <xsl:if test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides')">
-                    <xsl:call-template name="processAttrSetReflection">
-                        <xsl:with-param name="attrSet" select="'__tableframe__left'"/>
-                        <xsl:with-param name="path" select="$tableAttrs"/>
-                    </xsl:call-template>
-                    <xsl:call-template name="processAttrSetReflection">
-                        <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
-                        <xsl:with-param name="path" select="$tableAttrs"/>
-                    </xsl:call-template>
-                </xsl:if>
+                <xsl:apply-templates select="." mode="simpletableTopBorder">
+                    <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                </xsl:apply-templates>
+                <xsl:apply-templates select="." mode="simpletableSideBorders">
+                    <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                </xsl:apply-templates>
                 <fo:block>
                     <fo:inline>&#160;</fo:inline>
                 </fo:block>
@@ -1018,31 +1001,20 @@ See the accompanying LICENSE file for applicable license.
         <fo:table-cell xsl:use-attribute-sets="sthead.stentry">
             <xsl:call-template name="commonattributes"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
-            <xsl:variable name="frame" as="xs:string">
-                <xsl:variable name="f" select="ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame"/>
-                <xsl:choose>
-                    <xsl:when test="$f">
-                        <xsl:value-of select="$f"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="$table.frame-default"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:variable>
+            <xsl:variable name="frame" as="xs:string" select="if (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+                then (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+                else ($table.frame-default)"/>
 
-            <xsl:call-template name="generateSimpleTableHorizontalBorders">
-                <xsl:with-param name="frame" select="$frame"/>
-            </xsl:call-template>
-            <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
-            </xsl:if>
+            <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
+                <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+            </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="simpletableTopBorder">
+                <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+            </xsl:apply-templates>
             <xsl:if test="following-sibling::*[contains(@class, ' topic/stentry ')]">
-                <xsl:call-template name="generateSimpleTableVerticalBorders">
-                    <xsl:with-param name="frame" select="$frame"/>
-                </xsl:call-template>
+                <xsl:apply-templates select="." mode="simpletableVerticalBorders">
+                    <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                </xsl:apply-templates>
             </xsl:if>
 
             <xsl:choose>
@@ -1068,27 +1040,19 @@ See the accompanying LICENSE file for applicable license.
         <fo:table-cell xsl:use-attribute-sets="strow.stentry">
             <xsl:call-template name="commonattributes"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
-            <xsl:variable name="frame" as="xs:string">
-                <xsl:variable name="f" select="ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame"/>
-                <xsl:choose>
-                    <xsl:when test="$f">
-                        <xsl:value-of select="$f"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="$table.frame-default"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:variable>
+            <xsl:variable name="frame" as="xs:string" select="if (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+                then (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+                else ($table.frame-default)"/>
 
             <xsl:if test="../following-sibling::*[contains(@class, ' topic/strow ')]">
-                <xsl:call-template name="generateSimpleTableHorizontalBorders">
-                    <xsl:with-param name="frame" select="$frame"/>
-                </xsl:call-template>
+                <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
+                    <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                </xsl:apply-templates>
             </xsl:if>
             <xsl:if test="following-sibling::*[contains(@class, ' topic/stentry ')]">
-                <xsl:call-template name="generateSimpleTableVerticalBorders">
-                    <xsl:with-param name="frame" select="$frame"/>
-                </xsl:call-template>
+                <xsl:apply-templates select="." mode="simpletableVerticalBorders">
+                    <xsl:with-param name="frame" select="$frame" as="xs:string"/>
+                </xsl:apply-templates>
             </xsl:if>
 
             <xsl:choose>
@@ -1108,6 +1072,52 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:otherwise>
             </xsl:choose>
         </fo:table-cell>
+    </xsl:template>
+
+    <xsl:template match="*" mode="simpletableHorizontalBorders">
+        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            else ($table.frame-default)"
+            as="xs:string"/>
+        <xsl:call-template name="generateSimpleTableHorizontalBorders">
+            <xsl:with-param name="frame" select="$frame"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="*" mode="simpletableTopBorder">
+        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            else ($table.frame-default)"
+            as="xs:string"/>
+        <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
+            <xsl:call-template name="processAttrSetReflection">
+                <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
+                <xsl:with-param name="path" select="$tableAttrs"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="*" mode="simpletableSideBorders">
+        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            else ($table.frame-default)" as="xs:string"/>
+        <xsl:if test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides')">
+            <xsl:call-template name="processAttrSetReflection">
+                <xsl:with-param name="attrSet" select="'__tableframe__left'"/>
+                <xsl:with-param name="path" select="$tableAttrs"/>
+            </xsl:call-template>
+            <xsl:call-template name="processAttrSetReflection">
+                <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
+                <xsl:with-param name="path" select="$tableAttrs"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="*" mode="simpletableVerticalBorders">
+        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
+            else ($table.frame-default)"
+            as="xs:string"/>
+        <xsl:call-template name="generateSimpleTableVerticalBorders">
+            <xsl:with-param name="frame" select="$frame"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xsl:template name="generateSimpleTableHorizontalBorders">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -1059,7 +1059,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="simpletableTopBorder">
         <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
-        <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
+        <xsl:if test="$frame = ('all', 'topbot', 'top')">
             <xsl:call-template name="processAttrSetReflection">
                 <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
                 <xsl:with-param name="path" select="$tableAttrs"/>
@@ -1069,7 +1069,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="simpletableSideBorders">
         <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
-        <xsl:if test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides')">
+        <xsl:if test="$frame = ('all', 'topbot', 'sides')">
             <xsl:call-template name="processAttrSetReflection">
                 <xsl:with-param name="attrSet" select="'__tableframe__left'"/>
                 <xsl:with-param name="path" select="$tableAttrs"/>
@@ -1091,7 +1091,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="generateSimpleTableHorizontalBorders">
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
-            <xsl:when test="$frame = ('all', 'topbot', 'sides') or not($frame)">
+            <xsl:when test="$frame = ('all', 'topbot', 'sides') or empty($frame)">
                 <xsl:call-template name="processAttrSetReflection">
                     <xsl:with-param name="attrSet" select="'__tableframe__bottom'"/>
                     <xsl:with-param name="path" select="$tableAttrs"/>
@@ -1103,7 +1103,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="generateSimpleTableVerticalBorders">
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
-            <xsl:when test="$frame = ('all', 'topbot', 'sides') or not($frame)">
+            <xsl:when test="$frame = ('all', 'topbot', 'sides') or empty($frame)">
                 <xsl:call-template name="processAttrSetReflection">
                     <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
                     <xsl:with-param name="path" select="$tableAttrs"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -653,20 +653,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:variable name="rowsep" as="xs:string">
             <xsl:call-template name="getTableRowsep"/>
         </xsl:variable>
-        <xsl:variable name="frame" as="xs:string">
-          <xsl:variable name="f" select="ancestor::*[contains(@class, ' topic/table ')][1]/@frame"/>
-          <xsl:choose>
-            <xsl:when test="$f">
-              <xsl:value-of select="$f"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$table.frame-default"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+        <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/table ')][1]/@frame, $table.frame-default)[1]"/>
         <xsl:variable name="needTopBorderOnBreak" as="xs:boolean">
             <xsl:choose>
-                <xsl:when test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
+                <xsl:when test="$frame = ('all', 'topbot', 'top')">
                     <xsl:choose>
                         <xsl:when test="../parent::node()[contains(@class, ' topic/thead ')]">
                             <xsl:sequence select="true()"/>
@@ -780,16 +770,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template name="displayAtts">
         <xsl:param name="element" as="element()"/>
-        <xsl:variable name="frame" as="xs:string">
-          <xsl:choose>
-            <xsl:when test="$element/@frame">
-              <xsl:value-of select="$element/@frame"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="$table.frame-default"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+        <xsl:variable name="frame" as="xs:string" select="($element/@frame, $table.frame-default)[1]"/>
 
         <xsl:if test="$element/@expanse">
           <xsl:for-each select="$element">
@@ -929,9 +910,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:for-each select="$current">
             <fo:table-cell xsl:use-attribute-sets="strow.stentry">
                 <xsl:call-template name="commonattributes"/>
-                <xsl:variable name="frame" as="xs:string" select="if (../@frame)
-                    then (../@frame)
-                    else ($table.frame-default)"/>
+                <xsl:variable name="frame" as="xs:string" select="(../@frame, $table.frame-default)[1]"/>
                 <xsl:if test="following-sibling::*[contains(@class, ' topic/strow ')]">
                     <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
                         <xsl:with-param name="frame" select="$frame" as="xs:string"/>
@@ -1001,9 +980,7 @@ See the accompanying LICENSE file for applicable license.
         <fo:table-cell xsl:use-attribute-sets="sthead.stentry">
             <xsl:call-template name="commonattributes"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
-            <xsl:variable name="frame" as="xs:string" select="if (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-                then (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-                else ($table.frame-default)"/>
+            <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
 
             <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
                 <xsl:with-param name="frame" select="$frame" as="xs:string"/>
@@ -1040,9 +1017,7 @@ See the accompanying LICENSE file for applicable license.
         <fo:table-cell xsl:use-attribute-sets="strow.stentry">
             <xsl:call-template name="commonattributes"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
-            <xsl:variable name="frame" as="xs:string" select="if (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-                then (ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-                else ($table.frame-default)"/>
+            <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
 
             <xsl:if test="../following-sibling::*[contains(@class, ' topic/strow ')]">
                 <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
@@ -1075,18 +1050,14 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*" mode="simpletableHorizontalBorders">
-        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            else ($table.frame-default)"
+        <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
         <xsl:call-template name="generateSimpleTableHorizontalBorders">
             <xsl:with-param name="frame" select="$frame"/>
         </xsl:call-template>
     </xsl:template>
     <xsl:template match="*" mode="simpletableTopBorder">
-        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            else ($table.frame-default)"
+        <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
         <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top'">
             <xsl:call-template name="processAttrSetReflection">
@@ -1096,9 +1067,8 @@ See the accompanying LICENSE file for applicable license.
         </xsl:if>
     </xsl:template>
     <xsl:template match="*" mode="simpletableSideBorders">
-        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            else ($table.frame-default)" as="xs:string"/>
+        <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
+            as="xs:string"/>
         <xsl:if test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides')">
             <xsl:call-template name="processAttrSetReflection">
                 <xsl:with-param name="attrSet" select="'__tableframe__left'"/>
@@ -1111,9 +1081,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:if>
     </xsl:template>
     <xsl:template match="*" mode="simpletableVerticalBorders">
-        <xsl:param name="frame" select="if (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            then (ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame)
-            else ($table.frame-default)"
+        <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
         <xsl:call-template name="generateSimpleTableVerticalBorders">
             <xsl:with-param name="frame" select="$frame"/>
@@ -1123,7 +1091,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="generateSimpleTableHorizontalBorders">
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
-            <xsl:when test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides') or not($frame)">
+            <xsl:when test="$frame = ('all', 'topbot', 'sides') or not($frame)">
                 <xsl:call-template name="processAttrSetReflection">
                     <xsl:with-param name="attrSet" select="'__tableframe__bottom'"/>
                     <xsl:with-param name="path" select="$tableAttrs"/>
@@ -1135,7 +1103,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="generateSimpleTableVerticalBorders">
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
-            <xsl:when test="($frame = 'all') or ($frame = 'topbot') or ($frame = 'sides') or not($frame)">
+            <xsl:when test="$frame = ('all', 'topbot', 'sides') or not($frame)">
                 <xsl:call-template name="processAttrSetReflection">
                     <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
                     <xsl:with-param name="path" select="$tableAttrs"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -398,6 +398,9 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="univAttrs"/>
       <xsl:call-template name="globalAtts"/>
+      <xsl:call-template name="displayAtts">
+        <xsl:with-param name="element" select="."/>
+      </xsl:call-template>
 
       <xsl:if test="@relcolwidth">
         <xsl:variable name="fix-relcolwidth">
@@ -433,6 +436,9 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*" mode="emptyChoptionHd">
     <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
+      <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      <xsl:apply-templates select="." mode="simpletableTopBorder"/>
+      <xsl:apply-templates select="." mode="simpletableVerticalBorders"/>
       <fo:block xsl:use-attribute-sets="chhead.choptionhd__content">
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'Option'"/>
@@ -443,6 +449,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*" mode="emptyChdescHd">
     <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
+      <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'Description'"/>
@@ -476,6 +484,9 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/choptionhd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
       <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      <xsl:apply-templates select="." mode="simpletableTopBorder"/>
+      <xsl:apply-templates select="." mode="simpletableVerticalBorders"/>
       <fo:block xsl:use-attribute-sets="chhead.choptionhd__content">
         <xsl:apply-templates/>
       </fo:block>
@@ -485,6 +496,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/chdeschd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
       <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
         <xsl:apply-templates/>
       </fo:block>
@@ -495,6 +508,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="keyCol" select="ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.choption">
       <xsl:call-template name="commonattributes"/>
+      <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
+        <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      </xsl:if>
+      <xsl:apply-templates select="." mode="simpletableVerticalBorders"/>
       <xsl:choose>
         <xsl:when test="$keyCol = 1">
           <fo:block xsl:use-attribute-sets="chrow.choption__keycol-content">
@@ -514,6 +531,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="keyCol" select="number(ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol)"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.chdesc">
       <xsl:call-template name="commonattributes"/>
+      <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
+        <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
+      </xsl:if>
       <xsl:choose>
         <xsl:when test="$keyCol = 2">
           <fo:block xsl:use-attribute-sets="chrow.chdesc__keycol-content">


### PR DESCRIPTION
## Description

1. Moves logic for `simpletable/@frame` into mode templates to make the logic reusable
1. Reuse the logic from `choicetable`

## Motivation and Context

One of my customers noticed that `@frame` is ignored on `<choicetable>` -- all choice tables in PDF come out with no frames, no row separators, and no column separators. When I checked I noticed that the logic for supporting these on `<simpletable>` was overly verbose and not reusable without copying.

This pull request 1) puts the frame logic into mode templates that can be reused, and 2) calls those mode templates from the `<choicetable>` elements. The logic is set up so that it also works when called from the context of the actual `<choicetable>` context for generated headers.

Not currently adding the same support to `<properties>` because (unlike choice tables) it has columns that can disappear; with choice tables we know what the final column is.

## How Has This Been Tested?

Created a `<choicetable>` with each frame value, with and without default headers. Also created a `<simpletable>` with each frame value. Verified that the simple table appears the same before and after the fix, and verify that the frame values operate the same in equivalent choice tables.

Sample files:
[choicesample.zip](https://github.com/dita-ot/dita-ot/files/2052213/choicesample.zip)


## Type of Changes

Minor enhancement to simple tables to make logic reusable; bug fix for choice tables.