### PR TITLE
Add --plugins argument to dita command line #1960

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -64,6 +64,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import static org.dita.dost.util.Configuration.transtypes;
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
 import static org.dita.dost.util.Constants.PLUGIN_CONF;
 import static org.dita.dost.util.XMLUtils.getChildElements;
@@ -527,6 +528,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         boolean justPrintVersion = false;
         boolean justPrintDiagnostics = false;
         boolean justPrintPlugins = false;
+        boolean justPrintTranstypes = false;
         useColor = getUseColor();
 
         final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
@@ -539,6 +541,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 justPrintVersion = true;
             } else if (isLongForm(arg, "-plugins")) {
                 justPrintPlugins = true;
+            } else if (isLongForm(arg, "-transtypes")) {
+                justPrintTranstypes = true;
             } else if (isLongForm(arg, "-install")) {
                 handleArgInstall(arg, args);
             } else if (isLongForm(arg, "-uninstall")) {
@@ -611,7 +615,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // Load the property files specified by --propertyfile
         loadPropertyFiles();
 
-        if (justPrintUsage || justPrintVersion || justPrintDiagnostics || justPrintPlugins) {
+        if (justPrintUsage || justPrintVersion || justPrintDiagnostics || justPrintPlugins ||justPrintTranstypes) {
             if (justPrintVersion) {
                 printVersion(msgOutputLevel);
             }
@@ -623,6 +627,9 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             }
             if (justPrintPlugins) {
                 printPlugins(); 
+            }
+            if (justPrintTranstypes) {
+                printTranstypes();
             }
             return;
         } else if (install) {
@@ -799,6 +806,18 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             }
         } else {
             System.out.println("No DITA-OT plugins are installed.");
+        }
+    }
+
+    /** Handle the --transtypes argument */
+    private void printTranstypes() {
+        if (!transtypes.isEmpty()) {
+            System.out.println("The following DITA-OT transtypes are installed:");
+            for (final String transtype : transtypes) {
+                System.out.println("   " + transtype);
+            }
+        } else {
+            System.out.println("No DITA-OT transtypes are installed.");
         }
     }
 
@@ -1241,6 +1260,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         msg.append("   or: dita --install [=<file>]\n");
         msg.append("   or: dita --uninstall <id>\n");
         msg.append("   or: dita --plugins\n");
+        msg.append("   or: dita --transtypes\n");
         msg.append("   or: dita --help\n");
         msg.append("   or: dita --version\n");
         msg.append("Arguments: \n");
@@ -1251,6 +1271,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         msg.append("  --install                   reload plugins\n");
         msg.append("  --uninstall <id>            uninstall plug-in with the ID\n");
         msg.append("  --plugins                   print list of installed plug-ins\n");
+        msg.append("  --transtypes                print list of installed transtypes\n");
         msg.append("  -h, --help                  print this message\n");
         msg.append("  --version                   print version information and exit\n");
         msg.append("Options: \n");

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -799,25 +799,15 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     /** Handle the --plugins argument */
     private void printPlugins() {
         final List<String> installedPlugins = getInstalledPlugins();
-        if (installedPlugins != null) {
-            System.out.println("The following DITA-OT plugins are installed:");
-            for (final String plugin : installedPlugins) {
-                System.out.println("   " + plugin);
-            }
-        } else {
-            System.out.println("No DITA-OT plugins are installed.");
+        for (final String plugin : installedPlugins) {
+            System.out.println(plugin);
         }
     }
 
     /** Handle the --transtypes argument */
     private void printTranstypes() {
-        if (!transtypes.isEmpty()) {
-            System.out.println("The following DITA-OT transtypes are installed:");
-            for (final String transtype : transtypes) {
-                System.out.println("   " + transtype);
-            }
-        } else {
-            System.out.println("No DITA-OT transtypes are installed.");
+        for (final String transtype : transtypes) {
+            System.out.println(transtype);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Adds a new command line arguments `--plugins` and `--transtypes` to the `dita` command line. When used, they provide a list of installed plug-in IDs and transtype names, one per line.

Pretty sure my implementation could be improved, but I won't know until I open the pull request and wait for the comments...

## Motivation and Context

Requested in #1960 along with follow-up discussion.

There is also a request for an option that would display a list of transform types, but that is not (yet) part of this request - waiting to see how the `--plugins` implementation goes over.

## How Has This Been Tested?

Tested by running the command line `bin/dita --plugins` and `bin/dita --transtypes`, verifying that each installed plugin is listed.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

Have not updated unit tests - I don't see unit tests for the other command line parameters so not sure where this one should go.