### PR TITLE
Add support for custom integrator

### DIFF
--- a/src/main/java/org/dita/dost/platform/CustomIntegrator.java
+++ b/src/main/java/org/dita/dost/platform/CustomIntegrator.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.platform;
+
+import org.dita.dost.log.DITAOTLogger;
+
+import java.io.File;
+
+/**
+ * Custom integration processor.
+ *
+ * @since 3.3
+ */
+public interface CustomIntegrator {
+    /**
+     * Set logger
+     *
+     * @param logger integration log messages
+     */
+    void setLogger(final DITAOTLogger logger);
+
+    /**
+     * Set DITA-OT installation base directory
+     *
+     * @param ditaDir absolute path to DITA-OT installation directory
+     */
+    void setDitaDir(final File ditaDir);
+
+    /**
+     * Process custom integration process.
+     *
+     * @throws Exception if integration process fails
+     */
+    void process() throws Exception;
+}

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -371,6 +371,8 @@ public final class Integrator {
                 .build();
         writeStartcmdShell(libJars);
         writeStartcmdBatch(libJars);
+
+        customIntegration();
     }
 
     private Properties readMessageBundle() throws IOException, XMLStreamException {
@@ -436,6 +438,20 @@ public final class Integrator {
         }
         res.sort(Comparator.comparing(File::getAbsolutePath));
         return res;
+    }
+
+    private void customIntegration() {
+        final ServiceLoader<CustomIntegrator> customIntegrators = ServiceLoader.load(CustomIntegrator.class);
+        for (final CustomIntegrator customIntegrator : customIntegrators) {
+            customIntegrator.setLogger(logger);
+            customIntegrator.setDitaDir(ditaDir);
+            try {
+                customIntegrator.process();
+            } catch (final Exception e) {
+                logger.error("Custom integrator " + customIntegrator.getClass().getName() + " failed: " + e.getMessage(), e);
+
+            }
+        }
     }
 
     private Iterable<String> orderPlugins(final Set<String> ids) {


### PR DESCRIPTION
Add support for custom integrator via [services](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) to allow custom integration processing.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>