### PR TITLE
Support rotate attribute on table entries #2717

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -31,7 +31,7 @@ See the accompanying LICENSE file for applicable license.
         <fo:inline id="{.}"/>
     </xsl:template>
 
-  <xsl:template match="*[contains(@class,' topic/entry ')]" priority="1">
+  <xsl:template match="*[contains(@class,' topic/entry ')]">
     <xsl:choose>
       <xsl:when test="dita-ot:get-entry-end-position(.) gt number(ancestor::*[contains(@class,' topic/tgroup ')][1]/@cols)">
         <!-- FOP crashes if an entry extends beyond the table width -->
@@ -44,28 +44,26 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-
-  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
-    <xsl:apply-templates select="." mode="validate-entry-position"/>
-    <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
-      <xsl:call-template name="commonattributes"/>
-      <xsl:call-template name="applySpansAttrs"/>
-      <xsl:call-template name="applyAlignAttrs"/>
-      <xsl:call-template name="generateTableEntryBorder"/>
+  
+  <!-- By default in FOP, rotated text in a table entry does not change the cell size, so rotated text will overwrite other cells.
+       To enable rotation, explicitly set the height and width as follows:
+       1) Uncomment the fo:block-container
+       2) Adjust the height and width values to either
+       2a) An appropriate default that is acceptable for all of your rotated cells, or
+       2b) A specific or calculated value based on the cell content --> 
+  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+    <!--<fo:block-container reference-orientation="90" width="150px" height="80px">-->
       <fo:block xsl:use-attribute-sets="thead.row.entry__content">
         <xsl:call-template name="processEntryContent"/>
       </fo:block>
-    </fo:table-cell>
+    <!--</fo:block-container>-->
   </xsl:template>
-  
-  <xsl:template match="*" mode="processTableEntry">
-    <xsl:call-template name="commonattributes"/>
-    <xsl:call-template name="applySpansAttrs"/>
-    <xsl:call-template name="applyAlignAttrs"/>
-    <xsl:call-template name="generateTableEntryBorder"/>
-    <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
-      <xsl:call-template name="processEntryContent"/>
-    </fo:block>
+  <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+    <!--<fo:block-container reference-orientation="90" width="150px" height="80px">-->
+      <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+        <xsl:call-template name="processEntryContent"/>
+      </fo:block>
+    <!--</fo:block-container>-->
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -31,7 +31,7 @@ See the accompanying LICENSE file for applicable license.
         <fo:inline id="{.}"/>
     </xsl:template>
 
-  <xsl:template match="*[contains(@class,' topic/entry ')]">
+  <xsl:template match="*[contains(@class,' topic/entry ')]" priority="1">
     <xsl:choose>
       <xsl:when test="dita-ot:get-entry-end-position(.) gt number(ancestor::*[contains(@class,' topic/tgroup ')][1]/@cols)">
         <!-- FOP crashes if an entry extends beyond the table width -->
@@ -43,6 +43,29 @@ See the accompanying LICENSE file for applicable license.
         <xsl:next-match/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
+    <xsl:apply-templates select="." mode="validate-entry-position"/>
+    <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="applySpansAttrs"/>
+      <xsl:call-template name="applyAlignAttrs"/>
+      <xsl:call-template name="generateTableEntryBorder"/>
+      <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+        <xsl:call-template name="processEntryContent"/>
+      </fo:block>
+    </fo:table-cell>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="processTableEntry">
+    <xsl:call-template name="commonattributes"/>
+    <xsl:call-template name="applySpansAttrs"/>
+    <xsl:call-template name="applyAlignAttrs"/>
+    <xsl:call-template name="generateTableEntryBorder"/>
+    <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+      <xsl:call-template name="processEntryContent"/>
+    </fo:block>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
@@ -2,7 +2,7 @@
 <!--
 This file is part of the DITA Open Toolkit project.
 
-Copyright 2016 IBM Corporation
+Copyright 2019 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
@@ -13,27 +13,25 @@ See the accompanying LICENSE file for applicable license.
   version="2.0"
   exclude-result-prefixes="xs dita-ot">
   
