### PR TITLE
Create separate distribution packages for built-in plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
     secure: d2vveLfRh+KvjkuJtahHB4buR7qpUXZ7ccrmgwALVboh7BhMgZgdX/puHiEzsiS4CX0xNcV2PpdF6VBGsbMg8TAFn5ap5he7y5MnC5Rt9iaJQtMKuoV3GQ1IoZZOUCRswgpjyLOSxuP3HDgyNn44i9eYT5I9N0wkxQzaleho8Og=
   skip_cleanup: true
   file_glob: true
-  file: build/distributions/dita-ot-*.zip
+  file: build/distributions/*.zip
   on:
     tags: true
     repo: dita-ot/dita-ot

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,18 @@ task distPlugins() {
 }
 distPlugins.mustRunAfter integrateDistPlugins
 
-task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, distPlugins, generateDocs, cleanGenerateDocs, generateJavadocs]) {
+task distPluginChecksums() {
+    doLast {
+        ant.checksum(algorithm: "SHA-256", fileext: ".sha256") {
+            fileset(dir: "${buildDir}/distributions") {
+                include(name: '*.zip')
+            }
+        }
+    }
+}
+distPluginChecksums.mustRunAfter distPlugins
+
+task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, distPlugins, distPluginChecksums, generateDocs, cleanGenerateDocs, generateJavadocs]) {
     into("dita-ot-${distVersion}") {
         from (distTempDir) {
             exclude "bin/dita"

--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,33 @@ task generateJavadocs(type: Javadoc) {
 }
 generateJavadocs.onlyIf { skipDocs() }
 
-task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, generateDocs, cleanGenerateDocs, generateJavadocs]) {
+def plugins = [
+        "org.dita.eclipsehelp",
+        "org.dita.html5",
+        "org.dita.htmlhelp",
+        "org.dita.pdf2",
+        "org.dita.pdf2.axf",
+        "org.dita.pdf2.fop",
+        "org.dita.pdf2.xep",
+        "org.dita.xhtml",
+]
+
+task distPlugins() {
+    dependsOn plugins.collect{ name ->
+        def taskName = "distPlugin${name.split("\\.").collect{token -> return token.capitalize()}.join("")}"
+        return tasks.create(taskName, Zip) {
+            from ("${distTempDir}/plugins/${name}") {
+                exclude "build"
+                exclude "src"
+                exclude "out"
+            }
+            archiveName "${name}-${version}.zip"
+        }.name
+    }
+}
+distPlugins.mustRunAfter integrateDistPlugins
+
+task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, distPlugins, generateDocs, cleanGenerateDocs, generateJavadocs]) {
     into("dita-ot-${distVersion}") {
         from (distTempDir) {
             exclude "bin/dita"


### PR DESCRIPTION
Create separate distribution ZIP packages for each built-in plugin during distribution build and upload them to GitHub release in CI.