### PR TITLE
Allow text-only links to appear with related-links

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -489,7 +489,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:template>
 
-  <xsl:template match="*[contains(@class,' topic/link ')]" mode="processLink">
+  <xsl:template match="*[contains(@class,' topic/link ')][not(empty(@href) or @href='')]" mode="processLink">
     <xsl:variable name="destination" select="opentopic-func:getDestinationId(@href)"/>
     <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]"/>
 
@@ -544,6 +544,21 @@ See the accompanying LICENSE file for applicable license.
       <xsl:with-param name="linkScope" select="$linkScope"/>
     </xsl:call-template>
     </fo:block>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class,' topic/link ')][empty(@href) or @href='']" mode="processLink">   
+    <xsl:if test="*[contains(@class, ' topic/linktext ')]">
+      <fo:block xsl:use-attribute-sets="link">
+        <fo:inline>
+          <xsl:apply-templates select="*[contains(@class, ' topic/linktext ')]"/>
+        </fo:inline>
+        <xsl:if test="*[contains(@class, ' topic/desc ')]">
+          <fo:block xsl:use-attribute-sets="link__shortdesc">
+            <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
+          </fo:block>
+        </xsl:if>
+      </fo:block>
+    </xsl:if>
   </xsl:template>
 
     <xsl:template name="buildBasicLinkDestination">

--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -340,7 +340,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
     
     <xsl:for-each select="ancestor::*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position()!=$position]">
-      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
+      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
         <xsl:variable name="cellposition" as="xs:integer">
           <xsl:apply-templates mode="get-position" select="."/>
         </xsl:variable>
@@ -355,7 +355,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
           </xsl:when>
           <xsl:when test="not($linklist) and empty($cellgroup-title)">
-            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
+            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
               <xsl:with-param name="role">friend</xsl:with-param>
             </xsl:apply-templates>            
           </xsl:when>
@@ -363,7 +363,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:if>
     </xsl:for-each>
 
-    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
+    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
       <xsl:choose>
         <xsl:when test="$linklist and exists($group-title)">
           <xsl:apply-templates mode="generate-ordered-links-2" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]">
@@ -371,7 +371,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:apply-templates>
         </xsl:when>
         <xsl:when test="not($linklist) and empty($group-title)">
-          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
+          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
             <xsl:with-param name="role">friend</xsl:with-param>
           </xsl:apply-templates>
         </xsl:when>
@@ -398,13 +398,13 @@ See the accompanying LICENSE file for applicable license.
         <title class="- topic/title ">
           <xsl:value-of select="$group-title"/>
         </title>
-        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]" mode="link">
+        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]" mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
         </xsl:apply-templates>
       </linklist>
     </xsl:if>
     <xsl:if test="not($linklist) and (empty($group-title) or $group-title = '')">
-      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]" mode="link">
+      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]" mode="link">
         <xsl:with-param name="role">friend</xsl:with-param>
       </xsl:apply-templates>
     </xsl:if>
@@ -481,7 +481,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:value-of select="$group-title"/>
         </title>
         <xsl:apply-templates select="descendant::*[contains(@class, ' map/topicref ')]
-                                                  [(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]]
+                                                  [dita-ot:hasHrefOrLinktext(.)]
                                                   [not(@linking = ('none', 'sourceonly'))]"
                              mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
@@ -515,7 +515,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template mode="link" 
-    match="*[(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))][not(@processing-role = 'resource-only')]">
+    match="*[dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))][not(@processing-role = 'resource-only')]">
     <xsl:param name="role" as="xs:string?" select="()"/>
     <xsl:param name="otherrole" as="xs:string?" select="()"/>
     <xsl:param name="pathBackToMapDirectory" as="xs:string" tunnel="yes"/>
@@ -798,5 +798,11 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+  
+  <xsl:function name="dita-ot:hasHrefOrLinktext" as="xs:boolean">
+    <xsl:param name="el" as="element()"/>
+    <xsl:value-of select="if (($el/@href and not($el/@href = '')) or $el/*/*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')])
+                          then (true()) else (false())"/>
+  </xsl:function>
   
 </xsl:stylesheet>

--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -340,7 +340,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
     
     <xsl:for-each select="ancestor::*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position()!=$position]">
