### PR TITLE
Restore missing change bars in PDF

### DIFF
--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -232,6 +232,7 @@ public final class DitaValReader implements AbstractReader {
     private Flag readFlag(Element elem) {
         final String style = getValue(elem, ATTRIBUTE_NAME_STYLE);
         return new Flag(
+                elem.getLocalName(),
                 getValue(elem, ATTRIBUTE_NAME_COLOR),
                 getValue(elem, ATTRIBUTE_NAME_BACKCOLOR),
                 style != null ? style.trim().split("\\s+") : null,

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -221,7 +221,7 @@ public final class FilterUtils {
         if ((conflictColor && foregroundConflictColor != null)
                 || (conflictBackcolor && backgroundConflictColor != null)) {
             return res.stream()
-                    .map(f -> new Flag(conflictColor ? foregroundConflictColor : f.color,
+                    .map(f -> new Flag(ELEMENT_NAME_PROP, conflictColor ? foregroundConflictColor : f.color,
                             conflictBackcolor ? backgroundConflictColor : f.backcolor,
                             f.style, f.changebar, f.startflag, f.endflag))
                     .collect(Collectors.toSet());
@@ -700,6 +700,7 @@ public final class FilterUtils {
 
     public static class Flag implements Action {
 
+        public final String proptype;
         public final String color;
         public final String backcolor;
         public final String[] style;
@@ -707,8 +708,9 @@ public final class FilterUtils {
         public final FlagImage startflag;
         public final FlagImage endflag;
 
-        public Flag(String color, String backcolor, String[] style, String changebar,
-                    FlagImage startflag, FlagImage endflag) {
+        public Flag(String proptype, String color, String backcolor, String[] style, String changebar,
+                FlagImage startflag, FlagImage endflag) {
+            this.proptype = proptype;
             this.color = color;
             this.backcolor = backcolor;
             this.style = style;
@@ -718,7 +720,7 @@ public final class FilterUtils {
         }
 
         public Flag adjustPath(final URI currentFile, final Job job) {
-            return new Flag(color, backcolor, style, changebar,
+            return new Flag(proptype, color, backcolor, style, changebar,
                     adjustPath(startflag, currentFile, job),
                     adjustPath(endflag, currentFile, job));
         }
@@ -799,14 +801,17 @@ public final class FilterUtils {
             if (style != null) {
                 propAtts.add("style", Stream.of(style).collect(Collectors.joining(" ")));
             }
-            contentHandler.startElement(NULL_NS_URI, "prop", "prop", propAtts.build());
+            if (changebar != null) {
+                propAtts.add("changebar", changebar);
+            }
+            contentHandler.startElement(NULL_NS_URI, proptype, proptype, propAtts.build());
             if (isStart && startflag != null) {
                 startflag.writeFlag(contentHandler, "startflag");
             }
             if (!isStart && endflag != null) {
                 endflag.writeFlag(contentHandler, "endflag");
             }
-            contentHandler.endElement(NULL_NS_URI, "prop", "prop");
+            contentHandler.endElement(NULL_NS_URI, proptype, proptype);
         }
 
         public Element getStartFlag() {

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -41,6 +41,7 @@ public class FilterUtilsTest {
     private static final QName PROPS = QName.valueOf("props");
     private static final QName GUI = QName.valueOf("gui");
     private static final QName OTHERPROPS = QName.valueOf("otherprops");
+    private static final QName REV = QName.valueOf("rev");
 
     private static final Map<FilterKey, Action> filterMap = ImmutableMap.<FilterKey, Action>builder()
             .put(new FilterKey(PLATFORM, "unix"), Action.INCLUDE)
@@ -199,7 +200,7 @@ public class FilterUtilsTest {
 
     @Test
     public void testgetFlagsDefaultFlag() {
-        final Flag flag = new Flag("red", null, null, null, null, null);
+        final Flag flag = new Flag("prop", "red", null, null, null, null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, null), flag)
@@ -216,13 +217,15 @@ public class FilterUtilsTest {
 
     @Test
     public void testGetFlags() {
-        final Flag flag = new Flag("red", null, null, null, null, null);
+        final Flag flag = new Flag("prop", "red", null, null, null, null, null);
+        final Flag revflag = new Flag("revprop", null, null, null, "solid", null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, "unix"), flag)
                         .put(new FilterKey(PLATFORM, "osx"), flag)
                         .put(new FilterKey(PLATFORM, "linux"), flag)
                         .put(new FilterKey(AUDIENCE, "expert"), flag)
+                        .put(new FilterKey(REV, "r1"), revflag)
                         .build(), null, null);
         f.setLogger(new TestUtils.TestLogger());
 
@@ -232,6 +235,9 @@ public class FilterUtilsTest {
         assertEquals(
                 singleton(flag),
                 f.getFlags(attr(PLATFORM, "amiga unix"), new QName[0][0]));
+        assertEquals(
+                singleton(revflag),
+                f.getFlags(attr(REV, "r1 r2"), new QName[0][0]));
         assertEquals(
                 emptySet(),
                 f.getFlags(attr(PLATFORM, "amiga"), new QName[0][0]));
@@ -358,8 +364,8 @@ public class FilterUtilsTest {
 
     @Test
     public void testGetFlagLabel() {
-        final Flag flagRed = new Flag("red", null, null, null, null, null);
-        final Flag flagBlue = new Flag("blue", null, null, null, null, null);
+        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null);
+        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null);
         
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
@@ -387,8 +393,8 @@ public class FilterUtilsTest {
 
     @Test
     public void testConflict() {
-        final Flag flagRed = new Flag("red", null, null, null, null, null);
-        final Flag flagBlue = new Flag("blue", null, null, null, null, null);
+        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null);
+        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(OS, "amiga"), flagRed)
@@ -396,7 +402,7 @@ public class FilterUtilsTest {
                         .build(), "yellow", "green");
         f.setLogger(new TestUtils.TestLogger());
 
-        final Flag flagYellow = new Flag("yellow", null, null, null, null, null);
+        final Flag flagYellow = new Flag("prop", "yellow", null, null, null, null, null);
         assertEquals(
                 singleton(flagYellow),
                 f.getFlags(attr(PROPS, "os(amiga unix windows)"), new QName[][] {{PROPS, OS}}));


### PR DESCRIPTION
## Description

When the flagging step in `preprocess` was combined with the `filter` step, we lost the ability to mark change bars (or generally recognize active revisions as opposed to active properties).

The latest flagging code writes out active property information when elements are flagged. The `filter` code was originally concerned _only_ with properties, because revisions are not intended to result in filtering. Likely because of this, all information is grouped the same way, and written to files as `<prop>`. Along with this, the `@changebar` attribute that is only available on revisions is dropped. This has a few problems for our processing:

- Of course, with `@changebar` dropped, we lose our revision bars.
- The PDF code is set up to recognize `revprop/@changebar` so just writing it out on `<prop>` does not fix the problem. HTML5 also has a few places where `<revprop>` behaves differently, so that difference was lost.
- We generally use default images for revisions marked as `flag`. This is done by matching `<revprop>` elements that set `action="flag"` but don't set anything else. We don't do this for arbitrary other properties. So, we need to keep the DITAVAL distinction between `<prop>` and `<revprop>`.

To fix this I've just updated the `Flag` object to preserve the active flag's element name, which restores the processing we had previously.

## Motivation and Context

Was working on a less significant revision bar bug reported against our local 2.5 based toolkit, tested with 3.1, and all revision bars had disappeared.

## How Has This Been Tested?

Test case attached, using each possible property / revision actions individually, and together.
[droprevs.zip](https://github.com/dita-ot/dita-ot/files/2421125/droprevs.zip)

Note: the fix restores processing for PDF. Currently with 3.1.2 I'm getting an entirely separate failure from HTML5 when it tries to copy the flag image. That condition is not addressed by this fix. Running with `preprocess.copy-flag.skip=true` gives me a working HTML5 build and verifies the flagging works as expected.


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
