### PR TITLE
Implement defaults output for hazard domain in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/artwork/ISO_7010_W001.svg
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/artwork/ISO_7010_W001.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="600"
+   height="525"
+   id="svg3069">
+  <metadata
+     id="metadata3085">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3073">
+    <path
+       d="M 2.8117,-1.046 A 3,3 0 0 1 0.5,2.958 V 4.5119 A 10.5,10.5 0 0 1 2,25.3078 v 0.5583 A 15,15 0 0 0 14.7975,8.5433 15,15 0 0 0 23.4007,-11.201 l -0.4835,0.2792 A 10.5,10.5 0 0 1 4.1574,-1.8229 z m 3.4148,8.871 a 10,10 0 0 1 -12.453,0 9.5,9.5 0 0 0 -2.1756,2.7417 13.5,13.5 0 0 0 16.8042,0 A 10,10 0 0 0 6.2265,7.825 z"
+       transform="matrix(10,0,0,-10,260,260)"
+       id="p" />
+  </defs>
+  <path
+     d="M 597.6,499.6 313.8,8 C 310.9,3 305.6,0 299.9,0 294.2,0 288.9,3.1 286,8 L 2.2,499.6 c -2.9,5 -2.9,11.1 0,16 2.9,5 8.2,8 13.9,8 h 567.6 c 5.7,0 11,-3.1 13.9,-8 2.9,-5 2.9,-11.1 0,-16 z"
+     id="sign_border" />
+  <polygon
+     points="43.875,491.5 299.875,48.2 555.875,491.5 "
+     transform="matrix(1,0,0,0.99591458,0.125,2.0332437)"
+     id="polygon7"
+     style="fill:#f6bd16;fill-opacity:1;stroke:none;overflow:visible" />
+  <path
+     d="m -384.00937,417.52725 a 38.151581,36.156727 0 1 1 -76.30316,0 38.151581,36.156727 0 1 1 76.30316,0 z"
+     transform="matrix(0.99319888,0,0,1.0479962,719.28979,-2.9357862)"
+     id="path1995"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.62514842;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:0.4;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 300,168.60074 c -20.64745,0 -37.26716,16.97292 -37.26716,38.05658 l 11.01897,133.31318 c 2.10449,17.24457 3.90184,27.0149 11.01898,31.60966 4.64712,2.1172 9.79468,3.32214 15.22921,3.32214 5.40832,0 10.53383,-1.1913 15.16343,-3.28925 7.15697,-4.58178 8.97556,-14.35941 11.08476,-31.64255 l 11.01898,-133.31318 c 0,-21.08366 -16.61973,-38.05658 -37.26717,-38.05658 z"
+     id="rect1997"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.88582677;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0" />
+</svg>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
@@ -148,4 +148,6 @@ See the accompanying LICENSE file for applicable license.
   <variable id="#quote-start"><variable id="OpenQuote"/></variable>
   <variable id="#quote-end"><variable id="CloseQuote"/></variable>
     
+  <!-- Hazard statement domain -->
+  <variable id="hazard.image.default">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -172,4 +172,6 @@ See the accompanying LICENSE file for applicable license.
   <!-- Heading for a generated List of Figures -->
   <variable id="List of Figures">List of Figures</variable>
      
+  <!-- Hazard statement domain -->
+  <variable id="hazard.image.default">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -171,7 +171,4 @@ See the accompanying LICENSE file for applicable license.
      
   <!-- Heading for a generated List of Figures -->
   <variable id="List of Figures">List of Figures</variable>
-     
-  <!-- Hazard statement domain -->
-  <variable id="hazard.image.default">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
 </vars>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -21,21 +21,38 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:attribute name="border-color">black</xsl:attribute>
     <xsl:attribute name="border-width">2pt</xsl:attribute>
     <xsl:attribute name="padding">3pt</xsl:attribute>
+    <xsl:attribute name="keep-together">always</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="hazardstatement.title" use-attribute-sets="hazardstatement.cell common.title">
     <xsl:attribute name="number-columns-spanned">2</xsl:attribute>
-    <xsl:attribute name="background-color">orange</xsl:attribute>
     <xsl:attribute name="text-transform">uppercase</xsl:attribute>
     <xsl:attribute name="font-weight">bold</xsl:attribute>
     <xsl:attribute name="font-size">1.5em</xsl:attribute>
     <xsl:attribute name="text-align">center</xsl:attribute>
