### PR TITLE
Added optional attribute version to the require element in plugin.rnc.

### DIFF
--- a/src/main/resources/plugin.rnc
+++ b/src/main/resources/plugin.rnc
@@ -62,6 +62,7 @@ require =
     attribute plugin { xsd:NCName },
     attribute version { version }?,
     attribute importance { "required" | "optional" }?
+    attribute version { xsd:string }?
   }
 version = text
 metadata =


### PR DESCRIPTION
## Description
Added an optional @version attribute to the require element in the plugin xml description file.

##Motivation and Context
In order to implement dependency resolution with external tools I need to be able to specificy the version of an artifact, i.e., the plugin version.

This has little consequence for users and developpers and opens some possibilities for dependency management.

##How Has This Been 
Validated a plugin.xml file with a <require> elements with and without the version attribute.

##Type of change
Improvement