### PR TITLE
Avoid failure for cite in preprocessed link node

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -210,7 +210,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' topic/term ')]" name="topic.term">
     <xsl:param name="keys" select="@keyref" as="attribute()?"/>
     <xsl:param name="contents" as="node()*">
-      <xsl:variable name="target" select="key('id', substring(@href, 2))"/>
+      <!-- Current node can be preprocessed and may not be part of source document, check for root() to ensure key() is resolvable -->
+      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2)) else ()" as="element()?"/>
       <xsl:choose>
         <xsl:when test="not(normalize-space(.)) and $keys and $target/self::*[contains(@class,' topic/topic ')]">
           <xsl:apply-templates select="$target/*[contains(@class, ' topic/title ')]/node()"/>
@@ -1118,7 +1119,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="copyAttributes" as="element()?"/>
     <xsl:param name="keys" select="@keyref" as="attribute()?"/>
     <xsl:param name="contents" as="node()*">
-      <xsl:variable name="target" select="key('id', substring(@href, 2))"/>
+      <!-- Current node can be preprocessed and may not be part of source document, check for root() to ensure key() is resolvable -->
+      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2)) else ()" as="element()?"/>
       <xsl:choose>
         <xsl:when test="not(normalize-space(.)) and $keys and $target/self::*[contains(@class,' topic/topic ')]">
           <xsl:apply-templates select="$target/*[contains(@class, ' topic/title ')]/node()"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Avoids XSLT failure with PDF for inline markup inside of `<linktext>` elements.

## Motivation and Context

Link markup is initially preprocessed for PDF to place it into a variable. The variable is then processed to create the correct page layout.

When a `<linktext>` element contains inline markup like `<cite>` (phrase-like elements that can turn into links using a key), the phrase-like markup is tested to resolve that link. This uses a key to check if the target is part of the PDF. When the element is reprocessed as part of the variable, the context is no longer part of the original document, resulting in an XSLT failure:
```
 [pipeline] Failed to transform document: In the key() function, the node supplied
 in the third argument (or the context node if absent) must be in a tree whose
 root is a document node
```

The fix here ensures that if such inline markup is processed outside of the document context, the build will not fail, and the phrase contents will be used.

## How Has This Been Tested?

Create a topic that includes the following markup:
```
<related-links>
  <link href="http://example.com" scope="external" format="html">
    <linktext><ph><cite keyref="test">World without Mind</cite> by Franklin Foer</ph></linktext>
    <desc>Testing a link to a book without an href</desc>
  </link>
</related-links>
```

Tested adding that topic to one map that does and one map that does _not_ declare `keys="test"` -- the failure is now avoided in each case, and the specified link text is used.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_