-
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="hazardstatement.title.danger">
+    <xsl:attribute name="color">white</xsl:attribute>
+    <xsl:attribute name="background-color">red</xsl:attribute>
+    <xsl:attribute name="font-style">normal</xsl:attribute>
+  </xsl:attribute-set>
+  <xsl:attribute-set name="hazardstatement.title.warning">
+    <xsl:attribute name="background-color">orange</xsl:attribute>
+    <xsl:attribute name="font-style">normal</xsl:attribute>
+  </xsl:attribute-set>
+  <xsl:attribute-set name="hazardstatement.title.caution">
+    <xsl:attribute name="background-color">yellow</xsl:attribute>
+    <xsl:attribute name="font-style">normal</xsl:attribute>
+  </xsl:attribute-set>
+  <xsl:attribute-set name="hazardstatement.title.notice">
+    <xsl:attribute name="color">white</xsl:attribute>
+    <xsl:attribute name="font-style">italic</xsl:attribute>
+    <xsl:attribute name="background-color">blue</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="hazardstatement.image" use-attribute-sets="hazardstatement.cell">
     <xsl:attribute name="text-align">center</xsl:attribute>
-    <xsl:attribute name="keep-with-next">always</xsl:attribute>
   </xsl:attribute-set>
   
   <xsl:attribute-set name="hazardstatement.image.column">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -6,6 +6,20 @@ See the accompanying license.txt file for applicable licenses.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
 
+  <!-- Source: https://www.nema.org/Standards/ComplimentaryDocuments/ANSI%20Z535_1-2017%20CONTENTS%20AND%20SCOPE.pdf -->
+  <xsl:variable name="hazard.ansi.red" select="'#C8102E'"/>
+  <xsl:variable name="hazard.ansi.orange" select="'#FF8200'"/>
+  <xsl:variable name="hazard.ansi.yellow" select="'#FFD100'"/>
+  <xsl:variable name="hazard.ansi.green" select="'#007B5F'"/>
+  <xsl:variable name="hazard.ansi.blue" select="'#0072CE'"/>
+  <xsl:variable name="hazard.ansi.purple" select="'#6D2077'"/>
+
+  <!-- Source: https://en.wikipedia.org/wiki/ISO_3864 -->
+  <xsl:variable name="hazard.iso.red" select="'#9B2423'"/>
+  <xsl:variable name="hazard.iso.yellow" select="'#F9A800'"/>
+  <xsl:variable name="hazard.iso.green" select="'#237F52'"/>
+  <xsl:variable name="hazard.iso.blue" select="'#005387'"/>
+  
   <xsl:attribute-set name="hazardstatement">
     <xsl:attribute name="width">100%</xsl:attribute>
     <xsl:attribute name="space-before">8pt</xsl:attribute>
@@ -34,21 +48,21 @@ See the accompanying license.txt file for applicable licenses.
   
   <xsl:attribute-set name="hazardstatement.title.danger">
     <xsl:attribute name="color">white</xsl:attribute>
-    <xsl:attribute name="background-color">#d63231</xsl:attribute>
+    <xsl:attribute name="background-color" select="$hazard.ansi.red"/>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.warning">
-    <xsl:attribute name="background-color">#ed9c3d</xsl:attribute>
+    <xsl:attribute name="background-color" select="$hazard.ansi.orange"/>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.caution">
-    <xsl:attribute name="background-color">#eae639</xsl:attribute>
+    <xsl:attribute name="background-color" select="$hazard.ansi.yellow"/>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.notice">
     <xsl:attribute name="color">white</xsl:attribute>
     <xsl:attribute name="font-style">italic</xsl:attribute>
-    <xsl:attribute name="background-color">#2469a5</xsl:attribute>
+    <xsl:attribute name="background-color" select="$hazard.ansi.blue"/>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="hazardstatement.image" use-attribute-sets="hazardstatement.cell">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -34,21 +34,21 @@ See the accompanying license.txt file for applicable licenses.
   
   <xsl:attribute-set name="hazardstatement.title.danger">
     <xsl:attribute name="color">white</xsl:attribute>
