### PR TITLE
Allow conref to resolve with warnings for weak constraints #3084

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -370,6 +370,7 @@ test {
         'src/test/xsl/common/dita-utilities.xspec',
         'src/test/xsl/common/uri-utils.xspec',
         'src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec',
+        'src/test/xsl/preprocess/conrefImpl.xspec',
         'src/test/xsl/preprocess/maplinkImpl.xspec'
     )
 }

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -758,6 +758,17 @@ See the accompanying LICENSE file for applicable license.
     <response/>
   </message>
 
+  <message id="DOTX075W" type="WARN">
+    <reason>A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in "%1".</reason>
+    <response></response>
+  </message>
+  
+  <message id="DOTX076E" type="ERROR">
+    <reason>A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints "%1".</reason>
+    <response>The current constrained document may only reuse content from documents with equivalent constraints.</response>
+  </message>
+
+
   <!-- End of XSL Messages --> 
       
   <!-- Add any messages defined by plugins. -->

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -507,7 +507,7 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("badconref.dita"))
                 .put("validate", "false")
-                .warnCount(1)
+                .warnCount(2)
                 .errorCount(2)
                 .test();
     }

--- a/src/test/xsl/preprocess/conrefImpl.xspec
+++ b/src/test/xsl/preprocess/conrefImpl.xspec
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:conref="http://dita-ot.sourceforge.net/ns/200704/conref"
+  stylesheet="../../../main/xsl/preprocess/conrefImpl.xsl">
+  
+  <x:param name="ORIGINAL-DOMAINS" select="'(topic) (topic weakConstraint-c) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) s(topic strictConstraint-c)'"/>
+  <x:param name="STRICT-CONSTRAINTS" select="'s(topic strictConstraint-c)'"/>
+
+  <x:scenario label="Test domains validation">
+    <x:scenario label="Test equal domains, fail weak is false">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic weakConstraint-c) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) s(topic strictConstraint-c)'"/>
+        <x:param select="false()"/>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="Test equal domains, fail weak is true">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic weakConstraint-c) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) s(topic strictConstraint-c)'"/>
+        <x:param select="true()"/>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    
+    <x:scenario label="Target is missing a strict constraint; fail for weak is false, but should still should always fail">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic weakConstraint-c) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) '"/>
+        <x:param select="false()"/>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>
+    
+    <x:scenario label="Target is missing a constraint but also missing the related domain">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic weakConstraint-c) s(topic strictConstraint-c)'"/>
+        <x:param select="true()"/>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    
+    <x:scenario label="Target is missing a weak constraint; pass because fail for weak is false">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) s(topic strictConstraint-c)'"/>
+        <x:param select="false()"/>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    
+    <x:scenario label="Target is missing a weak constraint; fail because fail for weak is true">
+      <x:call function="conref:isValid">
+        <x:param select="'(topic) (topic hi-d) (topic hi-d sharedHighlightConstraint-c) s(topic strictConstraint-c)'"/>
+        <x:param select="true()"/>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>    
+    
+  </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Updates `@conref` processing around constraints based on this topic in the specification: http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part1-base/archSpec/base/constraints-conref-compatibility.html

Specifically, the update:

- Removes the call to `DOTX012W`, which was used long ago when a topic could not pull from a different document that had more domains. The message template claimed `DOTX012W` was unused, which it should have been because we generalize from excess domains, but the message was reused when we added constraint checking.
- Extends the `conref:isValid` function to take a parameter `failWeakConstraints`. When `failWeakConstraints=true`, **any** constraint that is not available in the target doc and applies to a shared domain will return `false()` (conref is not valid). When `failWeakConstraints=false`, only strict constraints will cause `conref:isValid` to return `false()`.
- Adds two new messages. One is an error message for failure based on invalid constraints (when the conref is left unresolved). The other is a warning for weak constraints that are not present, so invalid content _might_ be pulled in.
- The current `conref:isValid` check that determines whether to resolve the conref will only fail for incompatible strict constraints. This resolves #3084 because XDITA declares only a weak constraint - so with this update, you can use conref to pull content from full DITA into XDITA (albeit with a warning).
- If it is valid, we check again if there are incompatible weak constraints; if so, the warning is issued, but conref resolves.

The second call to `conref:isValid` causes Saxon to issue an extra warning message when the target doc is completely missing, which made our `conrefmissingfile` test to fail. I'm not sure why. In testing this, I found that just adding an extra `<xsl:iftest="conref:isValid($domains,false())"></xsl:if>` (inside the `xsl:when` that tests the same condition) resulted in a [new warning message](https://travis-ci.org/robander/dita-ot/builds/439852153#L1244); this happened for my local test as well as on Travis. I've adjusted the integration test to increase the warning count accordingly.

Finally, I've added a new XSPEC test for the conref module, and put in tests for the `conref:isValid` function that tests all of the new conditions as well as basic conditions.

