### PR TITLE
Rev marking should cover whole part, topic

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -123,9 +123,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="customTopicMarker"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/prolog ')]"/>
-        <xsl:apply-templates select="*[not(contains(@class, ' topic/title ')) and
-                                       not(contains(@class, ' topic/prolog ')) and
-                                       not(contains(@class, ' topic/topic '))]"/>
+          <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+              contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
         <!--xsl:apply-templates select="." mode="buildRelationships"/-->
         <xsl:apply-templates select="*[contains(@class,' topic/topic ')]"/>
         <xsl:apply-templates select="." mode="topicEpilog"/>
@@ -276,6 +275,7 @@ See the accompanying LICENSE file for applicable license.
             <fo:block xsl:use-attribute-sets="topic.title">
                 <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
                 </xsl:for-each>
@@ -283,8 +283,8 @@ See the accompanying LICENSE file for applicable license.
 
             <xsl:choose>
               <xsl:when test="$chapterLayout='BASIC'">
-                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                     contains(@class, ' topic/prolog '))]"/>
+                  <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+                      contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
                   <!--xsl:apply-templates select="." mode="buildRelationships"/-->
               </xsl:when>
               <xsl:otherwise>
@@ -347,6 +347,7 @@ See the accompanying LICENSE file for applicable license.
 
             <fo:block xsl:use-attribute-sets="topic.title">
                 <xsl:apply-templates select="." mode="customTopicAnchor"/>
+                <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
@@ -355,8 +356,8 @@ See the accompanying LICENSE file for applicable license.
 
             <xsl:choose>
               <xsl:when test="$appendixLayout='BASIC'">
-                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                     contains(@class, ' topic/prolog '))]"/>
+                  <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+                      contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
                   <!--xsl:apply-templates select="." mode="buildRelationships"/-->
               </xsl:when>
               <xsl:otherwise>
@@ -419,6 +420,7 @@ See the accompanying LICENSE file for applicable license.
       <fo:block xsl:use-attribute-sets="topic.title">
         <xsl:apply-templates select="." mode="customTopicAnchor"/>
         <xsl:call-template name="pullPrologIndexTerms"/>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
         <xsl:for-each select="*[contains(@class,' topic/title ')]">
           <xsl:apply-templates select="." mode="getTitle"/>
         </xsl:for-each>
@@ -426,8 +428,8 @@ See the accompanying LICENSE file for applicable license.
           
       <xsl:choose>
         <xsl:when test="$appendicesLayout='BASIC'">
-          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                             contains(@class, ' topic/prolog '))]"/>
+          <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+                contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
           <!--xsl:apply-templates select="." mode="buildRelationships"/-->
         </xsl:when>
         <xsl:otherwise>
@@ -497,6 +499,7 @@ See the accompanying LICENSE file for applicable license.
             <fo:block xsl:use-attribute-sets="topic.title">
                 <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                 <xsl:for-each select="*[contains(@class,' topic/title ')]">
                     <xsl:apply-templates select="." mode="getTitle"/>
                 </xsl:for-each>
@@ -504,8 +507,8 @@ See the accompanying LICENSE file for applicable license.
 
             <xsl:choose>
               <xsl:when test="$partLayout='BASIC'">
-                  <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                     contains(@class, ' topic/prolog '))]"/>
+                  <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+                      contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
                   <!--xsl:apply-templates select="." mode="buildRelationships"/-->
               </xsl:when>
               <xsl:otherwise>
@@ -562,6 +565,7 @@ See the accompanying LICENSE file for applicable license.
                     <fo:block xsl:use-attribute-sets="topic.title">
                         <xsl:apply-templates select="." mode="customTopicAnchor"/>
                         <xsl:call-template name="pullPrologIndexTerms"/>
+                        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                         <xsl:for-each select="*[contains(@class,' topic/title ')]">
                             <xsl:apply-templates select="." mode="getTitle"/>
                         </xsl:for-each>
@@ -569,8 +573,8 @@ See the accompanying LICENSE file for applicable license.
 
                     <xsl:choose>
                       <xsl:when test="$noticesLayout='BASIC'">
-                          <xsl:apply-templates select="*[not(contains(@class, ' topic/topic ') or contains(@class, ' topic/title ') or
-                                                             contains(@class, ' topic/prolog '))]"/>
+                          <xsl:apply-templates select="* except(*[contains(@class, ' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop ') or
+                              contains(@class, ' topic/prolog ') or contains(@class, ' topic/topic ')])"/>
                           <!--xsl:apply-templates select="." mode="buildRelationships"/-->
                       </xsl:when>
                       <xsl:otherwise>
@@ -623,11 +627,12 @@ See the accompanying LICENSE file for applicable license.
                          </xsl:attribute>
                          <xsl:apply-templates select="." mode="customTopicAnchor"/>
                          <xsl:call-template name="pullPrologIndexTerms"/>
+                         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                          <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
                              <xsl:apply-templates select="." mode="getTitle"/>
                          </xsl:for-each>
                      </fo:block>
-                     <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
+                     <xsl:apply-templates select="*[not(contains(@class,' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop '))]"/>
                  </fo:block>
    </xsl:template>
 
@@ -779,6 +784,7 @@ See the accompanying LICENSE file for applicable license.
                               </fo:block>
                             </xsl:if>
                             <xsl:apply-templates select="*[contains(@class,' topic/body ')]/*"/>
+                            <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]"/>
 
                             <xsl:if test="*[contains(@class,' topic/related-links ')]//
                                           *[contains(@class,' topic/link ')][not(@role) or @role!='child']">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -72,11 +72,12 @@ See the accompanying LICENSE file for applicable license.
              <fo:block xsl:use-attribute-sets="topic.title">
                  <xsl:apply-templates select="." mode="customTopicAnchor"/>
                  <xsl:call-template name="pullPrologIndexTerms"/>
+                 <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                  <xsl:for-each select="child::*[contains(@class,' topic/title ')]">
                      <xsl:apply-templates select="." mode="getTitle"/>
                  </xsl:for-each>
              </fo:block>
-             <xsl:apply-templates select="*[not(contains(@class,' topic/title '))]"/>
+             <xsl:apply-templates select="*[not(contains(@class,' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop '))]"/>
          </fo:block>
      </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -105,6 +105,7 @@ See the accompanying LICENSE file for applicable license.
                 </fo:wrapper>
                 <xsl:apply-templates select="." mode="customTopicAnchor"/>
                 <xsl:call-template name="pullPrologIndexTerms"/>
+                <xsl:apply-templates select="preceding-sibling::*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>
                 <xsl:apply-templates select="." mode="getTitle"/>
             </fo:block>
         </fo:block>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This update changes when revisions (stored in `dita-ot/startprop`) are processed for full topics. It moves processing to the start of topic titles, for the following benefits:

- When revision change bars are specified for an entire topic, the change bar now extends from the title of the topic down to the end of the body. Previously it only extended along the body, which some of my customers reported to me as a defect.
- When revision images are specified for start-change, the image now appears at the start of the title, which helps clarify that the full topic is revised; previously it appeared on its own between the title and the body.
- Previously change bars were missing for parts, chapters, and a few other bookmap-specific topics when the entire topic was revised, due to the way that those topics are processed to set up special flows. This update ensures that change bars now appear alongside parts / chapters / etc when needed.

This is a follow-on to #3100 which added revision bar support for entries in the TOC (I mentioned some of these outstanding issues in that update). It uses the same source maps + DITAVAL to test basic maps and bookmaps with change bars + image flagged + color revisions. https://github.com/dita-ot/dita-ot/files/2470022/revbar.zip