### PR TITLE
Fix for conref in title of submap in subdir

### DIFF
--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -202,7 +202,23 @@ See the accompanying LICENSE file for applicable license.
               <xsl:apply-templates select="$target/@chunk"/>
               <xsl:apply-templates select="@* except (@class, @href, @dita-ot:orig-href, @format, @dita-ot:orig-format, @keys, @keyscope, @type)"/>
               <xsl:apply-templates select="$target/@*" mode="preserve-submap-attributes"/>
-              <xsl:apply-templates select="$targetTitleAndTopicmeta" mode="preserve-submap-title-and-topicmeta"/>
+              <xsl:apply-templates select="$targetTitleAndTopicmeta" mode="preserve-submap-title-and-topicmeta">
+                <xsl:with-param name="relative-path" tunnel="yes">
+                  <xsl:choose>
+                    <xsl:when test="not($relative-path = ('#none#', ''))">
+                      <xsl:value-of select="$relative-path"/>
+                      <xsl:call-template name="find-relative-path">
+                        <xsl:with-param name="remainingpath" select="$href"/>
+                      </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:call-template name="find-relative-path">
+                        <xsl:with-param name="remainingpath" select="$href"/>
+                      </xsl:call-template>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </xsl:with-param>
+              </xsl:apply-templates>
               <xsl:apply-templates select="*[contains(@class, ' ditavalref-d/ditavalref ')]"/>
               <xsl:apply-templates select="$contents">
                 <xsl:with-param name="refclass" select="$refclass"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Fixes an issue introduced in #2739. That pull request uses a temporary container to preserve titles and metadata from submaps during the `mapref` process, so that later steps can still make use of the information. 

There is a defect when the preserved content uses a sub-element with `@conref`, *and* the submap is not in the same directory as the referencing map. For that case, the path on `@conref` is not updated when it is pulled into the temporary container in another directory, resulting in errors from the following `conref` step. 

This is handled for normal content in the map by passing a tunneled parameter `$relative-path`; passing the same parameter in the same way when working with the title fixes this issue.

## Motivation and Context

Came up in a customer document that had a map in one directory and sub-maps in subdirectories; titles in those maps reused a product name with `@conref` as in the attached sample files.

## How Has This Been Tested?

When fix is applied to 3.1.2, it fixes the original source document, as well as this smaller sample set:
[submapTitle.zip](https://github.com/dita-ot/dita-ot/files/2358708/submapTitle.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
