### PR TITLE
HTML5: Made Dublin Core property names lower-case

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -159,7 +159,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[1]" mode="gen-type-metadata"/>
   </xsl:template>
   <xsl:template match="*" mode="gen-type-metadata">
-    <meta name="dc.type" content="{name(.)}"/>
+    <meta name="DC.type" content="{name(.)}"/>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' topic/abstract ')]" mode="gen-shortdesc-metadata">
@@ -181,12 +181,12 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- CONTENT: Source - prolog/source/@href -->
   <xsl:template match="*[contains(@class,' topic/source ')]/@href" mode="gen-metadata">
-    <meta name="dc.source" content="{normalize-space(.)}"/>
+    <meta name="DC.source" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!-- CONTENT: Coverage prolog/metadata/category -->
   <xsl:template match="*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/category ')]" mode="gen-metadata">
-    <meta name="dc.coverage" content="{normalize-space(.)}"/>
+    <meta name="DC.coverage" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!-- CONTENT: Subject - prolog/metadata/keywords -->
@@ -203,7 +203,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
   
     <xsl:if test="string-length($keywords-content)>0">
-      <meta name="dc.subject" content="{$keywords-content}"/>
+      <meta name="DC.subject" content="{$keywords-content}"/>
       <meta name="keywords" content="{$keywords-content}"/>
     </xsl:if>
   </xsl:template>
@@ -227,7 +227,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
        </xsl:choose>
       </xsl:variable>
-      <meta name="dc.relation" scheme="URI">
+      <meta name="DC.relation" scheme="URI">
         <xsl:attribute name="content"><xsl:value-of select="$linkmeta_ext"/></xsl:attribute>
       </meta>
     </xsl:otherwise>
@@ -243,17 +243,17 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' topic/author ')]" mode="gen-metadata">
     <xsl:choose>
       <xsl:when test="@type= 'contributor'">
-        <meta name="dc.contributor" content="{normalize-space(.)}"/>
+        <meta name="DC.contributor" content="{normalize-space(.)}"/>
       </xsl:when>
       <xsl:otherwise>
-        <meta name="dc.creator" content="{normalize-space(.)}"/>
+        <meta name="DC.creator" content="{normalize-space(.)}"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
   
   <!-- INTELLECTUAL PROPERTY: Publisher - prolog/publisher -->
   <xsl:template match="*[contains(@class,' topic/publisher ')]" mode="gen-metadata">
-    <meta name="dc.publisher" content="{normalize-space(.)}"/>
+    <meta name="DC.publisher" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!--  Rights - prolog/copyright -->
@@ -298,37 +298,37 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Usage Rights - prolog/permissions -->
   <xsl:template match="*[contains(@class,' topic/permissions ')]" mode="gen-metadata">
-    <meta name="dc.rights.usage" content="{@view}"/>
+    <meta name="DC.rights.usage" content="{@view}"/>
   </xsl:template>
   
   <!-- = = = = = = = = = = = Product - Audience = = = = = = = = = = = -->
   <!-- Audience -->
   <xsl:template match="*[contains(@class,' topic/audience ')]/@experiencelevel" mode="gen-metadata">
-    <meta name="dc.audience.experiencelevel" content="{.}"/>
+    <meta name="DC.audience.experiencelevel" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@importance" mode="gen-metadata">
-    <meta name="dc.audience.importance" content="{.}"/>
+    <meta name="DC.audience.importance" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@name" mode="gen-metadata">
-    <meta name="dc.audience.name" content="{.}"/>
+    <meta name="DC.audience.name" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@job" mode="gen-metadata">
    <xsl:choose>
     <xsl:when test=".='other'">
-     <meta name="dc.audience.job" content="{normalize-space(../@otherjob)}"/>
+     <meta name="DC.audience.job" content="{normalize-space(../@otherjob)}"/>
     </xsl:when>
     <xsl:otherwise>
-     <meta name="dc.audience.job" content="{.}"/>
+     <meta name="DC.audience.job" content="{.}"/>
     </xsl:otherwise>
    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@type" mode="gen-metadata">
    <xsl:choose>
     <xsl:when test=".='other'">
-     <meta name="dc.audience.type" content="{normalize-space(../@othertype)}"/>
+     <meta name="DC.audience.type" content="{normalize-space(../@othertype)}"/>
     </xsl:when>
     <xsl:otherwise>
-     <meta name="dc.audience.type" content="{.}"/>
+     <meta name="DC.audience.type" content="{.}"/>
     </xsl:otherwise>
    </xsl:choose>
   </xsl:template>
@@ -408,23 +408,23 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- INSTANTIATION: Date - prolog/critdates/created -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/created ')]" mode="gen-metadata">
-    <meta name="dc.date.created" content="{@date}"/>
+    <meta name="DC.date.created" content="{@date}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@modified -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@modified" mode="gen-metadata">
-    <meta name="dc.date.modified" content="{.}"/>
+    <meta name="DC.date.modified" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@golive -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@golive" mode="gen-metadata">
-    <meta name="dc.date.issued" content="{.}"/>
-    <meta name="dc.date.available" content="{.}"/>
+    <meta name="DC.date.issued" content="{.}"/>
+    <meta name="DC.date.available" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@expiry -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@expiry" mode="gen-metadata">
-    <meta name="dc.date.expiry" content="{.}"/>
+    <meta name="DC.date.expiry" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/metadata/othermeta -->
@@ -436,18 +436,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- this value is based on output format used for DC indexing, not source.
        Put in this odd template for easy overriding, if creating another output format. -->
   <xsl:template match="*" mode="gen-format-metadata">
