### PR TITLE
Use intended block on section/example content #1248

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
@@ -53,7 +53,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:attribute-set name="refbody" use-attribute-sets="body">
   </xsl:attribute-set>
 
-  <xsl:attribute-set name="refsyn">
+  <xsl:attribute-set name="refsyn" use-attribute-sets="section">
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="refsyn__content" use-attribute-sets="section__content">
   </xsl:attribute-set>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -9,7 +9,8 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
-  exclude-result-prefixes="xs"
+  xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
+  exclude-result-prefixes="xs dita2xslfo"
   version="2.0">
 
   <xsl:template match="*[contains(@class, ' reference/reference ')]" mode="processTopic"
@@ -54,7 +55,11 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' reference/refsyn ')]">
     <fo:block xsl:use-attribute-sets="refsyn">
       <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
+      <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
+      <fo:block xsl:use-attribute-sets="refsyn__content">
+        <xsl:apply-templates select="node() except (*[contains(@class,' topic/title ')])"/>
+      </fo:block>
     </fo:block>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -691,7 +691,10 @@ See the accompanying LICENSE file for applicable license.
         <fo:block xsl:use-attribute-sets="section">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
-            <xsl:apply-templates/>
+            <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
+            <fo:block xsl:use-attribute-sets="section__content">
+                <xsl:apply-templates select="node() except (*[contains(@class,' topic/title ')])"/>
+            </fo:block>
         </fo:block>
     </xsl:template>
 
@@ -705,7 +708,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/example ')]">
         <fo:block xsl:use-attribute-sets="example">
             <xsl:call-template name="commonattributes"/>
-            <xsl:apply-templates/>
+            <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
+            <fo:block xsl:use-attribute-sets="example__content">
+                <xsl:apply-templates select="node() except (*[contains(@class,' topic/title ')])"/>
+            </fo:block>
         </fo:block>
     </xsl:template>
 


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

The request in #1248 asked (after some discussion) for an extra block around section contents, so that there would be one block around the whole section (attribute set `section`), another around the title (attribute set `section.title`) and another around the content (which ended up as `section__content`). The same request applies to `<example>`.

It looks like the change was made for all of the sections within task, but the `section__content` block wasn't actually created around the default section; similarly, `example__content` is used around examples content in tasks, but not for the default example.

This pull request:

- Finally puts the existing `section__content` attribute set on a block around the non-titled content in sections, processing titles first to create their own block
- Finally puts the existing `example__content` attribute set on a block around the non-titled content in examples, processing titles first to create their own block
- Does the same for `refsyn`, which has its own attribute set but was never brought up to date with other section processing

## Motivation and Context

Finally finishes off #1248

## How Has This Been Tested?

Default tests + Travis, and verify that sections with elements + sections with just text still render as they did before (the extra `fo:block` does not change default presentation because it doesn't get any attributes until the attribute set is customized).

## Type of Changes

- New feature _(non-breaking change which adds functionality)_