### PR TITLE
Feature/2523 keyscopes in flattened map not handled

### DIFF
--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -260,6 +260,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
         if (hrefNode == null) {
             hrefNode = elem.getAttributeNode(ATTRIBUTE_NAME_HREF);
         }
+        if (hrefNode == null && SUBMAP.matches(elem)) {
+            hrefNode = elem.getAttributeNode(ATTRIBUTE_NAME_DITA_OT_ORIG_HREF);
+        }
         final boolean isResourceOnly = isResourceOnly(elem);
         for (final KeyScope s: ss) {
             if (hrefNode != null) {

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -934,6 +934,8 @@ public final class Constants {
     public static final String DITA_OT_NS_PREFIX = "dita-ot";
     public static final String DITA_OT_NAMESPACE = "http://dita-ot.sourceforge.net";
     public static final String DITA_OT_NS = "http://dita-ot.sourceforge.net/ns/201007/dita-ot";
+    /**dita-ot:orig-href.*/
+    public static final String ATTRIBUTE_NAME_DITA_OT_ORIG_HREF = DITA_OT_NS_PREFIX + ":" + "orig-href";
 
 
     /**ATTR_CLASS_VALUE_SUBJECT_SCHEME_BASE. Deprecated since 3.0 */

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -119,7 +119,11 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             ATTRIBUTE_NAME_DATAKEYREF
     ));
 
-    private KeyScope definitionMap;
+
+    /**
+     * Stack used to store the current KeyScope, and its start uri.
+     */
+    private final Deque<KeyScopeInfo> definitionMaps;
 
     /**
      * Stack used to store the place of current element
@@ -149,8 +153,11 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     private boolean empty;
 
+    /** Stack of element names. */
+    private final Deque<String> elemNames;
+
     /** Stack of element names of the element containing keyref attribute. */
-    private final Deque<String> elemName;
+    private final Deque<String> keyRefElemNames;
 
     /** Current element keyref info, {@code null} if not keyref type element. */
     private KeyrefInfo currentElement;
@@ -172,12 +179,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     public KeyrefPaser() {
         keyrefLevel = 0;
+        definitionMaps = new ArrayDeque<>();
         keyrefLevalStack = new ArrayDeque<>();
         validKeyref = new ArrayDeque<>();
         empty = true;
-        elemName = new ArrayDeque<>();
+        elemNames = new ArrayDeque<>();
+        keyRefElemNames = new ArrayDeque<>();
         hasSubElem = new ArrayDeque<>();
         mergeUtils = new MergeUtils();
+    }
+
+    public String getCurrentElemId() {
+        return String.join(".", elemNames);
     }
 
     @Override
@@ -187,7 +200,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     }
 
     public void setKeyDefinition(final KeyScope definitionMap) {
-        this.definitionMap = definitionMap;
+        this.definitionMaps.push(new KeyScopeInfo(null, definitionMap));
     }
 
     /**
@@ -232,7 +245,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
 
     @Override
     public void endElement(final String uri, final String localName, final String name) throws SAXException {
-        if (keyrefLevel != 0 && empty && !elemName.peek().equals(MAP_TOPICREF.localName)) {
+        if (keyrefLevel != 0 && empty && !keyRefElemNames.peek().equals(MAP_TOPICREF.localName)) {
             // If current element is in the scope of key reference element
             // and the element is empty
             if (!validKeyref.isEmpty() && validKeyref.peek()) {
@@ -241,7 +254,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 // need to pull matching content from the key definition
                 // If current element name doesn't equal the key reference element
                 // just grab the content from the matching element of key definition
-                if (!name.equals(elemName.peek())) {
+                if (!name.equals(keyRefElemNames.peek())) {
                     final NodeList nodeList = elem.getElementsByTagName(name);
                     if (nodeList.getLength() > 0) {
                         final Element node = (Element) nodeList.item(0);
@@ -373,9 +386,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             // To the end of key reference, pop the stacks.
             keyrefLevel = keyrefLevalStack.pop();
             validKeyref.pop();
-            elemName.pop();
+            keyRefElemNames.pop();
             hasSubElem.pop();
         }
+
+        final String keyscopeElemID = definitionMaps.peek().id;
+        if (keyscopeElemID != null && keyscopeElemID.equals(getCurrentElemId())) {
+            definitionMaps.pop();
+            logger.debug("Using " + (definitionMaps.peek().scope.name != null ? definitionMaps.peek().scope.name + " scope" : "root scope"));
+        }
+
+        elemNames.pop();
+
         getContentHandler().endElement(uri, localName, name);
     }
 
@@ -436,6 +458,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     @Override
     public void startElement(final String uri, final String localName, final String name,
             final Attributes atts) throws SAXException {
+
+        elemNames.push(name);
+        final String keyscopeName = atts.getValue(ATTRIBUTE_NAME_KEYSCOPE);
+        if (keyscopeName != null) {
+            KeyScope childScope = definitionMaps.peek().scope.getChildScope(keyscopeName);
+
+            if (childScope != null) {
+                logger.debug("Using " + (childScope.name != null ? childScope.name + " scope" : "root scope"));
+                definitionMaps.push(new KeyScopeInfo(getCurrentElemId(), childScope));
+            }
+        }
+
         currentElement = null;
         final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
         for (final KeyrefInfo k : keyrefInfos) {
@@ -455,7 +489,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 hasSubElem.push(true);
             }
         } else {
-            elemName.push(name);
+            keyRefElemNames.push(name);
             if (keyrefLevel != 0) {
                 keyrefLevalStack.push(keyrefLevel);
                 hasSubElem.pop();
@@ -488,7 +522,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                     elementId = keyrefValue.substring(slashIndex);
                 }
 
-                keyDef = definitionMap.get(keyName);
+                keyDef = definitionMaps.peek().scope.get(keyName);
                 final Element elem = keyDef != null ? keyDef.element : null;
 
                 // If definition is not null
@@ -557,9 +591,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                             XMLUtils.removeAttribute(resAtts, ATTRIBUTE_NAME_FORMAT);
                         } else {
                             // key does not exist.
-                            final MessageBean m = definitionMap.name == null
+                            final MessageBean m = definitionMaps.peek().scope.name == null
                                     ? MessageUtils.getMessage("DOTJ047I", atts.getValue(ATTRIBUTE_NAME_KEYREF))
-                                    : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMap.name);
+                                    : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMaps.peek().scope.name);
                             logger.info(m.setLocation(atts).toString());
                         }
 
@@ -586,9 +620,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                     }
                 } else {
                     // key does not exist
-                    final MessageBean m = definitionMap.name == null
+                    final MessageBean m = definitionMaps.peek().scope.name == null
                             ? MessageUtils.getMessage("DOTJ047I", atts.getValue(ATTRIBUTE_NAME_KEYREF))
-                            : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMap.name);
+                            : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMaps.peek().scope.name);
                     logger.info(m.setLocation(atts).toString());
                 }
 
@@ -763,6 +797,27 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             this.attrs = attrs;
             this.isEmpty = isEmpty;
             this.hasNestedElements = hasNestedElements;
+        }
+    }
+
+    /** Store keyscope start information. **/
+    private final class KeyScopeInfo {
+        /** Element identifier from getCurrentElemId(). */
+        String id;
+
+        /** KeyScope */
+        KeyScope scope;
+
+
+        /**
+         * Construct a new key scope info object.
+         *
+         * @param id id generated by getCurrentElemId()
+         * @param scope key scope
+         */
+        private KeyScopeInfo(String id, KeyScope scope) {
+            this.id = id;
+            this.scope = scope;
         }
     }
 

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -122,6 +122,19 @@ public class KeyrefPaserTest {
     }
 
     @Test