-      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
+      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]">
         <xsl:variable name="cellposition" as="xs:integer">
           <xsl:apply-templates mode="get-position" select="."/>
         </xsl:variable>
@@ -355,7 +355,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
           </xsl:when>
           <xsl:when test="not($linklist) and empty($cellgroup-title)">
-            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
+            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]">
               <xsl:with-param name="role">friend</xsl:with-param>
             </xsl:apply-templates>            
           </xsl:when>
@@ -363,7 +363,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:if>
     </xsl:for-each>
 
-    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
+    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]">
       <xsl:choose>
         <xsl:when test="$linklist and exists($group-title)">
           <xsl:apply-templates mode="generate-ordered-links-2" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]">
@@ -371,7 +371,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:apply-templates>
         </xsl:when>
         <xsl:when test="not($linklist) and empty($group-title)">
-          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]">
+          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]">
             <xsl:with-param name="role">friend</xsl:with-param>
           </xsl:apply-templates>
         </xsl:when>
@@ -398,13 +398,13 @@ See the accompanying LICENSE file for applicable license.
         <title class="- topic/title ">
           <xsl:value-of select="$group-title"/>
         </title>
-        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]" mode="link">
+        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]" mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
         </xsl:apply-templates>
       </linklist>
     </xsl:if>
     <xsl:if test="not($linklist) and (empty($group-title) or $group-title = '')">
-      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))]" mode="link">
+      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][dita-ot:hasHrefOrLinktext(.)]" mode="link">
         <xsl:with-param name="role">friend</xsl:with-param>
       </xsl:apply-templates>
     </xsl:if>
@@ -481,8 +481,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:value-of select="$group-title"/>
         </title>
         <xsl:apply-templates select="descendant::*[contains(@class, ' map/topicref ')]
-                                                  [dita-ot:hasHrefOrLinktext(.)]
-                                                  [not(@linking = ('none', 'sourceonly'))]"
+                                                  [dita-ot:hasHrefOrLinktext(.)]"
                              mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
         </xsl:apply-templates> 
@@ -515,7 +514,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template mode="link" 
-    match="*[dita-ot:hasHrefOrLinktext(.)][not(@linking = ('none', 'sourceonly'))][not(@processing-role = 'resource-only')]">
+    match="*[dita-ot:hasHrefOrLinktext(.)][not(@processing-role = 'resource-only')]">
     <xsl:param name="role" as="xs:string?" select="()"/>
     <xsl:param name="otherrole" as="xs:string?" select="()"/>
     <xsl:param name="pathBackToMapDirectory" as="xs:string" tunnel="yes"/>
@@ -803,8 +802,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="el" as="element()"/>
     <xsl:sequence
       select="
-        ($el/@href and not($el/@href = '')) or
-        $el/*/*[contains(@class, ' map/linktext ') or contains(@class, ' topic/linktext ')]"
+        (
+          ($el/@href and not($el/@href = '')) or
+          $el/*/*[contains(@class, ' map/linktext ') or contains(@class, ' topic/linktext ')]
+        ) and
+        not($el/@linking = ('none', 'sourceonly'))"
     />
   </xsl:function>
   

--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -801,8 +801,11 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:function name="dita-ot:hasHrefOrLinktext" as="xs:boolean">
     <xsl:param name="el" as="element()"/>
