### PR TITLE
Add support for SAX filter in pipeline modules

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -266,6 +266,9 @@ public final class ExtensibleAntInvoker extends Task {
     }
 
     private static Predicate<FileInfo> combine(final Collection<FileInfoFilterElem> filters) {
+        if (filters.isEmpty()) {
+            return f -> true;
+        }
         final List<Predicate<FileInfo>> res = filters.stream()
                 .map(FileInfoFilterElem::toFilter)
                 .collect(Collectors.toList());

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -49,13 +49,21 @@ public final class ExtensibleAntInvoker extends Task {
 
     private DITAOTAntLogger logger;
     private final ModuleFactory factory = ModuleFactory.instance();
-    /** Pipeline attributes and parameters */
+    /**
+     * Pipeline attributes and parameters
+     */
     private final Map<String, String> attrs = new HashMap<>();
-    /** Nested params. */
+    /**
+     * Nested params.
+     */
     private final ArrayList<ParamElem> pipelineParams;
-    /** Nested modules. */
+    /**
+     * Nested modules.
+     */
     private final ArrayList<ModuleElem> modules;
-    /** Temporary directory. */
+    /**
+     * Temporary directory.
+     */
     private File tempDir;
 
     /**
@@ -70,6 +78,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Set message.
+     *
      * @param m message
      */
     public void setMessage(final String m) {
@@ -78,6 +87,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Set input map.
+     *
      * @param inputmap input map file, may be relative or absolute
      */
     public void setInputmap(final String inputmap) {
@@ -86,6 +96,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Set temporary directory.
+     *
      * @param tempdir temporary directory
      */
     public void setTempdir(final File tempdir) {
@@ -96,6 +107,7 @@ public final class ExtensibleAntInvoker extends Task {
     /**
      * Handle nested parameters. Add the key/value to the pipeline hash, unless
      * the "if" attribute is set and refers to a unset property.
+     *
      * @return parameter
      */
     public ParamElem createParam() {
@@ -137,7 +149,7 @@ public final class ExtensibleAntInvoker extends Task {
             if (!p.isValid()) {
                 throw new BuildException("Incomplete parameter");
             }
-            if (isValid(getProject(),getLocation(), p.getIf(), p.getUnless())) {
+            if (isValid(getProject(), getLocation(), p.getIf(), p.getUnless())) {
                 attrs.put(p.getName(), p.getValue());
             }
         }
@@ -147,6 +159,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Execution point of this invoker.
+     *
      * @throws BuildException exception
      */
     @Override
@@ -155,11 +168,11 @@ public final class ExtensibleAntInvoker extends Task {
 
         final Job job = getJob(tempDir, getProject());
         try {
-            for (final ModuleElem m: modules) {
+            for (final ModuleElem m : modules) {
                 m.setProject(getProject());
                 m.setLocation(getLocation());
                 final PipelineHashIO pipelineInput = new PipelineHashIO();
-                for (final Map.Entry<String, String> e: attrs.entrySet()) {
+                for (final Map.Entry<String, String> e : attrs.entrySet()) {
                     pipelineInput.setAttribute(e.getKey(), e.getValue());
                 }
                 AbstractPipelineModule mod = getPipelineModule(m, pipelineInput);
@@ -292,7 +305,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     private Set<File> readListFile(final List<IncludesFileElem> includes, final DITAOTAntLogger logger) {
         final Set<File> inc = new HashSet<>();
-        for (final IncludesFileElem i: includes) {
+        for (final IncludesFileElem i : includes) {
             if (!isValid(getProject(), getLocation(), i.ifProperty, null)) {
                 continue;
             }
@@ -306,6 +319,7 @@ public final class ExtensibleAntInvoker extends Task {
         }
         return inc;
     }
+
     public static boolean isValid(final Project project, final Location location, final String ifProperty, final String unlessProperty) {
         if (ifProperty != null) {
             final String msg = MessageUtils.getMessage("DOTA014W", "if", "if:set")
@@ -355,7 +369,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         public List<FilterPair> getFilters() throws IllegalAccessException, InstantiationException {
             final List<FilterPair> res = new ArrayList<>(filters.size());
-            for (final XmlFilterElem f: filters) {
+            for (final XmlFilterElem f : filters) {
                 if (isValid(getProject(), getLocation(), f.getIf(), f.getUnless())) {
                     final AbstractXMLFilter fc = f.getImplementation().newInstance();
                     for (final ParamElem p : f.params) {
@@ -399,6 +413,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Nested pipeline XSLT element configuration.
+     *
      * @author jelovirt
      */
     public static class XsltElem extends ModuleElem {
@@ -456,9 +471,9 @@ public final class ExtensibleAntInvoker extends Task {
         }
 
         public void setIncludesfile(final File includesfile) {
-              final IncludesFileElem i = new IncludesFileElem();
-              i.setName(includesfile);
-              includes.add(i);
+            final IncludesFileElem i = new IncludesFileElem();
+            i.setName(includesfile);
+            includes.add(i);
         }
 
         public void setExcludesfile(final File excludesfile) {
@@ -503,12 +518,15 @@ public final class ExtensibleAntInvoker extends Task {
     public static class OutputPropertyElem extends ConfElem {
         private String name;
         private String value;
+
         public void setName(final String name) {
             this.name = name;
         }
+
         public void setValue(final String value) {
             this.value = value;
         }
+
         public boolean isValid() {
             return (name != null && value != null);
         }
@@ -516,6 +534,7 @@ public final class ExtensibleAntInvoker extends Task {
 
     public static class IncludesFileElem extends ConfElem {
         private File file;
+
         public void setName(final File file) {
             this.file = file;
         }
@@ -558,12 +577,11 @@ public final class ExtensibleAntInvoker extends Task {
 
     /**
      * Nested pipeline SAX filter pipe element configuration.
+     *
      * @author jelovirt
      */
     public static class SaxPipeElem extends ModuleElem {
 
-//        private final List<XmlFilterElem> filters = new ArrayList<>();
-//        private Project project;
         private List<String> format;
 
         // Ant setters
@@ -572,14 +590,10 @@ public final class ExtensibleAntInvoker extends Task {
             this.format = Collections.singletonList(format);
         }
 
-//        public void addConfiguredFilter(final XmlFilterElem filter) {
-//            filters.add(filter);
-//        }
-
         @Override
         public List<FilterPair> getFilters() throws IllegalAccessException, InstantiationException {
             final List<FilterPair> res = new ArrayList<>(filters.size());
-            for (final XmlFilterElem f: filters) {
+            for (final XmlFilterElem f : filters) {
                 if (isValid(getProject(), getLocation(), f.getIf(), f.getUnless())) {
                     final AbstractXMLFilter fc = f.getImplementation().newInstance();
                     for (final ParamElem p : f.params) {
@@ -612,7 +626,9 @@ public final class ExtensibleAntInvoker extends Task {
         }
     }
 
-    /** Nested pipeline SAX filter element configuration. */
+    /**
+     * Nested pipeline SAX filter element configuration.
+     */
     public static class XmlFilterElem extends ConfElem {
 
         public final List<FileInfoFilterElem> fileInfoFilters = new ArrayList<>();
@@ -640,7 +656,9 @@ public final class ExtensibleAntInvoker extends Task {
 
     }
 
-    /** Nested parameters. */
+    /**
+     * Nested parameters.
+     */
     public static class ParamElem extends ConfElem {
 
         private String name;
@@ -648,6 +666,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Get parameter name.
+         *
          * @return parameter name, {@code null} if not set
          */
         public String getName() {
@@ -656,6 +675,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Validate that all required attributes have been set.
+         *
          * @return isValid {@code true} is valid object, otherwise {@code false}
          */
         public boolean isValid() {
@@ -664,6 +684,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Set parameter name.
+         *
          * @param s name
          */
         public void setName(final String s) {
@@ -672,6 +693,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Get parameter value.
+         *
          * @return parameter value, {@code null} if not set
          */
         public String getValue() {
@@ -680,6 +702,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Set parameter value.
+         *
          * @param v parameter value
          */
         public void setExpression(final String v) {
@@ -688,6 +711,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Set parameter value.
+         *
          * @param v parameter value
          */
         public void setValue(final String v) {
@@ -696,6 +720,7 @@ public final class ExtensibleAntInvoker extends Task {
 
         /**
          * Set parameter file value.
+         *
          * @param v parameter file value
          */
         public void setLocation(final File v) {

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -47,5 +48,7 @@ public interface AbstractPipelineModule {
     void setJob(Job job);
 
     void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter);
+
+    void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe);
 
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -49,6 +49,7 @@ public interface AbstractPipelineModule {
 
     void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter);
 
-    void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe);
+    default void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {
+    }
 
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -14,6 +14,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -24,6 +25,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     protected DITAOTLogger logger;
     protected Job job;
     Predicate<FileInfo> fileInfoFilter;
+    List<XmlFilterModule.FilterPair> filters;
 
     @Override
     public void setLogger(final DITAOTLogger logger) {
@@ -40,5 +42,10 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     @Override
     public void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter) {
         this.fileInfoFilter = fileInfoFilter;
+    }
+
+    @Override
+    public void setProcessingPipe(List<XmlFilterModule.FilterPair> filters) {
+        this.filters = filters;
     }
 }

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -246,7 +246,8 @@ public final class DebugAndFilterModule extends SourceReaderModule {
      *
      * @param fileToParse absolute URI to current file being processed
      */
-    private List<XMLFilter> getProcessingPipe(final URI fileToParse) {
+    @Override
+    List<XMLFilter> getProcessingPipe(final URI fileToParse) {
         final List<XMLFilter> pipe = new ArrayList<>();
 
         if (genDebugInfo) {
@@ -279,6 +280,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
 
         pipe.add(topicFragmentFilter);
 
+        pipe.addAll(super.getProcessingPipe(fileToParse));
 //        linkRewriteFilter.setCurrentFile(currentFile);
 //        pipe.add(linkRewriteFilter);
 

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -324,7 +324,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
      *
      * @param fileToParse absolute path to current file being processed
      */
-    private List<XMLFilter> getProcessingPipe(final URI fileToParse) {
+    @Override
+    List<XMLFilter> getProcessingPipe(final URI fileToParse) {
         assert fileToParse.isAbsolute();
         final List<XMLFilter> pipe = new ArrayList<>();
 

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -11,13 +11,14 @@ import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.XMLReader;
+import org.dita.dost.writer.*;
+import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderFactory;
 
 import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -127,4 +128,22 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
         reader.setEntityResolver(CatalogUtils.getCatalogResolver());
     }
 
+    /**
+     * Get pipe line filters
+     *
+     * @param fileToParse absolute URI to current file being processed
+     */
+    List<XMLFilter> getProcessingPipe(final URI fileToParse) {
+        final List<XMLFilter> pipe = new ArrayList<>();
+
+        for (XmlFilterModule.FilterPair pair : filters) {
+            final AbstractXMLFilter filter = pair.filter;
+            filter.setLogger(logger);
+            filter.setJob(job);
+            filter.setCurrentFile(fileToParse);
+            pipe.add(filter);
+        }
+
+        return pipe;
+    }
 }

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -29,7 +29,6 @@ import java.util.function.Predicate;
 public final class XmlFilterModule extends AbstractPipelineModuleImpl {
 
     private final XMLUtils xmlUtils = new XMLUtils();
-    private List<FilterPair> pipe;
 
     @Override
     public void setLogger(final DITAOTLogger logger) {
@@ -59,10 +58,6 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
         return null;
     }
 
-    public void setProcessingPipe(final List<FilterPair> pipe) {
-        this.pipe = pipe;
-    }
-
     /**
      * Get pipe line filters
      *
@@ -72,7 +67,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
         final URI fileToParse = job.tempDirURI.resolve(fi.uri);
         assert fileToParse.isAbsolute();
         final List<XMLFilter> res = new ArrayList<>();
-        for (final FilterPair p: pipe) {
+        for (final FilterPair p: filters) {
             if (p.predicate.test(fi)) {
                 final AbstractXMLFilter f = p.filter;
                 logger.debug("Configure filter " + f.getClass().getCanonicalName());

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -17,10 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -96,6 +93,8 @@ public class DebugAndFilterModuleTest {
         final DebugAndFilterModule module = new DebugAndFilterModule();
         module.setLogger(new TestUtils.TestLogger());
         module.setJob(job);
+        module.setProcessingPipe(Collections.emptyList());
+        
         module.execute(pipelineInput);
     }
 

--- a/src/test/java/org/dita/dost/module/DummyPipelineModule.java
+++ b/src/test/java/org/dita/dost/module/DummyPipelineModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -44,6 +45,11 @@ public class DummyPipelineModule implements AbstractPipelineModule {
 
     @Override
     public void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter) {
+        // Noop
+    }
+
+    @Override
+    public void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {
         // Noop
     }
 


### PR DESCRIPTION
Allow pipeline modules to be configured to use SAX filters. This allows configuring the module's behavior more at Ant level and add additional processing to a module.