### PR TITLE
add priority to template match

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/glossdisplay.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/glossdisplay.xsl
@@ -22,7 +22,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <!-- Wrapper for glossentry (concept) group: "Related concepts" in a <div>. -->
-  <xsl:template match="*[contains(@class, ' topic/link ')][@type='glossentry']" mode="related-links:result-group" name="related-links:result.glossentry">
+  <xsl:template match="*[contains(@class, ' topic/link ')][@type='glossentry']" mode="related-links:result-group" name="related-links:result.glossentry" priority="1">
     <xsl:param name="links"/>
     <xsl:call-template name="related-links:result.concept">
       <xsl:with-param name="links" select="$links"/>


### PR DESCRIPTION
If I reference a glossentry in a topic related-links:
```
  <related-links>
    <link keyref="gloss_entry"/>
  </related-links>
```

I get an ambiguous rule match in the logs.

>      [xslt] : Error! Ambiguous rule match for /topic/related-links[1]/link[1]
>      [xslt] Matches both "*[contains(@class, ' topic/link ')]" on line 274 of DITA-OT2.x/plugins/org.dita.html5/xsl/rel-links.xsl
>      [xslt] and "*[contains(@class, ' topic/link ')][@type='glossentry']" on line 25 of DITA-OT2.x/plugins/org.dita.html5/xsl/glossdisplay.xsl

I think the correct way to handle this is setting a higher priority on the more specific match?

I have tested this in DITA-OT 2.5.4 but it looks like it is still an issue in the latest