### PR TITLE
Update Java dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,22 +24,21 @@ repositories {
      mavenCentral()
 }
 dependencies {
-    compile group: 'commons-io', name: 'commons-io', version: '2.5'
-    compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
+    compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'xerces', name: 'xercesImpl', version:'2.11.0'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     compile group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
-    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.8.0-7'
-    compile group: 'com.ibm.icu', name: 'icu4j', version:'57.1'
-    compile group: 'org.apache.ant', name: 'ant', version:'1.10.1'
-    compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.10.1'
-    compile group: 'com.google.guava', name: 'guava', version: '19.0'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.23'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.1'
-    runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.1'
+    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.8.0-12'
+    compile group: 'com.ibm.icu', name: 'icu4j', version:'61.1'
+    compile group: 'org.apache.ant', name: 'ant', version:'1.10.3'
+    compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.10.3'
+    compile group: 'com.google.guava', name: 'guava', version: '25.1-jre'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.3'
     testCompile group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testCompile group: 'junit', name: 'junit', version:'4.12'
-    testCompile group: 'org.xmlunit', name: 'xmlunit-core', version: '2.3.0'
+    testCompile group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.0'
 }
 
 jar.archiveName = "${project.name}.jar"

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -8,7 +8,7 @@
 package org.dita.dost.writer;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.codec.binary.Base64;
+import com.google.common.io.BaseEncoding;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.reader.SvgMetadataReader;
 import org.dita.dost.util.Job;
@@ -262,7 +262,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
             final String metadata = data.substring(0, separator);
             if (metadata.endsWith(";base64")) {
                 logger.info("Base-64 encoded data URI");
-                return new ByteArrayInputStream(Base64.decodeBase64(data.substring(separator + 1)));
+                return new ByteArrayInputStream(BaseEncoding.base64().decode(data.substring(separator + 1)));
             } else {
                 logger.info("ASCII encoded data URI");
                 return new ByteArrayInputStream(data.substring(separator).getBytes());


### PR DESCRIPTION
Update Java library dependencies to latest stable versions. Remove Commons Codes and use Guava instead of Base-64 decoding.