### PR TITLE
Add LwDITA XDITA to distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,8 @@ def bundled = [
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.0.6/org.lwdita-2.0.6.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
         "troff": "https://github.com/dita-ot/org.dita.troff/archive/3.1.1.zip",
-        "tocjs": "https://github.com/dita-ot/com.sophos.tocjs/archive/2.5.zip"
+        "tocjs": "https://github.com/dita-ot/com.sophos.tocjs/archive/2.5.zip",
+        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.1/org.oasis-open.xdita.v0_2_1.zip"
 ]
 
 task cleanDistTemp(type: Delete) {


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Adds the Lightweight DITA XDITA document types as a plugin. This adds out-of-the-box processing support for documents that use the pre-release XDITA document types.

The plugin is pulled from the latest XDITA release (created today): https://github.com/oasis-tcs/dita-lwdita/releases/tag/v0.2.1

I haven't yet been able to test this properly - whenever I try to build the distribution package on my system I get Java failures (also true before this update):
```
> Task :integrateDistmarkdown
Buildfile: C:\Users\IBM_ADMIN\github\dita-ot\build\tmp\dist\integrator.xml

install:

BUILD FAILED
C:\Users\IBM_ADMIN\github\dita-ot\build\tmp\dist\integrator.xml:70: java.nio.fil
e.InvalidPathException: Illegal char <:> at index 5: https://github.com/jelovirt
/org.lwdita/releases/download/2.0.6/org.lwdita-2.0.6.zip
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:194)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:165)
        ...
```