### PR TITLE
Remove unnecessary files from `docsrc` distribution 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,7 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         include "*.*"
         include "bin/dita"
         include "bin/dita.bat"
+        exclude "docsrc/.editorconfig"
         exclude "docsrc/.github"
         exclude "docsrc/.gradle"
         exclude "docsrc/.travis"

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,7 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         exclude "docsrc/site.*"
         exclude "docsrc/build"
         exclude "docsrc/out"
+        exclude "docsrc/platform.ditaval"
         exclude "docsrc/temp"
         include "docsrc/**"
         include "dtd/**"

--- a/build.gradle
+++ b/build.gradle
@@ -196,7 +196,6 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         exclude "docsrc/.travis.yml"
         exclude "docsrc/*.md"
         exclude "docsrc/*.xpr"
-        exclude "docsrc/site.*"
         exclude "docsrc/build"
         exclude "docsrc/out"
         exclude "docsrc/platform.ditaval"


### PR DESCRIPTION
After the changes in 244da96 for #2972, several unnecessary files are copied to the `docsrc` folder of the distribution package and an obsolete exclusion can be removed from the build file.