### PR TITLE
Update links to use new issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ To send a pull request, create a feature branch in your fork with a name like `f
 
 For more information, see [Contributing to Open Source on GitHub][9].
 
-[1]: https://github.com/dita-ot/dita-ot/issues/new
+[1]: https://github.com/dita-ot/dita-ot/issues/new/choose
 [2]: https://github.com/dita-ot/dita-ot/issues
 [3]: https://help.github.com/articles/fork-a-repo/
 [4]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,8 @@
 _DITA Open Toolkit_, or _DITA-OT_ for short, is an open-source publishing engine for XML content authored in the _Darwin Information Typing Architecture_.
 
 Visit the project website at [dita-ot.org][site] for documentation, information about releases, and [download packages][dist].  
-For information on additional DITA and DITA-OT resources, see [SUPPORT].
+
+For information on additional DITA and DITA-OT resources, see [SUPPORT]. To report a bug or suggest a feature, [create an issue][issue]. For more information on how you can help contribute to the project, see [CONTRIBUTING].
 
 - [Prerequisites: Java 8](#prerequisites-java-8)
 - [Installing](#installing)
@@ -104,3 +105,5 @@ DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 [options]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html
 [javadoc]: http://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html#BABHDABI
 [apache]: http://www.apache.org/licenses/LICENSE-2.0
+[issue]: https://github.com/dita-ot/dita-ot/issues/new/choose
+[contributing]: https://github.com/dita-ot/dita-ot/blob/develop/.github/CONTRIBUTING.md


### PR DESCRIPTION
The changes in https://github.com/dita-ot/dita-ot/pull/3061 provide dedicated [issue templates](
https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/) for bug reports, feature requests, and PRs.

This PR updates the [ReadMe](https://github.com/infotexture/dita-ot/blob/feature/select-issue-template/README.markdown) & [Contribution Guidelines](https://github.com/infotexture/dita-ot/blob/feature/select-issue-template/.github/CONTRIBUTING.md) to prompt the user to select a template via the new `/choose` endpoint when creating new issues.

_(Otherwise, the plain "new issue" links will bypass the template chooser and present a blank form.)_