### PR TITLE
Update msg so broken link does not halt PDF build

### DIFF
--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -60,11 +60,11 @@ See the accompanying LICENSE file for applicable license.
     <reason>There are multiple index entries found to close the index range for "%1".</reason>
     <response>Ensure that any index term with start="%1" has only one matching end term with end="%1".</response>
   </message>
-  <message id="PDFX004F" type="FATAL">
+  <message id="PDFX004F" type="ERROR">
     <reason>A topic reference was found with href="".</reason>
     <response>Please specify a target or remove the href attribute.</response>
   </message>
-  <message id="PDFX005F" type="FATAL">
+  <message id="PDFX005F" type="ERROR">
     <reason>The topic reference href="%1" could not be found.</reason>
     <response>Please correct the reference, or set the scope or format attribute if the target is not a local DITA topic.</response>
   </message>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Changes the status of two error messages from `FATAL` to `ERROR`. These messages can indicate a problem in the build but should not halt the build.

## Motivation and Context

In DITA-OT 3.0.3 the hotfix #2894 fixed a long-standing issue where fatal messages did not actually stop the build. This had worked in the early years of DITA-OT but stopped working in DITA-OT one dot (somthing).

With this update in place, I'm now getting occasional fatal PDF builds caused by simple broken / unresolved links. These links are not uncommon, especially when building early drafts of a document. They should result in errors, as they did before 3.0.3. Every other step of the build treats broken links as an error and continues; the final PDF rendering steps should do the same.

I considered making new message like `<message id="PDFX004E" type="ERROR">` with an `E` instead of `F`, but this seems better -- the message ID does not really matter, and the XSLT keys off of `@type` when deciding whether to fail. So, we can fix the issue without duplicating the message.

## How Has This Been Tested?

The following map demonstrates the problem -- it ends up with a reported broken ID, and the build stops without producing a PDF. With the change from `FATAL` TO `ERROR` I get a complete PDF to review, with the same error in the log.

https://raw.githubusercontent.com/robander/metadita-sampledocs/master/bookmap/bookmap-chaps.ditamap

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
