### PR TITLE
Update troff plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
 def bundled = [
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.0.5/org.lwdita-2.0.5.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
-        "troff": "https://github.com/dita-ot/org.dita.troff/archive/2.5.zip",
+        "troff": "https://github.com/dita-ot/org.dita.troff/archive/3.1.1.zip",
         "tocjs": "https://github.com/dita-ot/com.sophos.tocjs/archive/2.5.zip"
 ]
 


### PR DESCRIPTION
Update troff plugin to version 3.1.1.

Diff between [2.5 and 3.1.1](https://github.com/dita-ot/org.dita.troff/compare/f5abe97bbfaaafe49a69f452f0a342605f3f32fd...ddbdcff9032f76f4a8b0733c7467e0b8289692e2).