### PR TITLE
Use absolute URIs in XSLT imports and includes

### DIFF
--- a/src/main/plugins/org.dita.eclipsehelp/xsl/map2eclipse_template.xsl
+++ b/src/main/plugins/org.dita.eclipsehelp/xsl/map2eclipse_template.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Import the main ditamap to Eclipse TOC Contents conversion -->
-<xsl:import href="map2eclipse/map2eclipseImpl.xsl"/>
+<xsl:import href="plugin:org.dita.eclipsehelp:xsl/map2eclipse/map2eclipseImpl.xsl"/>
 
 <dita:extension id="dita.xsl.eclipse.toc" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.eclipsehelp/xsl/map2plugin_template.xsl
+++ b/src/main/plugins/org.dita.eclipsehelp/xsl/map2plugin_template.xsl
@@ -7,7 +7,7 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="map2pluginImpl.xsl"/>  
+  <xsl:import href="plugin:org.dita.eclipsehelp:xsl/map2pluginImpl.xsl"/>  
   <dita:extension id="dita.xsl.eclipse.plugin" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
   
-  <xsl:import href="dita2html5Impl.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/dita2html5Impl.xsl"/>
   
   <xsl:output method="html"
               encoding="UTF-8"

--- a/src/main/plugins/org.dita.html5/xsl/dita2html5Impl_template.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/dita2html5Impl_template.xsl
@@ -14,24 +14,24 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.base:xsl/common/related-links.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
   
-  <xsl:import href="topic.xsl"/>
-  <xsl:import href="concept.xsl"/>
-  <xsl:import href="glossdisplay.xsl"/>
-  <xsl:import href="task.xsl"/>
-  <xsl:import href="reference.xsl"/>  
-  <xsl:import href="ut-d.xsl"/>
-  <xsl:import href="sw-d.xsl"/>
-  <xsl:import href="pr-d.xsl"/>
-  <xsl:import href="ui-d.xsl"/>
-  <xsl:import href="hi-d.xsl"/>
-  <xsl:import href="abbrev-d.xsl"/>
-  <xsl:import href="markup-d.xsl"/>
-  <xsl:import href="xml-d.xsl"/>
-  <xsl:import href="svg-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/topic.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/concept.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/glossdisplay.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/task.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/reference.xsl"/>  
+  <xsl:import href="plugin:org.dita.html5:xsl/ut-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/sw-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/pr-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/ui-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/hi-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/abbrev-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/markup-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/xml-d.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/svg-d.xsl"/>
   
-  <xsl:import href="nav.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/nav.xsl"/>
   
-  <xsl:import href="htmlflag.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/htmlflag.xsl"/>
     
   <dita:extension id="dita.xsl.html5" 
       behavior="org.dita.dost.platform.ImportXSLAction" 

--- a/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
-  <xsl:import href="syntax-braces.xsl"/>
+  <xsl:import href="plugin:org.dita.html5:xsl/syntax-braces.xsl"/>
 
   <xsl:template match="*[contains(@class, ' pr-d/codeblock ')]" name="topic.pr-d.codeblock">
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -318,6 +318,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
 
-  <xsl:include href="properties.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/properties.xsl"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -674,6 +674,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
 
-  <xsl:include href="choicetable.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/choicetable.xsl"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -11,8 +11,8 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot dita2html ditamsg">
   
-  <xsl:include href="get-meta.xsl"/>
-  <xsl:include href="rel-links.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/get-meta.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/rel-links.xsl"/>
 
   <!-- =========== DEFAULT VALUES FOR EXTERNALLY MODIFIABLE PARAMETERS =========== -->
   
@@ -2625,8 +2625,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:call-template>
   </xsl:template>
 
-  <xsl:include href="tables.xsl"/>
-  <xsl:include href="simpletable.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/tables.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/simpletable.xsl"/>
   
   <xsl:key name="enumerableByClass"
     match="*[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |
@@ -2746,7 +2746,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
   
-  <xsl:include href="css-class.xsl"/>
+  <xsl:include href="plugin:org.dita.html5:xsl/css-class.xsl"/>
   <xsl:include href="plugin:org.dita.html5:xsl/functions.xsl"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2hhc_template.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2hhc_template.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Import the main ditamap to HTML Help Contents conversion -->
-<xsl:import href="map2htmlhelp/map2hhcImpl.xsl"/>
+<xsl:import href="plugin:org.dita.htmlhelp:xsl/map2htmlhelp/map2hhcImpl.xsl"/>
 
 <dita:extension id="dita.xsl.htmlhelp.map2hhc" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2hhp_template.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2hhp_template.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
 <!-- Import the main ditamap to HTML Help Project file conversion -->