-  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
-    <xsl:apply-templates select="." mode="validate-entry-position"/>
-    <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
-      <xsl:call-template name="commonattributes"/>
-      <xsl:call-template name="applySpansAttrs"/>
-      <xsl:call-template name="applyAlignAttrs"/>
-      <xsl:call-template name="generateTableEntryBorder"/>
-      <fo:block xsl:use-attribute-sets="thead.row.entry__content">
-        <xsl:call-template name="processEntryContent"/>
-      </fo:block>
-    </fo:table-cell>
+  <!-- By default in XEP, rotated table entries will extend to the end of the page, unless a height is provided for the container.
+       To enable rotation, explicitly set the height (and optionally width) as follows:
+       1) Uncomment the fo:block-container
+       2) Adjust the height and width values to either
+       2a) An appropriate default that is acceptable for all of your rotated cells, or
+       2b) A specific or calculated value based on the cell content --> 
+  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+    <!--<fo:block-container reference-orientation="90" width="150px" height="80px">-->
+    <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+      <xsl:call-template name="processEntryContent"/>
+    </fo:block>
+    <!--</fo:block-container>-->
   </xsl:template>
-  
-  <xsl:template match="*" mode="processTableEntry">
-    <xsl:call-template name="commonattributes"/>
-    <xsl:call-template name="applySpansAttrs"/>
-    <xsl:call-template name="applyAlignAttrs"/>
-    <xsl:call-template name="generateTableEntryBorder"/>
+  <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+    <!--<fo:block-container reference-orientation="90" width="150px" height="80px">-->
     <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
       <xsl:call-template name="processEntryContent"/>
     </fo:block>
+    <!--</fo:block-container>-->
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/tables_xep.xsl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2016 IBM Corporation
+
+See the accompanying LICENSE file for applicable license.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  version="2.0"
+  exclude-result-prefixes="xs dita-ot">
+  
+  <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
+    <xsl:apply-templates select="." mode="validate-entry-position"/>
+    <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="applySpansAttrs"/>
+      <xsl:call-template name="applyAlignAttrs"/>
+      <xsl:call-template name="generateTableEntryBorder"/>
+      <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+        <xsl:call-template name="processEntryContent"/>
+      </fo:block>
+    </fo:table-cell>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="processTableEntry">
+    <xsl:call-template name="commonattributes"/>
+    <xsl:call-template name="applySpansAttrs"/>
+    <xsl:call-template name="applyAlignAttrs"/>
+    <xsl:call-template name="generateTableEntryBorder"/>
+    <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+      <xsl:call-template name="processEntryContent"/>
+    </fo:block>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -430,11 +430,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="generateTableEntryBorder"/>
             <xsl:choose>
                 <xsl:when test="@rotate eq '1'">
-                    <fo:block-container reference-orientation="90">
-                        <fo:block xsl:use-attribute-sets="thead.row.entry__content">
-                            <xsl:call-template name="processEntryContent"/>
-                        </fo:block>
-                    </fo:block-container>
+                    <xsl:apply-templates select="." mode="rotateTableEntryContent"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <fo:block xsl:use-attribute-sets="thead.row.entry__content">
@@ -443,6 +439,14 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:otherwise>
                 </xsl:choose>
         </fo:table-cell>
+    </xsl:template>
+    
+    <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+        <fo:block-container reference-orientation="90">
+            <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+                <xsl:call-template name="processEntryContent"/>
+            </fo:block>
+        </fo:block-container>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
@@ -469,11 +473,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:call-template name="generateTableEntryBorder"/>
         <xsl:choose>
             <xsl:when test="@rotate eq '1'">
-                <fo:block-container reference-orientation="90">
-                    <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
-                        <xsl:call-template name="processEntryContent"/>
-                    </fo:block>
-                </fo:block-container>
+                <xsl:apply-templates select="." mode="rotateTableEntryContent"/>
             </xsl:when>
             <xsl:otherwise>
                 <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
@@ -481,6 +481,14 @@ See the accompanying LICENSE file for applicable license.
                 </fo:block>
             </xsl:otherwise>
             </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="rotateTableEntryContent">