-    <meta name="dc.format" content="HTML5"/>
+    <meta name="DC.format" content="HTML5"/>
   </xsl:template>
   
   <!-- INSTANTIATION: Identifier --> <!-- id is an attribute on Topic -->
   <xsl:template match="@id" mode="gen-metadata">
-    <meta name="dc.identifier" content="{.}"/>
+    <meta name="DC.identifier" content="{.}"/>
   </xsl:template>
   
   <!-- INSTANTIATION: Language -->
   <!-- ideally, take the first token of the language attribute value -->
   <xsl:template match="@xml:lang" mode="gen-metadata">
-    <meta name="dc.language" content="{.}"/>
+    <meta name="DC.language" content="{.}"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -159,7 +159,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[1]" mode="gen-type-metadata"/>
   </xsl:template>
   <xsl:template match="*" mode="gen-type-metadata">
-    <meta name="DC.Type" content="{name(.)}"/>
+    <meta name="dc.type" content="{name(.)}"/>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' topic/abstract ')]" mode="gen-shortdesc-metadata">
@@ -181,12 +181,12 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- CONTENT: Source - prolog/source/@href -->
   <xsl:template match="*[contains(@class,' topic/source ')]/@href" mode="gen-metadata">
-    <meta name="DC.Source" content="{normalize-space(.)}"/>
+    <meta name="dc.source" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!-- CONTENT: Coverage prolog/metadata/category -->
   <xsl:template match="*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/category ')]" mode="gen-metadata">
-    <meta name="DC.Coverage" content="{normalize-space(.)}"/>
+    <meta name="dc.coverage" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!-- CONTENT: Subject - prolog/metadata/keywords -->
@@ -203,7 +203,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
   
     <xsl:if test="string-length($keywords-content)>0">
-      <meta name="DC.subject" content="{$keywords-content}"/>
+      <meta name="dc.subject" content="{$keywords-content}"/>
       <meta name="keywords" content="{$keywords-content}"/>
     </xsl:if>
   </xsl:template>
@@ -227,7 +227,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
        </xsl:choose>
       </xsl:variable>
-      <meta name="DC.Relation" scheme="URI">
+      <meta name="dc.relation" scheme="URI">
         <xsl:attribute name="content"><xsl:value-of select="$linkmeta_ext"/></xsl:attribute>
       </meta>
     </xsl:otherwise>
@@ -243,17 +243,17 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' topic/author ')]" mode="gen-metadata">
     <xsl:choose>
       <xsl:when test="@type= 'contributor'">
-        <meta name="DC.Contributor" content="{normalize-space(.)}"/>
+        <meta name="dc.contributor" content="{normalize-space(.)}"/>
       </xsl:when>
       <xsl:otherwise>
-        <meta name="DC.Creator" content="{normalize-space(.)}"/>
+        <meta name="dc.creator" content="{normalize-space(.)}"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
   
   <!-- INTELLECTUAL PROPERTY: Publisher - prolog/publisher -->
   <xsl:template match="*[contains(@class,' topic/publisher ')]" mode="gen-metadata">
-    <meta name="DC.Publisher" content="{normalize-space(.)}"/>
+    <meta name="dc.publisher" content="{normalize-space(.)}"/>
   </xsl:template>
   
   <!--  Rights - prolog/copyright -->
@@ -298,37 +298,37 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Usage Rights - prolog/permissions -->
   <xsl:template match="*[contains(@class,' topic/permissions ')]" mode="gen-metadata">
-    <meta name="DC.Rights.Usage" content="{@view}"/>
+    <meta name="dc.rights.usage" content="{@view}"/>
   </xsl:template>
   
   <!-- = = = = = = = = = = = Product - Audience = = = = = = = = = = = -->
   <!-- Audience -->
   <xsl:template match="*[contains(@class,' topic/audience ')]/@experiencelevel" mode="gen-metadata">
-    <meta name="DC.Audience.Experiencelevel" content="{.}"/>
+    <meta name="dc.audience.experiencelevel" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@importance" mode="gen-metadata">
-    <meta name="DC.Audience.Importance" content="{.}"/>
+    <meta name="dc.audience.importance" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@name" mode="gen-metadata">
-    <meta name="DC.Audience.Name" content="{.}"/>
+    <meta name="dc.audience.name" content="{.}"/>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@job" mode="gen-metadata">
    <xsl:choose>
     <xsl:when test=".='other'">
-     <meta name="DC.Audience.Job" content="{normalize-space(../@otherjob)}"/>
+     <meta name="dc.audience.job" content="{normalize-space(../@otherjob)}"/>
     </xsl:when>
     <xsl:otherwise>
