### PR TITLE
LQ should indent by default #3009

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -221,6 +221,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="lq" use-attribute-sets="common.block">
+        <xsl:attribute name="start-indent">30pt + from-parent(start-indent)</xsl:attribute>
+        <xsl:attribute name="end-indent">15pt + from-parent(end-indent)</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="lq_simple" use-attribute-sets="common.block">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -933,7 +933,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/lq ')]">
-        <fo:block>
+        <fo:block xsl:use-attribute-sets="lq">
             <xsl:call-template name="commonattributes"/>
             <xsl:choose>
                 <xsl:when test="@href or @reftitle">


### PR DESCRIPTION
## Description

Causes output from `<lq>` to be indented by default in PDF. Current formatting is no different than a paragraph. Implemented as requested in #3009.

## Motivation and Context

Default style makes it impossible to tell the difference between a `<lq>content...</lq>` and `<p>content...</p>`. It should be possible to control the indenting in a customization by adding values to the existing `lq` attribute set, but that isn't actually used.

The most common style for indented long quotes is to indent the block, which is the default browser rendition for HTML5, so I've added a default indent. I'm not sure what should be standard, but by calling the attribute set, anybody who wants more or less indent can add this to the `lq` attribute set.

## How Has This Been Tested?

[3009.zip](https://github.com/dita-ot/dita-ot/files/2243025/3009.zip)

## Type of Changes

- Breaking change _(fix or feature that changes existing functionality)_

Not sure this really counts as "breaking" but it does change existing behavior.