### PR TITLE
Fix #./element style XREF that is pulled with conref

### DIFF
--- a/src/main/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/xsl/preprocess/conrefImpl.xsl
@@ -539,6 +539,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="starts-with(., 'http://') or starts-with(., 'https://') or starts-with(., 'ftp://')">
           <xsl:value-of select="."/>
         </xsl:when>
+        
+        <xsl:when test=". = '#.' or starts-with(., '#./')">
+          <xsl:value-of select="."/>
+        </xsl:when>
 
         <xsl:when test="starts-with(., '#')">
           <xsl:choose>

--- a/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxref.dita
+++ b/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxref.dita
@@ -5,7 +5,10 @@
 <section class="- topic/section "><title class="- topic/title ">Section that is pulled to another topic.</title><p class="- topic/p ">Look
 as the figure in this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/fig" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
 at a figure in this topic, outside of this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/out" type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Now
-look at this topic: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target" type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p><p class="- topic/p ">Now
+look at this topic: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target" type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p>
+<p class="- topic/p ">Now look at "current topic" with #. syntax: <xref class="- topic/xref " href="#conrefbreaksxref" type="topic"><?ditaot gentext?>conrefbreaksxref source<?ditaot genshortdesc?><desc class="- topic/desc ">This topic conrefs to another, which uses xref internally.</desc></xref></p>
+<p class="- topic/p ">Now look at "fig in current topic" with #./fig syntax: <xref
+class="- topic/xref " href="#conrefbreaksxref/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Now
 look at the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#sub" type="topic"><?ditaot gentext?>Sub-topic in the reusable file</xref>.</p><p class="- topic/p ">Now look at a figure
 in the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#sub/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><fig class="- topic/fig " id="d7e40"><title class="- topic/title ">Figure In My Section</title>
 <p class="- topic/p ">This is a figure here.</p>
@@ -16,5 +19,9 @@ in this topic, outside the section: <xref class="- topic/xref " href="subdir/con
 at this topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir" type="topic"><?ditaot gentext?>conrefbreaksxref: target in the subdir<?ditaot genshortdesc?><desc class="- topic/desc ">Pull in a section, from a topic in the subdir.</desc></xref></p><p class="- topic/p ">Look at a figure in a sub-topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig/nestfig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Look at the subtopic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig" type="topic"><?ditaot gentext?>Subdir Subfig</xref></p><fig class="- topic/fig " id="d8e39"><title class="- topic/title ">This iz me fig</title>
 <p class="- topic/p ">here's a figure. Go figure.</p>
 </fig></section>
+<fig class="- topic/fig " id="fig">
+<title class="- topic/title ">Figure in the <b class="+ topic/ph hi-d/b ">referencing</b> topic</title>
+<p class="- topic/p ">Links pulled in with #./fig syntax should go here</p>
+</fig>
 </body>
 </topic><?Pub *0000000511?>

--- a/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxreftarget.dita
+++ b/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxreftarget.dita
@@ -5,7 +5,9 @@
 <section id="section" class="- topic/section "><title class="- topic/title ">Section that is pulled to another topic.</title><p class="- topic/p ">Look
 as the figure in this section: <xref href="#this-target/fig" class="- topic/xref " type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
 at a figure in this topic, outside of this section: <xref href="#this-target/out" class="- topic/xref " type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Now
-look at this topic: <xref href="#this-target" class="- topic/xref " type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p><p class="- topic/p ">Now
+look at this topic: <xref href="#this-target" class="- topic/xref " type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p>
+<p class="- topic/p ">Now look at "current topic" with #. syntax: <xref href="#this-target" class="- topic/xref " type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p>
+<p class="- topic/p ">Now look at "fig in current topic" with #./fig syntax: <xref href="#this-target/fig" class="- topic/xref " type="fig"><?ditaot gentext?>Figure 1</xref></p><p class="- topic/p ">Now
 look at the topic below: <xref href="#sub" class="- topic/xref " type="topic"><?ditaot gentext?>Sub-topic in the reusable file</xref>.</p><p class="- topic/p ">Now look at a figure
 in the topic below: <xref href="#sub/fig" class="- topic/xref " type="fig"><?ditaot gentext?>Figure 3</xref></p><fig id="fig" class="- topic/fig "><title class="- topic/title ">Figure
 In My Section</title>

