### PR TITLE
Merge adjacent text events before codeblock normalization

### DIFF
--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -65,6 +65,13 @@ public class NormalizeCodeblockTest {
     }
 
     @Test
+    public void testOnlyTextWithAdjacentText() throws Exception {
+        final Document act = filter(new File(srcDir, "onlyTextWithAdjacentText.xml"));
+        final Document exp = documentBuilder.parse(new File(expDir, "onlyTextWithAdjacentText.xml"));
+        assertXMLEqual(exp, act);
+    }
+
+    @Test
     public void testNestedElement() throws Exception {
         final Document act = filter(new File(srcDir, "nestedElement.xml"));
         final Document exp = documentBuilder.parse(new File(expDir, "nestedElement.xml"));

--- a/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithAdjacentText.xml
+++ b/src/test/resources/NormalizeCodeblockTest/exp/onlyTextWithAdjacentText.xml
@@ -1,0 +1,10 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">&lt;div id="app-2">
+  &lt;span v-bind:title="message">
+    Hover your mouse over me for a few seconds
+    to see my dynamically bound title!
+  &lt;/span>
+&lt;/div></codeblock>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithAdjacentText.xml
+++ b/src/test/resources/NormalizeCodeblockTest/src/onlyTextWithAdjacentText.xml
@@ -1,0 +1,10 @@
+<topic class="- topic/topic ">
+  <body class="- topic/body ">
+    <codeblock class="+ topic/pre pr-d/codeblock " xml:space="preserve" outputclass="normalize-space">    &lt;div id="app-2">
+      &lt;span v-bind:title="message">
+        Hover your mouse over me for a few seconds
+        to see my dynamically bound title!
+      &lt;/span>
+    &lt;/div></codeblock>
+  </body>
+</topic>


### PR DESCRIPTION
Fixes #3048

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>