+    public void testMapWithKeyScopes() throws Exception {
+        final KeyrefPaser parser = new KeyrefPaser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(srcDir));
+        parser.setKeyDefinition(keyDefinition);
+        parser.setCurrentFile(new File(srcDir, "d.ditamap").toURI());
+        parser.write(new File(srcDir, "d.ditamap"));
+
+        assertXMLEqual(new InputSource(new File(expDir, "d.ditamap").toURI().toString()),
+                new InputSource(new File(srcDir, "d.ditamap").toURI().toString()));
+    }
+
+    @Test
     public void testDomToSax() throws TransformerConfigurationException, SAXException, IOException, ParserConfigurationException, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         final DocumentBuilder b = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -30,6 +30,7 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 
+import org.dita.dost.reader.KeyrefReader;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
@@ -172,25 +173,17 @@ public class KeyrefPaserTest {
     }
 
     private static KeyScope readKeyMap(final Path map) throws Exception {
+
+        KeyrefReader reader = new KeyrefReader();
         final URI keyMapFile = srcDir.toPath().resolve(map).toUri();
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         final InputSource inputSource = new InputSource(keyMapFile.toString());
         final DocumentBuilder documentBuilder = factory.newDocumentBuilder();
         final Document document = documentBuilder.parse(inputSource);
 
-        final Map<String, Element> keys = new HashMap<>();
-        final NodeList keydefs = document.getElementsByTagName("keydef");
-        final Map<String, KeyDef> keymap = new HashMap<>();
-        for (int i = 0; i < keydefs.getLength(); i++) {
-            final Element elem = (Element) keydefs.item(i);
-            final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-            doc.appendChild(doc.importNode(elem, true));
-            keys.put(elem.getAttribute("keys"), elem);
-            final KeyDef keyDef = new KeyDef(elem.getAttribute("keys"), new URI(elem.getAttribute("href")),
-                    null, null, srcDir.toPath().resolve(map).toUri(), elem);
-            keymap.put(keyDef.keys, keyDef);
-        }
-        return new KeyScope(null, null, keymap, Collections.emptyList());
+        reader.read(keyMapFile, document);
+
+        return reader.getKeyDefinition();
     }
 
 }

