### PR TITLE
Fix evaluation of char att in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -508,7 +508,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="char" as="xs:string"/>
     <xsl:param name="charoff" as="xs:integer"/>
         <xsl:choose>
-            <xsl:when test="not(descendant::*)">
+            <xsl:when test="not(descendant::* | descendant::processing-instruction() | descendant::comment())">
                 <xsl:variable name="text-before" select="substring-before(text(), $char)"/>
                 <xsl:variable name="text-after" select="substring-after(text(), $text-before)"/>
                 <fo:list-block start-indent="0pt"


### PR DESCRIPTION
The CALS attribute `@char` on table entries can be used to adjust alignment of entry content based on a specific character in a cell. The current code ignores the attribute entirely when there are sub-elements (it's not clear how that alignment would even be managed) -- the `@char` attribute is ignored for this case:
`<xsl:when test="not(descendant::*)">`

I've got some content from an old system that specified `@char` attributes which were always ignored. Some of the entries contained comments or processing instructions, such as:
`<entry char=".">test<?linebreak?>this</entry>`

That PI causes an XSLT failure, because we end up trying to run `substring` operations on a sequence of two text nodes -- we get the following build failure in `tables.xsl`:
`A sequence of more than one item is not allowed as the first argument of substring-before()`

This update extends the check for sub-elements so that we also do not try to run `substring` operations around processing instructions or comments.
