### PR TITLE
Copy topicmeta when keyref used on topicref

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -237,16 +237,22 @@ public final class KeyrefPaser extends AbstractXMLFilter {
 
     @Override
     public void endElement(final String uri, final String localName, final String name) throws SAXException {
-        if (keyrefLevel != 0 && empty && !elemName.peek().equals(MAP_TOPICREF.localName)) {
+        if (keyrefLevel != 0 && empty) {
             // If current element is in the scope of key reference element
             // and the element is empty
             if (!validKeyref.isEmpty() && validKeyref.peek()) {
                 final Element elem = keyDef.element;
                 // Key reference is valid,
                 // need to pull matching content from the key definition
-                // If current element name doesn't equal the key reference element
-                // just grab the content from the matching element of key definition
-                if (!name.equals(elemName.peek())) {
+                // If keyref on topicref, and no topicmeta, copy topicmeta from key definition
+                if (elemName.peek().equals(MAP_TOPICREF.localName)) {
+                    final Optional<Element> topicmetaNode = XMLUtils.getChildElement(elem, MAP_TOPICMETA);
+                    if (topicmetaNode.isPresent()) {
+                        domToSax(topicmetaNode.get(), true, false);
+                    }
+                } else if (!name.equals(elemName.peek())) {
+                    // If current element name doesn't equal the key reference element
+                    // just grab the content from the matching element of key definition
                     final NodeList nodeList = elem.getElementsByTagName(name);
                     if (nodeList.getLength() > 0) {
                         final Element node = (Element) nodeList.item(0);
@@ -648,18 +654,29 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     }
 
     /**
-     * Serialize DOM node into a SAX stream.
+     * Serialize DOM node into a SAX stream, while modifying map classes to topic classes for common elements.
      *
      * @param elem element to serialize
      * @param retainElements {@code true} to serialize elements, {@code false} to only serialize text nodes.
      */
     private void domToSax(final Element elem, final boolean retainElements) throws SAXException {
+        domToSax(elem, retainElements, true);
+    }
+    
+    /**
+     * Serialize DOM node into a SAX stream.
+     *
+     * @param elem element to serialize
+     * @param retainElements {@code true} to serialize elements, {@code false} to only serialize text nodes.
+     * @param swapMapClass {@code true} to change map/ to topic/ in common class attributes, {@code false} to leave as is
+     */
+    private void domToSax(final Element elem, final boolean retainElements, final boolean swapMapClass) throws SAXException {
         if (retainElements) {
             final AttributesImpl atts = new AttributesImpl();
             final NamedNodeMap attrs = elem.getAttributes();
             for (int i = 0; i < attrs.getLength(); i++) {
                 final Attr a = (Attr) attrs.item(i);
-                if (a.getNodeName().equals(ATTRIBUTE_NAME_CLASS)) {
+                if (a.getNodeName().equals(ATTRIBUTE_NAME_CLASS) && swapMapClass) {
                     XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_CLASS, changeclassValue(a.getNodeValue()));
                 } else {
                     XMLUtils.addOrSetAttribute(atts, a);
@@ -674,9 +691,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 final Element e = (Element) node;
                 // retain tm and text elements
                 if (TOPIC_TM.matches(e) || TOPIC_TEXT.matches(e)) {
-                    domToSax(e, true);
+                    domToSax(e, true, swapMapClass);
                 } else {
-                    domToSax(e, retainElements);
+                    domToSax(e, retainElements, swapMapClass);
                 }
             } else if (node.getNodeType() == Node.TEXT_NODE) {
                 final char[] ch = node.getNodeValue().toCharArray();

--- a/src/test/resources/KeyrefPaserTest/exp/b.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/b.ditamap
@@ -5,7 +5,67 @@
   <topicref class="- map/topicref " href="a.xml" keyref="third"/>
 
   <topicref class="- map/topicref " href="a.xml" keyref="second" keys="third"/>
-  <topicref class="- map/topicref " collection-type="family" format="html" href="a.xml" keyref="all" keys="second" linking="sourceonly" locktitle="yes" navtitle="override"/>
+  <topicref class="- map/topicref " collection-type="family" format="html" href="a.xml" keyref="all" keys="second" linking="sourceonly" locktitle="yes" navtitle="override">
+  <topicmeta class="- map/topicmeta ">
+  <navtitle class="- topic/navtitle ">navtitle</navtitle>
+  <linktext class="- map/linktext ">linktext</linktext>
+  <searchtitle class="- map/searchtitle ">searchtitle</searchtitle>
+  <shortdesc class="- map/shortdesc ">shortdesc</shortdesc>
+  <author class="- topic/author ">author</author>
+  <source class="- topic/source ">source</source>
+  <publisher class="- topic/publisher ">publisher</publisher>
+  <copyright class="- topic/copyright ">
+  <copyryear class="- topic/copyryear " year="2012"/>
+  <copyrholder class="- topic/copyrholder ">Example</copyrholder>
+  </copyright>
+  <critdates class="- topic/critdates ">
+  <created class="- topic/created " date="2012-08-16"/>
+  </critdates>
+  <permissions class="- topic/permissions " view="all"/>
+  <metadata class="- topic/metadata ">
+  <audience class="- topic/audience " name="metadata-audience"/>
+  <category class="- topic/category ">metadata category</category>
+  <keywords class="- topic/keywords ">
+  <keyword class="- topic/keyword ">metadata keywords</keyword>
+  </keywords>
+  <prodinfo class="- topic/prodinfo ">
+  <prodname class="- topic/prodname ">metadata test</prodname>
+  <vrmlist class="- topic/vrmlist ">
+  <vrm class="- topic/vrm " version="1"/>
+  </vrmlist>
+  </prodinfo>
+  <othermeta class="- topic/othermeta " content="metadata-othermeta" name="metadata-othermeta"/>
+  <data class="- topic/data ">metadata data</data>
+  <data-about class="- topic/data-about ">
+  <data class="- topic/data ">metadata data-about</data>
+  </data-about>
+  <foreign class="- topic/foreign ">metadata foreign</foreign>
+  <unknown class="- topic/unknown ">metadata unknown</unknown>
+  </metadata>
+  <audience class="- topic/audience " name="audience"/>
+  <category class="- topic/category ">category</category>
+  <keywords class="- topic/keywords ">
+  <keyword class="- topic/keyword ">keywords</keyword>
+  </keywords>
+  <exportanchors class="+ topic/keywords delay-d/exportanchors ">
+  <anchorid class="+ topic/keyword delay-d/anchorid " id="anchorid"/>
+  </exportanchors>
+  <prodinfo class="- topic/prodinfo ">
+  <prodname class="- topic/prodname ">test</prodname>
+  <vrmlist class="- topic/vrmlist ">
+  <vrm class="- topic/vrm " version="1"/>
+  </vrmlist>
+  </prodinfo>
+  <othermeta class="- topic/othermeta " content="othermeta" name="othermeta"/>
+  <resourceid class="- topic/resourceid " id="resourceid"/>
+  <data class="- topic/data ">data</data>
+  <data-about class="- topic/data-about ">
+  <data class="- topic/data ">data-about</data>
+  </data-about>
+  <foreign class="- topic/foreign ">foreign</foreign>
+  <unknown class="- topic/unknown ">unknown</unknown>
+  </topicmeta>
+</topicref>
   <topicref class="- map/topicref " collection-type="choice" format="dita" href="a.xml" id="all" keys="all" linking="normal" locktitle="no" navtitle="all" processing-role="resource-only">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">override navtitle</navtitle>
@@ -68,28 +128,187 @@
     </topicmeta>
   </topicref>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
-    <topicref class="- map/topicref " keyref="topicref"/>
+    <topicref class="- map/topicref " keyref="topicref">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">topicref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">topicref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
     <topicref class="- map/topicref " keyref="empty"/>
-    <topicref class="- map/topicref " keyref="author"/>
-    <topicref class="- map/topicref " keyref="data"/>
-    <topicref class="- map/topicref " keyref="data-about"/>
-    <topicref class="- map/topicref " keyref="publisher"/>
-    <topicref class="- map/topicref " keyref="source"/>
-    <topicref class="- map/topicref " keyref="indexterm"/>
-    <topicref class="- map/topicref " keyref="index-base"/>
-    <topicref class="- map/topicref " keyref="indextermref"/>
+    <topicref class="- map/topicref " keyref="author">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">author linktext</linktext>
+    <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+    <author class="- topic/author ">author author</author>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">author keyword</keyword>
+    </keywords>
+    </topicmeta></topicref>
+    <topicref class="- map/topicref " keyref="data">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data keyword</keyword>
+    </keywords>
+    <data class="- topic/data ">data data</data>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="data-about">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data-about linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data-about keyword</keyword>
+    </keywords>
+    <data-about class="- topic/data-about ">
+    <data class="- topic/data ">data-about data-about</data>
+    </data-about>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="publisher">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">publisher linktext</linktext>
+    <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+    <publisher class="- topic/publisher ">publisher publisher</publisher>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">publisher keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="source">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">source linktext</linktext>
+    <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+    <source class="- topic/source ">source source</source>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">source keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="indexterm">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indexterm linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indexterm keyword</keyword>
+    <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="index-base">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">index-base linktext</linktext>
+    <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">index-base keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " keyref="indextermref">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indextermref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indextermref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
     <navref class="- map/navref " keyref="navref"/>
   </topicgroup>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
-    <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="author_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="data_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="data-about_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="publisher_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="source_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="indexterm_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="index-base_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">topicref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">topicref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="author_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">author linktext</linktext>
+    <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+    <author class="- topic/author ">author author</author>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">author keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="data_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data keyword</keyword>
+    </keywords>
+    <data class="- topic/data ">data data</data>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="data-about_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data-about linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data-about keyword</keyword>
+    </keywords>
+    <data-about class="- topic/data-about ">
+    <data class="- topic/data ">data-about data-about</data>
+    </data-about>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="publisher_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">publisher linktext</linktext>
+    <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+    <publisher class="- topic/publisher ">publisher publisher</publisher>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">publisher keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="source_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">source linktext</linktext>
+    <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+    <source class="- topic/source ">source source</source>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">source keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="indexterm_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indexterm linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indexterm keyword</keyword>
+    <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="index-base_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">index-base linktext</linktext>
+    <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">index-base keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indextermref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indextermref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
     <navref class="- map/navref " keyref="navref_link" mapref="a.xml"/>
   </topicgroup>
   <topicref class="- map/topicref " keyref="copy" href="a-copy.xml" copy-to="a-copy.xml"/>

--- a/src/test/resources/KeyrefPaserTest/exp/d.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/d.ditamap
@@ -3,26 +3,186 @@
   ditaarch:DITAArchVersion="1.2">
 
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="KEY_SCOPE">
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_topicref_link" type="dead"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_author_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_data_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_data-about_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_publisher_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_source_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_indexterm_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_index-base_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="ks_indextermref_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_topicref_link" type="dead">
+     <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">topicref linktext</linktext>
+      <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+      <keywords class="- topic/keywords ">
+       <keyword class="- topic/keyword ">topicref keyword</keyword>
+      </keywords>
+     </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_author_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">author linktext</linktext>
+    <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+    <author class="- topic/author ">author author</author>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">author keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data keyword</keyword>
+    </keywords>
+    <data class="- topic/data ">data data</data>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data-about_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data-about linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data-about keyword</keyword>
+    </keywords>
+    <data-about class="- topic/data-about ">
+    <data class="- topic/data ">data-about data-about</data>
+    </data-about>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_publisher_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">publisher linktext</linktext>
+    <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+    <publisher class="- topic/publisher ">publisher publisher</publisher>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">publisher keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_source_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">source linktext</linktext>
+    <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+    <source class="- topic/source ">source source</source>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">source keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indexterm_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indexterm linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indexterm keyword</keyword>
+    <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_index-base_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">index-base linktext</linktext>
+    <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">index-base keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indextermref_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indextermref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indextermref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
     <navref class="- map/navref " keyref="ks_navref_link" mapref="a.xml"/>
 
-    <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="author_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="data_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="data-about_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="publisher_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="source_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="indexterm_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="index-base_link"/>
-    <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">topicref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">topicref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="author_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">author linktext</linktext>
+    <shortdesc class="- map/shortdesc ">author shortdesc</shortdesc>
+    <author class="- topic/author ">author author</author>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">author keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="data_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data keyword</keyword>
+    </keywords>
+    <data class="- topic/data ">data data</data>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="data-about_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">data-about linktext</linktext>
+    <shortdesc class="- map/shortdesc ">data-about shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">data-about keyword</keyword>
+    </keywords>
+    <data-about class="- topic/data-about ">
+    <data class="- topic/data ">data-about data-about</data>
+    </data-about>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="publisher_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">publisher linktext</linktext>
+    <shortdesc class="- map/shortdesc ">publisher shortdesc</shortdesc>
+    <publisher class="- topic/publisher ">publisher publisher</publisher>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">publisher keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="source_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">source linktext</linktext>
+    <shortdesc class="- map/shortdesc ">source shortdesc</shortdesc>
+    <source class="- topic/source ">source source</source>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">source keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="indexterm_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indexterm linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indexterm shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indexterm keyword</keyword>
+    <indexterm class="- topic/indexterm ">indexterm indexterm</indexterm>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="index-base_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">index-base linktext</linktext>
+    <shortdesc class="- map/shortdesc ">index-base shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">index-base keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="a.xml" keyref="indextermref_link">
+    <topicmeta class="- map/topicmeta ">
+    <linktext class="- map/linktext ">indextermref linktext</linktext>
+    <shortdesc class="- map/shortdesc ">indextermref shortdesc</shortdesc>
+    <keywords class="- topic/keywords ">
+    <keyword class="- topic/keyword ">indextermref keyword</keyword>
+    </keywords>
+    </topicmeta>
+    </topicref>
     <navref class="- map/navref " keyref="navref_link" mapref="a.xml"/>
   </topicgroup>
 </map>

--- a/src/test/resources/keyref/exp/preprocess/test.ditamap
+++ b/src/test/resources/keyref/exp/preprocess/test.ditamap
@@ -24,10 +24,9 @@
   </topicref>
   <topicref class="- map/topicref " href="b.xml" keyref="topicref" navtitle="b" scope="peer">
     <topicmeta class="- map/topicmeta ">
-      <navtitle class="- topic/navtitle ">b</navtitle>
-      <?ditaot gentext?>
-      <linktext class="- map/linktext ">b</linktext>
-    </topicmeta>
+      <navtitle class="- topic/navtitle ">b</navtitle><?ditaot usertext?><linktext class="- map/linktext ">topicref linktext</linktext><?ditaot usershortdesc?><shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+      <keywords class="- topic/keywords "><keyword class="- topic/keyword ">topicref keyword</keyword></keywords>
+      </topicmeta>
   </topicref>
   <navref class="- map/navref " mapref="b.xml" keyref="navref" scope="peer"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " href="b.xml" keys="author" navtitle="b" processing-role="resource-only" scope="peer">


### PR DESCRIPTION
## Description

Today, when I define a key with `<topicmeta>` (including a title, link text, or anything else), and then I refer to that key from a `topicref` (`<topicref keyref="sample"/>`), none of the topicmeta is preserved on the reference -- only attributes are copied. In the Keyref writer, this is because it explicitly checks for `topicref` elements, and does not write out any sub-elements when the element ends. For other elements (such as `link`, `keyword`, etc) it checks for empty content, and then writes out any required text.

This update removes that "if topicref" test that skips all sub-element, processing. Then, if the element is `topicref`, *and* if there is no sub-element, *and* there is a `topicmeta` element with the key definition, it copies that `topicmeta` into the keyref element. This ensures we preserve link text and any other metadata.

There is also an additional tweak to the `domToSax` method. Currently, in all cases, when writing out `<linktext>` from the key definition, the `@class` value is changed from `map/linktext` to `topic/linktext`. This makes sense for all previously handled cases but breaks map processing; when the link text is written out inside of `topicmeta` the original class must be preserved. I've updated the method so that by default it keeps the current behavior (change classes), but when calling from the topicref context, we can turn off that swap and keep the original classes.

This is not a complete fix: it does not add `topicmeta` if the element with `@keyref` has other `topicref` children, AND it does not add or merge metadata if the element with `@keyref` has _different_ metadata. Both of those should be possible, but with the streaming nature of this class I think it would require a *lot* more tests in `startElement` and/or `endElement` to ensure elements are added/merged in the right order. I didn't need any of that so focused here on the simple case.

## Motivation and Context

I have external links defined using keys, for example:
```
<keydef keys="ditaot" href="https://www.dita-ot.org" scope="external" format="html">
  <topicmeta>
    <linktext>DITA Open Toolkit</linktext>
  </topicmeta>
</keydef>
```

I refer to that key in a relationship table:
`<relcell><topicref keyref="ditaot"/></relcell>`

When `@keyref` is resolved today, *only the attributes are preserved* -- so I get the correct link, but everything in `topicmeta` is discarded. As a result, all links added based on this relationship table appear using the link text `https://www.dita-ot.org` rather than the actual desired link text `DITA Open Toolkit`. With this fix, the link text is preserved inside the key reference, and the link is correct.

This also fixes #1439 using the sample provided in that report -- because the `topicmeta` is preserved, the link text is preserved to be used in whatever way needed for the TOC, so we now get consistent TOC behavior for links defined with a URI and for the same links used via keys.

## How Has This Been Tested?

Test set here, based on #1439 and adding my relationship table case:
[1439.zip](https://github.com/dita-ot/dita-ot/files/2738007/1439.zip)

Also resulted in modifications to several existing unit / integration test cases that exhibited this behavior.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.