### PR TITLE
Add Homebrew installation details to ReadMe

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,17 +5,18 @@ The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing en
 Visit the project website at [dita-ot.org][site] for documentation, information about releases, and [download packages][dist].  
 For information on additional DITA and DITA-OT resources, see [SUPPORT].
 
-- [Prerequisites](#prerequisites)
+- [Prerequisites: Java 8](#prerequisites-java-8)
 - [Installing](#installing)
 - [Building output](#building-output)
 - [For developers](#for-developers)
 - [License](#license)
 
-## Prerequisites
+## Prerequisites: Java 8
 
-To build and use DITA-OT, you’ll need:
+- To _build_ DITA-OT, you’ll need Java Development Kit (JDK), version 8 or newer
+- To _run_ DITA-OT, the Java Runtime Environment (JRE) is sufficient
 
-- Java Development Kit 8 or newer
+You can download the Oracle JRE or JDK from [oracle.com/technetwork/java][java].
 
 ## Installing
 
@@ -84,7 +85,7 @@ See the [documentation][docs] for arguments and [options].
 
     If Gradle throws an error like `java.lang.OutOfMemoryError: Java heap space`, you probably need to increase the maximum Java heap size. One way to do this is to set the `GRADLE_OPTS` environment variable to a value like `-Xmx1024m`.
 
-    For more information on the `-Xmx` option, see the [Java SE Documentation][java].
+    For more information on the `-Xmx` option, see the [Java SE Documentation][javadoc].
 
 </details>
 
@@ -97,8 +98,9 @@ The DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache]
 [site]: https://www.dita-ot.org/
 [dist]: https://www.dita-ot.org/download
 [support]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
+[java]: http://www.oracle.com/technetwork/java/javase/downloads
 [homebrew]: https://brew.sh
 [docs]: https://www.dita-ot.org/dev/
 [options]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
-[java]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
+[javadoc]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
 [apache]: http://www.apache.org/licenses/LICENSE-2.0

--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,12 @@ See [dita-ot.org][2] for documentation, information about releases, and download
 
 For information on additional DITA and DITA-OT resources, see [SUPPORT][8].
 
+- [Prerequisites](#prerequisites)
+- [Installing](#installing)
+- [Building output](#building-output)
+- [For developers](#for-developers)
+- [License](#license)
+
 ## Prerequisites
 
 To build and use DITA-OT, you’ll need:

--- a/README.markdown
+++ b/README.markdown
@@ -12,11 +12,18 @@ To build and use DITA-OT, you’ll need:
 
 - Java Development Kit 8 or newer
 
-## Install
+## Installing
 
-On macOS you can install dita-ot using homebrew:
+1.  Download the distribution package from [dita-ot.org/download][9].
+2.  Extract the contents of the package to the directory where you want to install the DITA-OT.
 
-`brew install dita-ot`
+### Installing on macOS via Homebrew
+
+On macOS, you can also install DITA-OT using the [Homebrew][10] package manager:
+
+    brew install dita-ot
+
+Homebrew will automatically download the latest version of the toolkit, install it in a subfolder of the local package Cellar and symlink the `dita` command to `/usr/local/bin/dita`.
 
 ## Building
 
@@ -72,3 +79,5 @@ The DITA Open Toolkit is licensed for use under the [Apache License 2.0][6].
 [6]: http://www.apache.org/licenses/LICENSE-2.0
 [7]: http://slack.dita-ot.org/badge.svg
 [8]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
+[9]: https://www.dita-ot.org/download
+[10]: https://brew.sh

--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,25 @@ On macOS, you can also install DITA-OT using the [Homebrew][10] package manager:
 
 Homebrew will automatically download the latest version of the toolkit, install it in a subfolder of the local package Cellar and symlink the `dita` command to `/usr/local/bin/dita`.
 
+## Building output
+
+You can generate output using the DITA Open Toolkit `dita` command-line tool.
+
+1.  On the command line, change to the `bin` folder of the DITA-OT installation directory:
+
+        cd path/to/dita-ot-dir/bin
+
+2.  Run the `dita` command to generate output:
+
+        dita --input=input-file --format=format [options]
+
+    where:
+
+    - _`input-file`_ is the DITA map or DITA file that you want to process
+    - _`format`_ is the output format (or “transformation type”)
+
+See the [documentation][3] for arguments and [options][4].
+
 ## Building
 
 1.  Clone the DITA-OT Git repository:
@@ -42,14 +61,6 @@ Homebrew will automatically download the latest version of the toolkit, install 
 4.  In the root directory, run Gradle to compile the Java code and install plugins:
 
         ./gradlew
-
-## Usage
-
-1.  Run the `dita` command to generate output:
-
-        src/main/bin/dita [options]
-
-    See the [documentation][3] for arguments and [options][4].
 
 ## Distribution
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # DITA Open Toolkit [![Build]](http://travis-ci.org/dita-ot/dita-ot) [![Slack]](http://slack.dita-ot.org/)
 
-The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
+_DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
 Visit the project website at [dita-ot.org][site] for documentation, information about releases, and [download packages][dist].  
 For information on additional DITA and DITA-OT resources, see [SUPPORT].
@@ -21,7 +21,7 @@ You can download the Oracle JRE or JDK from [oracle.com/technetwork/java][java].
 ## Installing
 
 1.  Download the distribution package from [dita-ot.org/download][dist].
-2.  Extract the contents of the package to the directory where you want to install the DITA-OT.
+2.  Extract the contents of the package to the directory where you want to install DITA-OT.
 
 ### Installing on macOS via Homebrew
 
@@ -33,7 +33,7 @@ Homebrew will automatically download the latest version of the toolkit, install 
 
 ## Building output
 
-You can generate output using the DITA Open Toolkit `dita` command-line tool.
+You can generate output using the `dita` command-line tool included with DITA Open Toolkit.
 
 1.  On the command line, change to the `bin` folder of the DITA-OT installation directory:
 
@@ -91,7 +91,7 @@ See the [documentation][docs] for arguments and [options].
 
 ## License
 
-The DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
+DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 
 [build]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
 [slack]: http://slack.dita-ot.org/badge.svg

--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,9 @@
-# DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][2]](http://slack.dita-ot.org/)
+# DITA Open Toolkit [![Build]](http://travis-ci.org/dita-ot/dita-ot) [![Slack]](http://slack.dita-ot.org/)
 
 The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
-Visit the project website at [dita-ot.org][3] for documentation, information about releases, and [download packages][4].  
-For information on additional DITA and DITA-OT resources, see [SUPPORT][5].
+Visit the project website at [dita-ot.org][site] for documentation, information about releases, and [download packages][dist].  
+For information on additional DITA and DITA-OT resources, see [SUPPORT].
 
 - [Prerequisites](#prerequisites)
 - [Installing](#installing)
@@ -19,12 +19,12 @@ To build and use DITA-OT, you’ll need:
 
 ## Installing
 
-1.  Download the distribution package from [dita-ot.org/download][4].
+1.  Download the distribution package from [dita-ot.org/download][dist].
 2.  Extract the contents of the package to the directory where you want to install the DITA-OT.
 
 ### Installing on macOS via Homebrew
 
-On macOS, you can also install DITA-OT using the [Homebrew][6] package manager:
+On macOS, you can also install DITA-OT using the [Homebrew] package manager:
 
     brew install dita-ot
 
@@ -47,7 +47,7 @@ You can generate output using the DITA Open Toolkit `dita` command-line tool.
     - _`input-file`_ is the DITA map or DITA file that you want to process
     - _`format`_ is the output format (or “transformation type”)
 
-See the [documentation][7] for arguments and [options][8].
+See the [documentation][docs] for arguments and [options].
 
 ## For developers
 
@@ -84,21 +84,21 @@ See the [documentation][7] for arguments and [options][8].
 
     If Gradle throws an error like `java.lang.OutOfMemoryError: Java heap space`, you probably need to increase the maximum Java heap size. One way to do this is to set the `GRADLE_OPTS` environment variable to a value like `-Xmx1024m`.
 
-    For more information on the `-Xmx` option, see the [Java SE Documentation][9].
+    For more information on the `-Xmx` option, see the [Java SE Documentation][java].
 
 </details>
 
 ## License
 
-The DITA Open Toolkit is licensed for use under the [Apache License 2.0][10].
+The DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 
-[1]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
-[2]: http://slack.dita-ot.org/badge.svg
-[3]: https://www.dita-ot.org/
-[4]: https://www.dita-ot.org/download
-[5]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
-[6]: https://brew.sh
-[7]: https://www.dita-ot.org/dev/
-[8]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
-[9]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
-[10]: http://www.apache.org/licenses/LICENSE-2.0
+[build]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
+[slack]: http://slack.dita-ot.org/badge.svg
+[site]: https://www.dita-ot.org/
+[dist]: https://www.dita-ot.org/download
+[support]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
+[homebrew]: https://brew.sh
+[docs]: https://www.dita-ot.org/dev/
+[options]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
+[java]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
+[apache]: http://www.apache.org/licenses/LICENSE-2.0

--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,9 @@
-# DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][7]](http://slack.dita-ot.org/)
+# DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][2]](http://slack.dita-ot.org/)
 
 The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
-Visit the project website at [dita-ot.org][2] for documentation, information about releases, and [download packages][9].  
-For information on additional DITA and DITA-OT resources, see [SUPPORT][8].
+Visit the project website at [dita-ot.org][3] for documentation, information about releases, and [download packages][4].  
+For information on additional DITA and DITA-OT resources, see [SUPPORT][5].
 
 - [Prerequisites](#prerequisites)
 - [Installing](#installing)
@@ -19,12 +19,12 @@ To build and use DITA-OT, you’ll need:
 
 ## Installing
 
-1.  Download the distribution package from [dita-ot.org/download][9].
+1.  Download the distribution package from [dita-ot.org/download][4].
 2.  Extract the contents of the package to the directory where you want to install the DITA-OT.
 
 ### Installing on macOS via Homebrew
 
-On macOS, you can also install DITA-OT using the [Homebrew][10] package manager:
+On macOS, you can also install DITA-OT using the [Homebrew][6] package manager:
 
     brew install dita-ot
 
@@ -47,7 +47,7 @@ You can generate output using the DITA Open Toolkit `dita` command-line tool.
     - _`input-file`_ is the DITA map or DITA file that you want to process
     - _`format`_ is the output format (or “transformation type”)
 
-See the [documentation][3] for arguments and [options][4].
+See the [documentation][7] for arguments and [options][8].
 
 ## For developers
 
@@ -84,21 +84,21 @@ See the [documentation][3] for arguments and [options][4].
 
     If Gradle throws an error like `java.lang.OutOfMemoryError: Java heap space`, you probably need to increase the maximum Java heap size. One way to do this is to set the `GRADLE_OPTS` environment variable to a value like `-Xmx1024m`.
 
-    For more information on the `-Xmx` option, see the [Java SE Documentation][5].
+    For more information on the `-Xmx` option, see the [Java SE Documentation][9].
 
 </details>
 
 ## License
 
-The DITA Open Toolkit is licensed for use under the [Apache License 2.0][6].
+The DITA Open Toolkit is licensed for use under the [Apache License 2.0][10].
 
 [1]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
-[2]: https://www.dita-ot.org/
-[3]: https://www.dita-ot.org/dev/
-[4]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
-[5]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
-[6]: http://www.apache.org/licenses/LICENSE-2.0
-[7]: http://slack.dita-ot.org/badge.svg
-[8]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
-[9]: https://www.dita-ot.org/download
-[10]: https://brew.sh
+[2]: http://slack.dita-ot.org/badge.svg
+[3]: https://www.dita-ot.org/
+[4]: https://www.dita-ot.org/download
+[5]: https://github.com/dita-ot/dita-ot/blob/develop/.github/SUPPORT.md
+[6]: https://brew.sh
+[7]: https://www.dita-ot.org/dev/
+[8]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
+[9]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
+[10]: http://www.apache.org/licenses/LICENSE-2.0

--- a/README.markdown
+++ b/README.markdown
@@ -65,9 +65,9 @@ On macOS you can install dita-ot using homebrew:
 The DITA Open Toolkit is licensed for use under the [Apache License 2.0][6].
 
 [1]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
-[2]: http://www.dita-ot.org/
-[3]: http://www.dita-ot.org/dev/
-[4]: http://www.dita-ot.org/dev/user-guide/build-using-dita-command.html
+[2]: https://www.dita-ot.org/
+[3]: https://www.dita-ot.org/dev/
+[4]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
 [5]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
 [6]: http://www.apache.org/licenses/LICENSE-2.0
 [7]: http://slack.dita-ot.org/badge.svg

--- a/README.markdown
+++ b/README.markdown
@@ -2,8 +2,7 @@
 
 The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
-See [dita-ot.org][2] for documentation, information about releases, and download packages.
-
+Visit the project website at [dita-ot.org][2] for documentation, information about releases, and [download packages][9].  
 For information on additional DITA and DITA-OT resources, see [SUPPORT][8].
 
 - [Prerequisites](#prerequisites)

--- a/README.markdown
+++ b/README.markdown
@@ -1,16 +1,16 @@
 # DITA Open Toolkit [![Build Status][1]](http://travis-ci.org/dita-ot/dita-ot) [![Slack][7]](http://slack.dita-ot.org/)
 
-The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_. 
+The _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
-See [dita-ot.org][2] for documentation, information about releases, and download packages. 
+See [dita-ot.org][2] for documentation, information about releases, and download packages.
 
-For information on additional DITA and DITA-OT resources, see [SUPPORT][8]. 
+For information on additional DITA and DITA-OT resources, see [SUPPORT][8].
 
 ## Prerequisites
 
 To build and use DITA-OT, you’ll need:
 
-* Java Development Kit 8 or newer
+- Java Development Kit 8 or newer
 
 ## Install
 
@@ -20,25 +20,25 @@ On macOS you can install dita-ot using homebrew:
 
 ## Building
 
-1. Clone the DITA-OT Git repository:
+1.  Clone the DITA-OT Git repository:
 
         git clone git://github.com/dita-ot/dita-ot.git
 
-2. Move to the DITA-OT directory:
+2.  Move to the DITA-OT directory:
 
         cd dita-ot
 
-3. Fetch the submodules:
+3.  Fetch the submodules:
 
         git submodule update --init --recursive
 
-4. In the root directory, run Gradle to compile the Java code and install plugins:
+4.  In the root directory, run Gradle to compile the Java code and install plugins:
 
         ./gradlew
 
 ## Usage
 
-1. Run the `dita` command to generate output:
+1.  Run the `dita` command to generate output:
 
         src/main/bin/dita [options]
 
@@ -46,11 +46,11 @@ On macOS you can install dita-ot using homebrew:
 
 ## Distribution
 
-1. In the root directory, set up build environment:
+1.  In the root directory, set up build environment:
 
         ./gradlew
 
-2. Build distribution packages:
+2.  Build distribution packages:
 
         ./gradlew dist
 

--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,12 @@ To build and use DITA-OT, you’ll need:
 
 * Java Development Kit 8 or newer
 
+## Install
+
+On macOS you can install dita-ot using homebrew:
+
+`brew install dita-ot`
+
 ## Building
 
 1. Clone the DITA-OT Git repository:

--- a/README.markdown
+++ b/README.markdown
@@ -44,13 +44,16 @@ You can generate output using the DITA Open Toolkit `dita` command-line tool.
 
 See the [documentation][3] for arguments and [options][4].
 
-## Building
+## For developers
+
+<details>
+<summary>Building the toolkit from source code and compiling the distribution package</summary>
 
 1.  Clone the DITA-OT Git repository:
 
         git clone git://github.com/dita-ot/dita-ot.git
 
-2.  Move to the DITA-OT directory:
+2.  Change to the DITA-OT directory:
 
         cd dita-ot
 
@@ -62,13 +65,13 @@ See the [documentation][3] for arguments and [options][4].
 
         ./gradlew
 
-## Distribution
+### Distribution builds
 
-1.  In the root directory, set up build environment:
+1.  In the root directory, set up the build environment:
 
         ./gradlew
 
-2.  Build distribution packages:
+2.  Build the distribution packages:
 
         ./gradlew dist
 
@@ -77,6 +80,8 @@ See the [documentation][3] for arguments and [options][4].
     If Gradle throws an error like `java.lang.OutOfMemoryError: Java heap space`, you probably need to increase the maximum Java heap size. One way to do this is to set the `GRADLE_OPTS` environment variable to a value like `-Xmx1024m`.
 
     For more information on the `-Xmx` option, see the [Java SE Documentation][5].
+
+</details>
 
 ## License
 


### PR DESCRIPTION
This PR builds on the changes proposed by @SMillerDev in #3055 to provide additional details on downloading and installing the toolkit via [Homebrew](https://brew.sh).

_(There are a few things we could tweak in the formula, but I’ll create a [separate issue](https://github.com/dita-ot/dita-ot/issues/3059) for that.)_

To simplify the instructions for new users, this version also wraps developer details in a disclosure section that can be clicked to show info on building from source and compiling the distribution package.

Since the diff is a bit busy, see the [rendered results in my fork](https://github.com/infotexture/dita-ot/blob/feature/update-readme-homebrew/README.markdown).