### PR TITLE
Fix docs references & definite articles

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -95,7 +95,7 @@ See the accompanying LICENSE file for applicable license.
   
   <message id="DOTJ018I" type="INFO">
     <reason>Log file '%1' was generated successfully in directory '%2'.</reason>
-    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT user guide.</response>
+    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT documentation.</response>
   </message>
   
   <message id="DOTJ020W" type="WARN">
@@ -121,12 +121,12 @@ See the accompanying LICENSE file for applicable license.
   
   <message id="DOTJ025E" type="ERROR">
     <reason>The input to the "topic merge" transform process could not be found.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.</response>
+    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
   
   <message id="DOTJ026E" type="ERROR">
     <reason>The "topic merge" did not generate any output.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.</response>
+    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
 
   <message id="DOTJ028E" type="ERROR">
@@ -253,7 +253,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ052E" type="ERROR">
     <reason>Code reference charset "%1" not supported.</reason>
-    <response>See the DITA-OT User guide for supported charset values on the format attribute.</response>
+    <response>See the DITA-OT documentation for supported charset values on the format attribute.</response>
   </message>
 
   <!-- Obsolete since 2.3 -->

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -96,18 +96,18 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.input" desc="Specifies the master file for your documentation project." type="file" required="true"/>
     <param name="args.input.dir" desc="Specifies the base directory for your documentation project." type="dir"/>
     <!-- Deprecated since 2.5 -->
-    <param name="args.logdir" desc="Specifies the location where the DITA-OT places log files for your project." type="dir" deprecated="true"/>
+    <param name="args.logdir" desc="Specifies the location where DITA-OT places log files for your project." type="dir" deprecated="true"/>
     <param name="args.output.base" desc="Specifies the name of the output file without file extension." type="string"/>
     <param name="args.tablelink.style" desc="Specifies how cross references to tables are styled." type="enum">
       <val>NUMBER</val>
       <val>TITLE</val>
       <val>NUMTITLE</val>
     </param>
-    <param name="clean.temp" desc="Specifies whether the DITA-OT deletes the files in the temporary directory after it finishes a build." type="enum">
+    <param name="clean.temp" desc="Specifies whether DITA-OT deletes the files in the temporary directory after it finishes a build." type="enum">
       <val default="true">yes</val>
       <val>no</val>
     </param>
-    <param name="dita.dir" desc="Specifies where the DITA-OT is installed." type="dir"/>
+    <param name="dita.dir" desc="Specifies where DITA-OT is installed." type="dir"/>
     <param name="dita.temp.dir" desc="Specifies the location of the temporary directory." type="dir"/>
     <param name="dita.input.valfile" deprecated="true" desc="Specifies a filter file to be used to include, exclude, or flag content." type="file"/>
     <param name="filter-stage" desc="Specifies whether filtering is done before all other processing, or after key and conref processing." type="enum">
@@ -126,7 +126,7 @@ See the accompanying LICENSE file for applicable license.
       <val>true</val>
       <val default="true">false</val>
     </param>
-    <param name="outer.control" desc="Specifies how the DITA-OT handles content files that are not located in or below the directory containing the master DITA map." type="enum">
+    <param name="outer.control" desc="Specifies how DITA-OT handles content files that are not located in or below the directory containing the master DITA map." type="enum">
       <val desc="Fail quickly if files are going to be generated or copied outside of the directory.">fail</val>
       <val desc="Complete the operation if files will be generated or copied outside of the directory, but log a warning." default="true">warn</val>
       <val desc="Quietly finish without generating warnings or errors.">quiet</val>
@@ -134,7 +134,7 @@ See the accompanying LICENSE file for applicable license.
     <param name="output.dir" desc="Specifies the name and location of the output directory." type="dir"/>
     <param name="root-chunk-override" desc="Override for map chunk attribute value." type="string"/>
     <param name="transtype" desc="Specifies the output format (transformation type)." type="file" required="true"/>
-    <param name="validate" desc="Specifies whether the DITA-OT validates the content." type="enum">
+    <param name="validate" desc="Specifies whether DITA-OT validates the content." type="enum">
       <val default="true">true</val>
       <val>false</val>
     </param>
@@ -142,10 +142,10 @@ See the accompanying LICENSE file for applicable license.
       <val desc="Enables generation of debugging attributes" default="true">true</val>
       <val desc="Disables generation of debugging attributes">false</val>
     </param>
-    <param name="processing-mode" desc="Specifies how the DITA-OT handles errors and error recovery." type="enum">
-      <val desc="When an error is encountered, the DITA-OT stops processing">strict</val>
-      <val desc="When an error is encountered, the DITA-OT attempts to recover from it" default="true">lax</val>
-      <val desc="When an error is encountered, the DITA-OT continues processing but does not attempt error recovery">skip</val>
+    <param name="processing-mode" desc="Specifies how DITA-OT handles errors and error recovery." type="enum">
+      <val desc="When an error is encountered, DITA-OT stops processing">strict</val>
+      <val desc="When an error is encountered, DITA-OT attempts to recover from it" default="true">lax</val>
+      <val desc="When an error is encountered, DITA-OT continues processing but does not attempt error recovery">skip</val>
     </param>
     <param name="conserve-memory" desc="Conserve memory at the expense of processing speed" type="enum">
       <val>true</val>

--- a/src/test/resources/messages.xml
+++ b/src/test/resources/messages.xml
@@ -73,7 +73,7 @@
   
   <message id="DOTJ002F" type="FATAL">
     <reason>Unsupported parameter &apos;%1&apos;.</reason>
-    <response>Please refer to the DITA-OT User Guide for supported parameters.</response>
+    <response>Please refer to the DITA-OT documentation for supported parameters.</response>
   </message>
   
   <message id="DOTJ003F" type="FATAL">
