### PR TITLE
Div should inherit common block processing in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -213,7 +213,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:attribute name="start-indent">72pt</xsl:attribute>
     </xsl:attribute-set>
 
-    <xsl:attribute-set name="div">
+    <xsl:attribute-set name="div" use-attribute-sets="common.block">
     </xsl:attribute-set>
 
     <xsl:attribute-set name="p" use-attribute-sets="common.block">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Noticed that the PDF format for `<div>` does nothing more than add a newline; seems that it should be rendered like other blocks by default, separated by a bit of space from the previous block (and pick up any standard attribute overrides from the `common.block` set).

Tested with a topic that contains:
```
<body>
  <p>Topic paragraph</p>
  <p>Topic paragraph</p>
  <p>Topic paragraph</p>
  <div>hey this is div</div>
  <div>hey this is div
    <div>hey this is NESTED div</div>
    <div>hey this is NESTED div</div></div>
  <div>hey this is div</div>
  <p>Topic paragraph</p>
  <p>Topic paragraph</p>
  <p>Topic paragraph</p>
  <div>hey this is div</div>
  <div>hey this is div</div>
</body>
```

Without the update, there is no way to distinguish between the divisions other than the newline (which is meaningless if the lines are very long). After the update the `<div>` containment is clear.