### PR TITLE
New message when grammar file not found #2461

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -381,6 +381,16 @@ See the accompanying LICENSE file for applicable license.
     <reason>Invalid action attribute '%1' on DITAVAL property.</reason>
     <response></response>
   </message>
+  
+  <message id="DOTJ078F" type="FATAL">
+    <reason>Input file '%1' could not be loaded.</reason>
+    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+  </message>
+  
+  <message id="DOTJ079E" type="ERROR">
+    <reason>File '%1' could not be loaded.</reason>
+    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+  </message>
 
   <!-- End of Java Messages -->
     

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -407,12 +407,20 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             }
             failureList.add(currentFile);
         } catch (final FileNotFoundException e) {
-            if (currentFile.equals(rootFile)) {
-                throw new DITAOTException(MessageUtils.getMessage("DOTA069F", params).toString(), e);
+            if (!exists(currentFile)) {
+                if (currentFile.equals(rootFile)) {
+                    throw new DITAOTException(MessageUtils.getMessage("DOTA069F", params).toString(), e);
+                } else if (processingMode == Mode.STRICT) {
+                    throw new DITAOTException(MessageUtils.getMessage("DOTX008E", params).toString(), e);
+                } else {
+                    logger.error(MessageUtils.getMessage("DOTX008E", params).toString());
+                }
+            } else if (currentFile.equals(rootFile)) {
+                throw new DITAOTException(MessageUtils.getMessage("DOTJ078F", params).toString() + " Cannot load file: " + e.getMessage(), e);
             } else if (processingMode == Mode.STRICT) {
-                throw new DITAOTException(MessageUtils.getMessage("DOTX008E", params).toString() + ": " + e.getMessage(), e);
+                throw new DITAOTException(MessageUtils.getMessage("DOTJ079E", params).toString() + " Cannot load file: " + e.getMessage(), e);
             } else {
-                logger.error(MessageUtils.getMessage("DOTX008E", params).toString());
+                logger.error(MessageUtils.getMessage("DOTJ079E", params).toString() + " Cannot load file: " + e.getMessage());
             }
             failureList.add(currentFile);
         } catch (final Exception e) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -383,12 +383,20 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             }
             failureList.add(currentFile);
         } catch (final FileNotFoundException e) {
-            if (currentFile.equals(rootFile)) {
-                throw new DITAOTException(MessageUtils.getMessage("DOTA069F", params).toString(), e);
+            if (!exists(currentFile)) {
+                if (currentFile.equals(rootFile)) {
+                    throw new DITAOTException(MessageUtils.getMessage("DOTA069F", params).toString(), e);
+                } else if (processingMode == Mode.STRICT) {
+                    throw new DITAOTException(MessageUtils.getMessage("DOTX008E", params).toString(), e);
+                } else {
+                    logger.error(MessageUtils.getMessage("DOTX008E", params).toString());
+                }
+            } else if (currentFile.equals(rootFile)) {
+                throw new DITAOTException(MessageUtils.getMessage("DOTJ078F", params).toString() + " Cannot load file: " + e.getMessage(), e);
             } else if (processingMode == Mode.STRICT) {
-                throw new DITAOTException(MessageUtils.getMessage("DOTX008E", params).toString() + ": " + e.getMessage(), e);
+                throw new DITAOTException(MessageUtils.getMessage("DOTJ079E", params).toString() + " Cannot load file: " + e.getMessage(), e);
             } else {
-                logger.error(MessageUtils.getMessage("DOTX008E", params).toString());
+                logger.error(MessageUtils.getMessage("DOTJ079E", params).toString() + " Cannot load file: " + e.getMessage());
             }
             failureList.add(currentFile);
         } catch (final Exception e) {


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Implements #2461 (also reported as #2475 and reported in Slack today in relation to #3123) by adding new message to distinguish between "file not found" conditions. Currently, if any file cannot be found, we report the file we're trying to read (usually a DITA map or topic) and state that it cannot be found or loaded. If the DTD/Schema is missing, the `FileNotFoundException` actually applies to that grammar file, but we only report the source file. If the file exists but we receive the `FileNotFound` condition, then most likely it's a grammar file that was not found, so we should modify the message accordingly.

Old behavior:

- If the file cannot be parsed (because the file contents are not valid against the grammar, or because the grammar file itself cannot be parsed), there is a `SaxParseException` that reports the correct file (source or grammar) along with the parsing error
- Otherwise if any file could not be found, catch `FileNotFoundException` and report the _source_ file that could not be used. If it's the input file end with fatal "Input file could not be located or read, ensure it exists and you have permission", otherwise use an Error "File could not be located or read"

New behavior:
- If the file cannot be parsed (because the file contents are not valid against the grammar, or because the grammar file itself cannot be parsed), there is a `SaxParseException` that reports the correct file (source or grammar) along with the parsing error
- If we get the `FileNotFoundException` for the input file, but the input file really does exist, use a new fatal message "Input file XYZ could not be loaded" and point to the grammar file as the response; after that message include the actual exception text that states what file could not be found, such as `map.dtd`
- If we get the `FileNotFoundException` for any other file that really does exist, use a new error "File XYZ cannot be loaded" and point to the grammar file as the cause; after that message include the actual exception text that states what file could not be found, such as `my-topic.dtd`
- Otherwise treat the `FileNotFoundException` as we do today