### PR TITLE
Use base Jing as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.6'
-    compile group: 'org.dita-ot', name: 'jing', version: '2.0.0'
+    compile group: 'org.relaxng', name: 'jing', version: '20181222'
     runtime group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.3'
     testCompile group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testCompile group: 'junit', name: 'junit', version:'4.12'


### PR DESCRIPTION
Jing version 20181222 contains the necessary features to support RelaxNG schemas. Use the base release instead of https://github.com/dita-ot/jing-trang/.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>