### PR TITLE
Extract attributes from structural HTML5 elements into attribute sets

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -24,9 +24,13 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="document($input.map.url)" mode="normalize-map"/>
   </xsl:variable>
 
+  <xsl:attribute-set name="toc">
+    <xsl:attribute name="role">toc</xsl:attribute>
+  </xsl:attribute-set>
+
   <xsl:template match="*" mode="gen-user-sidetoc">
     <xsl:if test="$nav-toc = ('partial', 'full')">
-      <nav role="toc">
+      <nav xsl:use-attribute-sets="toc">
         <ul>
           <xsl:choose>
             <xsl:when test="$nav-toc = 'partial'">

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -157,9 +157,13 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
 
+  <xsl:attribute-set name="navigation">
+    <xsl:attribute name="role">navigation</xsl:attribute>
+  </xsl:attribute-set>
+
   <!--main template for setting up all links after the body - applied to the related-links container-->
   <xsl:template match="*[contains(@class, ' topic/related-links ')]" name="topic.related-links">
-    <nav role="navigation">
+    <nav xsl:use-attribute-sets="navigation">
       <xsl:call-template name="commonattributes"/>
       <xsl:if test="$include.roles = ('child', 'descendant')">
         <xsl:call-template name="ul-child-links"/>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2398,6 +2398,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="addAttributesToBody">
   </xsl:template>
 
+  <xsl:attribute-set name="banner">
+    <xsl:attribute name="role">banner</xsl:attribute>
+  </xsl:attribute-set>
+
   <!-- Process <body> content that is appropriate for HTML5 header section. -->
   <xsl:template match="*" mode="addHeaderToHtmlBodyElement">
     <xsl:variable name="header-content" as="node()*">
@@ -2411,15 +2415,24 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
 
     <xsl:if test="exists($header-content)">
-      <header role="banner">
+      <header xsl:use-attribute-sets="banner">
         <xsl:sequence select="$header-content"/>
       </header>
     </xsl:if>
   </xsl:template>
 
+  <xsl:attribute-set name="main">
+    <xsl:attribute name="role">main</xsl:attribute>
+  </xsl:attribute-set>
+
+  <xsl:attribute-set name="article">
+    <xsl:attribute name="role">article</xsl:attribute>
+  </xsl:attribute-set>
+  
+
   <xsl:template match="*" mode="addContentToHtmlBodyElement">
-    <main role="main">
-      <article role="article">
+    <main xsl:use-attribute-sets="main">
+      <article xsl:use-attribute-sets="article">
         <xsl:attribute name="aria-labelledby">
           <xsl:apply-templates select="*[contains(@class,' topic/title ')] |
                                        self::dita/*[1]/*[contains(@class,' topic/title ')]" mode="return-aria-label-id"/>
@@ -2437,13 +2450,18 @@ See the accompanying LICENSE file for applicable license.
     </main>
   </xsl:template>
 
+  <xsl:attribute-set name="footer">
+    <xsl:attribute name="role">contentinfo</xsl:attribute>
+  </xsl:attribute-set>
+  
+
   <xsl:template match="*" mode="addFooterToHtmlBodyElement">
     <xsl:variable name="footer-content" as="node()*">
       <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
       <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
     </xsl:variable>
     <xsl:if test="exists($footer-content)">
-      <footer role="contentinfo">
+      <footer xsl:use-attribute-sets="footer">
         <xsl:sequence select="$footer-content"/>
       </footer>
     </xsl:if>


### PR DESCRIPTION
Extract ARIA attributes from structural HTML5 elements into attribute sets to enable easier override and extension with e.g. custom `class` attributes.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>