-    <xsl:value-of select="if (($el/@href and not($el/@href = '')) or $el/*/*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')])
-                          then (true()) else (false())"/>
+    <xsl:sequence
+      select="
+        ($el/@href and not($el/@href = '')) or
+        $el/*/*[contains(@class, ' map/linktext ') or contains(@class, ' topic/linktext ')]"
+    />
   </xsl:function>
   
 </xsl:stylesheet>

--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -340,7 +340,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
     
     <xsl:for-each select="ancestor::*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position()!=$position]">
-      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]">
+      <xsl:if test="descendant::*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
         <xsl:variable name="cellposition" as="xs:integer">
           <xsl:apply-templates mode="get-position" select="."/>
         </xsl:variable>
@@ -355,7 +355,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
           </xsl:when>
           <xsl:when test="not($linklist) and empty($cellgroup-title)">
-            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]">
+            <xsl:apply-templates mode="link" select="descendant::*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
               <xsl:with-param name="role">friend</xsl:with-param>
             </xsl:apply-templates>            
           </xsl:when>
@@ -363,7 +363,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:if>
     </xsl:for-each>
 
-    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]">
+    <xsl:if test="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
       <xsl:choose>
         <xsl:when test="$linklist and exists($group-title)">
           <xsl:apply-templates mode="generate-ordered-links-2" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]">
@@ -371,7 +371,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:apply-templates>
         </xsl:when>
         <xsl:when test="not($linklist) and empty($group-title)">
-          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]">
+          <xsl:apply-templates mode="link" select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][position()=$position]/*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]">
             <xsl:with-param name="role">friend</xsl:with-param>
           </xsl:apply-templates>
         </xsl:when>
@@ -398,13 +398,13 @@ See the accompanying LICENSE file for applicable license.
         <title class="- topic/title ">
           <xsl:value-of select="$group-title"/>
         </title>
-        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]" mode="link">
+        <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]" mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
         </xsl:apply-templates>
       </linklist>
     </xsl:if>
     <xsl:if test="not($linklist) and (empty($group-title) or $group-title = '')">
-      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))]" mode="link">
+      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relrow ')]/*[contains(@class, ' map/relcell ')][position() = $position]//*[contains(@class, ' map/topicref ')][(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))]" mode="link">
         <xsl:with-param name="role">friend</xsl:with-param>
       </xsl:apply-templates>
     </xsl:if>
@@ -481,7 +481,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:value-of select="$group-title"/>
         </title>
         <xsl:apply-templates select="descendant::*[contains(@class, ' map/topicref ')]
-                                                  [@href and not(@href = '')]
+                                                  [(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]]
                                                   [not(@linking = ('none', 'sourceonly'))]"
                              mode="link">
           <xsl:with-param name="role">friend</xsl:with-param>
@@ -515,7 +515,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template mode="link" 
-              match="*[@href and not(@href = '')][not(@linking = ('none', 'sourceonly'))][not(@processing-role = 'resource-only')]">
+    match="*[(@href and not(@href = '')) or */*[contains(@class,' map/linktext ') or contains(@class,' topic/linktext ')]][not(@linking = ('none', 'sourceonly'))][not(@processing-role = 'resource-only')]">
     <xsl:param name="role" as="xs:string?" select="()"/>
     <xsl:param name="otherrole" as="xs:string?" select="()"/>
     <xsl:param name="pathBackToMapDirectory" as="xs:string" tunnel="yes"/>
@@ -528,22 +528,6 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="@class">
           <xsl:attribute name="mapclass" select="@class"/>
         </xsl:if>
-        <xsl:choose>
-          <xsl:when test="ancestor-or-self::*[@scope]">
-            <xsl:copy-of select="ancestor-or-self::*[@scope][1]/@scope"/>    
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:attribute name="scope">local</xsl:attribute>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:choose>
-          <xsl:when test="ancestor-or-self::*[@format]">
-            <xsl:copy-of select="ancestor-or-self::*[@format][1]/@format"/>    
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:attribute name="format">dita</xsl:attribute>
-          </xsl:otherwise>
-        </xsl:choose>
         <xsl:copy-of select="ancestor-or-self::*[@type][1]/@type |
                              ancestor-or-self::*[@platform][1]/@platform |
                              ancestor-or-self::*[@product][1]/@product |
@@ -551,22 +535,40 @@ See the accompanying LICENSE file for applicable license.
                              ancestor-or-self::*[@otherprops][1]/@otherprops |
                              ancestor-or-self::*[@rev][1]/@rev"/>
         <xsl:copy-of select="@importance | @xtrf | @xtrc"/>
-        <xsl:attribute name="href">
+        <xsl:if test="@href and not(@href = '')">
           <xsl:choose>
-            <xsl:when test="starts-with(@href,'http://') or starts-with(@href,'/') or
-                            starts-with(@href,'https://') or starts-with(@href,'ftp:/') or @scope = 'external'">
-              <xsl:value-of select="@href"/>
+            <xsl:when test="ancestor-or-self::*[@scope]">
+              <xsl:copy-of select="ancestor-or-self::*[@scope][1]/@scope"/>
             </xsl:when>
