### PR TITLE
Set title variable type to item instead of node

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -78,7 +78,7 @@ See the accompanying LICENSE file for applicable license.
                             </xsl:attribute>
                             <xsl:apply-templates select="$mapTopicref" mode="tocPrefix"/>
                             <fo:inline xsl:use-attribute-sets="__toc__title">
-                                <xsl:variable name="pulledNavigationTitle" as="node()*">
+                                <xsl:variable name="pulledNavigationTitle" as="item()*">
                                     <xsl:call-template name="getNavTitle" />
                                 </xsl:variable>
                                 <xsl:apply-templates select="$pulledNavigationTitle" mode="dropCopiedIds"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Changes return type for pulled title from `node()*` to `item()*`

## Motivation and Context

@jelovirt had PDF customizations that had errors with the `node()*` return type, when the result was actually `xs:string`. Changing to `item()*` makes the return type a bit more flexible for cases where only a string is returned.

## How Has This Been Tested?

Tested with book maps that use simple topic titles and titles with sub-elements.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
