### PR TITLE
Add support for truthy values in dita command property values

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -246,16 +246,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                         .map(XMLUtils::getText)
                         .collect(Collectors.toSet());
                 if (vals.size() == 2) {
-                    if (vals.contains("true") && vals.contains("false")) {
-                        return new BooleanArgument(name, "true", "false");
-                    } else if (vals.contains("TRUE") && vals.contains("FALSE")) {
-                        return new BooleanArgument(name, "TRUE", "FALSE");
-                    } else if (vals.contains("yes") && vals.contains("no")) {
-                        return new BooleanArgument(name, "yes", "no");
-                    } else if (vals.contains("1") && vals.contains("0")) {
-                        return new BooleanArgument(name, "1", "0");
-                    } else if (vals.contains("on") && vals.contains("off")) {
-                        return new BooleanArgument(name, "on", "off");
+                    for (Map.Entry<String, String> pair: TRUTHY_VALUES.entrySet()) {
+                        if (vals.contains(pair.getKey()) && vals.contains(pair.getValue())) {
+                            return new BooleanArgument(name, pair.getKey(), pair.getValue());
+                        }
                     }
                 }
                 return new EnumArgument(name, vals);
@@ -271,6 +265,19 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             "args.filter", "--filter",
             ANT_TEMP_DIR, "-t"
     );
+
+    private static final Map<String, String> TRUTHY_VALUES;
+    static {
+        TRUTHY_VALUES = ImmutableMap.<String, String>builder()
+                .put("true", "false")
+                .put("TRUE", "FALSE")
+                .put("yes", "no")
+                .put("YES", "NO")
+                .put("1", "0")
+                .put("on", "off")
+                .put("ON", "OFF")
+                .build();
+    }
 
     /** The default build file name. {@value} */
     public static final String DEFAULT_BUILD_FILENAME = "build.xml";

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -39,20 +39,14 @@ import org.apache.tools.ant.util.ProxySetup;
 import org.dita.dost.platform.Plugins;
 import org.dita.dost.util.Configuration;
 import org.dita.dost.util.XMLUtils;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.dita.dost.util.Configuration.transtypes;
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
-import static org.dita.dost.util.Constants.PLUGIN_CONF;
 import static org.dita.dost.util.XMLUtils.getChildElements;
 import static org.dita.dost.util.XMLUtils.toList;
 
@@ -102,10 +96,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 case "yes":
                 case "on":
                 case "1":
-                    System.err.println("Return " + trueValue + " for " + value);
                     return trueValue;
                 default:
-                    System.err.println("Return " + falseValue + " for " + value);
                     return falseValue;
             }
         }
@@ -971,7 +963,13 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             while (propertyNames.hasMoreElements()) {
                 final String name = propertyNames.nextElement().toString();
                 if (!definedProps.containsKey(name)) {
-                    definedProps.put(name, props.getProperty(name));
+                    final Argument arg = getPluginArguments().get("--" + name);
+                    final String value = props.getProperty(name);
+                    if (arg != null) {
+                        definedProps.put(name, arg.getValue(value));
+                    } else {
+                        definedProps.put(name, value);
+                    }
                 }
             }
         }

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -86,6 +86,31 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         }
     }
 
+    private static class BooleanArgument extends Argument {
+        final String trueValue;
+        final String falseValue;
+        BooleanArgument(final String property, final String trueValue, final String falseValue) {
+            super(property);
+            this.trueValue = trueValue;
+            this.falseValue = falseValue;
+        }
+
+        @Override
+        String getValue(final String value) {
+            switch(value.toLowerCase()) {
+                case "true":
+                case "yes":
+                case "on":
+                case "1":
+                    System.err.println("Return " + trueValue + " for " + value);
+                    return trueValue;
+                default:
+                    System.err.println("Return " + falseValue + " for " + value);
+                    return falseValue;
+            }
+        }
+    }
+
     private static class EnumArgument extends Argument {
         final Set<String> values;
         EnumArgument(final String property, final Set<String> values) {
@@ -228,6 +253,19 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 final Set<String> vals = getChildElements(param).stream()
                         .map(XMLUtils::getText)
                         .collect(Collectors.toSet());
+                if (vals.size() == 2) {
+                    if (vals.contains("true") && vals.contains("false")) {
+                        return new BooleanArgument(name, "true", "false");
+                    } else if (vals.contains("TRUE") && vals.contains("FALSE")) {
+                        return new BooleanArgument(name, "TRUE", "FALSE");
+                    } else if (vals.contains("yes") && vals.contains("no")) {
+                        return new BooleanArgument(name, "yes", "no");
+                    } else if (vals.contains("1") && vals.contains("0")) {
+                        return new BooleanArgument(name, "1", "0");
+                    } else if (vals.contains("on") && vals.contains("off")) {
+                        return new BooleanArgument(name, "on", "off");
+                    }
+                }
                 return new EnumArgument(name, vals);
             default:
                 return new StringArgument(name);


### PR DESCRIPTION
Add support for `true`, `yes`, `1`, and `on` values for truthy property values in _dita_ command.

Fixes #2225

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>