-<xsl:import href="map2htmlhelp/map2hhpImpl.xsl"/>
+<xsl:import href="plugin:org.dita.htmlhelp:xsl/map2htmlhelp/map2hhpImpl.xsl"/>
 
 <dita:extension id="dita.xsl.htmlhelp.map2hhp" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic2fo_shell_axf_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.axf/xsl/fo/topic2fo_shell_axf_template.xsl
@@ -11,12 +11,12 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
 
-  <xsl:import href="../../cfg/fo/attrs/tables-attr_axf.xsl"/>
-  <xsl:import href="../../cfg/fo/attrs/toc-attr_axf.xsl"/>
-  <xsl:import href="../../cfg/fo/attrs/index-attr_axf.xsl" />
-  <xsl:import href="root-processing_axf.xsl"/>
-  <xsl:import href="index_axf.xsl"/>
-  <xsl:import href="topic_axf.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.axf:cfg/fo/attrs/tables-attr_axf.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.axf:cfg/fo/attrs/toc-attr_axf.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.axf:cfg/fo/attrs/index-attr_axf.xsl" />
+  <xsl:import href="plugin:org.dita.pdf2.axf:xsl/fo/root-processing_axf.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.axf:xsl/fo/index_axf.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.axf:xsl/fo/topic_axf.xsl"/>
   
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
@@ -11,13 +11,13 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
 
-  <xsl:import href="../../cfg/fo/attrs/commons-attr_fop.xsl"/>
-  <xsl:import href="../../cfg/fo/attrs/tables-attr_fop.xsl"/>
-  <xsl:import href="root-processing_fop.xsl"/>
-  <xsl:import href="tables_fop.xsl"/>
-  <xsl:import href="index_fop.xsl"/>
-  <xsl:import href="flagging_fop.xsl"/>
-  <xsl:import href="topic_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:cfg/fo/attrs/commons-attr_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:cfg/fo/attrs/tables-attr_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/root-processing_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/tables_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/index_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/flagging_fop.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.fop:xsl/fo/topic_fop.xsl"/>
 
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic2fo_shell_xep_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/topic2fo_shell_xep_template.xsl
@@ -11,12 +11,12 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
 
-  <xsl:import href="../../cfg/fo/attrs/commons-attr_xep.xsl"/>
-  <xsl:import href="../../cfg/fo/attrs/layout-masters-attr_xep.xsl"/>
-  <xsl:import href="root-processing_xep.xsl"/>
-  <xsl:import href="../../cfg/fo/attrs/index-attr_xep.xsl"/>
-  <xsl:import href="index_xep.xsl"/>
-  <xsl:import href="topic_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:cfg/fo/attrs/commons-attr_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:cfg/fo/attrs/layout-masters-attr_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:xsl/fo/root-processing_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:cfg/fo/attrs/index-attr_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:xsl/fo/index_xep.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2.xep:xsl/fo/topic_xep.xsl"/>
 
   <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmerge_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmerge_template.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
 
-  <xsl:import href="topicmergeImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.pdf2:xsl/common/topicmergeImpl.xsl"/>
   <dita:extension id="org.dita.pdf2.xsl.topicmerge" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -44,8 +44,8 @@ See the accompanying LICENSE file for applicable license.
     version="2.0">
 
     <!-- FIXME these imports should be moved to shell -->
-    <xsl:import href="topic.xsl"/>
-    <xsl:import href="concept.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/concept.xsl"/>
 
     <xsl:key name="id" match="*[@id]" use="@id"/>
     <xsl:key name="map-id"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-preprocess_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-preprocess_template.xsl
@@ -15,7 +15,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:suitesol="http://suite-sol.com/namespaces/mapcounts"
     version="2.0">
 
-   <xsl:import href="flag-rules.xsl"/>
+   <xsl:import href="plugin:org.dita.pdf2:xsl/fo/flag-rules.xsl"/>
    <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
    <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
@@ -44,73 +44,73 @@ See the accompanying LICENSE file for applicable license.
     <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
     <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
     <xsl:import href="plugin:org.dita.base:xsl/common/related-links.xsl"/>
