### PR TITLE
Generate HTML5 section element for task steps

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -113,48 +113,52 @@ See the accompanying LICENSE file for applicable license.
         <xsl:otherwise>ul</xsl:otherwise>
       </xsl:choose>
     </xsl:param>
-    <xsl:apply-templates select="." mode="generate-task-label">
-      <xsl:with-param name="use-label">
-        <xsl:call-template name="getVariable">
-          <xsl:with-param name="id">
-            <xsl:choose>
-              <xsl:when test="contains(@class,' task/steps ')">task_procedure</xsl:when>
-              <xsl:otherwise>task_procedure_unordered</xsl:otherwise>
-            </xsl:choose>
-          </xsl:with-param>
-        </xsl:call-template>
-      </xsl:with-param>
-    </xsl:apply-templates>
-    <xsl:choose>
-      <xsl:when test="*[contains(@class,' task/step ')] and not(*[contains(@class,' task/step ')][2])">
-        <!-- Single step. Process any stepsection before the step (cannot appear after). -->
-        <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
-        <xsl:apply-templates select="*[contains(@class,' task/step ')]" mode="onestep">
-          <xsl:with-param name="step_expand" select="$step_expand"/>
-        </xsl:apply-templates>
-      </xsl:when>
-      <xsl:when test="not(*[contains(@class,' task/stepsection ')])">
-        <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
-          <xsl:with-param name="step_expand" select="$step_expand"/>
-          <xsl:with-param name="list-type" select="$list-type"/>
-        </xsl:apply-templates>
-      </xsl:when>
-      <xsl:when test="*[1][contains(@class,' task/stepsection ')] and not(*[contains(@class,' task/stepsection ')][2])">
-        <!-- Stepsection is first, no other appearances -->
-        <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
-        <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
-          <xsl:with-param name="step_expand" select="$step_expand"/>
-          <xsl:with-param name="list-type" select="$list-type"/>
-        </xsl:apply-templates>
-      </xsl:when>
-      <xsl:otherwise>
-        <!-- Stepsection elements mixed in with steps -->
-        <xsl:apply-templates select="." mode="step-elements-with-stepsection">
-          <xsl:with-param name="step_expand" select="$step_expand"/>
-          <xsl:with-param name="list-type" select="$list-type"/>
-        </xsl:apply-templates>
-      </xsl:otherwise>
-    </xsl:choose>
+    <section>
+      <xsl:call-template name="gen-toc-id"/>
+      <xsl:call-template name="setidaname"/>
+      <xsl:apply-templates select="." mode="generate-task-label">
+        <xsl:with-param name="use-label">
+          <xsl:call-template name="getVariable">
+            <xsl:with-param name="id">
+              <xsl:choose>
+                <xsl:when test="contains(@class,' task/steps ')">task_procedure</xsl:when>
+                <xsl:otherwise>task_procedure_unordered</xsl:otherwise>
+              </xsl:choose>
+            </xsl:with-param>
+          </xsl:call-template>
+        </xsl:with-param>
+      </xsl:apply-templates>
+      <xsl:choose>
+        <xsl:when test="*[contains(@class,' task/step ')] and not(*[contains(@class,' task/step ')][2])">
+          <!-- Single step. Process any stepsection before the step (cannot appear after). -->
+          <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
+          <xsl:apply-templates select="*[contains(@class,' task/step ')]" mode="onestep">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:when test="not(*[contains(@class,' task/stepsection ')])">
+          <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:when test="*[1][contains(@class,' task/stepsection ')] and not(*[contains(@class,' task/stepsection ')][2])">
+          <!-- Stepsection is first, no other appearances -->
+          <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
+          <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Stepsection elements mixed in with steps -->
+          <xsl:apply-templates select="." mode="step-elements-with-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:otherwise>
+      </xsl:choose>
+    </section>
   </xsl:template>
   
   <xsl:template match="*" mode="step-elements-with-no-stepsection">

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -612,6 +612,18 @@ See the accompanying LICENSE file for applicable license.
     </xsl:apply-templates>
   </xsl:template>
   
+  <xsl:template match="*[contains(@class,' task/taskbody ')]/*[contains(@class,' topic/example ')]">
+    <section>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="gen-toc-id"/>
+      <xsl:call-template name="setidaname"/>
+      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
+      <xsl:apply-templates select="." mode="dita2html:section-heading"/>
+      <xsl:apply-templates select="node() except *[contains(@class, ' topic/title ')]"/>
+      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
+    </section>
+  </xsl:template>
+  
   <xsl:template match="*[contains(@class,' task/taskbody ')]/*[contains(@class,' topic/example ')][not(*[contains(@class,' topic/title ')])]" mode="dita2html:section-heading">
     <xsl:apply-templates select="." mode="generate-task-label">
       <xsl:with-param name="use-label">

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -45,9 +45,8 @@ See the accompanying LICENSE file for applicable license.
   </div>
   </xsl:template>
   
-  <xsl:template match="*[contains(@class,' task/prereq ')]" mode="get-output-class">p</xsl:template>
   <xsl:template match="*[contains(@class,' task/prereq ')]" name="topic.task.prereq">
-  <div class="p">
+  <section>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="gen-toc-id"/>
     <xsl:call-template name="setidaname"/>
@@ -77,7 +76,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:call-template>
       </a></p>
     </xsl:if>
-  </div>
+  </section>
   </xsl:template>
   
   <xsl:template match="*" mode="make-steps-compact">


### PR DESCRIPTION
Add an HTML5 `<section>` element wrapper around task `<steps>` and output DITA section elements in task as HTML5 `<section>` elements.

DITA task body contains a mixture of section and list block elements and from DITA specialization perspective this makes sense. For HTML5 it makes more sense to wrap the list block into a section, to make the output more consistent and semantic.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>