### PR TITLE
Fix MapMeta bug that causes OutOfMemory Error

### DIFF
--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -35,6 +35,7 @@ import java.util.Map.Entry;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toFile;
+import static org.dita.dost.util.URLUtils.stripFragment;
 import static org.dita.dost.util.XMLUtils.withLogger;
 
 /**
@@ -149,7 +150,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
             mapInserter.setLogger(logger);
             mapInserter.setJob(job);
             for (final Entry<URI, Map<String, Element>> entry : mapSet.entrySet()) {
-                final URI key = entry.getKey();
+                final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
                     logger.error("File " + new File(job.tempDir, key.getPath()) + " was not found.");
@@ -173,7 +174,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
             topicInserter.setLogger(logger);
             topicInserter.setJob(job);
             for (final Entry<URI, Map<String, Element>> entry : mapSet.entrySet()) {
-                final URI key = entry.getKey();
+                final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
                     logger.error("File " + new File(job.tempDir, key.getPath()) + " was not found.");
@@ -182,6 +183,8 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final URI targetFileName = job.tempDirURI.resolve(fi.uri);
                 assert targetFileName.isAbsolute();
                 if (fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {
+                    final String topicid = entry.getKey().getFragment();
+                    topicInserter.setTopicId(topicid);
                     topicInserter.setMetaTable(entry.getValue());
                     if (toFile(targetFileName).exists()) {
                         topicInserter.read(toFile(targetFileName));

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -34,8 +34,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toFile;
 import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.toFile;
 import static org.dita.dost.util.XMLUtils.withLogger;
 
 /**

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -224,7 +224,7 @@ public final class MapMetaReader extends AbstractDomFilter {
                     final URI copyToUri = stripFragment(URLUtils.toURI(copytoAttr.getNodeValue()));
                     topicPath = job.tempDirURI.relativize(filePath.toURI().resolve(copyToUri));
                 } else {
-                    final URI hrefUri = stripFragment(URLUtils.toURI(hrefAttr.getNodeValue()));
+                    final URI hrefUri = URLUtils.toURI(hrefAttr.getNodeValue());
                     topicPath = job.tempDirURI.relativize(filePath.toURI().resolve(hrefUri));
                 }
                 if (resultTable.containsKey(topicPath)) {

--- a/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
@@ -32,9 +32,14 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
     )));
 
     private Map<String, Element> metaTable;
+    private String topicid = null;
 
     public void setMetaTable(final Map<String, Element> metaTable) {
         this.metaTable = metaTable;
+    }
+    
+    public void setTopicId(final String topicid) {
+        this.topicid = topicid;
     }
 
     public abstract Document process(final Document doc);
@@ -174,6 +179,49 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
             }
         }
         return res;
+    }
+ 
+    public Element getMatchingTopicElement(Element doc) {
+        Element res = null;
+        if (this.topicid == null) {
+            return matchFirstTopicInDoc(doc);
+        }
+        res = matchTopicElementById(doc);
+        if (res != null) {
+            return res;
+        } else {
+            return matchFirstTopicInDoc(doc);
+        }
+    }
+
+    private Element matchFirstTopicInDoc(Element doc) {
+        if (doc.getTagName().equals(ELEMENT_NAME_DITA)) {
+            return getFirstChildElement(doc, TOPIC_TOPIC);
+        } else {
+            return doc;
+        }
+    }
+ 
+    private Element matchTopicElementById(Element topic) {
+        if (!topic.getTagName().equals(ELEMENT_NAME_DITA) &&
+                topic.getAttribute(ATTRIBUTE_NAME_ID) != null &&
+                topic.getAttribute(ATTRIBUTE_NAME_ID).toString().equals(topicid)) {
+            return topic;
+        } else {
+            final NodeList children = topic.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                final Node child = children.item(i);
+                if (child.getNodeType() == Node.ELEMENT_NODE) {
+                    final Element elem = (Element) child;
+                    Element res = null;
+                    res = matchTopicElementById(elem);
+                    if (res != null) {
+                        return res;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private void insertAfter(final Node newChild, final Node refChild) {

--- a/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
@@ -9,6 +9,7 @@
 package org.dita.dost.writer;
 
 import org.dita.dost.util.DitaClass;
+import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -181,42 +182,32 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
         return res;
     }
  
-    public Element getMatchingTopicElement(Element doc) {
-        Element res = null;
-        if (this.topicid == null) {
-            return matchFirstTopicInDoc(doc);
+    public Element getMatchingTopicElement(Element root) {
+        if (this.topicid != null) {
+            final Element res = matchTopicElementById(root);
+            if (res != null) {
+                return res;
+            }
         }
-        res = matchTopicElementById(doc);
-        if (res != null) {
-            return res;
-        } else {
-            return matchFirstTopicInDoc(doc);
-        }
+        return matchFirstTopicInDoc(root);
     }
 
-    private Element matchFirstTopicInDoc(Element doc) {
-        if (doc.getTagName().equals(ELEMENT_NAME_DITA)) {
-            return getFirstChildElement(doc, TOPIC_TOPIC);
+    private Element matchFirstTopicInDoc(Element root) {
+        if (root.getTagName().equals(ELEMENT_NAME_DITA)) {
+            return getFirstChildElement(root, TOPIC_TOPIC);
         } else {
-            return doc;
+            return root;
         }
     }
  
     private Element matchTopicElementById(Element topic) {
-        if (topic.getAttribute(ATTRIBUTE_NAME_ID) != null &&
-                topic.getAttribute(ATTRIBUTE_NAME_ID).toString().equals(topicid)) {
+        if (topic.getAttribute(ATTRIBUTE_NAME_ID).equals(topicid)) {
             return topic;
         } else {
-            final NodeList children = topic.getChildNodes();
-            for (int i = 0; i < children.getLength(); i++) {
-                final Node child = children.item(i);
-                if (child.getNodeType() == Node.ELEMENT_NODE) {
-                    final Element elem = (Element) child;
-                    Element res = null;
-                    res = matchTopicElementById(elem);
-                    if (res != null) {
-                        return res;
-                    }
+            for (final Element elem : XMLUtils.getChildElements((topic))) {
+                final Element res = matchTopicElementById(elem);
+                if (res != null) {
+                    return res;
                 }
             }
         }

--- a/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
@@ -203,8 +203,7 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
     }
  
     private Element matchTopicElementById(Element topic) {
-        if (!topic.getTagName().equals(ELEMENT_NAME_DITA) &&
-                topic.getAttribute(ATTRIBUTE_NAME_ID) != null &&
+        if (topic.getAttribute(ATTRIBUTE_NAME_ID) != null &&
                 topic.getAttribute(ATTRIBUTE_NAME_ID).toString().equals(topicid)) {
             return topic;
         } else {

--- a/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
@@ -48,10 +48,7 @@ public final class DitaMapMetaWriter extends AbstractDitaMetaWriter {
     ));
 
     public Document process(final Document doc) {
-        Element root = doc.getDocumentElement();
-        if (root.getTagName().equals(ELEMENT_NAME_DITA)) {
-            root = getFirstChildElement(root, TOPIC_TOPIC);
-        }
+        Element root = getMatchingTopicElement(doc.getDocumentElement());
         if (hasMetadata(topicmetaOrder)) {
             final Element prolog = findMetadataContainer(root, topicmetaPosition, TOPIC_PROLOG);
             processMetadata(prolog, topicmetaOrder);

--- a/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
@@ -65,9 +65,6 @@ public final class DitaMetaWriter extends AbstractDitaMetaWriter {
 
     public Document process(final Document doc) {
         Element root = getMatchingTopicElement(doc.getDocumentElement());
-        if (root.getTagName().equals(ELEMENT_NAME_DITA)) {
-            root = getFirstChildElement(root, TOPIC_TOPIC);
-        }
         if (hasMetadata(titlealtsOrder)) {
             final Element titlealts = findMetadataContainer(root, titlealtsPosition, TOPIC_TITLEALTS);
             processMetadata(titlealts, titlealtsOrder);

--- a/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
@@ -64,7 +64,7 @@ public final class DitaMetaWriter extends AbstractDitaMetaWriter {
     ));
 
     public Document process(final Document doc) {
-        Element root = doc.getDocumentElement();
+        Element root = getMatchingTopicElement(doc.getDocumentElement());
         if (root.getTagName().equals(ELEMENT_NAME_DITA)) {
             root = getFirstChildElement(root, TOPIC_TOPIC);
         }

--- a/src/test/resources/MapMetaReaderTest/exp/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/exp/test.ditamap
@@ -295,4 +295,140 @@
       <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
     </topicmeta>
   </topicref>
+<topicref class="- map/topicref " href="nest.xml">
+<topicmeta class="- map/topicmeta ">
+<author class="- topic/author ">map author</author>
+<source class="- topic/source ">map source</source>
+<publisher class="- topic/publisher ">map publisher</publisher>
+<copyright class="- topic/copyright ">
+<copyryear class="- topic/copyryear " year="2010"/>
+<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+</copyright>
+<critdates class="- topic/critdates ">
+<created class="- topic/created " date="2010"/>
+<revised class="- topic/revised " modified="2010"/>
+</critdates>
+<permissions class="- topic/permissions " view="map permissins"/>
+<audience class="- topic/audience "/>
+<audience class="- topic/audience "/>
+<category class="- topic/category ">map category</category>
+<category class="- topic/category ">map category</category>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+</topicmeta>
+</topicref>
+<topicref class="- map/topicref " href="nest.xml#first">
+<topicmeta class="- map/topicmeta ">
+<author class="- topic/author ">map author</author>
+<source class="- topic/source ">map source</source>
+<publisher class="- topic/publisher ">map publisher</publisher>
+<copyright class="- topic/copyright ">
+<copyryear class="- topic/copyryear " year="2010"/>
+<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+</copyright>
+<critdates class="- topic/critdates ">
+<created class="- topic/created " date="2010"/>
+<revised class="- topic/revised " modified="2010"/>
+</critdates>
+<permissions class="- topic/permissions " view="map permissins"/>
+<audience class="- topic/audience "/>
+<audience class="- topic/audience "/>
+<category class="- topic/category ">map category</category>
+<category class="- topic/category ">map category</category>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+</topicmeta>
+</topicref>
+<topicref class="- map/topicref " href="nest.xml#second">
+<topicmeta class="- map/topicmeta ">
+<author class="- topic/author ">map author</author>
+<source class="- topic/source ">map source</source>
+<publisher class="- topic/publisher ">map publisher</publisher>
+<copyright class="- topic/copyright ">
+<copyryear class="- topic/copyryear " year="2010"/>
+<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+</copyright>
+<critdates class="- topic/critdates ">
+<created class="- topic/created " date="2010"/>
+<revised class="- topic/revised " modified="2010"/>
+</critdates>
+<permissions class="- topic/permissions " view="map permissins"/>
+<audience class="- topic/audience "/>
+<audience class="- topic/audience "/>
+<category class="- topic/category ">map category</category>
+<category class="- topic/category ">map category</category>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+</topicmeta>
+</topicref>
+<topicref class="- map/topicref " href="nest.xml#nest">
+<topicmeta class="- map/topicmeta ">
+<author class="- topic/author ">map author</author>
+<source class="- topic/source ">map source</source>
+<publisher class="- topic/publisher ">map publisher</publisher>
+<copyright class="- topic/copyright ">
+<copyryear class="- topic/copyryear " year="2010"/>
+<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+</copyright>
+<critdates class="- topic/critdates ">
+<created class="- topic/created " date="2010"/>
+<revised class="- topic/revised " modified="2010"/>
+</critdates>
+<permissions class="- topic/permissions " view="map permissins"/>
+<audience class="- topic/audience "/>
+<audience class="- topic/audience "/>
+<category class="- topic/category ">map category</category>
+<category class="- topic/category ">map category</category>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<prodinfo class="- topic/prodinfo ">
+<prodname class="- topic/prodname ">map prodnamefoo</prodname>
+<vrmlist class="- topic/vrmlist ">
+<vrm class="- topic/vrm " version="1.0"/>
+</vrmlist>
+</prodinfo>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+</topicmeta>
+</topicref>
 </map>

--- a/src/test/resources/MapMetaReaderTest/src/nest.xml
+++ b/src/test/resources/MapMetaReaderTest/src/nest.xml
@@ -1,0 +1,27 @@
+<dita xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.3">
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+domains="(topic hi-d)"
+id="first" ditaarch:DITAArchVersion="1.3">
+<title class="- topic/title ">first</title>
+<prolog class="- topic/prolog ">
+<metadata class="- topic/metadata ">
+<audience class="- topic/audience "/>
+</metadata>
+</prolog>
+</topic>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+domains="(topic hi-d)"
+id="second" ditaarch:DITAArchVersion="1.3">
+<title class="- topic/title ">Second</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+domains="(topic hi-d)"
+id="nest" ditaarch:DITAArchVersion="1.3">
+<title class="- topic/title ">Nested in second</title>
+<prolog class="- topic/prolog ">
+<metadata class="- topic/metadata ">
+<audience class="- topic/audience "/>
+</metadata>
+</prolog>
+</topic>
+</topic>
+</dita>

--- a/src/test/resources/MapMetaReaderTest/src/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/src/test.ditamap
@@ -187,4 +187,8 @@
       <unknown class="- topic/unknown ">topicref unknown</unknown>
     </topicmeta>
   </topicref>
+  <topicref class="- map/topicref " href="nest.xml"/>
+  <topicref class="- map/topicref " href="nest.xml#first"/>
+  <topicref class="- map/topicref " href="nest.xml#second"/>
+  <topicref class="- map/topicref " href="nest.xml#nest"/>
 </map>


### PR DESCRIPTION
Maps that contain many references to the same document (but with different topic IDs) are handled incorrectly in the `move-meta` process. Each reference to an individual topic is treated as a reference to the overall document, leading to the following condition:

We have a document with over 500 topics in it, each one defining an error message with response/recovery info. Each topic is referenced in the TOC so that the TOC includes every message. Any time we process this topic, the build fails with a core dump and memory error. For example:

```
move-meta-entries:
[move-meta] Processing file:/home/workspace/Transform@2/tmp/srv.msgs/plugin_msgs.ditamap
JVMDUMP039I Processing dump event "systhrow", detail "java/lang/OutOfMemoryError" at 2018/10/22 15:00:31 - please wait.
```

I've reproduced this with a generated map/topic document that reliably crashes when processing around the 480th reference to the document.
[outofmemory.zip](https://github.com/dita-ot/dita-ot/files/2511813/outofmemory.zip)


Diagnosed the cause:

- The first reference to any topic within the document (or to the document overall) creates an entry in the metadata table using the document file name. All metadata specified on that `topicref` is combined with metadata that cascades from the ancestry tree and placed in the table. That combination is written back out to the `topicref` metadata.
- With the next reference to any topic within the document, there is already an entry in the metadata table. All metadata specified on this `topicref` is combined with ancestor metadata and added to the table. **If this reference is in the same branch of the map, it means all cascading metadata added to the table twice, and written twice into this topicref.**
- If the two references to a file are actually to `file.dita#foo` and `file.dita#bar`, and specify unique metadata (like different `audience` elements), those are combined because the table only tracks by file name; this means the second reference to`file.dita#bar` writes out `audience` metadata that applies to both `#foo` and `#bar`
- By the 500th reference to the document, the metadata table has 500 copies of whatever metadata cascaded from above, plus whatever metadata existed in every one of the 500 previous references to independent topics. It writes out those 500 copies into the result tree for this single topic reference (after writing out 499 copies in the previous reference). Even with a small amount of cascading metadata this point is enough to hit out-of-memory errors.

The update:

- Changes the metadata table so that metadata for topics is stored using the actual reference. If you have two references to `myfile.dita`, you still get one entry in the table, and metadata is merged. If you have 500 entries to `file.dita#msg1`, `file.dita#msg2`, ... `file.dita#msg500` then you get 500 entries.
- When writing the metadata into the referenced file, it now uses that topic ID. When no ID is specified (or when the ID cannot be found on a topic in the document), it still merges metadata into the first topic. When a topic ID is specified and found, the metadata is now written to that specific topic.
- Added benefit / fix: if I've specified different metadata for each reference to a different topic in the document, those are no longer combined, and `move-meta` now writes them out to the intended topic within the document.

This still isn't the most _efficient_ way to process the document I've got, because with `<topicref>` elements that refer to 500 topics in a large document, we process the document 500 times (once for each entry in the table) to write metadata out. However, for this rather extreme edge case, that's preferable to the current behavior; inefficient processing is better than the old behavior of incorrect output + build failure, and could still be optimized in the future.