-            <!-- If the target has a copy-to value, link to that -->
-            <xsl:when test="@copy-to and not(contains(@chunk, 'to-content'))">
-              <xsl:value-of select="dita-ot:normalize-uri(concat($pathBackToMapDirectory, @copy-to))"/>
-            </xsl:when>
-            <!--ref between two local paths - adjust normally-->
             <xsl:otherwise>
-              <xsl:value-of select="dita-ot:normalize-uri(concat($pathBackToMapDirectory, @href))"/>
+              <xsl:attribute name="scope">local</xsl:attribute>
+            </xsl:otherwise>
+            </xsl:choose>
+        <xsl:choose>
+            <xsl:when test="ancestor-or-self::*[@format]">
+              <xsl:copy-of select="ancestor-or-self::*[@format][1]/@format"/>    
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:attribute name="format">dita</xsl:attribute>
             </xsl:otherwise>
           </xsl:choose>
-        </xsl:attribute>
+          <xsl:attribute name="href">
+            <xsl:choose>
+              <xsl:when test="starts-with(@href,'http://') or starts-with(@href,'/') or
+                              starts-with(@href,'https://') or starts-with(@href,'ftp:/') or @scope = 'external'">
+                <xsl:value-of select="@href"/>
+              </xsl:when>
+              <!-- If the target has a copy-to value, link to that -->
+              <xsl:when test="@copy-to and not(contains(@chunk, 'to-content'))">
+                <xsl:value-of select="dita-ot:normalize-uri(concat($pathBackToMapDirectory, @copy-to))"/>
+              </xsl:when>
+              <!--ref between two local paths - adjust normally-->
+              <xsl:otherwise>
+                <xsl:value-of select="dita-ot:normalize-uri(concat($pathBackToMapDirectory, @href))"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+        </xsl:if>
         <xsl:if test="exists($role)">
           <xsl:attribute name="role" select="$role"/>
         </xsl:if>

--- a/src/main/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/xsl/preprocess/topicpullImpl.xsl
@@ -363,7 +363,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
               <xsl:apply-templates/>
             </xsl:when>
             <xsl:otherwise>
-              <!--grab type, text and metadata, as long there's an href to grab from, otherwise error-->
+              <!--grab type, text and metadata, as long there's an href to grab from, otherwise allow local linktext, otherwise error-->
               <xsl:choose>
                 <xsl:when test="@href=''">
                   <xsl:apply-templates/>
@@ -373,6 +373,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
                     <xsl:with-param name="localtype" select="$type" as="xs:string?"/>
                     <xsl:with-param name="targetElement" select="$targetElement" as="element()?"/>
                   </xsl:apply-templates>
+                </xsl:when>
+                <xsl:when test="*[contains(@class, ' topic/linktext ')]">
+                  <xsl:apply-templates/>
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:apply-templates select="." mode="ditamsg:missing-href"/>
@@ -474,7 +477,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="*[dita-ot:is-link(.)]">
     <xsl:choose>
       <xsl:when test="normalize-space(@href)='' or empty(@href)">
-        <xsl:if test="empty(@keyref)">
+        <xsl:if test="empty(@keyref) and @href">
           <!-- If keyref is specified, keyref code can generate message about unresolved key -->
           <xsl:apply-templates select="." mode="ditamsg:empty-href"/>
         </xsl:if>

--- a/src/main/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/xsl/preprocess/topicpullImpl.xsl
@@ -365,7 +365,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
             <xsl:otherwise>
               <!--grab type, text and metadata, as long there's an href to grab from, otherwise error-->
               <xsl:choose>
-                <xsl:when test="@href=''"/>
+                <xsl:when test="@href=''">
+                  <xsl:apply-templates/>
+                </xsl:when>
                 <xsl:when test="@href">
                   <xsl:apply-templates select="." mode="topicpull:get-stuff">
                     <xsl:with-param name="localtype" select="$type" as="xs:string?"/>
@@ -374,6 +376,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:apply-templates select="." mode="ditamsg:missing-href"/>
+                  <xsl:apply-templates/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -67,6 +67,15 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("reltableheader.ditamap"))
                 .test();
