### PR TITLE
Fix PDF error when indexterm is in draft section + draft is off

### DIFF
--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -961,6 +961,10 @@ public final class Constants {
     public static final String DEFAULT_ACTION = "default";
     /**chunk attribute.*/
     public static final String ATTRIBUTE_NAME_CHUNK = "chunk";
+    
+    /** constants for args.draft argument value. **/
+    public static final String ARGS_DRAFT_YES = "yes";
+    public static final String ARGS_DRAFT_NO = "no";
 
     /**constants for indexterm prefix(See).*/
     public static final String IndexTerm_Prefix_See = "See";

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -294,7 +294,8 @@ with those set forth herein.
     </condition>
 
     <index-preprocess input="${inputFile.url}" output="${dita.temp.dir}/stage1.xml"
-                      indexConfig="${index.config.file}" locale="${document.locale}">
+                      indexConfig="${index.config.file}" locale="${document.locale}"
+                      draft="${args.draft}">
       <xmlcatalog refid="xml.catalog"/>
     </index-preprocess> 
   </target>

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
@@ -73,7 +73,7 @@ public final class IndexPreprocessor {
         this.namespace_url = theNamespace_url;
         this.excludedDraftSection.clear();
         this.excludedDraftSection.add(false);
-        includeDraft = draftParameter.equals(ARGS_DRAFT_YES) ? true : false;
+        includeDraft = draftParameter.equals(ARGS_DRAFT_YES);
         indexDitaProcessor = new IndexDitaProcessor();
         indexGroupProcessor = new IndexGroupProcessor();
     }

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
@@ -7,6 +7,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.XMLCatalog;
 import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.util.XMLUtils;
+import static org.dita.dost.util.Constants.*;
 import org.w3c.dom.Document;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -56,6 +57,7 @@ extends Task {
     private XMLCatalog xmlcatalog;
     private String locale = "ja";
     private String indexConfig = "";
+    private String draft = ARGS_DRAFT_NO;
     public static boolean failOnError = false;
     public static boolean processingFaild = false;
     private static final String prefix = "opentopic-index";
@@ -74,7 +76,7 @@ extends Task {
             documentBuilder.setEntityResolver(xmlcatalog);
 
             final Document doc = documentBuilder.parse(input);
-            final IndexPreprocessor preprocessor = new IndexPreprocessor(this.prefix, this.namespace_url);
+            final IndexPreprocessor preprocessor = new IndexPreprocessor(this.prefix, this.namespace_url, this.draft);
             preprocessor.setLogger(new DITAOTAntLogger(getProject()));
 
             // Walks through source document and builds an array of IndexEntry and builds
@@ -158,6 +160,10 @@ extends Task {
 
     public void setFailOnError(final String theFailOnErro) {
         this.failOnError = theFailOnErro.equals("true");
+    }
+    
+    public void setDraft(final String draftValue) {
+        this.draft = draftValue;
     }
 
     private void setActiveProjectProperty(final String propertyName, final String propertyValue) {


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

The `pdf2` index pre-processing code adds indexing anchors in the content + references in the index for all terms. Later steps convert this to the proper XSL-FO markup.

The index pre-process does not check the `args.draft` parameter, which means that index entries inside of draft comments always generate anchors (inside of `draft-comment` or `required-cleanup`), and always generate references. When the processed file is converted to XSL-FO and `args.draft=no`, the anchors do not end up in the FO but the references do, resulting in errors like:
`      [fop] WARNING: Page 5: Unresolved ID reference "index in draft comment:_unique_d83e47" found.`
or
```
      [ahf] Error Code  : 10777 (2A19)
      [ahf] Unresolved index-key value: "index in draft comment:".
```

The fix checks the value for `args.draft`. If it is `yes`, these index entries are processed as today in PDF (they are included and links work). If it is `no` the index entries are not processed, no anchors and no references are generated.

Originally I looked for a quicker fix in the XSL-FO, but if we drop entries at that point we can still be left with empty group headings (for example, if all entries beginning with `z` are in draft sections, we would have an empty `Z` heading in the index). So, this really has to be handled in the index preprocessor that creates the groups.

## Motivation and Context

Came up in a customer document where index entries were moved into a `<required-cleanup>` element, and the build started throwing out unresolved ID errors.

## How Has This Been Tested?

Test bookmap included with index entries in a paragraph, in `draft-comment`, and in `required-cleanup`.
[3066.zip](https://github.com/dita-ot/dita-ot/files/2362141/3066.zip)


When `args.draft=yes`, all entries appear, and the draft content is indexed.

When `args.draft=no`, entries from draft content do not appear in the index. Also added entries beginning with `B` that *only* appear in draft content, and in this case the **B** heading is also removed.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_