### PR TITLE
Fix for URI Exception when conref has backslash

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -660,7 +660,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             } else if (attrValue.startsWith(SHARP)) {
                 filename = currentFile;
             } else {
-                filename = currentDir.resolve(attrValue);
+                filename = currentDir.resolve(target);
             }
             filename = stripFragment(filename);
 

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -83,7 +83,8 @@ public final class ValidationFilter extends AbstractXMLFilter {
         AttributesImpl modified;
         modified = validateLang(atts, null);
         modified = validateId(localName, atts, modified);
-        modified = validateHref(atts, modified);
+        modified = validateReference(ATTRIBUTE_NAME_HREF, atts, modified);
+        modified = validateReference(ATTRIBUTE_NAME_CONREF, atts, modified);
         modified = validateScope(atts, modified);
         modified = processFormatDitamap(atts, modified);
         validateKeys(atts);
@@ -175,13 +176,13 @@ public final class ValidationFilter extends AbstractXMLFilter {
     }
 
     /**
-     * Validate and fix {@code href} attribute for URI validity.
+     * Validate and fix {@code href} or {@code conref} attribute for URI validity.
      *
      * @return modified attributes, {@code null} if there have been no changes
      */
-    private AttributesImpl validateHref(final Attributes atts, final AttributesImpl modified) {
+    private AttributesImpl validateReference (final String attrName, final Attributes atts, final AttributesImpl modified) {
         AttributesImpl res = modified;
-        final String href = atts.getValue(ATTRIBUTE_NAME_HREF);
+        final String href = atts.getValue(attrName);
         if (href != null) {
             URI uri = null;
             try {
@@ -189,9 +190,9 @@ public final class ValidationFilter extends AbstractXMLFilter {
             } catch (final URISyntaxException e) {
                 switch (processingMode) {
                 case STRICT:
-                    throw new RuntimeException(MessageUtils.getMessage("DOTJ054E", ATTRIBUTE_NAME_HREF, href).setLocation(locator) + ": " + e.getMessage(), e);
+                    throw new RuntimeException(MessageUtils.getMessage("DOTJ054E", attrName, href).setLocation(locator) + ": " + e.getMessage(), e);
                 case SKIP:
-                    logger.error(MessageUtils.getMessage("DOTJ054E", ATTRIBUTE_NAME_HREF, href).setLocation(locator) + ", using invalid value.");
+                    logger.error(MessageUtils.getMessage("DOTJ054E", attrName, href).setLocation(locator) + ", using invalid value.");
                     break;
                 case LAX:
                     try {
@@ -199,10 +200,10 @@ public final class ValidationFilter extends AbstractXMLFilter {
                         if (res == null) {
                             res = new AttributesImpl(atts);
                         }
-                        res.setValue(res.getIndex(ATTRIBUTE_NAME_HREF), uri.toASCIIString());
-                        logger.error(MessageUtils.getMessage("DOTJ054E", ATTRIBUTE_NAME_HREF, href).setLocation(locator) + ", using '" + uri.toASCIIString() + "'.");
+                        res.setValue(res.getIndex(attrName), uri.toASCIIString());
+                        logger.error(MessageUtils.getMessage("DOTJ054E", attrName, href).setLocation(locator) + ", using '" + uri.toASCIIString() + "'.");
                     } catch (final URISyntaxException e1) {
-                        logger.error(MessageUtils.getMessage("DOTJ054E", ATTRIBUTE_NAME_HREF, href).setLocation(locator) + ", using invalid value.");
+                        logger.error(MessageUtils.getMessage("DOTJ054E", attrName, href).setLocation(locator) + ", using invalid value.");
                     }
                     break;
                 }

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -180,13 +180,12 @@ public final class ValidationFilter extends AbstractXMLFilter {
      *
      * @return modified attributes, {@code null} if there have been no changes
      */
-    private AttributesImpl validateReference (final String attrName, final Attributes atts, final AttributesImpl modified) {
+    private AttributesImpl validateReference(final String attrName, final Attributes atts, final AttributesImpl modified) {
         AttributesImpl res = modified;
         final String href = atts.getValue(attrName);
         if (href != null) {
-            URI uri = null;
             try {
-                uri = new URI(href);
+                new URI(href);
             } catch (final URISyntaxException e) {
                 switch (processingMode) {
                 case STRICT:
@@ -196,7 +195,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
                     break;
                 case LAX:
                     try {
-                        uri = new URI(URLUtils.clean(href.trim()));
+                        final URI uri = new URI(URLUtils.clean(href.trim()));
                         if (res == null) {
                             res = new AttributesImpl(atts);
                         }

--- a/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
@@ -90,6 +90,31 @@ public class ValidationFilterTest {
         assertEquals("http://example.com/foo/bar%20baz:qux", res.get(0));
         assertEquals("http://example.com/valid/bar+baz:qux", res.get(1));
     }
+    
+    @Test
+    public void testConref() throws SAXException, URISyntaxException {
+        final List<String> res = new ArrayList<String>();
+        f.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+                res.add(atts.getValue(ATTRIBUTE_NAME_CONREF));
+            }
+        });
+        final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
+        f.setLogger(l);
+
+        f.startElement(NULL_NS_URI, TOPIC_KEYWORD.localName, TOPIC_KEYWORD.localName, new AttributesBuilder()
+                .add(ATTRIBUTE_NAME_CONREF, "sub\\backslash.dita#topic/back")
+                .build());
+        f.startElement(NULL_NS_URI, TOPIC_KEYWORD.localName, TOPIC_KEYWORD.localName, new AttributesBuilder()
+                .add(ATTRIBUTE_NAME_CONREF, "sub/slash.dita#topic/valid")
+                .build());
+
+        assertEquals(1, l.getMessages().size());
+        assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
+        assertEquals("sub/backslash.dita#topic/back", res.get(0));
+        assertEquals("sub/slash.dita#topic/valid", res.get(1));
+    }
 
     @Test
     public void testScope() throws SAXException, URISyntaxException {


### PR DESCRIPTION
Today when a `@conref` attribute includes a backslash, the build fails with a Java exception (both `preprocess` and `preprocess2`). For example:
`Error: Failed to run pipeline: Illegal character in path at index 33: ../../folder\doc\library.dita#common/keyword`

The `@conref` attribute is not currently normalized like `@href` attributes are, but code that reads the attribute expects a valid URI. When it finds the backslash, it fails with the exception.

The fix adds a test for this condition in the Validation Filter, and makes two updates:

- For `preprocess`, the conref parse method currently runs `toURI()` to normalize the value before using it, but then uses the original string when the target is a relative path. This fixes the exception in `gen-list` by using the normalized value.
- Also updates `ValidationFilter` which is used by both `preprocess` and `preprocess2`, so that we run the same normalization on `@conref` that we run on `@href`, including warnings if the value is not a URI + failure if not a URI and running in strict mode.