+    }    
+    
+    @Test
+    public void testreltableTextlink() throws Throwable {
+        builder().name("reltableTextlink")
+                .transtype(PREPROCESS)
+                .input(Paths.get("1132.ditamap"))
+                .errorCount(1)
+                .test();
     }
 
     @Test

--- a/src/test/resources/reltableTextlink/exp/preprocess/1132.ditamap
+++ b/src/test/resources/reltableTextlink/exp/preprocess/1132.ditamap
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><?workdir /C:\Users\IBM_ADMIN\github\robander\dita-ot-3.1\build\tmp\integrationTest\reltableTextlink\temp\preprocess?><?workdir-uri file:/C:/Users/IBM_ADMIN/github/robander/dita-ot-3.1/build/tmp/integrationTest/reltableTextlink/temp/preprocess/?><?path2project?><?path2project-uri ./?><?path2rootmap-uri ./?><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" cascade="nomerge" class="- map/map " ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" xml:lang="en"><title class="- topic/title ">Test text-only ref</title>
+<topicref class="- map/topicref " href="booklist.dita" type="topic"><topicmeta class="- map/topicmeta "><navtitle class="- topic/navtitle ">Good books</navtitle><?ditaot gentext?><linktext class="- map/linktext ">Good books</linktext></topicmeta></topicref>
+<topicref class="- map/topicref " href="booklist2.dita" type="topic"><topicmeta class="- map/topicmeta "><navtitle class="- topic/navtitle ">More good books</navtitle><?ditaot gentext?><linktext class="- map/linktext ">More good books</linktext></topicmeta></topicref>
+<keydef class="+ map/topicref mapgroup-d/keydef " keys="resolved" processing-role="resource-only"><topicmeta class="- map/topicmeta "><linktext class="- map/linktext ">
+<ph class="- topic/ph "><cite class="- topic/cite ">What if?</cite> by Randall Munroe</ph>
+</linktext><shortdesc class="- map/shortdesc ">Adding text-only link via keyref</shortdesc></topicmeta></keydef>
+<reltable class="- map/reltable " toc="no">
+<relrow class="- map/relrow ">
+<relcell class="- map/relcell " toc="no">
+<topicref class="- map/topicref " href="booklist.dita" toc="no" type="topic"><topicmeta class="- map/topicmeta "><navtitle class="- topic/navtitle ">Good books</navtitle><?ditaot gentext?><linktext class="- map/linktext ">Good books</linktext></topicmeta></topicref>
+</relcell>
+<relcell class="- map/relcell " toc="no">
+<topicref class="- map/topicref " toc="no"><topicmeta class="- map/topicmeta "><linktext class="- map/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">American Gods</cite> by Neil Gaiman</ph></linktext><shortdesc class="- map/shortdesc ">I often list this as my favorite book</shortdesc></topicmeta></topicref>
+<topicref class="- map/topicref " format="html" scope="external" href="https://en.wikipedia.org/wiki/Discworld" toc="no"><topicmeta class="- map/topicmeta "><navtitle class="- topic/navtitle ">Pretty much anything from Discworld</navtitle><?ditaot usertext?><linktext class="- map/linktext ">Pretty much anything from Discworld</linktext><?ditaot usershortdesc?><shortdesc class="- map/shortdesc ">Terry Pratchett is awesome</shortdesc></topicmeta></topicref>
+</relcell>
+</relrow>
+<relrow class="- map/relrow ">
+<relcell class="- map/relcell " toc="no">
+<topicref class="- map/topicref " href="booklist2.dita" toc="no" type="topic"><topicmeta class="- map/topicmeta "><navtitle class="- topic/navtitle ">More good books</navtitle><?ditaot gentext?><linktext class="- map/linktext ">More good books</linktext></topicmeta></topicref>
+</relcell>
+<relcell class="- map/relcell " toc="no">
+<topicref class="- map/topicref " toc="no"><topicmeta class="- map/topicmeta "><linktext class="- map/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">Good Omens</cite> by Neil Gaiman and Terry Pratchett</ph></linktext></topicmeta></topicref>
+</relcell>
+</relrow>
+</reltable>
+</map>

