### PR TITLE
Add support for exclusions in ditafileset 

### DIFF
--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -12,6 +12,7 @@ import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
 import static org.dita.dost.util.FileUtils.supportedImageExtensions;
 import static org.dita.dost.util.URLUtils.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.AbstractFileSet;
@@ -35,19 +36,24 @@ import java.util.*;
  */
 public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
 
-    private Set<String> formats = Collections.emptySet();
-    private Boolean hasConref;
-    private Boolean isInput;
-    private Boolean isResourceOnly;
+    private Includes include;
+    private List<Includes> includes;
+    private List<Includes> excludes;
     private Collection<Resource> res;
     private boolean isFilesystemOnly = true;
 
     public JobSourceSet() {
         super();
+        include = new Includes();
+        includes = new ArrayList<>();
+        excludes = new ArrayList<>();
     }
 
     private Collection<Resource> getResults() {
         if (res == null) {
+            if (!include.formats.isEmpty() || include.hasConref != null || include.isInput != null || include.isResourceOnly != null) {
+                includes.add(include);
+            }
             final Job job = getJob();
             res = new ArrayList<>();
             for (final FileInfo f : job.getFileInfo(this::filter)) {
@@ -82,7 +88,8 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         return res;
     }
 
-    private Job getJob() {
+    @VisibleForTesting
+    Job getJob() {
         String tempDir = getProject().getUserProperty(ANT_TEMP_DIR);
         if (tempDir == null) {
             tempDir = getProject().getProperty(ANT_TEMP_DIR);
@@ -114,30 +121,53 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
     }
 
     public void setFormat(final String format) {
-        final ImmutableSet.Builder<String> builder = ImmutableSet.<String>builder().add(format);
-        if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
-            supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
-        }
-        this.formats = builder.build();
+        include.setFormat(format);
     }
 
     public void setConref(final boolean conref) {
-        this.hasConref = conref;
+        include.setConref(conref);
     }
 
     public void setInput(final boolean isInput) {
-        this.isInput = isInput;
+        include.setInput(isInput);
     }
 
     public void setProcessingRole(final String processingRole) {
-        this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
+        include.setProcessingRole(processingRole);
     }
 
-    private boolean filter(final FileInfo f) {
-        return (formats == null || (formats.contains(f.format)/* || (format.equals(ATTR_FORMAT_VALUE_DITA) && f.format == null)*/)) &&
-                (hasConref == null || f.hasConref == hasConref) &&
-                (isInput == null || f.isInput == isInput) &&
-                (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
+    public void addConfiguredIncludes(final Includes include) {
+        includes.add(include);
+    }
+
+    public void addConfiguredExcludes(final Includes exclude) {
+        excludes.add(exclude);
+    }
+
+    @VisibleForTesting
+    public boolean filter(final FileInfo f) {
+        for (final Includes excl: excludes) {
+            if (filter(f, excl)) {
+                return false;
+            }
+        }
+        if (includes.isEmpty()) {
+            return true;
+        } else {
+            for (final Includes incl: includes) {
+                if (filter(f, incl)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private boolean filter(final FileInfo f, final Includes incl) {
+        return (incl.formats.isEmpty() || incl.formats.contains(f.format)) &&
+                (incl.hasConref == null || f.hasConref == incl.hasConref) &&
+                (incl.isInput == null || f.isInput == incl.isInput) &&
+                (incl.isResourceOnly == null || f.isResourceOnly == incl.isResourceOnly);
     }
 
     private static class JobResource extends URLResource {
@@ -162,4 +192,40 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         }
     }
 
+    public static class Includes {
+        private Set<String> formats = Collections.emptySet();
+        private Boolean hasConref;
+        private Boolean isInput;
+        private Boolean isResourceOnly;
+
+        public Includes() {
+        }
+
+        public Includes(Set<String> formats, Boolean hasConref, Boolean isInput, Boolean isResourceOnly) {
+            this.formats = formats != null ? formats : Collections.emptySet();
+            this.hasConref = hasConref;
+            this.isInput = isInput;
+            this.isResourceOnly = isResourceOnly;
+        }
+
+        public void setFormat(final String format) {
+            final ImmutableSet.Builder<String> builder = ImmutableSet.<String>builder().add(format);
+            if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
+                supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
+            }
+            this.formats = builder.build();
+        }
+
+        public void setConref(final boolean conref) {
+            this.hasConref = conref;
+        }
+
+        public void setInput(final boolean isInput) {
+            this.isInput = isInput;
+        }
+
+        public void setProcessingRole(final String processingRole) {
+            this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
+        }
+    }
 }

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -7,8 +7,7 @@
  */
 package org.dita.dost.ant.types;
 
-import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
+import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FileUtils.supportedImageExtensions;
 import static org.dita.dost.util.URLUtils.*;
 
@@ -164,7 +163,8 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
     }
 
     private boolean filter(final FileInfo f, final SelectorElem incl) {
-        return (incl.formats.isEmpty() || incl.formats.contains(f.format)) &&
+        final String format = f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA;
+        return (incl.formats.isEmpty() || (incl.formats.contains(format))) &&
                 (incl.hasConref == null || f.hasConref == incl.hasConref) &&
                 (incl.isInput == null || f.isInput == incl.isInput) &&
                 (incl.isResourceOnly == null || f.isResourceOnly == incl.isResourceOnly);

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -36,22 +36,22 @@ import java.util.*;
  */
 public class JobSourceSet extends AbstractFileSet implements ResourceCollection {
 
-    private Includes include;
-    private List<Includes> includes;
-    private List<Includes> excludes;
+    private SelectorElem include;
+    private List<SelectorElem> includes;
+    private List<SelectorElem> excludes;
     private Collection<Resource> res;
     private boolean isFilesystemOnly = true;
 
     public JobSourceSet() {
         super();
-        include = new Includes();
+        include = new SelectorElem();
         includes = new ArrayList<>();
         excludes = new ArrayList<>();
     }
 
     private Collection<Resource> getResults() {
         if (res == null) {
-            if (!include.formats.isEmpty() || include.hasConref != null || include.isInput != null || include.isResourceOnly != null) {
+            if (!include.isEmpty()) {
                 includes.add(include);
             }
             final Job job = getJob();
@@ -136,17 +136,17 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         include.setProcessingRole(processingRole);
     }
 
-    public void addConfiguredIncludes(final Includes include) {
+    public void addConfiguredIncludes(final SelectorElem include) {
         includes.add(include);
     }
 
-    public void addConfiguredExcludes(final Includes exclude) {
+    public void addConfiguredExcludes(final SelectorElem exclude) {
         excludes.add(exclude);
     }
 
     @VisibleForTesting
     public boolean filter(final FileInfo f) {
-        for (final Includes excl: excludes) {
+        for (final SelectorElem excl: excludes) {
             if (filter(f, excl)) {
                 return false;
             }
@@ -154,7 +154,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (includes.isEmpty()) {
             return true;
         } else {
-            for (final Includes incl: includes) {
+            for (final SelectorElem incl: includes) {
                 if (filter(f, incl)) {
                     return true;
                 }
@@ -163,7 +163,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         }
     }
 
-    private boolean filter(final FileInfo f, final Includes incl) {
+    private boolean filter(final FileInfo f, final SelectorElem incl) {
         return (incl.formats.isEmpty() || incl.formats.contains(f.format)) &&
                 (incl.hasConref == null || f.hasConref == incl.hasConref) &&
                 (incl.isInput == null || f.isInput == incl.isInput) &&
@@ -192,16 +192,16 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         }
     }
 
-    public static class Includes {
+    public static class SelectorElem {
         private Set<String> formats = Collections.emptySet();
         private Boolean hasConref;
         private Boolean isInput;
         private Boolean isResourceOnly;
 
-        public Includes() {
+        public SelectorElem() {
         }
 
-        public Includes(Set<String> formats, Boolean hasConref, Boolean isInput, Boolean isResourceOnly) {
+        public SelectorElem(Set<String> formats, Boolean hasConref, Boolean isInput, Boolean isResourceOnly) {
             this.formats = formats != null ? formats : Collections.emptySet();
             this.hasConref = hasConref;
             this.isInput = isInput;
@@ -226,6 +226,10 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
         public void setProcessingRole(final String processingRole) {
             this.isResourceOnly = processingRole.equals(Constants.ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY);
+        }
+
+        public boolean isEmpty() {
+            return formats.isEmpty() && hasConref == null && isInput == null && isResourceOnly == null;
         }
     }
 }

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -574,7 +574,12 @@ See the accompanying LICENSE file for applicable license.
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
     <copy todir="${copy-html.todir}" failonerror="false">
-      <ditafileset format="html" />
+      <ditafileset>
+        <excludes format="dita"/>
+        <excludes format="ditamap"/>
+        <excludes format="ditaval"/>
+        <excludes format="image"/>
+      </ditafileset>
     </copy>
   </target>
   

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -28,7 +28,6 @@ See the accompanying LICENSE file for applicable license.
                   debug-filter,
                   mapref,
                   branch-filter,
-                  copy-files,
                   keyref,
                   copy-to,
                   conrefpush,
@@ -40,6 +39,7 @@ See the accompanying LICENSE file for applicable license.
                   maplink,
                   topicpull,
                   clean-map,
+                  copy-files,
                   {depend.preprocess.post}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     description="Preprocessing ended" />

--- a/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
+++ b/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.ant.types;
+
+import com.google.common.io.Files;
+import org.apache.tools.ant.types.Resource;
+import org.dita.dost.TestUtils;
+import org.dita.dost.ant.types.JobSourceSet.Includes;
+import org.dita.dost.util.Job;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class JobSourceSetTest {
+
+    private static File tempDir;
+    private static Job job;
+    private JobSourceSet jobSourceSet;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        tempDir = TestUtils.createTempDir(JobSourceSetTest.class);
+        job = new Job(tempDir);
+        for (String ext : Arrays.asList("dita", "ditamap", "jpg", "html")) {
+            final String file = "a." + ext;
+            Files.touch(new File(tempDir, file));
+            job.add(new Job.FileInfo.Builder()
+                    .src(URI.create("file:///" + file))
+                    .uri(URI.create(file))
+                    .format(ext)
+                    .build());
+        }
+
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        jobSourceSet = new JobSourceSet() {
+            @Override
+            Job getJob() {
+                return job;
+            }
+        };
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException {
+        TestUtils.forceDelete(tempDir);
+    }
+
+    @Test
+    public void testEmpty() {
+        final List<Resource> act = jobSourceSet.stream().collect(Collectors.toList());
+        assertEquals(4, act.size());
+    }
+
+    @Test
+    public void testFormatAttribute() {
+        jobSourceSet.setFormat("dita");
+        final List<Resource> act = jobSourceSet.stream().collect(Collectors.toList());
+        assertEquals(1, act.size());
+    }
+
+    @Test
+    public void testFilterEmpty() {
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
+    }
+
+    @Test
+    public void testFilterIncludesFormat() {
+        jobSourceSet.addConfiguredIncludes(
+                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+        );
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
+    }
+
+    @Test
+    public void testFilterIncludesMultipleFormat() {
+        jobSourceSet.addConfiguredIncludes(
+                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+        );
+        jobSourceSet.addConfiguredIncludes(
+                new Includes(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
+        );
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
+    }
+
+    @Test
+    public void testFilterExcludesFormat() {
+        jobSourceSet.addConfiguredExcludes(
+                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+        );
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
+    }
+
+    @Test
+    public void testFilterExcludesMultipleFormat() {
+        jobSourceSet.addConfiguredExcludes(
+                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+        );
+        jobSourceSet.addConfiguredExcludes(
+                new Includes(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
+        );
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
+        assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
+        assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
+    }
+}

--- a/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
+++ b/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
@@ -11,7 +11,7 @@ package org.dita.dost.ant.types;
 import com.google.common.io.Files;
 import org.apache.tools.ant.types.Resource;
 import org.dita.dost.TestUtils;
-import org.dita.dost.ant.types.JobSourceSet.Includes;
+import org.dita.dost.ant.types.JobSourceSet.SelectorElem;
 import org.dita.dost.util.Job;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -86,7 +86,7 @@ public class JobSourceSetTest {
     @Test
     public void testFilterIncludesFormat() {
         jobSourceSet.addConfiguredIncludes(
-                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("dita")), null, null, null)
         );
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
@@ -96,10 +96,10 @@ public class JobSourceSetTest {
     @Test
     public void testFilterIncludesMultipleFormat() {
         jobSourceSet.addConfiguredIncludes(
-                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("dita")), null, null, null)
         );
         jobSourceSet.addConfiguredIncludes(
-                new Includes(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
         );
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
@@ -109,7 +109,7 @@ public class JobSourceSetTest {
     @Test
     public void testFilterExcludesFormat() {
         jobSourceSet.addConfiguredExcludes(
-                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("dita")), null, null, null)
         );
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
@@ -119,10 +119,10 @@ public class JobSourceSetTest {
     @Test
     public void testFilterExcludesMultipleFormat() {
         jobSourceSet.addConfiguredExcludes(
-                new Includes(new HashSet<>(Arrays.asList("dita")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("dita")), null, null, null)
         );
         jobSourceSet.addConfiguredExcludes(
-                new Includes(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
+                new SelectorElem(new HashSet<>(Arrays.asList("ditamap")), null, null, null)
         );
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));


### PR DESCRIPTION
Support nested `<includes>` and `<excludes>` elements in `<ditafileset>`. This allows changing the copy configuration of _copy-html_ to copy all resources, except DITA and image resources.

Move `copy-files` task in `preprocess` to end. This matches `preprocess2` and is more correct stage for file copy.

Fixes #2899