-     <meta name="DC.Audience.Job" content="{.}"/>
+     <meta name="dc.audience.job" content="{.}"/>
     </xsl:otherwise>
    </xsl:choose>
   </xsl:template>
   <xsl:template match="*[contains(@class,' topic/audience ')]/@type" mode="gen-metadata">
    <xsl:choose>
     <xsl:when test=".='other'">
-     <meta name="DC.Audience.Type" content="{normalize-space(../@othertype)}"/>
+     <meta name="dc.audience.type" content="{normalize-space(../@othertype)}"/>
     </xsl:when>
     <xsl:otherwise>
-     <meta name="DC.Audience.Type" content="{.}"/>
+     <meta name="dc.audience.type" content="{.}"/>
     </xsl:otherwise>
    </xsl:choose>
   </xsl:template>
@@ -408,23 +408,23 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- INSTANTIATION: Date - prolog/critdates/created -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/created ')]" mode="gen-metadata">
-    <meta name="DC.Date.Created" content="{@date}"/>
+    <meta name="dc.date.created" content="{@date}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@modified -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@modified" mode="gen-metadata">
-    <meta name="DC.Date.Modified" content="{.}"/>
+    <meta name="dc.date.modified" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@golive -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@golive" mode="gen-metadata">
-    <meta name="DC.Date.Issued" content="{.}"/>
-    <meta name="DC.Date.Available" content="{.}"/>
+    <meta name="dc.date.issued" content="{.}"/>
+    <meta name="dc.date.available" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/critdates/revised/@expiry -->
   <xsl:template match="*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@expiry" mode="gen-metadata">
-    <meta name="DC.Date.Expiry" content="{.}"/>
+    <meta name="dc.date.expiry" content="{.}"/>
   </xsl:template>
   
   <!-- prolog/metadata/othermeta -->
@@ -436,18 +436,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- this value is based on output format used for DC indexing, not source.
        Put in this odd template for easy overriding, if creating another output format. -->
   <xsl:template match="*" mode="gen-format-metadata">
-    <meta name="DC.Format" content="HTML5"/>
+    <meta name="dc.format" content="HTML5"/>
   </xsl:template>
   
   <!-- INSTANTIATION: Identifier --> <!-- id is an attribute on Topic -->
   <xsl:template match="@id" mode="gen-metadata">
-    <meta name="DC.Identifier" content="{.}"/>
+    <meta name="dc.identifier" content="{.}"/>
   </xsl:template>
   
   <!-- INSTANTIATION: Language -->
   <!-- ideally, take the first token of the language attribute value -->
   <xsl:template match="@xml:lang" mode="gen-metadata">
-    <meta name="DC.Language" content="{.}"/>
+    <meta name="dc.language" content="{.}"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/test/resources/html5_css/exp/html5/topic.html
+++ b/src/test/resources/html5_css/exp/html5/topic.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.Type" content="topic">
-  <meta name="DC.Format" content="HTML5">
-  <meta name="DC.Identifier" content="topic">
+  <meta name="DC.type" content="topic">
+  <meta name="DC.format" content="HTML5">
+  <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="commonltr.css">
   <link rel="stylesheet" type="text/css" href="custom.css">
   <title>Topic</title>

--- a/src/test/resources/html5_cssExternal/exp/html5/topic.html
+++ b/src/test/resources/html5_cssExternal/exp/html5/topic.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.Type" content="topic">
-  <meta name="DC.Format" content="HTML5">
-  <meta name="DC.Identifier" content="topic">
+  <meta name="DC.type" content="topic">
+  <meta name="DC.format" content="HTML5">
+  <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="https://example.com/styles/commonltr.css">
   <link rel="stylesheet" type="text/css" href="https://example.com/styles/custom.css">
   <title>Topic</title>

--- a/src/test/resources/html5_csspath/exp/html5/topic.html
+++ b/src/test/resources/html5_csspath/exp/html5/topic.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.Type" content="topic">
-  <meta name="DC.Format" content="HTML5">
-  <meta name="DC.Identifier" content="topic">
+  <meta name="DC.type" content="topic">
+  <meta name="DC.format" content="HTML5">
+  <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="styles/commonltr.css">
   <link rel="stylesheet" type="text/css" href="styles/custom.css">
   <title>Topic</title>


### PR DESCRIPTION
## Expected Behavior

[The Guidelines for implementing Dublin Core in XML](http://dublincore.org/documents/dc-xml-guidelines/), Section 4.2 Implementation guidelines says:

> “Recommendation 4. The property names for the 15 DC elements should be all lower-case.”
[Update:] The prefic DC needs to be all upper-case, the property name all-lowercase.
```xml
<meta name="DC.property1" content="foo" />
<meta name="DC.property2" content="foo" />
```

## Actual Behavior
Dublin Core Properties are currently output in upper-case and/or a mixture of them
```xml
<meta name="DC.property1" content="foo" />
<meta name="DC.Property2" content="foo" />
```

## Possible Solution
I have changed the property names as per Dublin Core recommendation and made them all lower-case.

Signed-off-by: Stefan Gentz <gentz@adobe.com>