### PR TITLE
Use plugin URI scheme in XSLT template imports

### DIFF
--- a/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
@@ -25,7 +25,7 @@ final class CheckTranstypeAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String property = paramTable.getOrDefault("property", "transtype");
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             buf.startElement(NULL_NS_URI, "not", "not", new AttributesBuilder().build());
             buf.startElement(NULL_NS_URI, "equals", "equals", new AttributesBuilder()
                 .add("arg1", "${" + property + "}")

--- a/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
@@ -25,11 +25,11 @@ final class CheckTranstypeAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String property = paramTable.getOrDefault("property", "transtype");
-        for (final String value: valueSet) {
+        for (final FileValue value: valueSet) {
             buf.startElement(NULL_NS_URI, "not", "not", new AttributesBuilder().build());
             buf.startElement(NULL_NS_URI, "equals", "equals", new AttributesBuilder()
                 .add("arg1", "${" + property + "}")
-                .add("arg2", value)
+                .add("arg2", value.value)
                 .add("casesensitive", "false")
                 .build());
             buf.endElement(NULL_NS_URI, "equals", "equals");

--- a/src/main/java/org/dita/dost/platform/Features.java
+++ b/src/main/java/org/dita/dost/platform/Features.java
@@ -35,7 +35,7 @@ final class Features {
     private final Hashtable<String, List<String>> featureTable;
     private final List<PluginRequirement> requireList;
     private final Hashtable<String, String> metaTable;
-    private final List<FileValue> templateList;
+    private final List<Value> templateList;
 
     /**
      * Constructor init pluginDir.
@@ -187,14 +187,14 @@ final class Features {
      * Add a template.
      * @param file file name
      */
-    public void addTemplate(final FileValue file) {
+    public void addTemplate(final Value file) {
         templateList.add(file);
     }
     /**
      * get all templates.
      * @return templates list
      */
-    public List<FileValue> getAllTemplates() {
+    public List<Value> getAllTemplates() {
         return templateList;
     }
 }

--- a/src/main/java/org/dita/dost/platform/Features.java
+++ b/src/main/java/org/dita/dost/platform/Features.java
@@ -35,7 +35,7 @@ final class Features {
     private final Hashtable<String, List<String>> featureTable;
     private final List<PluginRequirement> requireList;
     private final Hashtable<String, String> metaTable;
-    private final List<String> templateList;
+    private final List<FileValue> templateList;
 
     /**
      * Constructor init pluginDir.
@@ -187,14 +187,14 @@ final class Features {
      * Add a template.
      * @param file file name
      */
-    public void addTemplate(final String file) {
+    public void addTemplate(final FileValue file) {
         templateList.add(file);
     }
     /**
      * get all templates.
      * @return templates list
      */
-    public List<String> getAllTemplates() {
+    public List<FileValue> getAllTemplates() {
         return templateList;
     }
 }

--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -49,7 +49,7 @@ final class FileGenerator extends XMLFilterImpl {
 
     private DITAOTLogger logger;
     /** Plug-in features. */
-    private final Map<String, List<FileValue>> featureTable;
+    private final Map<String, List<Value>> featureTable;
     private final Map<String, Features> pluginTable;
     /** Template file. */
     private File templateFile;
@@ -65,7 +65,7 @@ final class FileGenerator extends XMLFilterImpl {
      * Constructor init featureTable.
      * @param featureTbl featureTbl
      */
-    public FileGenerator(final Hashtable<String, List<FileValue>> featureTbl, final Map<String, Features> pluginTable) {
+    public FileGenerator(final Hashtable<String, List<Value>> featureTbl, final Map<String, Features> pluginTable) {
         featureTable = featureTbl;
         this.pluginTable = pluginTable;
         templateFile = null;
@@ -156,8 +156,8 @@ final class FileGenerator extends XMLFilterImpl {
                                 action.setLogger(logger);
                                 action.setFeatures(pluginTable);
                                 action.addParam(PARAM_TEMPLATE, templateFile.getAbsolutePath());
-                                final List<FileValue> value = Stream.of(attributes.getValue(i).split(Integrator.FEAT_VALUE_SEPARATOR))
-                                        .map(val -> new FileValue(null, val))
+                                final List<Value> value = Stream.of(attributes.getValue(i).split(Integrator.FEAT_VALUE_SEPARATOR))
+                                        .map(val -> new Value(null, val))
                                         .collect(Collectors.toList());
                                 action.setInput(value);
                                 final String result = action.getResult();

--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -25,8 +25,8 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.util.*;
-
-import static java.util.Arrays.asList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Generate outputfile with templates.
@@ -49,7 +49,7 @@ final class FileGenerator extends XMLFilterImpl {
 
     private DITAOTLogger logger;
     /** Plug-in features. */
-    private final Map<String, List<String>> featureTable;
+    private final Map<String, List<FileValue>> featureTable;
     private final Map<String, Features> pluginTable;
     /** Template file. */
     private File templateFile;
@@ -65,7 +65,7 @@ final class FileGenerator extends XMLFilterImpl {
      * Constructor init featureTable.
      * @param featureTbl featureTbl
      */
-    public FileGenerator(final Hashtable<String, List<String>> featureTbl, final Map<String, Features> pluginTable) {
+    public FileGenerator(final Hashtable<String, List<FileValue>> featureTbl, final Map<String, Features> pluginTable) {
         featureTable = featureTbl;
         this.pluginTable = pluginTable;
         templateFile = null;
@@ -156,7 +156,10 @@ final class FileGenerator extends XMLFilterImpl {
                                 action.setLogger(logger);
                                 action.setFeatures(pluginTable);
                                 action.addParam(PARAM_TEMPLATE, templateFile.getAbsolutePath());
-                                action.setInput(asList(attributes.getValue(i).split(Integrator.FEAT_VALUE_SEPARATOR)));
+                                final List<FileValue> value = Stream.of(attributes.getValue(i).split(Integrator.FEAT_VALUE_SEPARATOR))
+                                        .map(val -> new FileValue(null, val))
+                                        .collect(Collectors.toList());
+                                action.setInput(value);
                                 final String result = action.getResult();
                                 atts.add(name, result);
                             } else {

--- a/src/main/java/org/dita/dost/platform/FileValue.java
+++ b/src/main/java/org/dita/dost/platform/FileValue.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.platform;
+
+import java.util.Objects;
+
+public class FileValue {
+    public final String id;
+    public final String value;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileValue fileValue = (FileValue) o;
+        return Objects.equals(id, fileValue.id) &&
+                Objects.equals(value, fileValue.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, value);
+    }
+
+    public FileValue(final String id, final String value) {
+        this.id = id;
+        this.value = value;
+    }
+}

--- a/src/main/java/org/dita/dost/platform/IAction.java
+++ b/src/main/java/org/dita/dost/platform/IAction.java
@@ -24,7 +24,7 @@ public interface IAction {
      * Set the input string.
      * @param input input
      */
-    void setInput(List<String> input);
+    void setInput(List<FileValue> input);
     /**
      * Add input parameter.
      * @param name parameter name

--- a/src/main/java/org/dita/dost/platform/IAction.java
+++ b/src/main/java/org/dita/dost/platform/IAction.java
@@ -24,7 +24,7 @@ public interface IAction {
      * Set the input string.
      * @param input input
      */
-    void setInput(List<FileValue> input);
+    void setInput(List<Value> input);
     /**
      * Add input parameter.
      * @param name parameter name

--- a/src/main/java/org/dita/dost/platform/ImportAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAction.java
@@ -26,7 +26,7 @@ import org.xml.sax.SAXException;
 abstract class ImportAction implements IAction {
 
     /** Action values. */
-    final Set<FileValue> valueSet;
+    final Set<Value> valueSet;
     /** Action parameters. */
     final Hashtable<String, String> paramTable;
     private DITAOTLogger logger;
@@ -57,7 +57,7 @@ abstract class ImportAction implements IAction {
      * @param input input
      */
     @Override
-    public void setInput(final List<FileValue> input) {
+    public void setInput(final List<Value> input) {
         valueSet.addAll(input);
     }
 

--- a/src/main/java/org/dita/dost/platform/ImportAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAction.java
@@ -26,7 +26,7 @@ import org.xml.sax.SAXException;
 abstract class ImportAction implements IAction {
 
     /** Action values. */
-    final Set<String> valueSet;
+    final Set<FileValue> valueSet;
     /** Action parameters. */
     final Hashtable<String, String> paramTable;
     private DITAOTLogger logger;
@@ -57,7 +57,7 @@ abstract class ImportAction implements IAction {
      * @param input input
      */
     @Override
-    public void setInput(final List<String> input) {
+    public void setInput(final List<FileValue> input) {
         valueSet.addAll(input);
     }
 

--- a/src/main/java/org/dita/dost/platform/ImportAntAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntAction.java
@@ -28,8 +28,8 @@ final class ImportAntAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final String value: valueSet) {
-            final String path = FileUtils.getRelativeUnixPath(templateFilePath, value);
+        for (final FileValue value: valueSet) {
+            final String path = FileUtils.getRelativeUnixPath(templateFilePath, value.value);
             buf.startElement(NULL_NS_URI, "import", "import", new AttributesBuilder()
                 .add("file", path)
                 .build());

--- a/src/main/java/org/dita/dost/platform/ImportAntAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntAction.java
@@ -28,7 +28,7 @@ final class ImportAntAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             final String path = FileUtils.getRelativeUnixPath(templateFilePath, value.value);
             buf.startElement(NULL_NS_URI, "import", "import", new AttributesBuilder()
                 .add("file", path)

--- a/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
@@ -27,7 +27,7 @@ final class ImportAntLibAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler retBuf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             final String resolvedValue = FileUtils.getRelativeUnixPath(templateFilePath, value.value);
             if (FileUtils.isAbsolutePath(resolvedValue)) {
                 // if resolvedValue is absolute path

--- a/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
@@ -27,9 +27,8 @@ final class ImportAntLibAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler retBuf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final String value: valueSet) {
-            final String resolvedValue = FileUtils.getRelativeUnixPath(
-                    templateFilePath, value);
+        for (final FileValue value: valueSet) {
+            final String resolvedValue = FileUtils.getRelativeUnixPath(templateFilePath, value.value);
             if (FileUtils.isAbsolutePath(resolvedValue)) {
                 // if resolvedValue is absolute path
                 retBuf.startElement(NULL_NS_URI, "pathelement", "pathelement", new AttributesBuilder()

--- a/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
@@ -23,7 +23,7 @@ final class ImportCatalogActionRelative extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             buf.startElement("urn:oasis:names:tc:entity:xmlns:xml:catalog", "nextCatalog", "nextCatalog", new AttributesBuilder()
                 .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value.value))
                 .build());

--- a/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
@@ -23,9 +23,9 @@ final class ImportCatalogActionRelative extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final String value: valueSet) {
+        for (final FileValue value: valueSet) {
             buf.startElement("urn:oasis:names:tc:entity:xmlns:xml:catalog", "nextCatalog", "nextCatalog", new AttributesBuilder()
-                .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value))
+                .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value.value))
                 .build());
             buf.endElement("urn:oasis:names:tc:entity:xmlns:xml:catalog", "nextCatalog", "nextCatalog");
         }

--- a/src/main/java/org/dita/dost/platform/ImportStringsAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportStringsAction.java
@@ -26,9 +26,9 @@ final class ImportStringsAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final String value: valueSet) {
+        for (final FileValue value: valueSet) {
             buf.startElement(NULL_NS_URI, "stringfile", "stringfile", new AttributesBuilder().build());
-            final char[] location =  FileUtils.getRelativeUnixPath(templateFilePath, value).toCharArray();
+            final char[] location =  FileUtils.getRelativeUnixPath(templateFilePath, value.value).toCharArray();
             buf.characters(location, 0, location.length);
             buf.endElement(NULL_NS_URI, "stringfile", "stringfile");
         }

--- a/src/main/java/org/dita/dost/platform/ImportStringsAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportStringsAction.java
@@ -26,7 +26,7 @@ final class ImportStringsAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             buf.startElement(NULL_NS_URI, "stringfile", "stringfile", new AttributesBuilder().build());
             final char[] location =  FileUtils.getRelativeUnixPath(templateFilePath, value.value).toCharArray();
             buf.characters(location, 0, location.length);

--- a/src/main/java/org/dita/dost/platform/ImportXSLAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportXSLAction.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.platform;
 
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
@@ -37,8 +38,12 @@ final class ImportXSLAction extends ImportAction {
 
     private URI getHref(final FileValue value) {
         final URI pluginDir = featureTable.get(value.id).getPluginDir().toURI();
-        final URI templateFile = URLUtils.toFile(value.value).toURI();
+        final URI templateFile = URLUtils.toFile(value.value).toURI().normalize();
         final URI template = pluginDir.relativize(templateFile);
+        if (value.id == null || template.isAbsolute()) {
+            final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
+            return URLUtils.toURI(FileUtils.getRelativeUnixPath(templateFilePath, value.value));
+        }
         return URI.create("plugin:" + value.id + ":" + template);
     }
 

--- a/src/main/java/org/dita/dost/platform/ImportXSLAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportXSLAction.java
@@ -8,10 +8,12 @@
  */
 package org.dita.dost.platform;
 
-import org.dita.dost.util.FileUtils;
+import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+
+import java.net.URI;
 
 /**
  * ImportXSLAction class.
@@ -25,17 +27,19 @@ final class ImportXSLAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         for (final FileValue value: valueSet) {
-            final String href = getHref(value);
+            final URI href = getHref(value);
             buf.startElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import", new AttributesBuilder()
-                .add("href", href)
+                .add("href", href.toString())
                 .build());
             buf.endElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import");
         }
     }
 
-    private String getHref(final FileValue value) {
-        final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        return FileUtils.getRelativeUnixPath(templateFilePath, value.value);
+    private URI getHref(final FileValue value) {
+        final URI pluginDir = featureTable.get(value.id).getPluginDir().toURI();
+        final URI templateFile = URLUtils.toFile(value.value).toURI();
+        final URI template = pluginDir.relativize(templateFile);
+        return URI.create("plugin:" + value.id + ":" + template);
     }
 
 }

--- a/src/main/java/org/dita/dost/platform/ImportXSLAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportXSLAction.java
@@ -27,7 +27,7 @@ final class ImportXSLAction extends ImportAction {
      */
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
-        for (final FileValue value: valueSet) {
+        for (final Value value: valueSet) {
             final URI href = getHref(value);
             buf.startElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import", new AttributesBuilder()
                 .add("href", href.toString())
@@ -36,7 +36,7 @@ final class ImportXSLAction extends ImportAction {
         }
     }
 
-    private URI getHref(final FileValue value) {
+    private URI getHref(final Value value) {
         final URI pluginDir = featureTable.get(value.id).getPluginDir().toURI();
         final URI templateFile = URLUtils.toFile(value.value).toURI().normalize();
         final URI template = pluginDir.relativize(templateFile);

--- a/src/main/java/org/dita/dost/platform/ImportXSLAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportXSLAction.java
@@ -24,13 +24,18 @@ final class ImportXSLAction extends ImportAction {
      */
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
-        final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final String value: valueSet) {
+        for (final FileValue value: valueSet) {
+            final String href = getHref(value);
             buf.startElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import", new AttributesBuilder()
-                .add("href", FileUtils.getRelativeUnixPath(templateFilePath, value))
+                .add("href", href)
                 .build());
             buf.endElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import");
         }
+    }
+
+    private String getHref(final FileValue value) {
+        final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
+        return FileUtils.getRelativeUnixPath(templateFilePath, value.value);
     }
 
 }

--- a/src/main/java/org/dita/dost/platform/InsertAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertAction.java
@@ -32,7 +32,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
 
     private final XMLReader reader;
     private DITAOTLogger logger;
-    private final Set<FileValue> fileNameSet;
+    private final Set<Value> fileNameSet;
     final Hashtable<String, String> paramTable;
     private int elemLevel = 0;
     /** Current processing file. */
@@ -54,7 +54,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
     }
 
     @Override
-    public void setInput(final List<FileValue> input) {
+    public void setInput(final List<Value> input) {
         fileNameSet.addAll(input);
     }
 
@@ -72,7 +72,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
     public void getResult(final ContentHandler retBuf) throws SAXException {
         setContentHandler(retBuf);
         try {
-            for (final FileValue fileName: fileNameSet) {
+            for (final Value fileName: fileNameSet) {
                 currentFile = fileName.value;
                 reader.parse(currentFile);
             }

--- a/src/main/java/org/dita/dost/platform/InsertAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertAction.java
@@ -32,7 +32,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
 
     private final XMLReader reader;
     private DITAOTLogger logger;
-    private final Set<String> fileNameSet;
+    private final Set<FileValue> fileNameSet;
     final Hashtable<String, String> paramTable;
     private int elemLevel = 0;
     /** Current processing file. */
@@ -54,7 +54,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
     }
 
     @Override
-    public void setInput(final List<String> input) {
+    public void setInput(final List<FileValue> input) {
         fileNameSet.addAll(input);
     }
 
@@ -72,8 +72,8 @@ class InsertAction extends XMLFilterImpl implements IAction {
     public void getResult(final ContentHandler retBuf) throws SAXException {
         setContentHandler(retBuf);
         try {
-            for (final String fileName: fileNameSet) {
-                currentFile = fileName;
+            for (final FileValue fileName: fileNameSet) {
+                currentFile = fileName.value;
                 reader.parse(currentFile);
             }
         } catch (final Exception e) {

--- a/src/main/java/org/dita/dost/platform/InsertDependsAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertDependsAction.java
@@ -26,7 +26,7 @@ import org.xml.sax.SAXException;
 final class InsertDependsAction implements IAction {
 
     /** Action value. */
-    private List<String> value;
+    private List<FileValue> value;
     /** Plug-in features. */
     private Map<String, Features> featureTable = null;
 
@@ -42,8 +42,8 @@ final class InsertDependsAction implements IAction {
     @Override
     public String getResult() {
         final List<String> result = new ArrayList<>();
-        for (final String t: value) {
-            final String token = t.trim();
+        for (final FileValue t: value) {
+            final String token = t.value.trim();
             // Pieces which are surrounded with braces are extension points.
             if (token.startsWith("{") && token.endsWith("}")) {
                 final String extension = token.substring(1, token.length() - 1);
@@ -66,7 +66,7 @@ final class InsertDependsAction implements IAction {
      * @param input input
      */
     @Override
-    public void setInput(final List<String> input) {
+    public void setInput(final List<FileValue> input) {
         value = input;
     }
     @Override

--- a/src/main/java/org/dita/dost/platform/InsertDependsAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertDependsAction.java
@@ -26,7 +26,7 @@ import org.xml.sax.SAXException;
 final class InsertDependsAction implements IAction {
 
     /** Action value. */
-    private List<FileValue> value;
+    private List<Value> value;
     /** Plug-in features. */
     private Map<String, Features> featureTable = null;
 
@@ -42,7 +42,7 @@ final class InsertDependsAction implements IAction {
     @Override
     public String getResult() {
         final List<String> result = new ArrayList<>();
-        for (final FileValue t: value) {
+        for (final Value t: value) {
             final String token = t.value.trim();
             // Pieces which are surrounded with braces are extension points.
             if (token.startsWith("{") && token.endsWith("}")) {
@@ -66,7 +66,7 @@ final class InsertDependsAction implements IAction {
      * @param input input
      */
     @Override
-    public void setInput(final List<FileValue> input) {
+    public void setInput(final List<Value> input) {
         value = input;
     }
     @Override

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -100,7 +100,7 @@ public final class Integrator {
 
     /** Plugin table which contains detected plugins. */
     private final Map<String, Features> pluginTable;
-    private final Map<String, FileValue> templateSet;
+    private final Map<String, Value> templateSet;
     private final File ditaDir;
     /** Plugin configuration file. */
     private final Set<File> descSet;
@@ -109,7 +109,7 @@ public final class Integrator {
     private final PluginParser parser;
     private DITAOTLogger logger;
     private final Set<String> loadedPlugin;
-    private final Hashtable<String, List<FileValue>> featureTable;
+    private final Hashtable<String, List<Value>> featureTable;
     @Deprecated
     private File propertiesFile;
     private final Set<String> extensionPoints;
@@ -262,7 +262,7 @@ public final class Integrator {
         }
 
         // generate the files from template
-        for (final Entry<String, FileValue> template : templateSet.entrySet()) {
+        for (final Entry<String, Value> template : templateSet.entrySet()) {
             final File templateFile = new File(ditaDir, template.getKey());
             logger.debug("Process template " + templateFile.getPath());
 //            fileGen.setPluginId(template.getValue().id);
@@ -280,7 +280,7 @@ public final class Integrator {
             }
         }
         if (featureTable.containsKey(FEAT_IMAGE_EXTENSIONS)) {
-            for (final FileValue ext : featureTable.get(FEAT_IMAGE_EXTENSIONS)) {
+            for (final Value ext : featureTable.get(FEAT_IMAGE_EXTENSIONS)) {
                 final String e = ext.value.trim();
                 if (e.length() != 0) {
                     imgExts.add(e);
@@ -303,7 +303,7 @@ public final class Integrator {
         // print transtypes
         final Set<String> printTranstypes = new HashSet<>();
         if (featureTable.containsKey(FEAT_PRINT_TRANSTYPES)) {
-            for (final FileValue ext : featureTable.get(FEAT_PRINT_TRANSTYPES)) {
+            for (final Value ext : featureTable.get(FEAT_PRINT_TRANSTYPES)) {
                 final String e = ext.value.trim();
                 if (e.length() != 0) {
                     printTranstypes.add(e);
@@ -473,10 +473,10 @@ public final class Integrator {
         return res;
     }
 
-    private Collection<File> relativize(final Collection<FileValue> src) {
+    private Collection<File> relativize(final Collection<Value> src) {
         final Collection<File> res = new ArrayList<>(src.size());
         final File base = new File(ditaDir, "dummy");
-        for (final FileValue lib: src) {
+        for (final Value lib: src) {
             final File libFile = toFile(lib.value);
             if (!libFile.exists()) {
                 throw new IllegalArgumentException("Library file not found: " + libFile.getAbsolutePath());
@@ -658,7 +658,7 @@ public final class Integrator {
     private String readExtensions(final String featureName) {
         final Set<String> exts = new HashSet<>();
         if (featureTable.containsKey(featureName)) {
-            for (final FileValue ext : featureTable.get(featureName)) {
+            for (final Value ext : featureTable.get(featureName)) {
                 final String e = ext.value.trim();
                 if (e.length() != 0) {
                     exts.add(e);
@@ -681,8 +681,8 @@ public final class Integrator {
             final Map<String, List<String>> featureSet = pluginFeatures.getAllFeatures();
             for (final Map.Entry<String, List<String>> currentFeature : featureSet.entrySet()) {
                 final String key = currentFeature.getKey();
-                final List<FileValue> values = currentFeature.getValue().stream()
-                        .map(val -> new FileValue(plugin, val))
+                final List<Value> values = currentFeature.getValue().stream()
+                        .map(val -> new Value(plugin, val))
                         .collect(Collectors.toList());
                 if (!extensionPoints.contains(key)) {
                     final String msg = "Plug-in " + plugin + " uses an undefined extension point "
@@ -690,17 +690,17 @@ public final class Integrator {
                     throw new RuntimeException(msg);
                 }
                 if (featureTable.containsKey(key)) {
-                    final List<FileValue> value = featureTable.get(key);
+                    final List<Value> value = featureTable.get(key);
                     value.addAll(values);
                     featureTable.put(key, value);
                 } else {
                     //Make shallow clone to avoid making modifications directly to list inside the current feature.
-                    List<FileValue> currentFeatureValue = values;
+                    List<Value> currentFeatureValue = values;
                     featureTable.put(key, currentFeatureValue != null ? new ArrayList<>(currentFeatureValue) : null);
                 }
             }
 
-            for (final FileValue templateName : pluginFeatures.getAllTemplates()) {
+            for (final Value templateName : pluginFeatures.getAllTemplates()) {
                 final String template = new File(pluginFeatures.getPluginDir().toURI().resolve(templateName.value)).getAbsolutePath();
                 final String templatePath = FileUtils.getRelativeUnixPath(ditaDir + File.separator + "dummy",
                         template);

--- a/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -29,7 +30,9 @@ final class ListTranstypeAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String separator = paramTable.getOrDefault("separator", "|");
-        final List<String> v = new ArrayList<>(valueSet);
+        final List<String> v = valueSet.stream()
+                .map(fileValue -> fileValue.value)
+                .collect(Collectors.toList());
         Collections.sort(v);
         final StringBuilder retBuf = new StringBuilder();
         for (final Iterator<String> i = v.iterator(); i.hasNext();) {

--- a/src/main/java/org/dita/dost/platform/PluginParser.java
+++ b/src/main/java/org/dita/dost/platform/PluginParser.java
@@ -114,7 +114,7 @@ public class PluginParser {
                 } else if (META_ELEM.equals(qName)) {
                     features.addMeta(elem.getAttribute(META_TYPE_ATTR), elem.getAttribute(META_VALUE_ATTR));
                 } else if (TEMPLATE_ELEM.equals(qName)) {
-                    features.addTemplate(new FileValue(currentPlugin, elem.getAttribute(TEMPLATE_FILE_ATTR)));
+                    features.addTemplate(new Value(currentPlugin, elem.getAttribute(TEMPLATE_FILE_ATTR)));
                 }
             }
         }

--- a/src/main/java/org/dita/dost/platform/PluginParser.java
+++ b/src/main/java/org/dita/dost/platform/PluginParser.java
@@ -114,7 +114,7 @@ public class PluginParser {
                 } else if (META_ELEM.equals(qName)) {
                     features.addMeta(elem.getAttribute(META_TYPE_ATTR), elem.getAttribute(META_VALUE_ATTR));
                 } else if (TEMPLATE_ELEM.equals(qName)) {
-                    features.addTemplate(elem.getAttribute(TEMPLATE_FILE_ATTR));
+                    features.addTemplate(new FileValue(currentPlugin, elem.getAttribute(TEMPLATE_FILE_ATTR)));
                 }
             }
         }

--- a/src/main/java/org/dita/dost/platform/Value.java
+++ b/src/main/java/org/dita/dost/platform/Value.java
@@ -10,7 +10,7 @@ package org.dita.dost.platform;
 
 import java.util.Objects;
 
-public class FileValue {
+public class Value {
     public final String id;
     public final String value;
 
@@ -18,9 +18,9 @@ public class FileValue {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        FileValue fileValue = (FileValue) o;
-        return Objects.equals(id, fileValue.id) &&
-                Objects.equals(value, fileValue.value);
+        Value value = (Value) o;
+        return Objects.equals(id, value.id) &&
+                Objects.equals(this.value, value.value);
     }
 
     @Override
@@ -28,7 +28,7 @@ public class FileValue {
         return Objects.hash(id, value);
     }
 
-    public FileValue(final String id, final String value) {
+    public Value(final String id, final String value) {
         this.id = id;
         this.value = value;
     }

--- a/src/test/java/org/dita/dost/platform/FeaturesTest.java
+++ b/src/test/java/org/dita/dost/platform/FeaturesTest.java
@@ -16,14 +16,7 @@ import static java.util.Arrays.*;
 import static org.dita.dost.platform.PluginParser.*;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -202,21 +195,18 @@ public class FeaturesTest {
         final List<FileValue> act = f.getAllTemplates();
         Collections.sort(act, new Comparator<FileValue>() {
             public int compare(final FileValue a0, final FileValue a1) {
-                final String arg0 = a0.value;
-                final String arg1 = a1.value;
-                if (arg0 == null && arg1 == null) {
-                    return 0;
-                } else if (arg0 == null) {
-                    return 1;
-                } else if (arg1 == null) {
+                if (a0 == null || a1 == null) {
                     return -1;
-                } else {
-                    return arg0.compareTo(arg1);
                 }
+                return Objects.compare(a0.value, a1.value, String::compareTo);
             }
         });
-        assertArrayEquals(new String[] {"bar", "foo", "foo", null},
-                act.toArray(new String[0]));
+        assertEquals(Arrays.asList(
+                null,
+                new FileValue("base", "bar"),
+                new FileValue("base", "foo"),
+                new FileValue("base", "foo")),
+                act);
     }
 
     private static Element getElement(final String value, final String type) {

--- a/src/test/java/org/dita/dost/platform/FeaturesTest.java
+++ b/src/test/java/org/dita/dost/platform/FeaturesTest.java
@@ -185,23 +185,25 @@ public class FeaturesTest {
     @Test
     public void testAddTemplate() {
         final Features f = new Features(new File("base", "plugins"), new File("base"));
-        f.addTemplate("foo");
-        f.addTemplate("foo");
-        f.addTemplate("bar");
+        f.addTemplate(new FileValue("base", "foo"));
+        f.addTemplate(new FileValue("base", "foo"));
+        f.addTemplate(new FileValue("base", "bar"));
         f.addTemplate(null);
     }
 
     @Test
     public void testGetAllTemplates() {
         final Features f = new Features(new File("base", "plugins"), new File("base"));
-        f.addTemplate("foo");
-        f.addTemplate("foo");
-        f.addTemplate("bar");
+        f.addTemplate(new FileValue("base", "foo"));
+        f.addTemplate(new FileValue("base", "foo"));
+        f.addTemplate(new FileValue("base", "bar"));
         f.addTemplate(null);
 
-        final List<String> act = f.getAllTemplates();
-        Collections.sort(act, new Comparator<String>() {
-            public int compare(final String arg0, final String arg1) {
+        final List<FileValue> act = f.getAllTemplates();
+        Collections.sort(act, new Comparator<FileValue>() {
+            public int compare(final FileValue a0, final FileValue a1) {
+                final String arg0 = a0.value;
+                final String arg1 = a1.value;
                 if (arg0 == null && arg1 == null) {
                     return 0;
                 } else if (arg0 == null) {

--- a/src/test/java/org/dita/dost/platform/FeaturesTest.java
+++ b/src/test/java/org/dita/dost/platform/FeaturesTest.java
@@ -178,23 +178,23 @@ public class FeaturesTest {
     @Test
     public void testAddTemplate() {
         final Features f = new Features(new File("base", "plugins"), new File("base"));
-        f.addTemplate(new FileValue("base", "foo"));
-        f.addTemplate(new FileValue("base", "foo"));
-        f.addTemplate(new FileValue("base", "bar"));
+        f.addTemplate(new Value("base", "foo"));
+        f.addTemplate(new Value("base", "foo"));
+        f.addTemplate(new Value("base", "bar"));
         f.addTemplate(null);
     }
 
     @Test
     public void testGetAllTemplates() {
         final Features f = new Features(new File("base", "plugins"), new File("base"));
-        f.addTemplate(new FileValue("base", "foo"));
-        f.addTemplate(new FileValue("base", "foo"));
-        f.addTemplate(new FileValue("base", "bar"));
+        f.addTemplate(new Value("base", "foo"));
+        f.addTemplate(new Value("base", "foo"));
+        f.addTemplate(new Value("base", "bar"));
         f.addTemplate(null);
 
-        final List<FileValue> act = f.getAllTemplates();
-        Collections.sort(act, new Comparator<FileValue>() {
-            public int compare(final FileValue a0, final FileValue a1) {
+        final List<Value> act = f.getAllTemplates();
+        Collections.sort(act, new Comparator<Value>() {
+            public int compare(final Value a0, final Value a1) {
                 if (a0 == null || a1 == null) {
                     return -1;
                 }
@@ -203,9 +203,9 @@ public class FeaturesTest {
         });
         assertEquals(Arrays.asList(
                 null,
-                new FileValue("base", "bar"),
-                new FileValue("base", "foo"),
-                new FileValue("base", "foo")),
+                new Value("base", "bar"),
+                new Value("base", "foo"),
+                new Value("base", "foo")),
                 act);
     }
 

--- a/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
+++ b/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
@@ -47,10 +47,18 @@ public class FileGeneratorTest {
     private File tempDir;
 
     private static File tempFile;
-    private final static Hashtable<String, List<String>> features = new Hashtable<String, List<String>>();
+    private final static Hashtable<String, List<FileValue>> features = new Hashtable<>();
     static {
-        features.put("element", asList("foo", "bar", "baz"));
-        features.put("attribute", asList("foo", "bar", "baz"));
+        features.put("element", asList(
+                new FileValue(null, "foo"),
+                new FileValue(null, "bar"),
+                new FileValue(null, "baz")
+        ));
+        features.put("attribute", asList(
+                new FileValue(null, "foo"),
+                new FileValue(null, "bar"),
+                new FileValue(null, "baz")
+        ));
     }
     private final static Map<String, Features> plugins = new HashMap<String, Features>();
     static {
@@ -96,19 +104,24 @@ public class FileGeneratorTest {
     }
 
     private static abstract class AbstractAction implements IAction {
-        protected List<String> inputs = new ArrayList<String>();
+        protected List<FileValue> inputs = new ArrayList<>();
         protected Map<String, String> params = new HashMap<String, String>();
         protected Map<String, Features> features;
-        public void setInput(final List<String> input) {
+        @Override
+        public void setInput(final List<FileValue> input) {
             inputs.addAll(input);
         }
+        @Override
         public void addParam(final String name, final String value) {
             params.put(name, value);
         }
+        @Override
         public void setFeatures(final Map<String, Features> features) {
             this.features = features;
         }
+        @Override
         public abstract String getResult();
+        @Override
         public void setLogger(final DITAOTLogger logger) {
             // NOOP
         }
@@ -122,7 +135,10 @@ public class FileGeneratorTest {
             paramsExp.put("id", "element");
             paramsExp.put("behavior", this.getClass().getName());
             assertEquals(paramsExp, params);
-            final List<String> inputExp = Arrays.asList(new String[] {"foo", "bar", "baz"});
+            final List<FileValue> inputExp = Arrays.asList(
+                    new FileValue(null, "foo"),
+                    new FileValue(null, "bar"),
+                    new FileValue(null, "baz"));
             assertEquals(inputExp, inputs);
             assertEquals(FileGeneratorTest.plugins, features);
             output.startElement(NULL_NS_URI, "foo", "foo", new AttributesBuilder().add("bar", "baz").build());
@@ -142,7 +158,7 @@ public class FileGeneratorTest {
             paramsExp.put(FileGenerator.PARAM_TEMPLATE, tempFile.getAbsolutePath());
 //            paramsExp.put(FileGenerator.PARAM_LOCALNAME, "foo");
             assertEquals(paramsExp, params);
-            final List<String> inputExp = Arrays.asList(new String[] {"attribute"});
+            final List<FileValue> inputExp = Arrays.asList(new FileValue[] {new FileValue(null, "attribute")});
             assertEquals(inputExp, inputs);
             assertEquals(FileGeneratorTest.plugins, features);
             return "bar";

--- a/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
+++ b/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
@@ -29,14 +29,12 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -47,17 +45,17 @@ public class FileGeneratorTest {
     private File tempDir;
 
     private static File tempFile;
-    private final static Hashtable<String, List<FileValue>> features = new Hashtable<>();
+    private final static Hashtable<String, List<Value>> features = new Hashtable<>();
     static {
         features.put("element", asList(
-                new FileValue(null, "foo"),
-                new FileValue(null, "bar"),
-                new FileValue(null, "baz")
+                new Value(null, "foo"),
+                new Value(null, "bar"),
+                new Value(null, "baz")
         ));
         features.put("attribute", asList(
-                new FileValue(null, "foo"),
-                new FileValue(null, "bar"),
-                new FileValue(null, "baz")
+                new Value(null, "foo"),
+                new Value(null, "bar"),
+                new Value(null, "baz")
         ));
     }
     private final static Map<String, Features> plugins = new HashMap<String, Features>();
@@ -104,11 +102,11 @@ public class FileGeneratorTest {
     }
 
     private static abstract class AbstractAction implements IAction {
-        protected List<FileValue> inputs = new ArrayList<>();
+        protected List<Value> inputs = new ArrayList<>();
         protected Map<String, String> params = new HashMap<String, String>();
         protected Map<String, Features> features;
         @Override
-        public void setInput(final List<FileValue> input) {
+        public void setInput(final List<Value> input) {
             inputs.addAll(input);
         }
         @Override
@@ -135,10 +133,10 @@ public class FileGeneratorTest {
             paramsExp.put("id", "element");
             paramsExp.put("behavior", this.getClass().getName());
             assertEquals(paramsExp, params);
-            final List<FileValue> inputExp = Arrays.asList(
-                    new FileValue(null, "foo"),
-                    new FileValue(null, "bar"),
-                    new FileValue(null, "baz"));
+            final List<Value> inputExp = Arrays.asList(
+                    new Value(null, "foo"),
+                    new Value(null, "bar"),
+                    new Value(null, "baz"));
             assertEquals(inputExp, inputs);
             assertEquals(FileGeneratorTest.plugins, features);
             output.startElement(NULL_NS_URI, "foo", "foo", new AttributesBuilder().add("bar", "baz").build());
@@ -158,7 +156,7 @@ public class FileGeneratorTest {
             paramsExp.put(FileGenerator.PARAM_TEMPLATE, tempFile.getAbsolutePath());
 //            paramsExp.put(FileGenerator.PARAM_LOCALNAME, "foo");
             assertEquals(paramsExp, params);
-            final List<FileValue> inputExp = Arrays.asList(new FileValue[] {new FileValue(null, "attribute")});
+            final List<Value> inputExp = Arrays.asList(new Value[] {new Value(null, "attribute")});
             assertEquals(inputExp, inputs);
             assertEquals(FileGeneratorTest.plugins, features);
             return "bar";

--- a/src/test/java/org/dita/dost/platform/PluginParserTest.java
+++ b/src/test/java/org/dita/dost/platform/PluginParserTest.java
@@ -38,7 +38,10 @@ public class PluginParserTest {
     @Test
     public void testGetAllTemplates() {
         final Features f = p.getFeatures();
-        assertEquals(Arrays.asList("xsl/shell_template.xsl", "xsl/shell2_template.xsl"),
+        assertEquals(
+                Arrays.asList(
+                        new FileValue("dummy", "xsl/shell_template.xsl"),
+                        new FileValue("dummy", "xsl/shell2_template.xsl")),
                 f.getAllTemplates());
     }
 

--- a/src/test/java/org/dita/dost/platform/PluginParserTest.java
+++ b/src/test/java/org/dita/dost/platform/PluginParserTest.java
@@ -20,9 +20,6 @@ import org.dita.dost.TestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.DefaultHandler;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 public class PluginParserTest {
 
@@ -40,8 +37,8 @@ public class PluginParserTest {
         final Features f = p.getFeatures();
         assertEquals(
                 Arrays.asList(
-                        new FileValue("dummy", "xsl/shell_template.xsl"),
-                        new FileValue("dummy", "xsl/shell2_template.xsl")),
+                        new Value("dummy", "xsl/shell_template.xsl"),
+                        new Value("dummy", "xsl/shell2_template.xsl")),
                 f.getAllTemplates());
     }
 

--- a/src/test/resources/IntegratorTest/exp/xsl/shell.xsl
+++ b/src/test/resources/IntegratorTest/exp/xsl/shell.xsl
@@ -2,6 +2,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="2.0">
   
-  <xsl:import href="../plugins/dummy/foo.xsl"/>
+  <xsl:import href="plugin:dummy:foo.xsl"/>
   
 </xsl:stylesheet>


### PR DESCRIPTION
Use `plugin` URI scheme on plugin configured XSLT imports in template files. Old code generated a relative link, but now we want to generate a `plugin` URI where possible.
