### PR TITLE
Fix invalid IDs in FO index links

### DIFF
--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
@@ -61,6 +61,7 @@ public final class IndexPreprocessor {
     private DITAOTLogger logger;
     private static final String elIndexRangeStartName = "start";
     private static final String elIndexRangeEndName = "end";
+    private static final String hashPrefix = "indexid";
 
     /**
      * Create new index preprocessor.
@@ -315,6 +316,7 @@ public final class IndexPreprocessor {
             final String[] refIDs = indexEntry.getRefIDs();
             for (final String refID : refIDs) {
                 final Element referenceIDElement = createElement(theTargetDocument, "refID");
+                referenceIDElement.setAttribute("indexid", hashPrefix + Integer.toString(refID.hashCode()));
                 referenceIDElement.setAttribute("value", refID);
                 indexEntryNode.appendChild(referenceIDElement);
             }

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -136,7 +136,7 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:call-template>
                       </xsl:when>
                       <xsl:otherwise>
-                          <fo:index-range-begin id="{$selfID}_{generate-id()}" index-key="{$selfID}" />
+                          <fo:index-range-begin id="{../@indexid}_{generate-id()}" index-key="{../@indexid}" />
                       </xsl:otherwise>
                   </xsl:choose>
               </xsl:otherwise>
@@ -169,7 +169,7 @@ See the accompanying LICENSE file for applicable license.
                       </xsl:when>
                       <xsl:otherwise>
                           <xsl:for-each select="$precMarker//opentopic-index:refID[@value = $selfID]/@value">
-                              <fo:index-range-end ref-id="{$selfID}_{generate-id()}" />
+                              <fo:index-range-end ref-id="{../@indexid}_{generate-id()}" />
                           </xsl:for-each>
                       </xsl:otherwise>
                   </xsl:choose>
@@ -180,7 +180,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   <xsl:template match="opentopic-index:index.entry">
       <xsl:for-each select="opentopic-index:refID[last()]">
-          <fo:inline index-key="{@value}"/>
+          <fo:inline index-key="{@indexid}"/>
       </xsl:for-each>
       <xsl:apply-templates/>
   </xsl:template>
@@ -473,7 +473,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:copy-of select="$index.separator"/>
           <fo:index-page-citation-list>
             <xsl:for-each select="$idxs">
-              <fo:index-key-reference ref-index-key="{@value}" xsl:use-attribute-sets="__index__page__link"/>
+              <fo:index-key-reference ref-index-key="{@indexid}" xsl:use-attribute-sets="__index__page__link"/>
             </xsl:for-each>
           </fo:index-page-citation-list>
         </xsl:if>


### PR DESCRIPTION
## Description

(Builds on #3066 so will need to be rebased if that one does not go in or requires further changes.)

Fix updates index processing in XSL-FO to ensure that index IDs are valid.

Currently index IDs use the literal term text plus the text of any ancestor terms, separated by a colon. These IDs are added during the Java preprocessor, and later copied as-is into XSL-FO attributes like `@id` / `@ref-id` / others. The colon is technically invalid in IDs, as reported in #2110, so some processors report this as an error. In addition, because the actual index text is part of the ID, any term that contains an invalid ID character (such as a space, comma, or most special characters) is reported as invalid.

The colon separator within IDs is used extensively in in the indexing logic to manage index terms, in particular to handle see, see-also, and index start/end ranges. This makes it difficult to fix the bug without modifying the whole design. Replacing every special character with a valid character or pattern is another option, but would result in more conflicts (replacing every special character with `_` would mean `test/key`, `test_key`, and `test`>`key` conflict).

The fix here leaves all of the existing linking logic alone. Instead the Java preprocessor adds a new attribute `indexid` that contains a hashed version of the current string; the characters in the hash are guaranteed to be valid as an XSL-FO ID. The logic for connecting terms in our XSLT is the same, still based on terms and `:` separators, but any place that previously generated an actual ID now uses the hash. 

This update also fixes a previously unreported bug with index ranges. The range used literal values from `indexterm/@start` in the FO `fo:index-range-begin/@id` attribute. When the start/end value contained spaces, Antenna House reported an error and no links appeared for the term. With the fix, the range appears and both start/end links work correctly.

## Motivation and Context

Motivated by #2110 which came up with a large (1000+ term) index, where most terms contained special characters; the formatting log was so full of index warnings that I could not find the meaningful warnings.

## How Has This Been Tested?

Tested with the sample set below, which extends the set from #3066 to add see, see-also, and index ranges. All links for all terms format properly with the fix, and the FO does not contain any invalid attributes.
[2110.zip](https://github.com/dita-ot/dita-ot/files/2383806/2110.zip)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