--- a/src/test/resources/reltableTextlink/exp/preprocess/booklist.dita
+++ b/src/test/resources/reltableTextlink/exp/preprocess/booklist.dita
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><?workdir /C:\Users\IBM_ADMIN\github\robander\dita-ot-3.1\build\tmp\integrationTest\reltableTextlink\temp\preprocess?><?workdir-uri file:/C:/Users/IBM_ADMIN/github/robander/dita-ot-3.1/build/tmp/integrationTest/reltableTextlink/temp/preprocess/?><?path2project?><?path2project-uri ./?><?path2rootmap-uri ./?><?doctype-public -//OASIS//DTD DITA Topic//EN?><?doctype-system topic.dtd?><topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" id="books" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" class="- topic/topic ">
+  <title class="- topic/title ">Good books</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">I'm gonna do text-only links to a couple of books.</p>
+  </body>
+<related-links class="- topic/related-links "><linkpool class="- topic/linkpool "><link class="- topic/link " mapclass="- map/topicref " role="friend"><linktext class="- topic/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">American Gods</cite> by Neil Gaiman</ph></linktext><desc class="- topic/desc ">I often list this as my favorite book</desc></link><link class="- topic/link " format="html" href="https://en.wikipedia.org/wiki/Discworld" mapclass="- map/topicref " role="friend" scope="external"><?ditaot usertext?><linktext class="- topic/linktext "><?ditaot usertext?>Pretty much anything from Discworld</linktext><?ditaot usershortdesc?><desc class="- topic/desc ">Terry Pratchett is awesome</desc></link></linkpool>
+<link class="- topic/link ">
+<linktext class="- topic/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">World without Mind</cite> by Franklin Foer</ph></linktext>
+<desc class="- topic/desc ">what happens to a desc?</desc>
+</link>
+<link href="booklist2.dita" class="- topic/link " type="topic"><?ditaot usertext?><linktext class="- topic/linktext ">This is a hard-coded link to booklist2</linktext><?ditaot usershortdesc?><desc class="- topic/desc ">With a short description</desc></link>
+</related-links>
+</topic>

--- a/src/test/resources/reltableTextlink/exp/preprocess/booklist2.dita
+++ b/src/test/resources/reltableTextlink/exp/preprocess/booklist2.dita
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><?workdir /C:\Users\IBM_ADMIN\github\robander\dita-ot-3.1\build\tmp\integrationTest\reltableTextlink\temp\preprocess?><?workdir-uri file:/C:/Users/IBM_ADMIN/github/robander/dita-ot-3.1/build/tmp/integrationTest/reltableTextlink/temp/preprocess/?><?path2project?><?path2project-uri ./?><?path2rootmap-uri ./?><?doctype-public -//OASIS//DTD DITA Topic//EN?><?doctype-system topic.dtd?><topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" id="morebooks" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" class="- topic/topic ">
+  <title class="- topic/title ">More good books</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">I'm gonna do text-only links to a couple of books, adding keys this time.</p>
+  </body>
+<related-links class="- topic/related-links "><linkpool class="- topic/linkpool "><link class="- topic/link " mapclass="- map/topicref " role="friend"><linktext class="- topic/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">Good Omens</cite> by Neil Gaiman and Terry Pratchett</ph></linktext></link></linkpool>
+<link class="- topic/link ">
+<linktext class="- topic/linktext "><ph class="- topic/ph "><cite class="- topic/cite ">Killers of the Flower Moon</cite> by David Grann</ph></linktext>
+<desc class="- topic/desc ">A depressing but important read</desc>
+</link>
+<link keyref="resolved" class="- topic/link "><linktext class="- topic/linktext ">
+<ph class="- topic/ph "><cite class="- topic/cite ">What if?</cite> by Randall Munroe</ph>
+</linktext></link>
+<link keyref="unresolved" class="- topic/link "/>
+<link href="http://metadita.org/books/" scope="external" format="html" class="- topic/link "><?ditaot usertext?><linktext class="- topic/linktext ">all sorts of books</linktext><desc class="- topic/desc ">this is a short description for my external linked book list</desc></link>
+</related-links>
+</topic>