-    <xsl:attribute name="background-color">red</xsl:attribute>
+    <xsl:attribute name="background-color">#d63231</xsl:attribute>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.warning">
-    <xsl:attribute name="background-color">orange</xsl:attribute>
+    <xsl:attribute name="background-color">#ed9c3d</xsl:attribute>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.caution">
-    <xsl:attribute name="background-color">yellow</xsl:attribute>
+    <xsl:attribute name="background-color">#eae639</xsl:attribute>
     <xsl:attribute name="font-style">normal</xsl:attribute>
   </xsl:attribute-set>
   <xsl:attribute-set name="hazardstatement.title.notice">
     <xsl:attribute name="color">white</xsl:attribute>
     <xsl:attribute name="font-style">italic</xsl:attribute>
-    <xsl:attribute name="background-color">blue</xsl:attribute>
+    <xsl:attribute name="background-color">#2469a5</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="hazardstatement.image" use-attribute-sets="hazardstatement.cell">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project. 
+See the accompanying license.txt file for applicable licenses.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0">
+
+  <xsl:attribute-set name="hazardstatement">
+    <xsl:attribute name="width">100%</xsl:attribute>
+    <xsl:attribute name="space-before">8pt</xsl:attribute>
+    <xsl:attribute name="space-after">10pt</xsl:attribute>
+    <xsl:attribute name="border-style">solid</xsl:attribute>
+    <xsl:attribute name="border-color">black</xsl:attribute>
+    <xsl:attribute name="border-width">5pt</xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="hazardstatement.cell">
+    <xsl:attribute name="start-indent">0pt</xsl:attribute>
+    <xsl:attribute name="border-style">solid</xsl:attribute>
+    <xsl:attribute name="border-color">black</xsl:attribute>
+    <xsl:attribute name="border-width">2pt</xsl:attribute>
+    <xsl:attribute name="padding">3pt</xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="hazardstatement.title" use-attribute-sets="hazardstatement.cell">
+    <xsl:attribute name="number-columns-spanned">2</xsl:attribute>
+    <xsl:attribute name="background-color">orange</xsl:attribute>
+    <xsl:attribute name="text-transform">uppercase</xsl:attribute>
+    <xsl:attribute name="font-weight">bold</xsl:attribute>
+    <xsl:attribute name="font-size">1.5em</xsl:attribute>
+    <xsl:attribute name="text-align">center</xsl:attribute>
+
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="hazardstatement.image" use-attribute-sets="hazardstatement.cell">
+    <xsl:attribute name="text-align">center</xsl:attribute>
+    <xsl:attribute name="keep-with-next">always</xsl:attribute>
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="hazardstatement.image.column">
+    <xsl:attribute name="column-width">6em</xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="hazardstatement.content" use-attribute-sets="hazardstatement.cell">
+    
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="hazardstatement.content.column">
+    
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="messagepanel">
+    
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="consequence">
+    
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="howtoavoid">
+    
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="typeofhazard">
+    
+  </xsl:attribute-set>
+  
+  <xsl:attribute-set name="hazardsymbol" use-attribute-sets="image">
+    <xsl:attribute name="content-width">4em</xsl:attribute>
+    <xsl:attribute name="width">4em</xsl:attribute>
+  </xsl:attribute-set>
+  
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -23,7 +23,7 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:attribute name="padding">3pt</xsl:attribute>
   </xsl:attribute-set>
 
-  <xsl:attribute-set name="hazardstatement.title" use-attribute-sets="hazardstatement.cell">
+  <xsl:attribute-set name="hazardstatement.title" use-attribute-sets="hazardstatement.cell common.title">
     <xsl:attribute name="number-columns-spanned">2</xsl:attribute>
     <xsl:attribute name="background-color">orange</xsl:attribute>
     <xsl:attribute name="text-transform">uppercase</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -6,8 +6,9 @@ See the accompanying license.txt file for applicable licenses.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 version="2.0"
-                exclude-result-prefixes="xs">
+                exclude-result-prefixes="xs dita-ot">
 
   <xsl:template match="*[contains(@class, ' hazard-d/hazardstatement ')]">
     <xsl:variable name="number-cells" as="xs:integer" select="2"/>
@@ -22,7 +23,9 @@ See the accompanying license.txt file for applicable licenses.
         <fo:table-row>
           <fo:table-cell xsl:use-attribute-sets="hazardstatement.title">
             <fo:block>
