### PR TITLE
Ensure root file is never marked resource-only

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -686,6 +686,11 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
         job.setInputDir(baseInputDir);
         job.setInputMap(rootTemp);
+        
+        //If root input file is marked resource only due to conref or other feature, remove that designation
+        if (resourceOnlySet.contains(rootFile)) {
+            resourceOnlySet.remove(rootFile);
+        }
 
         job.setProperty(INPUT_DITAMAP_LIST_FILE_LIST, USER_INPUT_FILE_LIST_FILE);
         final File inputfile = new File(job.tempDir, USER_INPUT_FILE_LIST_FILE);

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -317,6 +317,16 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .warnCount(1)
                 .test();
     }
+    
+    @Test
+    public void testconref_topiconly() throws Throwable {
+        builder().name("conref_topiconly")
+                .transtype(XHTML)
+                .input(Paths.get("conref_to_self.dita"))
+                .put("validate", "false")
+                .warnCount(1)
+                .test();
+    }
 
     @Test
     public void testpushAfter_between_Specialization() throws Throwable {

--- a/src/test/resources/conref_topiconly/exp/xhtml/conref_to_self.html
+++ b/src/test/resources/conref_topiconly/exp/xhtml/conref_to_self.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+<meta name="copyright" content="(C) Copyright 2018" />
+<meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="DC.Type" content="topic" />
+<meta name="DC.Title" content="Conref test for #2948" />
+<meta name="DC.Format" content="XHTML" />
+<meta name="DC.Identifier" content="topic" />
+<meta name="DC.Language" content="en" />
+<link rel="stylesheet" type="text/css" href="commonltr.css" />
+<title>Conref test for #2948</title>
+</head>
+<body id="topic">
+
+  <h1 class="title topictitle1" id="ariaid-title1">Conref test for #2948</h1>
+
+  <div class="body">
+    <p class="p" id="topic__test">Same-topic conref</p>
+
+    <p class="p">Same-topic conref</p>
+
+  </div>
+
+</body>
+</html>

--- a/src/test/resources/conref_topiconly/src/conref_to_self.dita
+++ b/src/test/resources/conref_topiconly/src/conref_to_self.dita
@@ -1,0 +1,8 @@
+<topic class="- topic/topic " domains="(topic hi-d)" id="topic" ditaarch:DITAArchVersion="1.3" xml:lang="en"
+  xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/">
+  <title class="- topic/title ">Conref test for #2948</title>
+  <body class="- topic/body ">
+    <p class="- topic/p " id="test">Same-topic conref</p>
+    <p class="- topic/p " conref="#./test"/>
+  </body>
+</topic>


### PR DESCRIPTION
## Description

In at least one case (maybe others), when the root input file is a topic, that topic can be marked as `resource-only` based on markup in the document. In #2948 this happens because the topic has a conref to itself. I'm not sure if other features could produce the same result, but it seems possible.

The fix here ensures that before the job information is finalized, if the root input file was added to `resourceOnlySet`, it gets removed. This resolves the issue reported in 2948, where the root topic does not generate output because our build thinks it is resource-only.

## How Has This Been Tested?

Tested with the original source in the issue.

Updated the integration test with an equivalent topic, and it failed because no XHTML was generated; tests passed with the fix.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
