### PR TITLE
Handle namespace atts in conref push module

### DIFF
--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -14,8 +14,10 @@ import static org.dita.dost.util.URLUtils.*;
 import java.io.File;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.stream.FactoryConfigurationError;
@@ -253,6 +255,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
         //conref information like @conref @conaction in current element
         //when copying it to pushcontent. True means remove and false means
         //not remove.
+        final Set<String> namespaces = new HashSet<>(32);
         try {
             pushcontentWriter.writeStartElement(elemName);
             for (int index = 0; index < atts.getLength(); index++) {
@@ -266,9 +269,14 @@ public final class ConrefPushReader extends AbstractXMLReader {
                     }
                     final int offset = atts.getQName(index).indexOf(":");
                     final String prefix = offset != -1 ? atts.getQName(index).substring(0, offset) : "";
+                    if (!namespaces.contains(prefix)) {
+                        namespaces.add(prefix);
+                        if (!(prefix.equals(""))) {
+                            pushcontentWriter.writeNamespace(prefix, atts.getURI(index));
+                        }
+                    }
                     pushcontentWriter.writeAttribute(prefix, atts.getURI(index), atts.getLocalName(index), value);
                 }
-
             }
             //id attribute should only be added to the starting element
             //which dosen't have id attribute set

--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -255,7 +255,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
         //conref information like @conref @conaction in current element
         //when copying it to pushcontent. True means remove and false means
         //not remove.
