### PR TITLE
Add extension points to contribute params to reader modules

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -142,6 +142,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="profiling.enable" value="${map.filter-on-parse}" unless:set="map.filter-on-parse"/>
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
     <!-- TODO replace with direct resource collection availability test -->
@@ -265,6 +266,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         <!-- Not needed for topics -->
         <!--param name="force-unique" value="${force-unique}" if:set="force-unique"/-->
+        <dita:extension id="dita.preprocess.topic-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -136,6 +136,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="profiling.enable" value="${filter-on-parse}" unless:set="filter-on-parse"/>
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        <dita:extension id="dita.preprocess.debug-filter.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
     <!-- generate list files -->

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -51,6 +51,9 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 2.1 -->
   <extension-point id="depend.preprocess.copy-subsidiary.pre" name="Copy subsidiary pre-target"/>
   <extension-point id="depend.preprocess.post" name="Preprocessing post-target"/>
+  <extension-point id="dita.preprocess.debug-filter.param" name="Debug filter module parameters"/>
+  <extension-point id="dita.preprocess.map-reader.param" name="Debug filter module parameters"/>
+  <extension-point id="dita.preprocess.topic-reader.param" name="Debug filter module parameters"/>
   <extension-point id="dita.preprocess.conref.param" name="Content reference XSLT parameters"/>
   <extension-point id="dita.preprocess.mapref.param" name="Map reference XSLT parameters"/>
   <extension-point id="dita.preprocess.mappull.param" name="Map pull  XSLT parameters"/>


### PR DESCRIPTION
Add extension points to add parameters and filters to preprocess reader modules:

* `dita.preprocess.debug-filter.param`
* `dita.preprocess.map-reader.param`
* `dita.preprocess.topic-reader.param`

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>