### PR TITLE
Remove references to obsolete JAR files #2832

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -125,10 +125,6 @@ with those set forth herein.
         
     <path id="project.class.path">
       <pathelement path="${java.class.path}"/>
-      <pathelement location="${lib.dir}/saxon.jar"/>
-      <pathelement location="${lib.dir}/saxon-dom.jar"/>
-      <pathelement location="${lib.dir}/resolver.jar"/>
-      <pathelement location="${lib.dir}/icu4j.jar"/>
       <pathelement location="${fo.lib.dir}/fo.jar"/>
     </path>
   </target>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Fixes the issue reported in #2832.

## Motivation and Context

Ant code in DITA-OT 3.1 and earlier sets up a special classpath for PDF; that classpath refers to JAR files that don't exist, as reported in #2832. This classpath does not exist in 3.2 so the issue is already resolved in `develop`.

Seemed like an easy issue to knock out of the backlog for the current release - we should either remove the invalid references in 3.1.2, or close the issue as obsolete / fixed in 3.2.

## How Has This Been Tested?

Travis end-to-end test still passes, PDF still builds.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_