-        final Set<String> namespaces = new HashSet<>(32);
+        final Set<String> namespaces = new HashSet<>();
         try {
             pushcontentWriter.writeStartElement(elemName);
             for (int index = 0; index < atts.getLength(); index++) {
@@ -271,7 +271,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
                     final String prefix = offset != -1 ? atts.getQName(index).substring(0, offset) : "";
                     if (!namespaces.contains(prefix)) {
                         namespaces.add(prefix);
-                        if (!(prefix.equals(""))) {
+                        if (!prefix.isEmpty()) {
                             pushcontentWriter.writeNamespace(prefix, atts.getURI(index));
                         }
                     }

--- a/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
+++ b/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
@@ -61,12 +61,12 @@ public class TestConrefPushParser {
         /*
          * the part of content of conrefpush_stub2.xml is
          * <ol>
-         *     <li id="A">A</li>
+         *     <li id="A" dita-ot:orig-foobar="foo.dita#bar/buzz" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot">A</li>
          *     <li id="B">B</li>
          *     <li id="C">C</li>
          * </ol>
          * 
-         * the part of content of conrefpush_stup.xml is
+         * the part of content of conrefpush_stub.xml is
          *  <steps>
          *      <step conaction="pushbefore"><cmd>before</cmd></step>
          *   <step conref="conrefpush_stub2.xml#X/A" conaction="mark"/>
@@ -82,7 +82,7 @@ public class TestConrefPushParser {
          *      before
          *      </ph>
          *  </li>
-         *  <li id="A" class="- topic/li ">A</li>
+         *  <li id="A" class="- topic/li " dita-ot:orig-foobar="foo.dita#bar/buzz" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot">A</li>
          *    <li id="B" class="- topic/li ">B</li>
          *    <li class="- topic/li task/step ">
          *        <ph class="- topic/ph task/cmd ">
@@ -133,12 +133,14 @@ public class TestConrefPushParser {
                 if(node.getNodeType() == Node.ELEMENT_NODE){
                     element = (Element)node;
                     if(element.getAttributes().getNamedItem("id")!=null && element.getAttributes().getNamedItem("id").getNodeValue().equals("A")){
+                        //Verify that namespace atts on A were preserved
+                        assertEquals("<li class=\"- topic/li \" dita-ot:orig-foobar=\"foo.dita#bar/buzz\" id=\"A\" xmlns:dita-ot=\"http://dita-ot.sourceforge.net/ns/201007/dita-ot\">A</li>", nodeToString(element));
                         // get node of before
                         node = element.getPreviousSibling();
                         while(node.getNodeType() != Node.ELEMENT_NODE){
                             node = node.getPreviousSibling();
                         }
-                        assertEquals("<li class=\"- topic/li task/step \"><ph class=\"- topic/ph task/cmd \">before</ph></li>", nodeToString((Element)node));
+                        assertEquals("<li class=\"- topic/li task/step \" xmlns:dita-ot=\"http://dita-ot.sourceforge.net/ns/201007/dita-ot\"><ph class=\"- topic/ph task/cmd \">before</ph></li>", nodeToString((Element)node));
                     }else if(element.getAttributes().getNamedItem("id")!=null && element.getAttributes().getNamedItem("id").getNodeValue().equals("B")){
                         // get node of after
                         node = element.getNextSibling();

--- a/src/test/resources/TestConrefPushParser/src/conrefpush_stub2.xml
+++ b/src/test/resources/TestConrefPushParser/src/conrefpush_stub2.xml
@@ -1,7 +1,7 @@
 <topic id="X" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.1" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " class="- topic/topic ">
 <body class="- topic/body ">
 <ol class="- topic/ol ">
-<li class="- topic/li task/step "><ph class="- topic/ph task/cmd ">before</ph></li><li id="A" class="- topic/li ">A</li>
+<li class="- topic/li task/step "><ph class="- topic/ph task/cmd ">before</ph></li><li id="A" class="- topic/li " dita-ot:orig-foobar="foo.dita#bar/buzz" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot">A</li>
 <li id="B" class="- topic/li ">B</li><li class="- topic/li task/step "><ph class="- topic/ph task/cmd ">after</ph></li>
 <li class="- topic/li task/step "><ph class="- topic/ph task/cmd ">replace</ph></li>
 </ol>

--- a/src/test/resources/TestConrefPushParser/src/conrefpush_stub2_backup.xml
+++ b/src/test/resources/TestConrefPushParser/src/conrefpush_stub2_backup.xml
@@ -1,7 +1,7 @@
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="X" ditaarch:DITAArchVersion="1.2">
 <body class="- topic/body ">
 <ol class="- topic/ol ">
-<li class="- topic/li " id="A">A</li>
+<li class="- topic/li " id="A" dita-ot:orig-foobar="foo.dita#bar/buzz" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot">A</li>
 <li class="- topic/li " id="B">B</li>
 <li class="- topic/li " id="C">C</li>
 </ol>


### PR DESCRIPTION
This came up when I was playing with a fix for #1381.

I added a namespaced attribute `@dita-ot:orig-conkeyref` onto an element for debug purposes. The namespace was defined on the same element. When the conref push filter tried to write that element, it threw an exception because it wrote out `@dita-ot:orig-conkeyref` but did not preserve the definition of `xmlns:dita-ot`:
```
conrefpush:
[conref-push] Reading  C:\DCS\test\temp\topic1.dita
[conref-push] The namespace URI "http://dita-ot.sourceforge.net/ns/201007/dita-ot" has not been bound to a prefix.
[conref-push] javax.xml.stream.XMLStreamException: The namespace URI "http://dita-ot.sourceforge.net/ns/201007/dita-ot" has not been bound to a prefix.
[conref-push]   at org.dita.dost.reader.ConrefPushReader.putElement(ConrefPushReader.java:304)
[conref-push]   at org.dita.dost.reader.ConrefPushReader.startElement(ConrefPushReader.java:187)
[conref-push]   at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
[conref-push]   at org.ditang.relaxng.defaults.RelaxNGDefaultsComponent.startElement(RelaxNGDefaultsComponent.java:210)
[conref-push]   at org.apache.xerces.impl.XMLNSDocumentScannerImpl.scanStartElement(Unknown Source)
[conref-push]   at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
...
```

When running the integration tests with an update that preserved `@conref` with `@dita-ot:orig-conref`, a large number of tests failed during `conref-push` with that same exception.

I updated the JUnit for `conref-push` and got an exception when it tried to work with the namespaced attribute. The fix here ensures that when writing out any attribute with a namespace, that namespace is also declared. It also ensures that we only define the namespace once for any given element.