### PR TITLE
Fix PDF indentation for shortdesc in abstract

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -519,36 +519,39 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
+    
+    <xsl:function name="dita-ot:formatShortdescAsBlock" as="xs:boolean">
+        <xsl:param name="ctx" as="element()"/>
+        <xsl:choose>
+            <xsl:when test="not($ctx/parent::*[contains(@class,' topic/abstract ')])">
+                <xsl:sequence select="true()"/>
+            </xsl:when>
+            <xsl:when test="$ctx/preceding-sibling::*[contains(@class,' topic/p ') or contains(@class,' topic/dl ') or
+                contains(@class,' topic/fig ') or contains(@class,' topic/lines ') or
+                contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
+                contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
+                contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
+                contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
+                <xsl:sequence select="true()"/>
+            </xsl:when>
+            <xsl:when test="$ctx/following-sibling::*[contains(@class,' topic/p ') or contains(@class,' topic/dl ') or
+                contains(@class,' topic/fig ') or contains(@class,' topic/lines ') or
+                contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
+                contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
+                contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
+                contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
+                <xsl:sequence select="true()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
 
     <!-- For SF Bug 2879171: modify so that shortdesc is inline when inside
          abstract with only other text or inline markup. -->
     <xsl:template match="*[contains(@class,' topic/shortdesc ')]">
-        <xsl:variable name="format-as-block" as="xs:boolean">
-            <xsl:choose>
-                <xsl:when test="not(parent::*[contains(@class,' topic/abstract ')])">
-                  <xsl:sequence select="true()"/>
-                </xsl:when>
-                <xsl:when test="preceding-sibling::*[contains(@class,' topic/p ') or contains(@class,' topic/dl ') or
-                                         contains(@class,' topic/fig ') or contains(@class,' topic/lines ') or
-                                         contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
-                                         contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
-                                         contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
-                                         contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
-                  <xsl:sequence select="true()"/>
-                </xsl:when>
-                <xsl:when test="following-sibling::*[contains(@class,' topic/p ') or contains(@class,' topic/dl ') or
-                                         contains(@class,' topic/fig ') or contains(@class,' topic/lines ') or
-                                         contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
-                                         contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
-                                         contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
-                                         contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
-                  <xsl:sequence select="true()"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:sequence select="false()"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
+        <xsl:variable name="format-as-block" as="xs:boolean" select="dita-ot:formatShortdescAsBlock(.)"/>
         <xsl:choose>
             <xsl:when test="$format-as-block">
                 <xsl:apply-templates select="." mode="format-shortdesc-as-block"/>
@@ -560,9 +563,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*" mode="format-shortdesc-as-block">
-        <!--fo:block xsl:use-attribute-sets="shortdesc" id="{@id}">
-            <xsl:apply-templates/>
-        </fo:block-->
         <!--compare the length of shortdesc with the got max chars-->
         <fo:block xsl:use-attribute-sets="topic__shortdesc">
             <xsl:call-template name="commonattributes"/>
@@ -570,6 +570,9 @@ See the accompanying LICENSE file for applicable license.
             <xsl:if test="string-length(.) lt $maxCharsInShortDesc">
                 <!-- Low-strength keep to avoid conflict with keeps on titles. -->
                 <xsl:attribute name="keep-with-next.within-page">5</xsl:attribute>
+            </xsl:if>
+            <xsl:if test="parent::*[contains(@class,' topic/abstract ')]">
+                <xsl:attribute name="start-indent">from-parent(start-indent)</xsl:attribute>
             </xsl:if>
             <xsl:apply-templates/>
         </fo:block>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -531,7 +531,8 @@ See the accompanying LICENSE file for applicable license.
                 contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
                 contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
                 contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
-                contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
+                contains(@class,' topic/table ') or contains(@class,' topic/ul ') or
+                contains(@class,' topic/div ')]">
                 <xsl:sequence select="true()"/>
             </xsl:when>
             <xsl:when test="$ctx/following-sibling::*[contains(@class,' topic/p ') or contains(@class,' topic/dl ') or
@@ -539,7 +540,8 @@ See the accompanying LICENSE file for applicable license.
                 contains(@class,' topic/lq ') or contains(@class,' topic/note ') or
                 contains(@class,' topic/ol ') or contains(@class,' topic/pre ') or
                 contains(@class,' topic/simpletable ') or contains(@class,' topic/sl ') or
-                contains(@class,' topic/table ') or contains(@class,' topic/ul ')]">
+                contains(@class,' topic/table ') or contains(@class,' topic/ul ') or
+                contains(@class,' topic/div ')]">
                 <xsl:sequence select="true()"/>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
Fixes #3063.

- When `shortdesc` is processed on its own (outside of `abstract`), it creates a block with the proper settings for indentation. The indentation comes from the existing attribute set.
- When processed as a block inside of `abstract`, the `abstract` container already sets the proper indentation. Adding the extra `shortdesc` indentation on top of that results in bad formatting for the `MINITOC` style.
- This update ensures that when `shortdesc` is processed as a block inside of `<abstract>`, indentation is taken from the parent (which is already correct for both `BASIC` and `MINITOC` layout).
- As part of this, I also cleaned up the block/inline test by putting it into a function, to simplify the actual `shortdesc` match template
- Final update -- after DITA 1.3, `<div>` was never added to the list of block elements that can appear inside of the abstract; it's now added to the test for block elements.

Tested with the attached maps (normal map and book map), building the book map with both default `MINITOC` style and with `--Dargs.chapter.layout=BASIC`. 