### PR TITLE
Fix configuration file generation and reading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,8 +202,6 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         exclude "docsrc/temp"
         include "docsrc/**"
         include "dtd/**"
-        //include "lib/**/*.properties"
-        exclude "lib/configuration.properties"
         include "plugins/org.dita.base/**"
         include "plugins/org.dita.eclipsehelp/**"
         include "plugins/org.dita.html5/**"
@@ -240,18 +238,7 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
 }
 copyDistTemp.outputs.dir distTempDir
 
-task updateConfiguration() {
-    doLast {
-        if (project.hasProperty('commit') && !commit.empty) {
-            ant.propertyfile(file: "${distTempDir}/lib/configuration.properties") {
-                entry(key: "otversion", operation: "=", value: "${distVersion}")
-            }
-        }
-    }
-}
-updateConfiguration.mustRunAfter copyDistTemp
-
-task integrateDistTemp(type: JavaExec, dependsOn: [copyDistTemp, ":fo:copyDistTemp", ":axf:copyDistTemp", ":fop:copyDistTemp", ":xep:copyDistTemp", ":eclipsehelp:copyDistTemp", ":htmlhelp:copyDistTemp", updateConfiguration]) {
+task integrateDistTemp(type: JavaExec, dependsOn: [copyDistTemp, ":fo:copyDistTemp", ":axf:copyDistTemp", ":fop:copyDistTemp", ":xep:copyDistTemp", ":eclipsehelp:copyDistTemp", ":htmlhelp:copyDistTemp"]) {
     main = "org.apache.tools.ant.launch.Launcher"
     classpath = sourceSets.main.runtimeClasspath + files("${distTempDir}", "${projectDir}/src/main/config")
     workingDir distTempDir

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -61,7 +61,7 @@ public final class Configuration {
             if (plugingConfigurationInputStream != null) {
                 pluginProperties.load(plugingConfigurationInputStream);
             } else {
-                final File configurationFile = new File("lib", Integrator.class.getPackage().getName() + File.separator + GEN_CONF_PROPERTIES);
+                final File configurationFile = new File("config", Integrator.class.getPackage().getName() + File.separator + GEN_CONF_PROPERTIES);
                 if (configurationFile.exists()) {
                     plugingConfigurationInputStream = new BufferedInputStream(new FileInputStream(configurationFile));
                     pluginProperties.load(plugingConfigurationInputStream);
@@ -90,7 +90,7 @@ public final class Configuration {
             if (configurationInputStream != null) {
                 properties.load(configurationInputStream);
             } else {
-                final File configurationFile = new File("lib", CONF_PROPERTIES);
+                final File configurationFile = new File("config", CONF_PROPERTIES);
                 if (configurationFile.exists()) {
                     configurationInputStream = new BufferedInputStream(new FileInputStream(configurationFile));
                     properties.load(configurationInputStream);

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -12,8 +12,8 @@ See the accompanying LICENSE file for applicable license.
   <loadproperties>
     <javaresource name="application.properties"/>
   </loadproperties>
-  <property file="${dita.dir}/lib/org.dita.dost.platform/plugin.properties"/>
-  <property file="${dita.dir}/lib/configuration.properties"/>
+  <property file="${dita.dir}/config/org.dita.dost.platform/plugin.properties"/>
+  <property file="${dita.dir}/config/configuration.properties"/>
   
   <xmlcatalog id="dita.catalog">
     <catalogpath path="${dita.plugin.org.dita.base.dir}/catalog-dita.xml"/>


### PR DESCRIPTION
Various configuration files are not read from correct locations, thus not all configuration data is available in all places. Fix the issue by removing `lib/configuration.properties` and retain only `config/configuration.properties`.