-  
-    <xsl:import href="../common/attr-set-reflection.xsl"/>
-    <xsl:import href="../common/vars.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/basic-settings.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/layout-masters-attr.xsl"/>
-    <xsl:import href="../../cfg/fo/layout-masters.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/links-attr.xsl"/>
-    <xsl:import href="links.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/lists-attr.xsl"/>
-    <xsl:import href="lists.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/tables-attr.xsl"/>
-    <xsl:import href="tables.xsl"/>
-    <xsl:import href="root-processing.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/topic-attr.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/concept-attr.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/commons-attr.xsl"/>
-    <xsl:import href="commons.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/toc-attr.xsl"/>
-    <xsl:import href="toc.xsl"/>
-    <xsl:import href="bookmarks.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/index-attr.xsl"/>
-    <xsl:import href="index.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/front-matter-attr.xsl"/>
-    <xsl:import href="front-matter.xsl"/>
-    <xsl:import href="preface.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/map-elements-attr.xsl"/>
-    <xsl:import href="map-elements.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/task-elements-attr.xsl"/>
-    <xsl:import href="task-elements.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/reference-elements-attr.xsl"/>
-    <xsl:import href="reference-elements.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/sw-domain-attr.xsl"/>
-    <xsl:import href="sw-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/pr-domain-attr.xsl"/>
-    <xsl:import href="pr-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/hi-domain-attr.xsl"/>
-    <xsl:import href="hi-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/ui-domain-attr.xsl"/>
-    <xsl:import href="ui-domain.xsl"/>
-    <xsl:import href="ut-domain.xsl"/>
-    <xsl:import href="abbrev-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/markup-domain-attr.xsl"/>
-    <xsl:import href="markup-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/xml-domain-attr.xsl"/>
-    <xsl:import href="xml-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/svg-domain-attr.xsl"/>
-    <xsl:import href="svg-domain.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/hazard-d-attr.xsl"/>
-    <xsl:import href="hazard-d.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/static-content-attr.xsl"/>
-    <xsl:import href="static-content.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/glossary-attr.xsl"/>
-    <xsl:import href="glossary.xsl"/>
-    <xsl:import href="../../cfg/fo/attrs/lot-lof-attr.xsl"/>
-    <xsl:import href="lot-lof.xsl"/>
-
-    <xsl:import href="../../cfg/fo/attrs/learning-elements-attr.xsl"/>
-    <xsl:import href="learning-elements.xsl"/>
-
-    <xsl:import href="flagging.xsl"/>
-    <xsl:import href="flagging-from-preprocess.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:xsl/common/attr-set-reflection.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/common/vars.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/basic-settings.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/layout-masters-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/layout-masters.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/links-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/links.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/lists-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/lists.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/tables-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/tables.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/root-processing.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/topic-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/concept-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/commons-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/commons.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/toc-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/toc.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/bookmarks.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/index-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/index.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/front-matter-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/front-matter.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/preface.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/map-elements-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/map-elements.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/task-elements-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/task-elements.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/reference-elements-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/reference-elements.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/sw-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/sw-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/pr-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/pr-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/hi-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/hi-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/ui-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/ui-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/ut-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/abbrev-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/markup-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/markup-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/xml-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/xml-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/svg-domain-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/svg-domain.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/hazard-d-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/hazard-d.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/static-content-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/static-content.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/glossary-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/glossary.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/lot-lof-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/lot-lof.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:cfg/fo/attrs/learning-elements-attr.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/learning-elements.xsl"/>
+    
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/flagging.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/flagging-from-preprocess.xsl"/>
 
 
     <xsl:output method="xml" encoding="utf-8" indent="no"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo_shell_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo_shell_template.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
 
-    <xsl:import href="topic2fo.xsl"/>
+    <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
     
     <dita:extension id="dita.xsl.xslfo" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2html-base_template.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2html-base_template.xsl
@@ -18,38 +18,38 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- stylesheet imports -->
 <!-- the main dita to xhtml converter -->
-<xsl:import href="xslhtml/dita2htmlImpl.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/dita2htmlImpl.xsl"/>
 
 <!-- the dita to xhtml converter for concept documents -->
-<xsl:import href="xslhtml/conceptdisplay.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/conceptdisplay.xsl"/>
 
 <!-- the dita to xhtml converter for glossentry documents -->
-<xsl:import href="xslhtml/glossdisplay.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/glossdisplay.xsl"/>
 
 <!-- the dita to xhtml converter for task documents -->
-<xsl:import href="xslhtml/taskdisplay.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/taskdisplay.xsl"/>
 
 <!-- the dita to xhtml converter for reference documents -->