--- a/src/test/resources/reltableTextlink/src/1132.ditamap
+++ b/src/test/resources/reltableTextlink/src/1132.ditamap
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map xml:lang="en"><title>Test text-only ref</title>
+<topicref href="booklist.dita"/>
+<topicref href="booklist2.dita"/>
+<keydef keys="resolved">
+<topicmeta>
+<linktext>
+<ph><cite>What if?</cite> by Randall Munroe</ph>
+</linktext>
+<shortdesc>Adding text-only link via keyref</shortdesc>
+</topicmeta>
+</keydef>
+<reltable>
+<relrow>
+<relcell>
+<topicref href="booklist.dita"/>
+</relcell>
+<relcell>
+<topicref>
+<topicmeta>
+<linktext><ph><cite>American Gods</cite> by Neil Gaiman</ph></linktext>
+<shortdesc>I often list this as my favorite book</shortdesc>
+</topicmeta>
+</topicref>
+<topicref href="https://en.wikipedia.org/wiki/Discworld" format="html" scope="external">
+<topicmeta>
+<linktext>Pretty much anything from Discworld</linktext>
+<shortdesc>Terry Pratchett is awesome</shortdesc>
+</topicmeta>
+</topicref>
+</relcell>
+</relrow>
+<relrow>
+<relcell>
+<topicref href="booklist2.dita"/>
+</relcell>
+<relcell>
+<topicref>
+<topicmeta>
+<linktext><ph><cite>Good Omens</cite> by Neil Gaiman and Terry Pratchett</ph></linktext>
+</topicmeta>
+</topicref>
+</relcell>
+</relrow>
+</reltable>
+</map>

--- a/src/test/resources/reltableTextlink/src/booklist.dita
+++ b/src/test/resources/reltableTextlink/src/booklist.dita
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="books">
+  <title>Good books</title>
+  <body>
+    <p>I'm gonna do text-only links to a couple of books.</p>
+  </body>
+<related-links>
+<link>
+<linktext><ph><cite>World without Mind</cite> by Franklin Foer</ph></linktext>
+<desc>what happens to a desc?</desc>
+</link>
+<link href="booklist2.dita">
+<linktext>This is a hard-coded link to booklist2</linktext>
+<desc>With a short description</desc>
+</link>
+</related-links>
+</topic>

--- a/src/test/resources/reltableTextlink/src/booklist2.dita
+++ b/src/test/resources/reltableTextlink/src/booklist2.dita
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="morebooks">
+  <title>More good books</title>
+  <body>
+    <p>I'm gonna do text-only links to a couple of books, adding keys this time.</p>
+  </body>
+<related-links>
+<link>
+<linktext><ph><cite>Killers of the Flower Moon</cite> by David Grann</ph></linktext>
+<desc>A depressing but important read</desc>
+</link>
+<link keyref="resolved"/>
+<link keyref="unresolved"><!--Should still log a message--></link>
+<link href="http://metadita.org/books/" scope="external" format="html">
+<linktext>all sorts of books</linktext>
+<desc>this is a short description for my external linked book list</desc>
+</link>
+</related-links>
+</topic>


### PR DESCRIPTION
## Description

Includes several related fixes / enhancements in order to implement #1132:

- Bug fix: currently `topicpull` removes any specified `<linktext>` or `<desc>` content when there is no link target, resulting in a truly empty link. This should be deferred to rendering to determine whether / how to render links without `@href`.
- Bug fix / enhancement: if a link with link text but no `@href` does make its way to PDF processing today, it results in a build failure. The build failure has been removed and the text is rendered with other links.
- Enhancement: If text-only links appear in a reltable (`<topicref> that does not have a link target, but _does_ include `<linktext>`), those links are generated, and the final rendering step is allowed to render or hide them as needed.
- Bug fix: when `<xref>` does not specify any `@href` value at all, remove the error message that complains about an _empty_ `@href` value
- Enhancement: When `<link>` does not specify `@href`, avoid generating a build error in `topicpull`, and leave this to rendering steps or customizations to determine if it is an error.

## Motivation and Context

Reported / requested long ago with #1132, request is still valid and outstanding.

## How Has This Been Tested?

Test files attached in the original issue to reproduce all issues. 

Also encountered #3029 while testing this issue, but that is a more general issue that should be fixed ASAP in a hotfix rather than bundled with this enhancement.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_
