### PR TITLE
Fix NPE from index process when topic has empty title

### DIFF
--- a/src/main/java/org/dita/dost/reader/IndexTermReader.java
+++ b/src/main/java/org/dita/dost/reader/IndexTermReader.java
@@ -237,6 +237,9 @@ public final class IndexTermReader extends AbstractXMLReader {
             inTitleElement = false;
             if (!topicIdStack.empty() && !titleMap.containsKey(topicIdStack.peek())) {
                 //If this is the first topic title
+                if (title == null) {  //Guard against zero-content titles
+                    title = "***";
+                }
                 if (titleMap.size() == 0) {
                     defaultTitle = title;
                 }

--- a/src/test/java/org/dita/dost/reader/IndexTermReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/IndexTermReaderTest.java
@@ -75,6 +75,7 @@ public class IndexTermReaderTest {
         exp.add(generateIndexTerms(target, "Primary", "Secondary", "Tertiary"));
         exp.add(generateIndexTerms(target, "Primary normalized", "Secondary normalized", "Tertiary normalized"));
         exp.add(generateIndexTerms(target, " Primary unnormalized ", " Secondary unnormalized ", " Tertiary unnormalized "));
+        exp.add(generateIndexTermErrorCondition(target, "Test empty title"));
 
         assertEquals(new HashSet<IndexTerm>(exp),
                 new HashSet<IndexTerm>(act));
@@ -105,6 +106,19 @@ public class IndexTermReaderTest {
             final IndexTermTarget primaryTarget = new IndexTermTarget();
             primaryTarget.setTargetName("Index test");
             primaryTarget.setTargetURI(target.getAbsolutePath() + "#concept");
+            primary.addTarget(primaryTarget);
+        }
+        return primary;
+    }
+    
+    private IndexTerm generateIndexTermErrorCondition(final File target, final String text) {
+        final IndexTerm primary = new IndexTerm();
+        primary.setTermName(text);
+        primary.setTermKey(text);
+        if (target != null) {
+            final IndexTermTarget primaryTarget = new IndexTermTarget();
+            primaryTarget.setTargetName("***");
+            primaryTarget.setTargetURI(target.getAbsolutePath() + "#error");
             primary.addTarget(primaryTarget);
         }
         return primary;

--- a/src/test/resources/IndexTermReaderTest/concept.dita
+++ b/src/test/resources/IndexTermReaderTest/concept.dita
@@ -20,4 +20,7 @@
           <indexterm class="- topic/indexterm ">  Tertiary  unnormalized  </indexterm></indexterm></indexterm>
     </p>
   </conbody>
+  <concept xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic concept/concept " domains="(topic concept)                            (topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="error" ditaarch:DITAArchVersion="1.2">
+    <title class="- topic/title "><indexterm class="- topic/indexterm ">Test empty title</indexterm></title>
+  </concept>
 </concept>


### PR DESCRIPTION
## Description

If a topic:
- Has index terms, and
- Has an empty title, or title with only metadata, such as `<title><indexterm>test</indexterm></title>`, and
- Is part of a map build to HTML Help or Eclipse help (or, probably, Javahelp using the older plugin)

Then the build will crash with a null pointer error. This is caused by a `Map` that stores topic IDs with their title for generating index output; a title with zero content results in a `null` title, which fails in the various steps that try to generate the title later.

Fixed by replacing the null title with `***`, the same value already used (with a warning) for empty index terms and for the HTML `<title>` output with the same empty condition.

## Motivation and Context

Fixes the NPE reported in #2940

## How Has This Been Tested?

Fixes the NPE in the original test files. Also added the empty-title condition to the `IndexTermReader` unit test; as expected, that resulted in the NPE, but passed again with this fix.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