-<xsl:import href="xslhtml/refdisplay.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/refdisplay.xsl"/>
 
 <!-- user technologies domain -->
-<xsl:import href="xslhtml/ut-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/ut-d.xsl"/>
 <!-- software domain -->
-<xsl:import href="xslhtml/sw-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/sw-d.xsl"/>
 <!-- programming domain -->
-<xsl:import href="xslhtml/pr-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/pr-d.xsl"/>
 <!-- ui domain -->
-<xsl:import href="xslhtml/ui-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/ui-d.xsl"/>
 <!-- highlighting domain -->
-<xsl:import href="xslhtml/hi-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/hi-d.xsl"/>
 <!-- abbreviated-form domain -->
-<xsl:import href="xslhtml/abbrev-d.xsl"/>
-<xsl:import href="xslhtml/markup-d.xsl"/>
-<xsl:import href="xslhtml/xml-d.xsl"/>
-<xsl:import href="xslhtml/svg-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/abbrev-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/markup-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/xml-d.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/svg-d.xsl"/>
 <!-- Integrate support for flagging with dita-ot pseudo-domain -->
-<xsl:import href="xslhtml/htmlflag.xsl"/>  
-  
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/htmlflag.xsl"/>  
+
 <dita:extension id="dita.xsl.xhtml" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 
 <!-- the dita to xhtml converter for element reference documents - not used now -->

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2html.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2html.xsl
@@ -17,7 +17,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- stylesheet imports -->
 <!-- the main dita to xhtml converter -->
-<xsl:import href="dita2html-base.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/dita2html-base.xsl"/>
 
 <xsl:output method="html"
             encoding="UTF-8"

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
 
-  <xsl:import href="dita2html-base.xsl"/>
+  <xsl:import href="plugin:org.dita.xhtml:xsl/dita2html-base.xsl"/>
   
   <xsl:output method="xhtml"
               encoding="UTF-8"

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
@@ -17,7 +17,7 @@ See the accompanying LICENSE file for applicable license.
               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/>
  
-  <xsl:include href="dita2xhtml-util.xsl"/>
+  <xsl:include href="plugin:org.dita.xhtml:xsl/dita2xhtml-util.xsl"/>
   
   <!-- Add both lang and xml:lang attributes -->
   <xsl:template match="@xml:lang" name="generate-lang">

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmltoc_template.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmltoc_template.xsl
@@ -11,8 +11,8 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Import the main ditamap to HTML TOC conversion -->
-<xsl:import href="map2htmtoc/map2htmtocImpl.xsl"/>
-<xsl:import href="map2htmtoc/map2htmlImpl.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/map2htmtoc/map2htmtocImpl.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/map2htmtoc/map2htmlImpl.xsl"/>
 
 <dita:extension id="dita.xsl.htmltoc" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/map2xhtml-cover.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2xhtml-cover.xsl
@@ -17,6 +17,6 @@ See the accompanying LICENSE file for applicable license.
               doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
               doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/-->
 
-  <xsl:include href="plugin:org.dita.xhtml:xsl/dita2xhtml-util.xsl"/>
+  <!--xsl:include href="plugin:org.dita.xhtml:xsl/dita2xhtml-util.xsl"/-->
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
@@ -22,6 +22,6 @@ See the accompanying LICENSE file for applicable license.
   doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
   doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/>
 
-  <xsl:include href="dita2xhtml-util.xsl"/>
+  <xsl:include href="plugin:org.dita.xhtml:xsl/dita2xhtml-util.xsl"/>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!--main map to xhtml converter-->
-<xsl:import href="map2htmltoc.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/map2htmltoc.xsl"/>
 
 
 <xsl:output method="xhtml" encoding="UTF-8"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -21,8 +21,8 @@ See the accompanying LICENSE file for applicable license.
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
 <xsl:import href="plugin:org.dita.base:xsl/common/related-links.xsl"/>
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
-<xsl:include href="get-meta.xsl"/>
-<xsl:include href="rel-links.xsl"/>
+<xsl:include href="plugin:org.dita.xhtml:xsl/xslhtml/get-meta.xsl"/>
+<xsl:include href="plugin:org.dita.xhtml:xsl/xslhtml/rel-links.xsl"/>
 
 <!-- =========== OUTPUT METHOD =========== -->
 
@@ -1713,7 +1713,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- ===================================================================== -->
 
