### PR TITLE
Deprecate and remove Ant properties

### DIFF
--- a/src/main/build_template.xml
+++ b/src/main/build_template.xml
@@ -23,6 +23,7 @@ See the accompanying LICENSE file for applicable license.
     </not>
   </condition>
     
+  <!-- Deprecated since 3.1 -->
   <path id="dost.class.path">
     <dita:extension id="dita.conductor.lib.import" behavior="org.dita.dost.platform.ImportAntLibAction"/>
     <pathelement location="${dita.dir}/lib/dost.jar"/>

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -29,6 +29,7 @@ See the accompanying LICENSE file for applicable license.
     </not>
   </condition>
   
+  <!-- Deprecated since 3.1 -->
   <path id="dost.class.path">
     <pathelement location="${dita.dir}/lib/dost.jar"/>
     <pathelement location="${dita.dir}/lib/dost-configuration.jar"/>

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -19,9 +19,6 @@ See the accompanying LICENSE file for applicable license.
     <catalogpath path="${dita.plugin.org.dita.base.dir}/catalog-dita.xml"/>
   </xmlcatalog>
 
-  <!-- Deprecated -->
-  <path id="dost.jar.path" refid="dost.class.path"/>
-
   <taskdef name="pipeline" classname="org.dita.dost.ant.ExtensibleAntInvoker"/>
   <taskdef name="dita-ot-echo" classname="org.dita.dost.ant.DITAOTEchoTask"/>
   <taskdef name="dita-ot-fail" classname="org.dita.dost.ant.DITAOTFailTask"/>

--- a/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
@@ -141,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!--Run FOP-->
   <target name="transform.fo2pdf.fop" if="use.fop.pdf.formatter">
-    <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop" classpathref="dost.class.path"/>
+    <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop"/>
     
     <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
       <not><isset property="outputFile"/></not>

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -140,7 +140,6 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
         destdir="${dita.output.dir}"
         reloadstylesheet="${dita.xhtml.reloadstylesheet}"
-        classpathref="dost.class.path"
         extension="${out.ext}" style="${args.xsl}"
         filenameparameter="FILENAME"
         filedirparameter="FILEDIR">


### PR DESCRIPTION
## Description
Remove `dost.jar.path` property and deprecate `dost.class.path` properties.

## Motivation and Context
The currently correct way to define the classpath is outside the Ant process, thus `dost.class.path` is obsolete. The `dost.jar.path` is a previously deprecated alias for `dost.class.path` and can be removed after being deprecated since 2.1.

