### PR TITLE
Use correct error message for missing image

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -553,7 +553,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
             formatSet.add(file);
             if (!exists(file.filename)) {
-                logger.warn(MessageUtils.getMessage("DOTX008W", file.filename.toString()).toString());
+                logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
             }
         } else if (ATTR_FORMAT_VALUE_DITAVAL.equals(file.format)) {
             formatSet.add(file);

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -134,7 +134,7 @@ public final class MapReaderModule extends AbstractReaderModule {
             } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
                 formatSet.add(file);
                 if (!exists(file.filename)) {
-                    logger.warn(MessageUtils.getMessage("DOTX008W", file.filename.toString()).toString());
+                    logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
                 }
             } else if (ATTR_FORMAT_VALUE_DITAVAL.equals(file.format)) {
                 formatSet.add(file);

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -265,7 +265,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
             } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
                 formatSet.add(file);
                 if (!exists(file.filename)) {
-                    logger.warn(MessageUtils.getMessage("DOTX008W", file.filename.toString()).toString());
+                    logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
                 }
             } else {
                 htmlSet.put(file.format, file.filename);


### PR DESCRIPTION
## Description

Currently if an image is missing the first message from the build is DOTX008W, which complains that the file does not specify a navigation title for the TOC. For example:
```
 [gen-list] [DOTX008W][WARN] File 'file:/C:/belfry/hello.gif' cannot be loaded, and no navigation title is specified for the table of contents.
```

The message template contains an incorrect comment stating that DOTX008W is only called from HTML Help processing (it is called twice there, for topics in a TOC context). However, there are 3 references in the core Java code that use it for images. From other comments in the messages file, it looks like these should be using the more generic DOTX008E; with the update, that results in:
```
 [gen-list] [DOTX008E][ERROR] File 'file:/C:/belfry/hello.gif' does not exist or cannot be loaded.
```

The message DOTX008E already exists, and is already used by the Java code for other missing files.

## Motivation and Context

Over the last few months I've had several different people complain about this message being invalid. It's wrong for a couple reasons -- 1) you cannot add a `navtitle` so the message should not complain that it's missing, and 2) images referenced in a document do not appear in the TOC. Responses vary, but are always confused -- some think the message is warning about the wrong file, others think the image reference must be in a map because of the TOC comment, and some easily identify that the message is wrong but don't realize that the image is actually missing.

## How Has This Been Tested?

Tested with image references to missing files, and the change from DOTX008W to DOTX008E passes unit / regression tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
