### PR TITLE
Feature/newmarkers

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -134,6 +134,9 @@ See the accompanying LICENSE file for applicable license.
     
     <!-- Hook that allows extra markers at the start of any topic block -->
     <xsl:template match="*" mode="customTopicMarker"/>
+    
+    <!-- Hook that allows extra markers at the start of any topic block -->
+    <xsl:template match="*" mode="customTopicAnchor"/>
 
     <!-- Hook that allows common end-of-topic processing (after nested topics). -->
     <xsl:template match="*" mode="topicEpilog">
@@ -271,6 +274,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
 
             <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
@@ -342,6 +346,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
 
             <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
@@ -412,6 +417,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:apply-templates>
           
       <fo:block xsl:use-attribute-sets="topic.title">
+        <xsl:apply-templates select="." mode="customTopicAnchor"/>
         <xsl:call-template name="pullPrologIndexTerms"/>
         <xsl:for-each select="*[contains(@class,' topic/title ')]">
           <xsl:apply-templates select="." mode="getTitle"/>
@@ -489,6 +495,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
 
             <fo:block xsl:use-attribute-sets="topic.title">
+                <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
@@ -553,6 +560,7 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:apply-templates>
 
                     <fo:block xsl:use-attribute-sets="topic.title">
+                        <xsl:apply-templates select="." mode="customTopicAnchor"/>
                         <xsl:call-template name="pullPrologIndexTerms"/>
                         <xsl:for-each select="*[contains(@class,' topic/title ')]">
                             <xsl:apply-templates select="." mode="getTitle"/>
@@ -613,6 +621,7 @@ See the accompanying LICENSE file for applicable license.
                          <xsl:attribute name="id">
                              <xsl:call-template name="generate-toc-id"/>
                          </xsl:attribute>
+                         <xsl:apply-templates select="." mode="customTopicAnchor"/>
                          <xsl:call-template name="pullPrologIndexTerms"/>
                          <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
                              <xsl:apply-templates select="." mode="getTitle"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -120,6 +120,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:if>
       <fo:block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes"/>
+        <xsl:apply-templates select="." mode="customTopicMarker"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/prolog ')]"/>
         <xsl:apply-templates select="*[not(contains(@class, ' topic/title ')) and
@@ -130,6 +131,9 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="topicEpilog"/>
       </fo:block>
     </xsl:template>
+    
+    <!-- Hook that allows extra markers at the start of any topic block -->
+    <xsl:template match="*" mode="customTopicMarker"/>
 
     <!-- Hook that allows common end-of-topic processing (after nested topics). -->
     <xsl:template match="*" mode="topicEpilog">
@@ -258,6 +262,7 @@ See the accompanying LICENSE file for applicable license.
                 </fo:marker>
                 <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
             </xsl:if>
+            <xsl:apply-templates select="." mode="customTopicMarker"/>
 
             <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
@@ -328,6 +333,7 @@ See the accompanying LICENSE file for applicable license.
                 </fo:marker>
                 <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
             </xsl:if>
+            <xsl:apply-templates select="." mode="customTopicMarker"/>
 
             <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
@@ -397,6 +403,7 @@ See the accompanying LICENSE file for applicable license.
         </fo:marker>
         <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
       </xsl:if>
+      <xsl:apply-templates select="." mode="customTopicMarker"/>
           
       <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
           
@@ -473,6 +480,7 @@ See the accompanying LICENSE file for applicable license.
                 </fo:marker>
                 <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
             </xsl:if>
+            <xsl:apply-templates select="." mode="customTopicMarker"/>
 
             <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
@@ -536,6 +544,7 @@ See the accompanying LICENSE file for applicable license.
                         </fo:marker>
                         <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
                     </xsl:if>
+                    <xsl:apply-templates select="." mode="customTopicMarker"/>
 
                     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
 
@@ -598,6 +607,7 @@ See the accompanying LICENSE file for applicable license.
                          </fo:marker>
                          <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
                      </xsl:if>
+                     <xsl:apply-templates select="." mode="customTopicMarker"/>
                      <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
                      <fo:block xsl:use-attribute-sets="topic.title">
                          <xsl:attribute name="id">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -21,6 +21,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:with-param name="id" select="'Glossary'"/>
           </xsl:call-template>
         </fo:marker>
+        <xsl:apply-templates select="." mode="customTopicMarker"/>
         <fo:block xsl:use-attribute-sets="__glossary__label" id="{$id.glossary}">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Glossary'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -23,6 +23,7 @@ See the accompanying LICENSE file for applicable license.
         </fo:marker>
         <xsl:apply-templates select="." mode="customTopicMarker"/>
         <fo:block xsl:use-attribute-sets="__glossary__label" id="{$id.glossary}">
+          <xsl:apply-templates select="." mode="customTopicAnchor"/>
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Glossary'"/>
           </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -541,6 +541,7 @@ See the accompanying LICENSE file for applicable license.
 
             <fo:flow flow-name="xsl-region-body">
                 <fo:block xsl:use-attribute-sets="__index__label" id="{$id.index}">
+                    <xsl:apply-templates select="." mode="customTopicAnchor"/>
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="'Index'"/>
                     </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -521,6 +521,7 @@ See the accompanying LICENSE file for applicable license.
                             <xsl:with-param name="id" select="'Index'"/>
                           </xsl:call-template>
                         </fo:marker>
