### PR TITLE
Fail if an enumerated argument does not lie within a given set of values

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -50,6 +50,10 @@ See the accompanying LICENSE file for applicable license.
     <reason>Attribute @%1 is deprecated.</reason>
     <response>Use attribute @%2 instead.</response>
   </message>
+  <message id="DOTA015F" type="FATAL">
+    <reason>Invalid value for argument '%1'</reason>
+    <response>Supported values are %2</response>
+  </message>
 
   <!-- Start of Java Messages -->
   

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -147,6 +147,16 @@ See the accompanying LICENSE file for applicable license.
 
     <!--solution for the output control-->
     <property name="generate.copy.outer" value="1"/>
+    <!-- Check for valid values -->
+    <dita-ot-fail id="DOTA015F">
+      <condition>
+        <not>
+          <matches pattern="^(1|3)$" string="${generate.copy.outer}"/>
+        </not>
+      </condition>
+      <param name="1" value="generate.copy.outer"/>
+      <param name="2" value="1,3"/>
+    </dita-ot-fail>
 
     <property name="onlytopic.in.map" value="false"/>
 

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -239,6 +239,35 @@ with those set forth herein.
     <property name="args.bookmap-order" value="discard"/>
     <property name="args.figurelink.style" value="NUMTITLE"/>
     <property name="args.tablelink.style" value="NUMTITLE"/>
+     <!-- Check for valid values -->
+     <dita-ot-fail id="DOTA015F">
+      <condition>
+        <not>
+          <matches pattern="^(retain|discard)$" string="${args.bookmap-order}"/>
+        </not>
+      </condition>
+      <param name="1" value="args.bookmap-order"/>
+      <param name="2" value="retain,discard"/>
+    </dita-ot-fail>
+
+    <dita-ot-fail id="DOTA015F">
+      <condition>
+        <not>
+          <matches pattern="^(NUMBER|TITLE|NUMTITLE)$" string="${args.figurelink.style}"/>
+        </not>
+      </condition>
+      <param name="1" value="args.figurelink.style"/>
+      <param name="2" value="NUMBER,TITLE,NUMTITLE"/>
+    </dita-ot-fail>
+    <dita-ot-fail id="DOTA015F">
+      <condition>
+        <not>
+          <matches pattern="^(NUMBER|TITLE|NUMTITLE)$" string="${args.tablelink.style}"/>
+        </not>
+      </condition>
+      <param name="1" value="args.tablelink.style"/>
+      <param name="2" value="NUMBER,TITLE,NUMTITLE"/>
+    </dita-ot-fail>
   </target>
 
   <target name="transform.topic2fo.index">


### PR DESCRIPTION
## Description
* ~Simplified ANT scripts by removing unnecessary  `<condition>` statements.~
* Add new failure message `DOTA015F`
* Checked for parameter values using `<matches>` condition

## Motivation and Context
Adds a check for enumerated parameters. Fails if parameter is not in the required range.Fixes #1935. 

## How Has This Been Tested?
Manual testing. Ran xhtml transform with and without valid generate.copy.outer parameter

## Type of Changes

- New feature  : Parameter checking - currently added to 3 enumerated parameters

## Checklist

I have not found any coding convention for ANT scripts.
No unit test has been added.
