### PR TITLE
Feature/2523 keyscopes in flattened map not handled

### DIFF
--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -260,6 +260,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
         if (hrefNode == null) {
             hrefNode = elem.getAttributeNode(ATTRIBUTE_NAME_HREF);
         }
+        if (hrefNode == null && SUBMAP.matches(elem)) {
+            hrefNode = elem.getAttributeNode(ATTRIBUTE_NAME_DITA_OT_ORIG_HREF);
+        }
         final boolean isResourceOnly = isResourceOnly(elem);
         for (final KeyScope s: ss) {
             if (hrefNode != null) {

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1011,6 +1011,8 @@ public final class Constants {
     public static final String DITA_OT_NS_PREFIX = "dita-ot";
     public static final String DITA_OT_NAMESPACE = "http://dita-ot.sourceforge.net";
     public static final String DITA_OT_NS = "http://dita-ot.sourceforge.net/ns/201007/dita-ot";
+    /**dita-ot:orig-href.*/
+    public static final String ATTRIBUTE_NAME_DITA_OT_ORIG_HREF = DITA_OT_NS_PREFIX + ":" + "orig-href";
 
 
     /**ATTR_CLASS_VALUE_SUBJECT_SCHEME_BASE. Deprecated since 3.0 */

--- a/src/main/java/org/dita/dost/util/KeyScope.java
+++ b/src/main/java/org/dita/dost/util/KeyScope.java
@@ -36,7 +36,7 @@ public class KeyScope {
     }
 
     public Set<String> keySet() {
-        return keyDefinition.keySet();
+        return Collections.unmodifiableSet(keyDefinition.keySet());
     }
 
     public KeyScope getChildScope(final String scope) {

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -119,7 +119,11 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             ATTRIBUTE_NAME_DATAKEYREF
     ));
 
-    private KeyScope definitionMap;
+
+    /**
+     * Stack used to store the current KeyScope, and its start uri.
+     */
+    private final Deque<KeyScopeInfo> definitionMaps;
 
     /**
      * Stack used to store the place of current element
@@ -149,8 +153,11 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     private boolean empty;
 
+    /** Stack of element names. */
+    private final Deque<String> elemNames;
+
     /** Stack of element names of the element containing keyref attribute. */
-    private final Deque<String> elemName;
+    private final Deque<String> keyRefElemNames;
 
     /** Current element keyref info, {@code null} if not keyref type element. */
     private KeyrefInfo currentElement;
@@ -172,12 +179,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     public KeyrefPaser() {
         keyrefLevel = 0;
+        definitionMaps = new ArrayDeque<>();
         keyrefLevalStack = new ArrayDeque<>();
         validKeyref = new ArrayDeque<>();
         empty = true;
-        elemName = new ArrayDeque<>();
+        elemNames = new ArrayDeque<>();
+        keyRefElemNames = new ArrayDeque<>();
         hasSubElem = new ArrayDeque<>();
         mergeUtils = new MergeUtils();
+    }
+
+    public String getCurrentElemId() {
+        return String.join(".", elemNames);
     }
 
     @Override
@@ -187,7 +200,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     }
 
     public void setKeyDefinition(final KeyScope definitionMap) {
-        this.definitionMap = definitionMap;
+        this.definitionMaps.push(new KeyScopeInfo(null, definitionMap));
     }
 
     /**
@@ -232,7 +245,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
 
     @Override
     public void endElement(final String uri, final String localName, final String name) throws SAXException {
-        if (keyrefLevel != 0 && empty && !elemName.peek().equals(MAP_TOPICREF.localName)) {
+        if (keyrefLevel != 0 && empty && !keyRefElemNames.peek().equals(MAP_TOPICREF.localName)) {
             // If current element is in the scope of key reference element
             // and the element is empty
             if (!validKeyref.isEmpty() && validKeyref.peek()) {
@@ -241,7 +254,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 // need to pull matching content from the key definition
                 // If current element name doesn't equal the key reference element
                 // just grab the content from the matching element of key definition
-                if (!name.equals(elemName.peek())) {
+                if (!name.equals(keyRefElemNames.peek())) {
                     final NodeList nodeList = elem.getElementsByTagName(name);
                     if (nodeList.getLength() > 0) {
                         final Element node = (Element) nodeList.item(0);
@@ -373,9 +386,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             // To the end of key reference, pop the stacks.
             keyrefLevel = keyrefLevalStack.pop();
             validKeyref.pop();
-            elemName.pop();
+            keyRefElemNames.pop();
             hasSubElem.pop();
         }
+
+        final String keyscopeElemID = definitionMaps.peek().id;
+        if (keyscopeElemID != null && keyscopeElemID.equals(getCurrentElemId())) {
+            definitionMaps.pop();
+            logger.debug("Using " + (definitionMaps.peek().scope.name != null ? definitionMaps.peek().scope.name + " scope" : "root scope"));
+        }
+
+        elemNames.pop();
+
         getContentHandler().endElement(uri, localName, name);
     }
 
@@ -436,6 +458,18 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     @Override
     public void startElement(final String uri, final String localName, final String name,
             final Attributes atts) throws SAXException {
+
+        elemNames.push(name);
+        final String keyscopeName = atts.getValue(ATTRIBUTE_NAME_KEYSCOPE);
+        if (keyscopeName != null) {
+            KeyScope childScope = definitionMaps.peek().scope.getChildScope(keyscopeName);
+
+            if (childScope != null) {
+                logger.debug("Using " + (childScope.name != null ? childScope.name + " scope" : "root scope"));
+                definitionMaps.push(new KeyScopeInfo(getCurrentElemId(), childScope));
+            }
+        }
+
         currentElement = null;
         final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
         for (final KeyrefInfo k : keyrefInfos) {
@@ -455,7 +489,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 hasSubElem.push(true);
             }
         } else {
-            elemName.push(name);
+            keyRefElemNames.push(name);
             if (keyrefLevel != 0) {
                 keyrefLevalStack.push(keyrefLevel);
                 hasSubElem.pop();
@@ -488,7 +522,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                     elementId = keyrefValue.substring(slashIndex);
                 }
 
-                keyDef = definitionMap.get(keyName);
+                keyDef = definitionMaps.peek().scope.get(keyName);
                 final Element elem = keyDef != null ? keyDef.element : null;
 
                 // If definition is not null
@@ -557,9 +591,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                             XMLUtils.removeAttribute(resAtts, ATTRIBUTE_NAME_FORMAT);
                         } else {
                             // key does not exist.
-                            final MessageBean m = definitionMap.name == null
+                            final MessageBean m = definitionMaps.peek().scope.name == null
                                     ? MessageUtils.getMessage("DOTJ047I", atts.getValue(ATTRIBUTE_NAME_KEYREF))
-                                    : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMap.name);
+                                    : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMaps.peek().scope.name);
                             logger.info(m.setLocation(atts).toString());
                         }
 
@@ -586,9 +620,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                     }
                 } else {
                     // key does not exist
-                    final MessageBean m = definitionMap.name == null
+                    final MessageBean m = definitionMaps.peek().scope.name == null
                             ? MessageUtils.getMessage("DOTJ047I", atts.getValue(ATTRIBUTE_NAME_KEYREF))
-                            : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMap.name);
+                            : MessageUtils.getMessage("DOTJ048I", atts.getValue(ATTRIBUTE_NAME_KEYREF), definitionMaps.peek().scope.name);
                     logger.info(m.setLocation(atts).toString());
                 }
 
@@ -763,6 +797,27 @@ public final class KeyrefPaser extends AbstractXMLFilter {
             this.attrs = attrs;
             this.isEmpty = isEmpty;
             this.hasNestedElements = hasNestedElements;
+        }
+    }
+
+    /** Store keyscope start information. **/
+    private final class KeyScopeInfo {
+        /** Element identifier from getCurrentElemId(). */
+        String id;
+
+        /** KeyScope */
+        KeyScope scope;
+
+
+        /**
+         * Construct a new key scope info object.
+         *
+         * @param id id generated by getCurrentElemId()
+         * @param scope key scope
+         */
+        private KeyScopeInfo(String id, KeyScope scope) {
+            this.id = id;
+            this.scope = scope;
         }
     }
 

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -153,8 +153,8 @@ public class KeyrefModuleTest {
         final Job.FileInfo subMapInfo = module.job.getFileInfo(subMap);
         final Optional<ResolveTask> subMapTask =  res.stream().filter(r -> r.in.equals(subMapInfo)).findFirst();
 
-        assertFalse(subMapTask.isPresent());
-//        assertEquals(subMapTask.get().scope, childScope);
+        assertTrue(subMapTask.isPresent());
+        assertEquals(subMapTask.get().scope, childScope);
 
         assertXMLEqual(exp, act);
     }

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -16,7 +16,7 @@ import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo.Builder;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -31,14 +31,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.net.URI.create;
 import static java.util.Collections.*;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.TestUtils.createTempDir;
-import static org.dita.dost.util.Constants.INPUT_DITAMAP_URI;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class KeyrefModuleTest {
 
@@ -46,11 +44,12 @@ public class KeyrefModuleTest {
     private static final URI inputMap = new File(baseDir, "xsrc" + File.separator + "test.ditamap").toURI();
     private static final URI subMap = new File(baseDir, "xsrc" + File.separator + "submap.ditamap").toURI();
 
-    KeyrefModule module;
+    private File tempDir;
+    private KeyrefModule module;
 
     @Before
     public void setUp() throws IOException {
-        final File tempDir = createTempDir(KeyrefModuleTest.class);
+        tempDir = createTempDir(KeyrefModuleTest.class);
 
         module = new KeyrefModule();
         final Job job = new Job(tempDir);
@@ -79,6 +78,11 @@ public class KeyrefModuleTest {
                 .build());
         module.setJob(job);
         module.setLogger(new TestLogger());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+       TestUtils.forceDelete(tempDir);
     }
 
     @Test
@@ -150,11 +154,8 @@ public class KeyrefModuleTest {
         module.walkMap(act.getDocumentElement(), keyScope, res);
         final Document exp = b.parse(new File(baseDir, "exp" + File.separator + "test.ditamap"));
 
-        final Job.FileInfo subMapInfo = module.job.getFileInfo(subMap);
-        final Optional<ResolveTask> subMapTask =  res.stream().filter(r -> r.in.equals(subMapInfo)).findFirst();
-
-        assertTrue(subMapTask.isPresent());
-        assertEquals(subMapTask.get().scope, childScope);
+        final ResolveTask subMapTask = res.stream().filter(r -> r.in.src.equals(subMap)).findFirst().get();
+        assertEquals(subMapTask.scope, childScope);
 
         assertXMLEqual(exp, act);
     }

--- a/src/test/resources/KeyrefPaserTest/exp/d.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/d.ditamap
@@ -3,16 +3,16 @@
   ditaarch:DITAArchVersion="1.2">
 
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="KEY_SCOPE">
-    <topicref class="- map/topicref " format="dead" href="dead" keyref="ks_topicref_link" scope="external" type="dead"/>
-    <topicref class="- map/topicref " keyref="ks_author_link"/>
-    <topicref class="- map/topicref " keyref="ks_data_link"/>
-    <topicref class="- map/topicref " keyref="ks_data-about_link"/>
-    <topicref class="- map/topicref " keyref="ks_publisher_link"/>
-    <topicref class="- map/topicref " keyref="ks_source_link"/>
-    <topicref class="- map/topicref " keyref="ks_indexterm_link"/>
-    <topicref class="- map/topicref " keyref="ks_index-base_link"/>
-    <topicref class="- map/topicref " keyref="ks_indextermref_link"/>
-    <navref class="- map/navref " keyref="ks_navref_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_topicref_link" type="dead"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_author_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_data-about_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_publisher_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_source_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indexterm_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_index-base_link"/>
+    <topicref class="- map/topicref " href="a.xml" keyref="ks_indextermref_link"/>
+    <navref class="- map/navref " keyref="ks_navref_link" mapref="a.xml"/>
 
     <topicref class="- map/topicref " href="a.xml" keyref="topicref_link" type="dead"/>
     <topicref class="- map/topicref " href="a.xml" keyref="author_link"/>


### PR DESCRIPTION
_Migrated to new PR from #3141 in order to allow commiters to modify the code._

Fixes test cases reported in issue #2523.
Two issues were identified:

1. When collecting resolve tasks in KeyRefModule.WalkMap, files referenced through mapref but flattened in map-ref stage are not picked up. They are instead added in collectProcessingTopics. This means they are parsed with root scope instead of their correct scope.
2. When transforming a flattened map key using the KeyRefPaser module it's assumed that one file only has a single key scope. Scopes added outside topicrefs or maprefs are then ignored.

I refactored the elemName deque to keyRefElemNames to make the distinction between the two deques elemNames and keyRefElemNames more clear.