+                        <xsl:apply-templates select="." mode="customTopicMarker"/>
                         <xsl:copy-of select="$index"/>
                     </fo:flow>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -628,6 +628,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' topic/linklist ')]/*[contains(@class,' topic/title ')]">
     <fo:block xsl:use-attribute-sets="linklist.title">
+      <xsl:apply-templates select="." mode="customTitleAnchor"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -72,6 +72,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:call-template>
       </fo:marker>
       <xsl:apply-templates select="." mode="customTopicMarker"/>
+      <xsl:apply-templates select="." mode="customTopicAnchor"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'List of Tables'"/>
       </xsl:call-template>
@@ -149,6 +150,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:call-template>
       </fo:marker>
       <xsl:apply-templates select="." mode="customTopicMarker"/>
+      <xsl:apply-templates select="." mode="customTopicAnchor"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'List of Figures'"/>
       </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -71,6 +71,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:with-param name="id" select="'List of Tables'"/>
         </xsl:call-template>
       </fo:marker>
+      <xsl:apply-templates select="." mode="customTopicMarker"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'List of Tables'"/>
       </xsl:call-template>
@@ -147,6 +148,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:with-param name="id" select="'List of Figures'"/>
         </xsl:call-template>
       </fo:marker>
+      <xsl:apply-templates select="." mode="customTopicMarker"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'List of Figures'"/>
       </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -356,6 +356,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram.title">
             <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -64,6 +64,7 @@ See the accompanying LICENSE file for applicable license.
                  </fo:marker>
                  <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
              </xsl:if>
+             <xsl:apply-templates select="." mode="customTopicMarker"/>
              <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
              <xsl:apply-templates select="." mode="insertChapterFirstpageStaticContent">
                  <xsl:with-param name="type" select="'preface'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -70,6 +70,7 @@ See the accompanying LICENSE file for applicable license.
                  <xsl:with-param name="type" select="'preface'"/>
              </xsl:apply-templates>
              <fo:block xsl:use-attribute-sets="topic.title">
+                 <xsl:apply-templates select="." mode="customTopicAnchor"/>
                  <xsl:call-template name="pullPrologIndexTerms"/>
                  <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
                      <xsl:apply-templates select="." mode="getTitle"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -297,6 +297,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]">
         <fo:block xsl:use-attribute-sets="table.title">
             <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Table.title'"/>
                 <xsl:with-param name="params">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -260,6 +260,7 @@ See the accompanying LICENSE file for applicable license.
                             <xsl:with-param name="id" select="'Table of Contents'"/>
                           </xsl:call-template>
                         </fo:marker>
+                        <xsl:apply-templates select="." mode="customTopicMarker"/>
                         <xsl:copy-of select="$toc"/>
                     </fo:block>
                 </fo:flow>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -45,12 +45,13 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template name="createTocHeader">
         <fo:block xsl:use-attribute-sets="__toc__header" id="{$id.toc}">
+            <xsl:apply-templates select="." mode="customTopicAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Table of Contents'"/>
             </xsl:call-template>
         </fo:block>
     </xsl:template>
-
+    
     <xsl:template match="/" mode="toc">
         <xsl:apply-templates mode="toc">
             <xsl:with-param name="include" select="'true'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -103,6 +103,7 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:call-template>
                     </xsl:attribute>
                 </fo:wrapper>
+                <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:apply-templates select="." mode="getTitle"/>
             </fo:block>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -140,10 +140,14 @@ See the accompanying LICENSE file for applicable license.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+    
+    <!-- Hook that allows adding anchors to titled non topic elements. -->
+    <xsl:template match="*[contains(@class,' topic/title ')]" mode="customTitleAnchor"/>
 
     <xsl:template match="*[contains(@class,' topic/section ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="section.title">
             <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates select="." mode="getTitle"/>
         </fo:block>
     </xsl:template>
@@ -151,6 +155,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/example ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="example.title">
             <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -158,6 +163,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/fig ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="fig.title">
             <xsl:call-template name="commonattributes"/>
+            <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Figure.title'"/>
                 <xsl:with-param name="params">


### PR DESCRIPTION
## Description

Provides two related capabilities:

- Ability to insert custom topic level markers - for example, to declare markers for use in a running header - without having to customize every topic level template.
- Ability to insert custom topic level anchors (with the same benefits) as well as the ability to insert custom anchors for titled elements within a topic

## Motivation and Context

For markers: we had a need to generate markers for retrieval keys in a header. This is most common with message topics or glossary topics, with dictionary style keys in the header. To do this we had to customize every template that processes topics (such as `processTopicChapter`, `processTopicPreface`, etc) -- resulting in a lot of code duplication for something that seems relatively simple. Our internal implementation matches this pull request (we copy all of those templates, then add a hook to create markers; when relevant, the markers are inserted).

For anchors: when unique IDs are specified for topics, those IDs can easily be used as link targets into the PDF. We use this successfully with the same logic as above: copy every template that processes topics, and add a call out to generate anchors where applicable. We do not want to _modify_ any of the IDs in use today (no reason to do so, it would be risky and would mean changing all of the PDF linking logic). Instead, when anchors are required, we generate `<fo:inline id="some-id"/>`, which then turns into a named destination in the PDF.

Titled elements in topics (`example`, `fig`, `linklist`, `section`, `table`): although this one isn't burdensome like the topics, we've also extended this to generate named destinations for titled elements inside of a topic. I used a separate hook for these because it's likely that topics and non-topic elements will be handled differently, but all non-topic elements will likely be handled the same.

I've been using this successfully for a few weeks now to generate PDFs using custom anchors, and am now able to link directly to those anchors within the PDF.

## How Has This Been Tested?

- Tested with unit / integration / end-to-end tests
- Build DITA-OT user guide with no new errors / proper generated content
- Tested generating `<fo:marker marker-class-name="test">test content</fo:marker>` in the marker hook, and `<fo:inline id="{generate-id(.)}"/>` for the anchor hooks; PDF of user guide still builds correctly, with no new duplicate IDs appearing for any element in the FO file
- Tested with our own content, using the hooks to generate markers for running headers and to generate anchors for named destinations

## Type of Changes

New feature / minor enhancement