+        <fo:block-container reference-orientation="90">
+            <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+                <xsl:call-template name="processEntryContent"/>
+            </fo:block>
+        </fo:block-container>
     </xsl:template>
 
     <xsl:template name="processEntryContent">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -428,11 +428,20 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="applySpansAttrs"/>
             <xsl:call-template name="applyAlignAttrs"/>
             <xsl:call-template name="generateTableEntryBorder"/>
-            <fo:block xsl:use-attribute-sets="thead.row.entry__content">
-                <xsl:apply-templates select="." mode="ancestor-start-flag"/>
-                <xsl:call-template name="processEntryContent"/>
-                <xsl:apply-templates select="." mode="ancestor-end-flag"/>
-            </fo:block>
+            <xsl:choose>
+                <xsl:when test="@rotate eq '1'">
+                    <fo:block-container reference-orientation="90">
+                        <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+                            <xsl:call-template name="processEntryContent"/>
+                        </fo:block>
+                    </fo:block-container>
+                </xsl:when>
+                <xsl:otherwise>
+                    <fo:block xsl:use-attribute-sets="thead.row.entry__content">
+                        <xsl:call-template name="processEntryContent"/>
+                    </fo:block>
+                </xsl:otherwise>
+                </xsl:choose>
         </fo:table-cell>
     </xsl:template>
 
@@ -458,11 +467,20 @@ See the accompanying LICENSE file for applicable license.
         <xsl:call-template name="applySpansAttrs"/>
         <xsl:call-template name="applyAlignAttrs"/>
         <xsl:call-template name="generateTableEntryBorder"/>
-        <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
-            <xsl:apply-templates select="." mode="ancestor-start-flag"/>
-            <xsl:call-template name="processEntryContent"/>
-            <xsl:apply-templates select="." mode="ancestor-end-flag"/>
-        </fo:block>
+        <xsl:choose>
+            <xsl:when test="@rotate eq '1'">
+                <fo:block-container reference-orientation="90">
+                    <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+                        <xsl:call-template name="processEntryContent"/>
+                    </fo:block>
+                </fo:block-container>
+            </xsl:when>
+            <xsl:otherwise>
+                <fo:block xsl:use-attribute-sets="tbody.row.entry__content">
+                    <xsl:call-template name="processEntryContent"/>
+                </fo:block>
+            </xsl:otherwise>
+            </xsl:choose>
     </xsl:template>
 
     <xsl:template name="processEntryContent">
@@ -491,6 +509,7 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
+        <xsl:apply-templates select="." mode="ancestor-start-flag"/>
         <xsl:choose>
             <xsl:when test="exists($char) and string-length($char) ne 0">
                 <xsl:call-template name="processCharAlignment">
@@ -502,6 +521,7 @@ See the accompanying LICENSE file for applicable license.
                 <xsl:apply-templates/>
             </xsl:otherwise>
         </xsl:choose>
+        <xsl:apply-templates select="." mode="ancestor-end-flag"/>
     </xsl:template>
 
   <xsl:template name="processCharAlignment">


### PR DESCRIPTION
Implements #2717 -- adds PDF support for `entry/@rotate` (added in DITA 1.3) using the container method suggested by @raducoravu in that issue.

I've tested the result with Antenna House and it works well. FOP gave bad results -- the text was rotated, but the cell kept its original dimensions, so that the rotated text writes over surrounding cells. I've updated the FOP table override to skip adding the container. I'll have the XEP test completed soon; if it works or if the rotation is ignored, I expect to keep the code as-is; if the output is broken as in FOP, we should update the `org.dita.pdf2.xep` plugin to skip rotation here.

As part of this, I've moved where `<row>` based flagging is processed within the entry and put it into the `processEntryContent` named template. This seems like an acceptable spot because any row flag has to be processed as entry content; it also simplifies the code, allowing us to call the `ancestor-start-flag` and `ancestor-end-flag` modes once each rather than 4 times each. Provided we keep this change, any DITA-OT 3.2 migration instructions may want to mention the move in case people have custom processing for `entry` elements.