### PR TITLE
Avoid NPE with invalid use of keyref attribute

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -448,8 +448,8 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         Attributes resAtts = atts;
         hasChecked = false;
         empty = true;
-        if (!hasKeyref(atts)) {
-            // If the keyrefLevel doesn't equal 0, it means that current element is under the key reference element
+        if (!hasKeyref(atts) || currentElement == null) {
+            // If the keyrefLevel doesn't equal 0, it means that current element is under the key reference element;
             if (keyrefLevel != 0) {
                 keyrefLevel++;
                 hasSubElem.pop();

--- a/src/test/resources/KeyrefPaserTest/exp/id.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/id.xml
@@ -10,7 +10,7 @@
     id="nolink" ditaarch:DITAArchVersion="1.2">
     <title class="- topic/title ">Without href</title>
     <body class="- topic/body ">
-      <p class="- topic/p " id="p"/>
+      <p class="- topic/p " id="p" keyref="invalid-attribute">Keyref not valid on this element, caused failure in #3008</p>
     </body>
   </topic>
   <related-links class="- topic/related-links ">

--- a/src/test/resources/KeyrefPaserTest/src/id.xml
+++ b/src/test/resources/KeyrefPaserTest/src/id.xml
@@ -10,7 +10,7 @@
     id="nolink" ditaarch:DITAArchVersion="1.2">
     <title class="- topic/title ">Without href</title>
     <body class="- topic/body ">
-      <p class="- topic/p " id="p"/>
+      <p class="- topic/p " id="p" keyref="invalid-attribute">Keyref not valid on this element, caused failure in #3008</p>
     </body>
   </topic>
   <related-links class="- topic/related-links ">


### PR DESCRIPTION
## Description

Remove a build crash caused by invalid markup (`@keyref` on an element that does not allow `@keyref`). Current code assumes the `@keyref` is valid, looks up the element in a static list of element/attribute pairs, and crashes when the element is not listed. The fix avoids the issue by ignoring `@keyref` resolution on any element that is not in the list.

## Motivation and Context

Fixes the null pointer exception in #3008 

## How Has This Been Tested?

Used the test doc I added to #3008; extended existing keyref unit test to include the failing condition, which is fixed with the update.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