-              <xsl:value-of select="@type"/>
+              <xsl:call-template name="getVariable">
+                <xsl:with-param name="id" select="if (exists(@type)) then dita-ot:capitalize(@type) else 'Caution'"/>
+              </xsl:call-template>
             </fo:block>
           </fo:table-cell>
         </fo:table-row>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -20,8 +20,25 @@ See the accompanying license.txt file for applicable licenses.
       <fo:table-column xsl:use-attribute-sets="hazardstatement.image.column"/>
       <fo:table-column xsl:use-attribute-sets="hazardstatement.content.column"/>
       <fo:table-body>
-        <fo:table-row>
+        <fo:table-row keep-with-next="always">
           <fo:table-cell xsl:use-attribute-sets="hazardstatement.title">
+            <xsl:variable name="atts" as="element()">
+              <xsl:choose>
+                <xsl:when test="@type = 'danger'">
+                  <w xsl:use-attribute-sets="hazardstatement.title.danger"/>
+                </xsl:when>
+                <xsl:when test="@type = 'warning'">
+                  <w xsl:use-attribute-sets="hazardstatement.title.warning"/>
+                </xsl:when>
+                <xsl:when test="@type = 'caution'">
+                  <w xsl:use-attribute-sets="hazardstatement.title.caution"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <w xsl:use-attribute-sets="hazardstatement.title.notice"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:sequence select="$atts/@*"/>
             <fo:block>
               <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="if (exists(@type)) then dita-ot:capitalize(@type) else 'Caution'"/>
@@ -31,12 +48,12 @@ See the accompanying license.txt file for applicable licenses.
         </fo:table-row>
         <fo:table-row>
           <fo:table-cell xsl:use-attribute-sets="hazardstatement.image">
-            <fo:block>
               <xsl:choose>
-                <xsl:when test="exists(*[contains(@class, ' hazard-d/hazardsymbol ')])">
-                  <xsl:apply-templates select="*[contains(@class, ' hazard-d/hazardsymbol ')]"/>
-                </xsl:when>
-                <xsl:otherwise>
+              <xsl:when test="exists(*[contains(@class, ' hazard-d/hazardsymbol ')])">
+                <xsl:apply-templates select="*[contains(@class, ' hazard-d/hazardsymbol ')]"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <fo:block>
                   <xsl:variable name="image" as="xs:string">
                     <xsl:call-template name="getVariable">
                       <xsl:with-param name="id" select="'hazard.image.default'"/>
@@ -44,9 +61,9 @@ See the accompanying license.txt file for applicable licenses.
                   </xsl:variable>
                   <fo:external-graphic src="url('{concat($artworkPrefix, $image)}')"
                     xsl:use-attribute-sets="hazardsymbol"/>
-                </xsl:otherwise>
-              </xsl:choose>
-            </fo:block>
+                </fo:block>
+              </xsl:otherwise>
+            </xsl:choose>
           </fo:table-cell>
           <fo:table-cell  xsl:use-attribute-sets="hazardstatement.content">
             <xsl:apply-templates select="*[contains(@class, ' hazard-d/messagepanel ')]/*"/>
@@ -71,6 +88,12 @@ See the accompanying license.txt file for applicable licenses.
   
   <xsl:template match="*[contains(@class, ' hazard-d/howtoavoid ')]">
     <xsl:call-template name="p"/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' hazard-d/hazardsymbol ')]">
+    <fo:block>
+      <xsl:next-match/>
+    </fo:block>
   </xsl:template>
     
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -37,7 +37,11 @@ See the accompanying license.txt file for applicable licenses.
                   <xsl:apply-templates select="*[contains(@class, ' hazard-d/hazardsymbol ')]"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:variable name="image" as="xs:string">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</xsl:variable>
+                  <xsl:variable name="image" as="xs:string">
+                    <xsl:call-template name="getVariable">
+                      <xsl:with-param name="id" select="'hazard.image.default'"/>
+                    </xsl:call-template>
+                  </xsl:variable>
                   <fo:external-graphic src="url('{concat($artworkPrefix, $image)}')"
                     xsl:use-attribute-sets="hazardsymbol"/>
                 </xsl:otherwise>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project. 