--- a/src/test/resources/KeyrefModuleTest/exp/test.ditamap
+++ b/src/test/resources/KeyrefModuleTest/exp/test.ditamap
@@ -2,6 +2,9 @@
   <topicref class="- map/topicref " href="topic.dita"/>
   <topicref class="- map/topicref " href="topic.dita"/>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="A">
+    <submap class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap " dita-ot:orig-class="+ map/topicref mapgroup-d/mapref " dita-ot:orig-format="ditamap" dita-ot:orig-href="submap.ditamap" dita-ot:submap-DITAArchVersion="1.3" dita-ot:submap-cascade="merge" dita-ot:submap-class="- map/map " dita-ot:submap-domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" dita-ot:submap-title="Ditamap A">
+      <topicref class="- map/topicref " href="topic-1.dita"/>
+    </submap>
     <topicref class="- map/topicref " href="topic-1.dita"/>
     <topicref class="- map/topicref " href="topic-1.dita"/>
   </topicgroup>

--- a/src/test/resources/KeyrefModuleTest/src/submap.ditamap
+++ b/src/test/resources/KeyrefModuleTest/src/submap.ditamap
@@ -1,0 +1,3 @@
+<map title="Ditamap A" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" cascade="merge" class="- map/map " ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <topicref class="- map/topicref " href="topic.dita"/>
+</map>

--- a/src/test/resources/KeyrefModuleTest/src/test.ditamap
+++ b/src/test/resources/KeyrefModuleTest/src/test.ditamap
@@ -2,6 +2,9 @@
   <topicref class="- map/topicref " href="topic.dita"/>
   <topicref class="- map/topicref " href="topic.dita"/>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="A">
+    <submap class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap " dita-ot:orig-class="+ map/topicref mapgroup-d/mapref " dita-ot:orig-format="ditamap" dita-ot:orig-href="submap.ditamap" dita-ot:submap-DITAArchVersion="1.3" dita-ot:submap-cascade="merge" dita-ot:submap-class="- map/map " dita-ot:submap-domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" dita-ot:submap-title="Ditamap A">
+       <topicref class="- map/topicref " href="topic.dita"/>
+    </submap>
     <topicref class="- map/topicref " href="topic.dita"/>
     <topicref class="- map/topicref " href="topic.dita"/>
   </topicgroup>

--- a/src/test/resources/KeyrefPaserTest/exp/b.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/b.ditamap
@@ -92,5 +92,5 @@
     <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link"/>
     <navref class="- map/navref " keyref="navref_link" mapref="a.xml"/>
   </topicgroup>
-  <topicref class="- map/topicref " keyref="copy" href="a.xml" copy-to="a-copy.xml"/>
+  <topicref class="- map/topicref " keyref="copy" href="a-copy.xml" copy-to="a-copy.xml"/>
 </map>

