### PR TITLE
Fix support for non-file input URI

### DIFF
--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -91,8 +91,8 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
     @Override
     public void startDocument() throws SAXException {
         // XXX May be require fixup
-        final File relativeToMap = FileUtils.getRelativePath(toFile(job.getInputFile()), toFile(currentFile));
-        final File path2Project = DebugAndFilterModule.getPathtoProject(relativeToMap,
+        final URI relativeToMap = URLUtils.getRelativePath(job.getInputFile(), currentFile);
+        final File path2Project = DebugAndFilterModule.getPathtoProject(toFile(relativeToMap),
                 toFile(currentFile),
                 toFile(job.getInputFile()),
                 job);


### PR DESCRIPTION
Resolution of base directory assumes input file to be a local file URI. Fix support to support non-local URIs.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>