### PR TITLE
Ensure footnote body is properly aligned in PDF #3060

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -1435,7 +1435,7 @@ See the accompanying LICENSE file for applicable license.
                                 </fo:inline>
                             </fo:block>
                         </fo:list-item-label>
-                        <fo:list-item-body start-indent="body-start()">
+                        <fo:list-item-body start-indent="body-start()" text-align="start">
                             <fo:block>
                                 <xsl:apply-templates/>
                             </fo:block>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Fixes broken footnote alignment when the footnote is defined inside of a table cell that sets a specific text align value.

## Motivation and Context

Reported in #3060; confirmed that the fix Radu suggested resolves the issue.

## How Has This Been Tested?

Tested with the sample files in 3060.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
