### PR TITLE
PDF2: Force footnotes to 'normal' when anchor is bold

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -455,6 +455,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:attribute name="line-height">1.2</xsl:attribute>
         <xsl:attribute name="start-indent">0pt</xsl:attribute>
         <xsl:attribute name="font-weight">normal</xsl:attribute>
+        <xsl:attribute name="font-style">normal</xsl:attribute>
+        <xsl:attribute name="text-decoration">no-underline no-overline</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__align__left">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -454,6 +454,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:attribute name="provisional-label-separation">2mm</xsl:attribute>
         <xsl:attribute name="line-height">1.2</xsl:attribute>
         <xsl:attribute name="start-indent">0pt</xsl:attribute>
+        <xsl:attribute name="font-weight">normal</xsl:attribute>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__align__left">


### PR DESCRIPTION
PDF2: Force footnotes to 'normal' in situations were the footnote was added to a title, such as a fig or table title, or some other style that is bolded. The footnote body was inheriting the bold property.