--- a/src/test/resources/conrefbreaksxref/src/conrefbreaksxref.dita
+++ b/src/test/resources/conrefbreaksxref/src/conrefbreaksxref.dita
@@ -9,6 +9,10 @@
 <body>
 <section conref="conrefbreaksxreftarget.dita#this-target/section"><?Pub Caret?></section>
 <section conref="subdir/conrefbreaksxrefsubdir.dita#subdir/section"></section>
+<fig id="fig">
+<title>Figure in the <b>referencing</b> topic</title>
+<p>Links pulled in with #./fig syntax should go here</p>
+</fig>
 </body>
 </topic>
 <?Pub *0000000511?>

--- a/src/test/resources/conrefbreaksxref/src/conrefbreaksxreftarget.dita
+++ b/src/test/resources/conrefbreaksxref/src/conrefbreaksxreftarget.dita
@@ -10,7 +10,9 @@
 <section id="section"><title>Section that is pulled to another topic.</title><p>Look
 as the figure in this section: <xref href="#this-target/fig"></xref>.</p><p>Look
 at a figure in this topic, outside of this section: <xref href="#this-target/out"></xref></p><p>Now
-look at this topic: <xref href="#this-target"><?Pub Caret?></xref></p><p>Now
+look at this topic: <xref href="#this-target"><?Pub Caret?></xref></p>
+<p>Now look at "current topic" with #. syntax: <xref href="#."/></p>
+<p>Now look at "fig in current topic" with #./fig syntax: <xref href="#./fig"/></p><p>Now
 look at the topic below: <xref href="#sub"></xref>.</p><p>Now look at a figure
 in the topic below: <xref href="#sub/fig"></xref></p><fig id="fig"><title>Figure
 In My Section</title>


### PR DESCRIPTION
## Description

Fixes a bug in processing of `href="#./fig"` style "same-topic" references that are pulled with conref.

The specification describes how to process `<xref>` elements within content that is referenced with `@conref`:

> When the address is a same-topic fragment identifier, processors _MUST_ resolve it relative to the location of the content reference (referencing context). 

See the [spec topic on xref with conref]((https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part1-base/archSpec/base/handling-xref-and-conref-within-topics.html). There is an example of this exact case (paragraph `C` referencing `p3`) showing the expected result.

Currently, when _any_ local cross reference begins with `#` and is pulled into another file via `@conref`, it is treated the same way: the file name of the original file is added so that the resulting link always goes to the original file. This is correct for links that begin with a topic ID such as `#topic`, but the `#.` syntax is explicitly intended as a way around this behavior, allowing pulled cross references to link to an ID within the _referencing_ file. The result today is always broken.

## Motivation and Context

Reported as a bug by one of my internal customers, who was pulling a section with cross references into another topic as part of a PDF publishing process. The resulting PDF ends up with broken links (the target of the `@conref` is not part of the PDF; even when part of the PDF, the link is still broken, because the modified href value `filename.dita#./d1e123` is invalid). 

This does *not* handle the case where you might have a section that includes both `id="test"` and `href="#./test"`. This cannot be handled with the current code, which always modifies IDs to generated values to ensure the resulting topic is correct. I think any fix for that issue likely requires larger design changes inappropriate for a hotfix.

## How Has This Been Tested?

Tested with a document based on the source I originally got with the problem.

Also updated an existing Integration test case where `@conref` pulls in a section full of `#topic` style cross references, so that it also tests the `#.` condition.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

X My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
X I have updated the unit tests to reflect the changes in my code.