-<xsl:include href="tables.xsl"/>
+<xsl:include href="plugin:org.dita.xhtml:xsl/xslhtml/tables.xsl"/>
 
 <!-- =========== FOOTNOTE =========== -->
 <xsl:template match="*[contains(@class, ' topic/fn ')]" name="topic.fn">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/map2TOC.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/map2TOC.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
         exclude-result-prefixes="html">
 
 <!-- stylesheet imports -->
-<xsl:import href="mapwalker.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/mapwalker.xsl"/>
 
 <xsl:template match="*[contains(@class,' map/map ')]">
   <xsl:apply-templates select="." mode="toctop"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet version="2.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:import href="syntax-braces.xsl"/>
+<xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/syntax-braces.xsl"/>
 
 <!-- programming-domain.ent domain: codeblock | codeph | var | kwd | synph | oper | delim | sep | repsep |
                                     option | parmname | apiname-->

--- a/src/main/xsl/common/dita-textonly.xsl
+++ b/src/main/xsl/common/dita-textonly.xsl
@@ -19,9 +19,9 @@ See the accompanying LICENSE file for applicable license.
   exclude-result-prefixes="dita-ot"
   >
 
-  <xsl:import href="topic2textonly.xsl"/>
-  <xsl:import href="map2textonly.xsl"/>
-  <xsl:import href="ui-d2textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/topic2textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/map2textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/ui-d2textonly.xsl"/>
      
   
 </xsl:stylesheet>

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -434,7 +434,7 @@ See the accompanying LICENSE file for applicable license.
       select="$n/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]"/>
   </xsl:function>
 
-  <xsl:include href="uri-utils.xsl"/>
+  <xsl:include href="plugin:org.dita.base:xsl/common/uri-utils.xsl"/>
 
 </xsl:stylesheet>
 

--- a/src/main/xsl/common/dita-utilities.xsl
+++ b/src/main/xsl/common/dita-utilities.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 exclude-result-prefixes="xs dita-ot">
 
-  <xsl:include href="functions.xsl"/>
+  <xsl:include href="plugin:org.dita.base:xsl/common/functions.xsl"/>
 
   <xsl:param name="defaultLanguage" select="'en'" as="xs:string"/>
 

--- a/src/main/xsl/common/output-message.xsl
+++ b/src/main/xsl/common/output-message.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
   message template. To include this file, you will need the following
   two commands in your XSL:
   
-  <xsl:include href="output-message.xsl"/>           - Place with other included files
+  <xsl:include href="plugin:org.dita.base:xsl/common/output-message.xsl"/>           - Place with other included files
   
   <xsl:variable name="msgprefix">DOTX</xsl:variable> - Place with other variables
   

--- a/src/main/xsl/preprocess/clean-map.xsl
+++ b/src/main/xsl/preprocess/clean-map.xsl
@@ -11,8 +11,8 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0"
                 exclude-result-prefixes="xs">
   
-  <xsl:import href="../common/dita-utilities.xsl"/>
-  <xsl:import href="../common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 
   <!-- Deprecated since 2.3 -->
   <xsl:variable name="msgprefix">DOTX</xsl:variable>

--- a/src/main/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/xsl/preprocess/conrefImpl.xsl
@@ -13,8 +13,8 @@ See the accompanying LICENSE file for applicable license.
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="ditamsg conref xs dita-ot">
 
-  <xsl:import href="../common/output-message.xsl"/>
-  <xsl:import href="../common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
 
   <!-- Define the error message prefix identifier -->
   <xsl:variable name="msgprefix" select="'DOTX'"/>

--- a/src/main/xsl/preprocess/conref_template.xsl
+++ b/src/main/xsl/preprocess/conref_template.xsl
@@ -7,7 +7,7 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="conrefImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/conrefImpl.xsl"/>
   <dita:extension id="dita.xsl.conref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
 </xsl:stylesheet>

--- a/src/main/xsl/preprocess/map-conref_template.xsl
+++ b/src/main/xsl/preprocess/map-conref_template.xsl
@@ -7,7 +7,7 @@ Copyright 2017 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="conrefImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/conrefImpl.xsl"/>
   <dita:extension id="dita.xsl.conref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
   

--- a/src/main/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/xsl/preprocess/maplinkImpl.xsl
@@ -13,9 +13,9 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 exclude-result-prefixes="xs dita-ot">
   
-  <xsl:import href="../common/output-message.xsl"/>
-  <xsl:import href="../common/dita-utilities.xsl"/>
-  <xsl:import href="../common/dita-textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
   
   <xsl:output method="xml" encoding="utf-8" indent="no" />
   