+See the accompanying license.txt file for applicable licenses.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                version="2.0"
+                exclude-result-prefixes="xs">
+
+  <xsl:template match="*[contains(@class, ' hazard-d/hazardstatement ')]">
+    <xsl:variable name="number-cells" as="xs:integer" select="2"/>
+    <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+    <fo:table xsl:use-attribute-sets="hazardstatement">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="globalAtts"/>
+      <xsl:call-template name="displayAtts"/>
+      <fo:table-column xsl:use-attribute-sets="hazardstatement.image.column"/>
+      <fo:table-column xsl:use-attribute-sets="hazardstatement.content.column"/>
+      <fo:table-body>
+        <fo:table-row>
+          <fo:table-cell xsl:use-attribute-sets="hazardstatement.title">
+            <fo:block>
+              <xsl:value-of select="@type"/>
+            </fo:block>
+          </fo:table-cell>
+        </fo:table-row>
+        <fo:table-row>
+          <fo:table-cell xsl:use-attribute-sets="hazardstatement.image">
+            <fo:block>
+              <xsl:choose>
+                <xsl:when test="exists(*[contains(@class, ' hazard-d/hazardsymbol ')])">
+                  <xsl:apply-templates select="*[contains(@class, ' hazard-d/hazardsymbol ')]"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:variable name="image" as="xs:string">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</xsl:variable>
+                  <fo:external-graphic src="url('{concat($artworkPrefix, $image)}')"
+                    xsl:use-attribute-sets="hazardsymbol"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </fo:block>
+          </fo:table-cell>
+          <fo:table-cell  xsl:use-attribute-sets="hazardstatement.content">
+            <xsl:apply-templates select="*[contains(@class, ' hazard-d/messagepanel ')]/*"/>
+          </fo:table-cell>
+        </fo:table-row>
+      </fo:table-body>
+    </fo:table>
+    <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
+  </xsl:template>
+    
+  <xsl:template match="*[contains(@class, ' hazard-d/messagepanel ')]">
+    <xsl:apply-templates/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' hazard-d/typeofhazard ')]">
+    <xsl:call-template name="p"/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' hazard-d/consequence ')]">
+    <xsl:call-template name="p"/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' hazard-d/howtoavoid ')]">
+    <xsl:call-template name="p"/>
+  </xsl:template>
+    
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -16,7 +16,9 @@ See the accompanying license.txt file for applicable licenses.
     <fo:table xsl:use-attribute-sets="hazardstatement">
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="globalAtts"/>
-      <xsl:call-template name="displayAtts"/>
+      <xsl:call-template name="displayAtts">
+        <xsl:with-param name="element" select="."/>
+      </xsl:call-template>
       <fo:table-column xsl:use-attribute-sets="hazardstatement.image.column"/>
       <fo:table-column xsl:use-attribute-sets="hazardstatement.content.column"/>
       <fo:table-body>
@@ -92,15 +94,24 @@ See the accompanying license.txt file for applicable licenses.
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' hazard-d/typeofhazard ')]">
-    <xsl:call-template name="p"/>
+    <fo:block xsl:use-attribute-sets="p">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates/>
+    </fo:block>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' hazard-d/consequence ')]">
-    <xsl:call-template name="p"/>
+    <fo:block xsl:use-attribute-sets="p">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates/>
+    </fo:block>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' hazard-d/howtoavoid ')]">
-    <xsl:call-template name="p"/>
+    <fo:block xsl:use-attribute-sets="p">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates/>
+    </fo:block>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' hazard-d/hazardsymbol ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -11,6 +11,7 @@ See the accompanying license.txt file for applicable licenses.
                 exclude-result-prefixes="xs dita-ot">
 
   <xsl:template match="*[contains(@class, ' hazard-d/hazardstatement ')]">
+    <xsl:variable name="type" select="(@type, 'caution')[1]" as="xs:string"/>
     <xsl:variable name="number-cells" as="xs:integer" select="2"/>
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
     <fo:table xsl:use-attribute-sets="hazardstatement">
@@ -26,13 +27,13 @@ See the accompanying license.txt file for applicable licenses.
           <fo:table-cell xsl:use-attribute-sets="hazardstatement.title">
             <xsl:variable name="atts" as="element()">
               <xsl:choose>
