### PR TITLE
Drop duplicate ID from dt #3180

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -97,7 +97,6 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dt ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dt__content">
-            <xsl:call-template name="commonattributes"/>
             <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/dt ')])">
               <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
             </xsl:if>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes #3180 

Currently when processing `<dt>` we create a block, call `<xsl:call-template name="commonattributes"/>` (which adds language info and `@id`), then call the common processing for inline elements that can turn into links with a key. The common processing creates an `fo:inline` element and then calls `<xsl:call-template name="commonattributes"/>` again, resulting in a duplicate ID.

This update drops the ID from the block and keeps it on the inline element. Links to the ID still resolve correctly using the term text.