### PR TITLE
Improve handling of <q> in html5 / xhtml

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -986,16 +986,10 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- quotes - only do 1 level, no flip-flopping -->
   <xsl:template match="*[contains(@class, ' topic/q ')]" name="topic.q">
-    <span class="q">
+    <q>
       <xsl:call-template name="commonattributes"/>
-      <xsl:call-template name="getVariable">
-        <xsl:with-param name="id" select="'OpenQuote'"/>
-      </xsl:call-template>
       <xsl:apply-templates/>
-      <xsl:call-template name="getVariable">
-        <xsl:with-param name="id" select="'CloseQuote'"/>
-      </xsl:call-template>
-    </span>
+    </q>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' topic/term ')]" mode="output-term">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1151,16 +1151,10 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- quotes - only do 1 level, no flip-flopping -->
 <xsl:template match="*[contains(@class, ' topic/q ')]" name="topic.q">
-  <span class="q">
+  <q>
     <xsl:call-template name="commonattributes"/>
-    <xsl:call-template name="getVariable">
-      <xsl:with-param name="id" select="'OpenQuote'"/>
-    </xsl:call-template>
     <xsl:apply-templates/>
-    <xsl:call-template name="getVariable">
-      <xsl:with-param name="id" select="'CloseQuote'"/>
-    </xsl:call-template>
-  </span>
+  </q>
 </xsl:template>
 
 <xsl:template match="*[contains(@class, ' topic/term ')]" mode="output-term">

--- a/src/test/resources/image_extension_mixedcase/exp/xhtml/testpng.html
+++ b/src/test/resources/image_extension_mixedcase/exp/xhtml/testpng.html
@@ -18,11 +18,11 @@
   <h1 class="title topictitle1" id="ariaid-title1">Test upper case PNG</h1>
 
   <div class="body conbody">
-    <p class="p">This is lower case <span class="q">“.png”</span> <img class="image" src="images/lowercase.png" /></p>
+    <p class="p">This is lower case <q class="q">.png</q> <img class="image" src="images/lowercase.png" /></p>
 
     
     
-    <p class="p">This is upper case <span class="q">“.PNG”</span> <img class="image" src="images/uppercase.PNG" /> </p>
+    <p class="p">This is upper case <q class="q">.PNG</q> <img class="image" src="images/uppercase.PNG" /> </p>
 
   </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-areg.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">شكل 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml/lang-beby.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Малюнак 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-bgbg.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Фигура 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml/lang-caes.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-concept.html
+++ b/src/test/resources/lang/exp/xhtml/lang-concept.html
@@ -26,7 +26,7 @@
 <p class="p">stuff</p>
 
 <div class="fig fignone" id="lang-concept__fig"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml/lang-cscz.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Obrázek 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dadk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Abbildung 1. </span>figure title</span>
-<p class="p">test <span class="q">„quote“</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Abbildung 1. </span>figure title</span>
-<p class="p">test <span class="q">„quote“</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-elgr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Σχήμα 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enca.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml/lang-engb.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enus.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml/lang-eses.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">«quote»</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml/lang-etee.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Joonis 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-fifi.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Kuva 1. </span>figure title</span>
-<p class="p">test <span class="q">”quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frbe.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">« quote »</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frca.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">« quote »</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frch.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">« quote »</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frfr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figure 1. </span>figure title</span>
-<p class="p">test <span class="q">« quote »</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml/lang-heil.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">תרשים 1. </span>figure title</span>
-<p class="p">test <span class="q">„quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hiin.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">संख्या 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hrhr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Slika 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml/lang-huhu.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">1. Ábra </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml/lang-isis.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Mynd 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itch.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">«quote»</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itit.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">«quote»</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-jajp.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">図 1. </span>figure title</span>
-<p class="p">test <span class="q">「quote」</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-kokr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">그림 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ltlt.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Piešinys 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml/lang-lvlv.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Attēls 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-mkmk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Слика 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlbe.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figuur 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlnl.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figuur 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nono.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-plpl.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Rysunek 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptbr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptpt.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml/lang-roro.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figura 1. </span>figure title</span>
-<p class="p">test <span class="q">„quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ruru.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Рис. 1. </span>figure title</span>
-<p class="p">test <span class="q">«quote»</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-sksk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Obrázok 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-slsi.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Slika 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-srsp.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Илустрација 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml/lang-svse.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Figur 1. </span>figure title</span>
-<p class="p">test <span class="q">”quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml/lang-thth.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">รูปที่ 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-trtr.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Şekil 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ukua.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">Мал. 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-urpk.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">تصویر 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhcn.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">图 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -55,7 +55,7 @@
 <p class="p">Xref to an external website with an anchor: <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">http://www.ibm.com/index.html#anchor</a>. Now do it again, <a class="xref" href="http://www.ibm.com/index.html#anchor" target="_blank">with link text</a>.</p>
 
 <div class="fig fignone" id="topic__d7e166"><span class="figcap"><span class="fig--title-label">圖 1. </span>figure title</span>
-<p class="p">test <span class="q">“quote”</span> in a figure</p>
+<p class="p">test <q class="q">quote</q> in a figure</p>
 
 </div>
 


### PR DESCRIPTION
## Description

When processing the DITA `<q>` element for quotes, we currently generate `<span>` elements and quote characters based on variables. This request switches to using the native XHTML / HTML5 `<q>` element.

When originally implemented 15+ years ago, browser support for `<q>` was somewhat inconsistent. At this point, any recent browser does a good job of rendering the element with quotes, and if alternate quotes are desired they can be handled with CSS.

## Motivation and Context

Originally reported here as #2481.

Not long ago, I also got a report about this in other channels, because an accessibility checker was flagging `<span>"quote"</span>` for improper markup (as with any semantic markup, using it accurately to say the quote is a quote results in better automation from all sorts of tools).

## How Has This Been Tested?

Tested using the `<q>` element on my machine with Firefox, Chrome, and IE. All three automatically displayed quotes, though the actual quote characters were inconsistent. (Firefox displayed open/close quotes, Chrome displayed simple " quotes, and IE displayed locale-specific quotes).

## Type of Changes

- Breaking change _(fix or feature that changes existing functionality)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