--- a/src/main/xsl/preprocess/maplink_template.xsl
+++ b/src/main/xsl/preprocess/maplink_template.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="maplinkImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/maplinkImpl.xsl"/>
   <dita:extension id="dita.xsl.maplink" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
 </xsl:stylesheet>

--- a/src/main/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/xsl/preprocess/mappullImpl.xsl
@@ -40,9 +40,9 @@ Other modes can be found within the code, and may or may not prove useful for ov
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 xmlns:saxon="http://saxon.sf.net/"
                 exclude-result-prefixes="xs dita-ot mappull ditamsg saxon">
-  <xsl:import href="../common/output-message.xsl"/>
-  <xsl:import href="../common/dita-utilities.xsl"/>
-  <xsl:import href="../common/dita-textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
   <!-- Define the error message prefix identifier -->
   <xsl:variable name="msgprefix" as="xs:string">DOTX</xsl:variable>
   <!-- If converting to PDF, never try to pull info from targets with print="no" -->

--- a/src/main/xsl/preprocess/mappull_template.xsl
+++ b/src/main/xsl/preprocess/mappull_template.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="mappullImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/mappullImpl.xsl"/>
   <dita:extension id="dita.xsl.mappull" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
 </xsl:stylesheet>

--- a/src/main/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/xsl/preprocess/maprefImpl.xsl
@@ -14,8 +14,8 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 exclude-result-prefixes="xs dita-ot mappull ditamsg">
 
-  <xsl:import href="../common/dita-utilities.xsl"/>
-  <xsl:import href="../common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <!-- Deprecated since 2.3 -->
   <xsl:variable name="msgprefix">DOTX</xsl:variable>
 

--- a/src/main/xsl/preprocess/mapref_template.xsl
+++ b/src/main/xsl/preprocess/mapref_template.xsl
@@ -7,7 +7,7 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
     <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-        <xsl:import href="maprefImpl.xsl"/>
+        <xsl:import href="plugin:org.dita.base:xsl/preprocess/maprefImpl.xsl"/>
         <dita:extension id="dita.xsl.mapref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
         <xsl:output method="xml" encoding="utf-8" indent="no" />
     </xsl:stylesheet>

--- a/src/main/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/xsl/preprocess/topicpullImpl.xsl
@@ -53,9 +53,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="dita-ot topicpull ditamsg xs">
-  <xsl:import href="../common/dita-utilities.xsl"/>
-  <xsl:import href="../common/output-message.xsl"/>
-  <xsl:import href="../common/dita-textonly.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
   <!-- Define the error message prefix identifier -->
   <!-- Deprecated since 2.3 -->
   <xsl:variable name="msgprefix">DOTX</xsl:variable>

--- a/src/main/xsl/preprocess/topicpull_template.xsl
+++ b/src/main/xsl/preprocess/topicpull_template.xsl
@@ -7,9 +7,9 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="topicpullImpl.xsl"/>
-  <xsl:import href="topicpull-task.xsl"/>
-  <xsl:import href="topicpull-pr-d.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpullImpl.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpull-task.xsl"/>
+  <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpull-pr-d.xsl"/>
   <dita:extension id="dita.xsl.topicpull" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
 </xsl:stylesheet>

--- a/src/test/java/org/dita/dost/util/XSpecTest.java
+++ b/src/test/java/org/dita/dost/util/XSpecTest.java
@@ -7,6 +7,8 @@
  */
 package org.dita.dost.util;
 
+import org.apache.xml.resolver.Catalog;
+import org.apache.xml.resolver.tools.CatalogResolver;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +28,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -71,7 +74,12 @@ public class XSpecTest {
     @BeforeClass
     public static void setUpClass() throws TransformerException {
         transformerFactory = TransformerFactory.newInstance();
-        resolver = new ClassPathResolver(transformerFactory.getURIResolver());
+        final File ditaDir = new File(Optional.ofNullable(System.getProperty("dita.dir"))
+                .orElse("src" + File.separator + "main"))
+                .getAbsoluteFile();
+        CatalogUtils.setDitaDir(ditaDir);
+        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+        resolver = new ClassPathResolver(catalogResolver);
         transformerFactory.setURIResolver(resolver);
         final Source stylesheet = resolver.resolve("classpath:///XSpec/generate-xspec-tests.xsl", "");
         compiler = transformerFactory.newTransformer(stylesheet);


### PR DESCRIPTION
Use absolute `plugin` URIs in XSLT imports and includes, even in cases where a relative URI inside a plugin could be used.

Possibly fixes #3156