-                <xsl:when test="@type = 'danger'">
+                <xsl:when test="$type = 'danger'">
                   <w xsl:use-attribute-sets="hazardstatement.title.danger"/>
                 </xsl:when>
-                <xsl:when test="@type = 'warning'">
+                <xsl:when test="$type = 'warning'">
                   <w xsl:use-attribute-sets="hazardstatement.title.warning"/>
                 </xsl:when>
-                <xsl:when test="@type = 'caution'">
+                <xsl:when test="$type = 'caution'">
                   <w xsl:use-attribute-sets="hazardstatement.title.caution"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -42,7 +43,7 @@ See the accompanying license.txt file for applicable licenses.
             </xsl:variable>
             <xsl:sequence select="$atts/@*"/>
             <fo:block>
-              <xsl:if test="@type = ('danger', 'warning', 'caution')">
+              <xsl:if test="$type = ('danger', 'warning', 'caution')">
                 <xsl:variable name="image" as="xs:string">
                   <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'hazard.image.default'"/>
@@ -55,7 +56,7 @@ See the accompanying license.txt file for applicable licenses.
               </xsl:if>
               <fo:inline>
                 <xsl:call-template name="getVariable">
-                  <xsl:with-param name="id" select="if (exists(@type)) then dita-ot:capitalize(@type) else 'Caution'"/>
+                  <xsl:with-param name="id" select="dita-ot:capitalize($type)"/>
                 </xsl:call-template>
               </fo:inline>
             </fo:block>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -40,9 +40,22 @@ See the accompanying license.txt file for applicable licenses.
             </xsl:variable>
             <xsl:sequence select="$atts/@*"/>
             <fo:block>
-              <xsl:call-template name="getVariable">
-                <xsl:with-param name="id" select="if (exists(@type)) then dita-ot:capitalize(@type) else 'Caution'"/>
-              </xsl:call-template>
+              <xsl:if test="@type = ('danger', 'warning', 'caution')">
+                <xsl:variable name="image" as="xs:string">
+                  <xsl:call-template name="getVariable">
+                    <xsl:with-param name="id" select="'hazard.image.default'"/>
+                  </xsl:call-template>
+                </xsl:variable>
+                <fo:external-graphic src="url('{concat($artworkPrefix, $image)}')"
+                                     content-height="1em" padding-right="3pt"
+                                     vertical-align="middle"
+                                     baseline-shift="baseline"/>
+              </xsl:if>
+              <fo:inline>
+                <xsl:call-template name="getVariable">
+                  <xsl:with-param name="id" select="if (exists(@type)) then dita-ot:capitalize(@type) else 'Caution'"/>
+                </xsl:call-template>
+              </fo:inline>
             </fo:block>
           </fo:table-cell>
         </fo:table-row>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
@@ -96,6 +96,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:import href="xml-domain.xsl"/>
     <xsl:import href="../../cfg/fo/attrs/svg-domain-attr.xsl"/>
     <xsl:import href="svg-domain.xsl"/>
+    <xsl:import href="../../cfg/fo/attrs/hazard-d-attr.xsl"/>
+    <xsl:import href="hazard-d.xsl"/>
 
     <xsl:import href="../../cfg/fo/attrs/static-content-attr.xsl"/>
     <xsl:import href="static-content.xsl"/>

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -30,6 +30,12 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template name="getLowerCaseLang">
     <xsl:value-of select="dita-ot:get-current-language(.)"/>
   </xsl:template>
+  
+  <xsl:function name="dita-ot:capitalize">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:value-of select="concat(upper-case(substring($text, 1, 1)),
+                                 lower-case(substring($text, 2)))"/>
+  </xsl:function>
 
   <xsl:template match="*" mode="get-first-topic-lang">
     <xsl:sequence select="dita-ot:get-first-topic-language(.)"/>


### PR DESCRIPTION
Implement a generic hazard statement styling for PDF2.

<img width="752" alt="screen shot 2018-08-10 at 18 33 01" src="https://user-images.githubusercontent.com/52934/43966936-e0d77aa2-9ccb-11e8-9274-3e2e53acf23d.png">

## References

* https://en.wikipedia.org/wiki/ISO_3864
* https://en.wikipedia.org/wiki/ANSI_Z535