### PR TITLE
Fix missing src for copy-to target

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -680,7 +680,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
         for (final URI target : filteredCopyTo.keySet()) {
             final URI tmp = tempFileNameScheme.generateTempFileName(target);
-            final FileInfo fi = new FileInfo.Builder().result(target).uri(tmp).build();
+            final URI src = filteredCopyTo.get(target);
+            final FileInfo fi = new FileInfo.Builder().src(src).result(target).uri(tmp).build();
             // FIXME: what's the correct value for this? Accept all?
             if (formatFilter.test(fi.format)
                     || fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {


### PR DESCRIPTION
The `src` field is not set when copying `source` field to `@copy-to` targets.