### PR TITLE
Add homebrew install method to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,12 @@ To build and use DITA-OT, you’ll need:
 
 * Java Development Kit 8 or newer
 
+## Install
+
+On macOS you can install dita-ot using homebrew:
+
+`brew install dita-ot`
+
 ## Building
 
 1. Clone the DITA-OT Git repository:


### PR DESCRIPTION
## Description
On macOS homebrew is able to install dita-ot, this makes it easier to use.

## Motivation and Context
This makes it easier for people to start using Dita-OT

## How Has This Been Tested?
I've installed dita-ot using brew

## Type of Changes
- documentation change
