### PR TITLE
Remove yellow and add warning for unknown elements #2033

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -752,6 +752,11 @@ See the accompanying LICENSE file for applicable license.
     <reason>Removing broken link to "%1".</reason>
     <response/>
   </message>
+  
+  <message id="DOTX074W" type="WARN">
+    <reason>No formatting defined for unknown class attribute value "%1".</reason>
+    <response/>
+  </message>
 
   <!-- End of XSL Messages --> 
       

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1870,19 +1870,12 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- (this rule should NOT produce output in production setting) -->
   <xsl:template match="*" name="topic.undefined_element">
-    <span style="background-color: yellow;">
-      <span style="font-weight: bold">
-        <xsl:text>[</xsl:text>
-        <xsl:for-each select="ancestor-or-self::*">
-         <xsl:text>/</xsl:text>
-         <xsl:value-of select="name()" />
-       </xsl:for-each>
-       {"<xsl:value-of select="@class"/>"}<xsl:text>) </xsl:text>
-      </span>
+    <xsl:call-template name="output-message">
+      <xsl:with-param name="id" select="'DOTX074W'"/>
+      <xsl:with-param name="msgparams">%1=<xsl:value-of select="@class"/></xsl:with-param>
+    </xsl:call-template>
+    <span class="undefined_element">
       <xsl:apply-templates/>
-      <span style="font-weight: bold">
-        <xsl:text> (</xsl:text><xsl:value-of select="name()"/><xsl:text>]</xsl:text>
-      </span>
     </span>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -2066,19 +2066,12 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- (this rule should NOT produce output in production setting) -->
 <xsl:template match="*" name="topic.undefined_element">
-  <span style="background-color: yellow;">
-    <span style="font-weight: bold">
-      <xsl:text>[</xsl:text>
-      <xsl:for-each select="ancestor-or-self::*">
-       <xsl:text>/</xsl:text>
-       <xsl:value-of select="name()" />
-     </xsl:for-each>
-     {"<xsl:value-of select="@class"/>"}<xsl:text>) </xsl:text>
-    </span>
+  <xsl:call-template name="output-message">
+    <xsl:with-param name="id" select="'DOTX074W'"/>
+    <xsl:with-param name="msgparams">%1=<xsl:value-of select="@class"/></xsl:with-param>
+  </xsl:call-template>
+  <span class="undefined_element">
     <xsl:apply-templates/>
-    <span style="font-weight: bold">
-      <xsl:text> (</xsl:text><xsl:value-of select="name()"/><xsl:text>]</xsl:text>
-    </span>
   </span>
 </xsl:template>
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Removes the yellow formatting, XPATH, and `@class` value generated in HTML / XHTML when an unknown `@class` value is encountered. This should never appear in valid content, but is there in case an author manually inserts a bad `@class` value, or if a preprocess step breaks that attribute.

Currently the output looks bad when this happens, but the build does not give any indication of the problem (you have to notice it in the HTML). This update puts a warning in the log for each unsupported element, and lets the content flow through without extra formatting as a better default. I've added a class token in the HTML `undefined_element` so that CSS can still be used to make the content obvious.

## Motivation and Context

Resolves the request in #2033

## How Has This Been Tested?

Sample file with broken class attribute:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN"  "topic.dtd">
<topic id="fake" xml:lang="en-us">
<title>Test fake element</title>
<body>
<p>The following element is incorrect: <ph class="- fake/element ">ack</ph></p>
</body>
</topic>
```

## Type of Changes

- Breaking change _(fix or feature that changes existing functionality)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
