### PR TITLE
Skip chunking for PDF by default #2479

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -56,6 +56,11 @@ with those set forth herein.
     
     <property name="preprocess.copy-image.skip" value="true"/>
     <property name="clean-preprocess.use-result-filename" value="false"/>
+    <condition property="preprocess.chunk.skip" value="true">
+      <not>
+        <equals arg1="${org.dita.pdf2.chunk.enabled}" arg2="true"/>
+      </not>
+    </condition>
     
     <condition property="args.rellinks" value="nofamily">
       <not><isset property="args.rellinks"/></not>

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -49,6 +49,10 @@ See the accompanying LICENSE file for applicable license.
       <val desc="Enables I18N processing" default="true">true</val>
       <val desc="Disables I18N processing">false</val>
     </param>
+    <param name="org.dita.pdf2.chunk.enabled" desc="Enables chunk attribute processing." type="enum">
+      <val desc="Enables chunk processing">true</val>
+      <val desc="Disables chunk processing" default="true">false</val>
+    </param>
   </transtype>
   <transtype name="pdf2" extends="pdf" desc="PDF2"/>
   <feature extension="dita.transtype.print" value="pdf"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Implements #2479 by adding a new option to skip chunking with PDF (based on the existing option to skip I18N processing).

When `org.dita.pdf2.chunk.enabled` is unspecified or `org.dita.pdf2.chunk.enabled=false`, the chunking step will not run.

When `org.dita.pdf2.chunk.enabled=true` the common chunk processing will run.

Tested with a map that sets `chunk="to-content"`. Before this fix, and with the fix + `org.dita.pdf2.chunk.enabled=true` specified, chunking runs and the build ends with a null pointer error.

With this fix, a normal build skips chunk and the PDF is produced; specifying `org.dita.pdf2.chunk.enabled=false` gives the same result of working build with no chunk processing.

[2579.zip](https://github.com/dita-ot/dita-ot/files/2496711/2579.zip)
