### PR TITLE
Fixes missing $file-being-processed parameter in xsl/preprocess/mapre…

### DIFF
--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -100,6 +100,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
             final Result result = new DOMResult(doc);
             final Transformer transformer = withLogger(templates.newTransformer(), logger);
             transformer.setURIResolver(CatalogUtils.getCatalogResolver());
+            transformer.setParameter("file-being-processed", inputFile.getName());
             transformer.transform(source, result);
         } catch (final RuntimeException e) {
             throw e;


### PR DESCRIPTION
## Description
maprefImpl.xsl depends on `file-being-processed parameter`. Previously, the template was applied by ant xslt task with the [corresponding attribute](https://github.com/dita-ot/dita-ot/blob/3.0.4/src/main/plugins/org.dita.base/build_preprocess_template.xml#L333). Now the template call has moved to [org.dita.dost.module.MaprefModule](https://github.com/dita-ot/dita-ot/blob/develop/src/main/plugins/org.dita.base/build_preprocess_template.xml#L332) which not defines this parameter. This leads to an errors in some cases.

## How Has This Been Tested?
- ./gradlew check
- the file attched: [reltable-topicset.tar.gz](https://github.com/dita-ot/dita-ot/files/2140140/reltable-topicset.tar.gz)


## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>