### PR TITLE
Add configuration option for default coderef charset

### DIFF
--- a/src/main/java/org/dita/dost/writer/CoderefResolver.java
+++ b/src/main/java/org/dita/dost/writer/CoderefResolver.java
@@ -17,6 +17,7 @@ import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.dita.dost.util.Configuration;
 import org.dita.dost.util.Job;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -320,7 +321,12 @@ public final class CoderefResolver extends AbstractXMLFilter {
             }
         }
         if (c == null) {
-            c = Charset.defaultCharset();
+            final String defaultCharset = Configuration.configuration.get("default.coderef-charset");
+            if (defaultCharset != null) {
+                c = Charset.forName(defaultCharset);
+            } else {
+                c = Charset.defaultCharset();
+            }
         }
         return c;
     }


### PR DESCRIPTION
Fixes #2165

# Documentation changes

Without configuration, the coderef processing defaults to platform default charset. The default for coderef can be changed by adding `default.coderef-charset` key to `configuration.properties`:

```properties
default.coderef-charset = ISO-8859-1
```

The charset values are those supported by Java [`Charset`](https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html) class.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>