--- a/src/test/resources/KeyrefPaserTest/exp/d.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/d.ditamap
@@ -1,0 +1,28 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.2">
+
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="KEY_SCOPE">
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_topicref_link" type="dead"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_author_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data-about_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_publisher_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_source_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indexterm_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_index-base_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indextermref_link"/>
+    <navref class="- map/navref " keyref="ks_navref_link" mapref="a.xml"/>
+
+    <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="author_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="data_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="data-about_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="publisher_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="source_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="indexterm_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="index-base_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link"/>
+    <navref class="- map/navref " keyref="navref_link" mapref="a.xml"/>
+  </topicgroup>
+</map>

--- a/src/test/resources/KeyrefPaserTest/src/d.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/d.ditamap
@@ -1,0 +1,30 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.2">
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="KEY_SCOPE">
+
+    <!-- Test scoped keys -->
+    <topicref class="- map/topicref " format="dead" href="dead" keyref="ks_topicref_link" scope="external" type="dead"/>
+    <topicref class="- map/topicref " keyref="ks_author_link"/>
+    <topicref class="- map/topicref " keyref="ks_data_link"/>
+    <topicref class="- map/topicref " keyref="ks_data-about_link"/>
+    <topicref class="- map/topicref " keyref="ks_publisher_link"/>
+    <topicref class="- map/topicref " keyref="ks_source_link"/>
+    <topicref class="- map/topicref " keyref="ks_indexterm_link"/>
+    <topicref class="- map/topicref " keyref="ks_index-base_link"/>
+    <topicref class="- map/topicref " keyref="ks_indextermref_link"/>
+    <navref class="- map/navref " keyref="ks_navref_link"/>
+
+    <!-- Test non-scoped keys -->
+    <topicref class="- map/topicref " format="dead" href="dead" keyref="topicref_link" scope="external" type="dead"/>
+    <topicref class="- map/topicref " keyref="author_link"/>
+    <topicref class="- map/topicref " keyref="data_link"/>
+    <topicref class="- map/topicref " keyref="data-about_link"/>
+    <topicref class="- map/topicref " keyref="publisher_link"/>
+    <topicref class="- map/topicref " keyref="source_link"/>
+    <topicref class="- map/topicref " keyref="indexterm_link"/>
+    <topicref class="- map/topicref " keyref="index-base_link"/>
+    <topicref class="- map/topicref " keyref="indextermref_link"/>
+    <navref class="- map/navref " keyref="navref_link"/>
+  </topicgroup>
+</map>