@@ -164,7 +164,7 @@
 
   <message id="DOTJ018I" type="INFO">
     <reason>Log file &apos;%1&apos; was generated successfully in directory &apos;%2&apos;.</reason>
-    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT user guide.</response>
+    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT documentation.</response>
   </message>
 
   <!-- 2012-06-08: This message no longer exists in the code; commenting out. -->
@@ -208,12 +208,12 @@
   
   <message id="DOTJ025E" type="ERROR">
     <reason>The input to the &quot;topic merge&quot; transform process could not be found.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.</response>
+    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
   
   <message id="DOTJ026E" type="ERROR">
     <reason>The &quot;topic merge&quot; did not generate any output.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.</response>
+    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
   
   <!-- 2012-06-08: This message no longer exists in the code; commenting out. -->
@@ -365,7 +365,7 @@
   
   <message id="DOTJ052E" type="ERROR">
     <reason>Code reference charset &quot;%1&quot; not supported.</reason>
-    <response>See the DITA-OT User guide for supported charset values on the format attribute.</response>
+    <response>See the DITA-OT documentation for supported charset values on the format attribute.</response>
   </message>
   
   <message id="DOTJ053W" type="WARN">

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -36,7 +36,7 @@ DOTA012W=Argument "{0}" is deprecated. Please use the argument "{1}" instead.
 DOTX022W=Unable to retrieve navtitle from target\: ''{0}''. Using linktext (specified in topicmeta) as the navigation title.
 DOTX062I=It appears that this document uses constraints, but the conref processor cannot validate that the target of a conref is valid. To enable constraint checking, please upgrade to an XSLT 2.0 processor.
 DOTJ038E=The tag "{0}" is specialized from unrecognized metadata. Please make sure that tag "{0}" is specialized from an existing metadata tag in the core DITA vocabulary.
-DOTJ018I=Log file ''{0}'' was generated successfully in directory ''{1}''. Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT user guide.
+DOTJ018I=Log file ''{0}'' was generated successfully in directory ''{1}''. Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT documentation.
 DOTX002W=The title element or attribute in the ditamap is required for Eclipse output.
 DOTX042I=DITAVAL based flagging is not currently supported for inline phrases in XHTML; ignoring flag value on ''{0}'' attribute.
 DOTJ021W=File ''{0}'' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file. Please check the file ''{0}'' and the ditaval file to see if this is the intended result.
@@ -111,7 +111,7 @@ DOTJ072E=Email link without correct ''format'' attribute. Using ''format'' attri
 DOTX009W=Could not retrieve a title from ''{0}''. Using ''{1}'' instead.
 DOTX049I=References to non-dita files will be ignored by the PDF, ODT, and RTF output transforms.
 DOTX033E=Unable to generate link text for a cross reference to a list item\: ''{0}''
-DOTJ052E=Code reference charset "{0}" not supported. See the DITA-OT User guide for supported charset values on the format attribute.
+DOTJ052E=Code reference charset "{0}" not supported. See the DITA-OT documentation for supported charset values on the format attribute.
 DOTA003F=Cannot find the user specified XSLT stylesheet ''{0}''.
 DOTX029I=The type attribute on a {0} element was set to {2}, but the reference is to a more specific {3} {1}. This may cause your links to sort incorrectly in the output.
 DOTJ068E=Conref action "mark" without conref target.
@@ -154,7 +154,7 @@ DOTX007I=Only DITA topics, HTML files, and images may be included in your compil
 DOTX030W=The type attribute on a {0} element was set to {2}, but the reference is to a {3} {1}. This may cause your links to sort incorrectly in the output.
 DOTJ046E=Conkeyref\="{0}" can not be resolved because it does not contain a key or the key is not defined. The build will use the conref attribute for fallback, if one exists.
 DOTX046W=Area shape should be\: default, rect, circle, poly, or blank (no value). The value ''{0}'' is not recognized.
-DOTJ026E=The "topic merge" did not generate any output. Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.
+DOTJ026E=The "topic merge" did not generate any output. Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.
 DOTX026W=Unable to retrieve linktext from target\: ''{0}''. Using navigation title as fallback.
 DOTJ065I=Branch filter generated topic {0} used more than once. Renaming {0} to {1}.
 DOTX010E=Unable to find target for conref\="{0}".
@@ -163,7 +163,7 @@ DOTJ045I=The key "{0}" is defined more than once in the same map file. The refer
 DOTX045W=The area element in an image map should specify link text for greater accessibility. Link text should be specified directly when the target is not a local DITA resource.
 DOTX006E=Unknown file extension in href\="{0}". References to non-DITA resources should set the format attribute to match the resource (for example, ''txt'', ''pdf'', or ''html'').
 DOTJ064W=Chunk attribute uses both "to-content" and "by-topic" that conflict with each other. Ignoring "by-topic" token.
-DOTJ025E=The input to the "topic merge" transform process could not be found. Correct any earlier transform errors and try the build again, or see the DITA-OT User Guide for additional causes.
+DOTJ025E=The input to the "topic merge" transform process could not be found. Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.
 PDFX009E=Attribute set reflection cannot handle XSLT element {0}.
 DOTJ005F=Failed to create new instance for ''{0}''. Please ensure that ''{0}'' exists and that you have permission to access it.
 DOTJ044W=There is a redundant conref action "pushbefore". Please make sure that "mark" and "pushbefore" occur in pairs.


### PR DESCRIPTION
This PR corrects several outdated references to the DITA-OT _User Guide_, which no longer exists as such since the documentation was refactored for the 3.0 release.

A second commit removes remaining definite articles from DITA-OT references per project conventions.
