### PR TITLE
Remove src from copy-to fileinfos during initial read #3083

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -681,7 +681,9 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         for (final URI target : filteredCopyTo.keySet()) {
             final URI tmp = tempFileNameScheme.generateTempFileName(target);
             final URI src = filteredCopyTo.get(target);
-            final FileInfo fi = new FileInfo.Builder().src(src).result(target).uri(tmp).build();
+            final FileInfo fi = new FileInfo.Builder()
+                    .result(target)
+                    .uri(tmp).build();
             // FIXME: what's the correct value for this? Accept all?
             if (formatFilter.test(fi.format)
                     || fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {


### PR DESCRIPTION
Signed-off-by: Jarno Elovirta <jarno@elovirta.com>

## Description
Remove `src` field population for copy-to targets during initial map read.

## Motivation and Context
Fixes #3083
## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

Passes test suite.