--- a/src/test/resources/KeyrefPaserTest/src/keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/keys.ditamap
@@ -477,6 +477,488 @@
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="root" href="a.xml"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="root-with-id" href="a.xml#a"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="nested-with-id" href="a.xml#nolink"/>
+
+
+  <!-- Keys to test key scope resolution -->
+  <topicgroup keyscope="KEY_SCOPE">
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_empty" processing-role="resource-only"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_third" processing-role="resource-only"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_second" processing-role="resource-only"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " collection-type="family" format="html" href="a.xml" id="override" keys="ks_all" linking="sourceonly" locktitle="yes" navtitle="override"
+            processing-role="normal">
+      <topicmeta class="- map/topicmeta ">
+        <navtitle class="- topic/navtitle ">navtitle</navtitle>
+        <linktext class="- map/linktext ">linktext</linktext>
+        <searchtitle class="- map/searchtitle ">searchtitle</searchtitle>
+        <shortdesc class="- map/shortdesc ">shortdesc</shortdesc>
+        <author class="- topic/author ">author</author>
+        <source class="- topic/source ">source</source>
+        <publisher class="- topic/publisher ">publisher</publisher>
+        <copyright class="- topic/copyright ">
+          <copyryear class="- topic/copyryear " year="2012"/>
+          <copyrholder class="- topic/copyrholder ">Example</copyrholder>
+        </copyright>
+        <critdates class="- topic/critdates ">
+          <created class="- topic/created " date="2012-08-16"/>
+        </critdates>
+        <permissions class="- topic/permissions " view="all"/>
+        <metadata class="- topic/metadata ">
+          <audience class="- topic/audience " name="metadata-audience"/>
+          <category class="- topic/category ">metadata category</category>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">metadata keywords</keyword>
+          </keywords>
+          <prodinfo class="- topic/prodinfo ">
+            <prodname class="- topic/prodname ">metadata test</prodname>
+            <vrmlist class="- topic/vrmlist ">
+              <vrm class="- topic/vrm " version="1"/>
+            </vrmlist>
+          </prodinfo>
+          <othermeta class="- topic/othermeta " content="metadata-othermeta" name="metadata-othermeta"/>
+          <data class="- topic/data ">metadata data</data>
+          <data-about class="- topic/data-about ">
+            <data class="- topic/data ">metadata data-about</data>
+          </data-about>
+          <foreign class="- topic/foreign ">metadata foreign</foreign>
+          <unknown class="- topic/unknown ">metadata unknown</unknown>
+        </metadata>
+        <audience class="- topic/audience " name="audience"/>
+        <category class="- topic/category ">category</category>
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">keywords</keyword>
+        </keywords>
+        <exportanchors class="+ topic/keywords delay-d/exportanchors ">
+          <anchorid class="+ topic/keyword delay-d/anchorid " id="anchorid"/>
+        </exportanchors>
+        <prodinfo class="- topic/prodinfo ">
+          <prodname class="- topic/prodname ">test</prodname>
+          <vrmlist class="- topic/vrmlist ">
+            <vrm class="- topic/vrm " version="1"/>
+          </vrmlist>
+        </prodinfo>
+        <othermeta class="- topic/othermeta " content="othermeta" name="othermeta"/>
+        <resourceid class="- topic/resourceid " id="resourceid"/>
+        <data class="- topic/data ">data</data>
+        <data-about class="- topic/data-about ">
+          <data class="- topic/data ">data-about</data>
+        </data-about>
+        <foreign class="- topic/foreign ">foreign</foreign>
+        <unknown class="- topic/unknown ">unknown</unknown>
+      </topicmeta>
+    </keydef>
+    <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_author" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">author linktext</linktext>
+          <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+          <author class="- topic/author ">author author</author>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">author keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_data" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">data linktext</linktext>
+          <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">data keyword</keyword>
+          </keywords>
+          <data class="- topic/data ">data data</data>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_data-about" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">data-about linktext</linktext>
+          <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">data-about keyword</keyword>
+          </keywords>
+          <data-about class="- topic/data-about ">
+            <data class="- topic/data ">data-about data-about</data>
+          </data-about>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_image" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">image linktext</linktext>
+          <shortdesc class="- map/shortdesc ">image shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">image keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">link linktext</linktext>
+          <shortdesc class="- map/shortdesc ">link shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">link keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_lq" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">lq linktext</linktext>
+          <shortdesc class="- map/shortdesc ">lq shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">lq keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_navref" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">navref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">navref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">navref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_publisher" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">publisher linktext</linktext>
+          <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+          <publisher class="- topic/publisher ">publisher publisher</publisher>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">publisher keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_source" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">source linktext</linktext>
+          <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+          <source class="- topic/source ">source source</source>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">source keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_topicref" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">topicref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">topicref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_xref" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">xref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">xref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">xref keyword</keyword>
+            <keyword class="- topic/keyword ">xref keyword B</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_cite" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">cite linktext</linktext>
+          <shortdesc class="- map/shortdesc ">cite shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">cite keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_dt" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">dt linktext</linktext>
+          <shortdesc class="- map/shortdesc ">dt shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">dt keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_keyword" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">keyword linktext</linktext>
+          <shortdesc class="- map/shortdesc ">keyword shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">keyword keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_term" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">term linktext</linktext>
+          <shortdesc class="- map/shortdesc ">term shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">term keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_ph" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">ph linktext</linktext>
+          <shortdesc class="- map/shortdesc ">ph shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">ph keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_indexterm" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">indexterm linktext</linktext>
+          <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">indexterm keyword</keyword>
+            <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_index-base" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">index-base linktext</linktext>
+          <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">index-base keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_indextermref" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">indextermref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">indextermref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_object" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">object linktext</linktext>
+          <shortdesc class="- map/shortdesc ">object shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">object keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_param" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">param linktext</linktext>
+          <shortdesc class="- map/shortdesc ">param shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">param keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+    </topicgroup>
+    <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_author_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">author linktext</linktext>
+          <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+          <author class="- topic/author ">author author</author>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">author keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_data_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">data linktext</linktext>
+          <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">data keyword</keyword>
+          </keywords>
+          <data class="- topic/data ">data data</data>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_data-about_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">data-about linktext</linktext>
+          <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">data-about keyword</keyword>
+          </keywords>
+          <data-about class="- topic/data-about ">
+            <data class="- topic/data ">data-about data-about</data>
+          </data-about>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="b.gif" keys="ks_image_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">image linktext</linktext>
+          <shortdesc class="- map/shortdesc ">image shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">image keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="b.gif" keys="ks_image_link_common" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">Normal practice: use linktext for alt text</linktext>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_link_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">link linktext</linktext>
+          <shortdesc class="- map/shortdesc ">link shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">link keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_lq_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">lq linktext</linktext>
+          <shortdesc class="- map/shortdesc ">lq shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">lq keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_navref_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">navref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">navref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">navref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_publisher_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">publisher linktext</linktext>
+          <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+          <publisher class="- topic/publisher ">publisher publisher</publisher>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">publisher keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_source_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">source linktext</linktext>
+          <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+          <source class="- topic/source ">source source</source>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">source keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_topicref_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">topicref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">topicref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_xref_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">xref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">xref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">xref keyword</keyword>
+            <keyword class="- topic/keyword ">xref keyword B</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_cite_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">cite linktext</linktext>
+          <shortdesc class="- map/shortdesc ">cite shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">cite keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_dt_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">dt linktext</linktext>
+          <shortdesc class="- map/shortdesc ">dt shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">dt keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_keyword_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">keyword linktext</linktext>
+          <shortdesc class="- map/shortdesc ">keyword shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">keyword keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_term_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">term linktext</linktext>
+          <shortdesc class="- map/shortdesc ">term shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">term keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_ph_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">ph linktext</linktext>
+          <shortdesc class="- map/shortdesc ">ph shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">ph keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_indexterm_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">indexterm linktext</linktext>
+          <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">indexterm keyword</keyword>
+            <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_index-base_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">index-base linktext</linktext>
+          <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">index-base keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_indextermref_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">indextermref linktext</linktext>
+          <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">indextermref keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_object_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">object linktext</linktext>
+          <shortdesc class="- map/shortdesc ">object shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">object keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+      <keydef class="+ map/topicref mapgroup-d/keydef " href="a.xml" keys="ks_param_link" processing-role="resource-only">
+        <topicmeta class="- map/topicmeta ">
+          <linktext class="- map/linktext ">param linktext</linktext>
+          <shortdesc class="- map/shortdesc ">param shortdesc</shortdesc>
+          <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">param keyword</keyword>
+          </keywords>
+        </topicmeta>
+      </keydef>
+    </topicgroup>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_scope-local" href="a.xml"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_scope-peer" href="b.xml" scope="peer"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_scope-external" href="http://www.example.com/" format="html" scope="external"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_root" href="a.xml"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_root-with-id" href="a.xml#a"/>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="ks_nested-with-id" href="a.xml#nolink"/>
+  </topicgroup>
+
   <!-- Keys to test fallback text resolution against DITA 1.3 rules, cases not covered above
   http://docs.oasis-open.org/dita/dita/v1.3/errata01/os/complete/part1-base/archSpec/base/processing-keyref-for-text.html
   -->


### PR DESCRIPTION
_Migrated to #3194 to allow commiters to modify code._

Fixes test cases reported in issue #2523.
Two issues were identified:

1. When collecting resolve tasks in KeyRefModule.WalkMap, files referenced through mapref but flattened in map-ref stage are not picked up. They are instead added in collectProcessingTopics. This means they are parsed with root scope instead of their correct scope.
2. When transforming a flattened map key using the KeyRefPaser module it's assumed that one file only has a single key scope. Scopes added outside topicrefs or maprefs are then ignored.

I refactored the elemName deque to keyRefElemNames to make the distinction between the two deques elemNames and keyRefElemNames more clear.