### PR TITLE
Add [1] and as= for key() lookups as appropriate

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' abbrev-d/abbreviated-form ')]" name="topic.abbreviated-form">
     <xsl:variable name="keys" select="@keyref"/>
-    <xsl:variable name="target" select="key('id', substring(@href, 2))"/>
+    <xsl:variable name="target" select="key('id', substring(@href, 2))[1]" as="element()?"/>
     <xsl:choose>
       <xsl:when test="$keys and $target/self::*[contains(@class,' glossentry/glossentry ')]">
         <xsl:call-template name="topic.term">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
@@ -50,7 +50,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="map" select="//opentopic:map"/>
 
     <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="bookmark">
-        <xsl:variable name="mapTopicref" select="key('map-id', @id)[1]"/>
+        <xsl:variable name="mapTopicref" select="key('map-id', @id)[1]" as="element()?"/>
         <xsl:variable name="topicTitle">
             <xsl:call-template name="getNavTitle"/>
         </xsl:variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -112,7 +112,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="commonTopicProcessing">
       <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
         <fo:marker marker-class-name="current-topic-number">
-          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+          <xsl:variable name="topicref" 
+            select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')]/@id)[1]" 
+            as="element()?"
+          />
           <xsl:for-each select="$topicref">
             <xsl:apply-templates select="." mode="topicTitleNumber"/>
           </xsl:for-each>
@@ -257,7 +260,9 @@ See the accompanying LICENSE file for applicable license.
             </xsl:variable>
             <xsl:if test="$level eq 1">
                 <fo:marker marker-class-name="current-topic-number">
-                  <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                  <xsl:variable name="topicref" 
+                    select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]" 
+                    as="element()?"/>
                   <xsl:for-each select="$topicref">
                     <xsl:apply-templates select="." mode="topicTitleNumber"/>
                   </xsl:for-each>
@@ -330,7 +335,9 @@ See the accompanying LICENSE file for applicable license.
             </xsl:variable>
             <xsl:if test="$level eq 1">
                 <fo:marker marker-class-name="current-topic-number">
-                    <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                  <xsl:variable name="topicref" 
+                    select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]" 
+                    as="element()?"/>
                     <xsl:for-each select="$topicref">
                       <xsl:apply-templates select="." mode="topicTitleNumber"/>
                     </xsl:for-each>
@@ -402,7 +409,10 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="commonattributes"/>
       <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
         <fo:marker marker-class-name="current-topic-number">
-          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+          <xsl:variable name="topicref" 
+            select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]" 
+            as="element()?"
+          />
           <xsl:for-each select="$topicref">
             <xsl:apply-templates select="." mode="topicTitleNumber"/>
           </xsl:for-each>
@@ -481,7 +491,10 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="commonattributes"/>
             <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                 <fo:marker marker-class-name="current-topic-number">
-                  <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                  <xsl:variable name="topicref" 
+                    select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]" 
+                    as="element()?"
+                  />
                   <xsl:for-each select="$topicref">
                     <xsl:apply-templates select="." mode="topicTitleNumber"/>
                   </xsl:for-each>
@@ -547,7 +560,10 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:call-template name="commonattributes"/>
                     <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                         <fo:marker marker-class-name="current-topic-number">
-                          <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)"/>
+                          <xsl:variable name="topicref" 
+                            select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]"
+                            as="element()?"
+                          />
                           <xsl:for-each select="$topicref">
                             <xsl:apply-templates select="." mode="topicTitleNumber"/>
                           </xsl:for-each>
@@ -825,8 +841,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:variable name="foundTopicType" as="xs:string?">
         <xsl:variable name="topic" select="ancestor-or-self::*[contains(@class, ' topic/topic ')][1]"/>
         <xsl:variable name="id" select="$topic/@id"/>
-        <xsl:variable name="mapTopics" select="key('map-id', $id)"/>
-        <xsl:apply-templates select="$mapTopics[1]" mode="determineTopicType"/>
+        <xsl:variable name="mapTopics" select="key('map-id', $id)[1]" as="element()?"/>
+        <xsl:apply-templates select="$mapTopics" mode="determineTopicType"/>
       </xsl:variable>
       <xsl:choose>
         <xsl:when test="exists($foundTopicType) and $foundTopicType != ''">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -69,7 +69,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/topic ')]" mode="index-entries">
         <xsl:variable name="id" select="ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id"/>
-        <xsl:variable name="mapTopicref" select="key('map-id', $id)[1]"/>
+        <xsl:variable name="mapTopicref" select="key('map-id', $id)[1]" as="element()?"/>
         <xsl:if test="not(contains($mapTopicref/@otherprops, 'noindex'))">
             <xsl:apply-templates mode="index-entries"/>
         </xsl:if>
@@ -77,7 +77,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/topic ')]" mode="index-postprocess">
         <xsl:variable name="id" select="ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id"/>
-        <xsl:variable name="mapTopicref" select="key('map-id', $id)[1]"/>
+        <xsl:variable name="mapTopicref" select="key('map-id', $id)[1]" as="element()?"/>
         <xsl:if test="not(contains($mapTopicref/@otherprops, 'noindex'))">
             <xsl:apply-templates mode="index-entries"/>
         </xsl:if>
@@ -284,7 +284,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="." mode="get-see-destination-id"/>
         </xsl:value-of>
       </xsl:variable>
-      <xsl:variable name="ref" select="key('opentopic-index:index.entry-def', $id)"/>
+      <xsl:variable name="ref" select="key('opentopic-index:index.entry-def', $id)[1]" as="element()?"/>
       <xsl:if test="exists($ref)">
         <xsl:value-of select="generate-id($ref[1])"/>
       </xsl:if>
@@ -492,7 +492,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="refID"/>
 
     <xsl:for-each select="$index-entries">
-      <xsl:variable name="entries" select="key('index-key',$value)"/>
+      <xsl:variable name="entries" select="key('index-key',$value)" as="element()*"/>
       <xsl:value-of select="$entries[opentopic-index:refID/@value = $refID]"/>
     </xsl:for-each>
   </xsl:function>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -263,7 +263,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/xref ')]" name="topic.xref">
 
     <xsl:variable name="destination" select="opentopic-func:getDestinationId(@href)"/>
-    <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]"/>
+    <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]" as="element()?"/>
 
     <xsl:variable name="referenceTitle" as="node()*">
       <xsl:apply-templates select="." mode="insertReferenceTitle">
@@ -330,7 +330,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:variable name="href-fragment" select="substring-after(@href, '#')"/>
         <xsl:variable name="elemId" select="substring-after($href-fragment, '/')"/>
         <xsl:variable name="topicId" select="substring-before($href-fragment, '/')"/>
-        <xsl:variable name="footnote-target" select="key('fnById', $elemId)[ancestor::*[contains(@class, ' topic/topic ')][1]/@id = $topicId]"/>
+        <xsl:variable name="footnote-target" 
+          select="(key('fnById', $elemId)[ancestor::*[contains(@class, ' topic/topic ')][1]/@id = $topicId])[1]" 
+          as="element()?"
+        />
         <xsl:apply-templates select="$footnote-target" mode="footnote-callout"/>
     </xsl:template>
 
@@ -502,7 +505,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class,' topic/link ')][not(empty(@href) or @href='')]" mode="processLink">
     <xsl:variable name="destination" select="opentopic-func:getDestinationId(@href)"/>
-    <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]"/>
+    <xsl:variable name="element" select="key('key_anchor',$destination, $root)[1]" as="element()?"/>
 
     <xsl:variable name="referenceTitle" as="node()*">
         <xsl:apply-templates select="." mode="insertReferenceTitle">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -65,7 +65,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="." mode="get-topic-level"/>
         </xsl:variable>
         <xsl:if test="$topicLevel &lt; $tocMaximumLevel">
-            <xsl:variable name="mapTopicref" select="key('map-id', @id)[1]"/>
+            <xsl:variable name="mapTopicref" select="key('map-id', @id)[1]" as="element()?"/>
             <xsl:choose>
               <!-- In a future version, suppressing Notices in the TOC should not be hard-coded. -->
               <xsl:when test="$retain-bookmap-order and $mapTopicref/self::*[contains(@class, ' bookmap/notices ')]"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -112,7 +112,10 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
   <xsl:template match="*" mode="get-topic-level" as="xs:integer">
-    <xsl:variable name="topicref" select="key('map-id', ancestor-or-self::*[contains(@class,' topic/topic ')][1]/@id)"/>
+    <xsl:variable name="topicref" 
+      select="key('map-id', ancestor-or-self::*[contains(@class,' topic/topic ')][1]/@id)[1]"
+      as="element()?"
+    />
     <xsl:sequence select="count(ancestor-or-self::*[contains(@class,' topic/topic ')]) -
                           count($topicref/ancestor-or-self::*[(contains(@class,' bookmap/part ') and
                                                                ((exists(@navtitle) or
@@ -212,7 +215,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="keys" select="@keyref" as="attribute()?"/>
     <xsl:param name="contents" as="node()*">
       <!-- Current node can be preprocessed and may not be part of source document, check for root() to ensure key() is resolvable -->
-      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2)) else ()" as="element()?"/>
+      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2))[1] else ()" as="element()?"/>
       <xsl:choose>
         <xsl:when test="not(normalize-space(.)) and $keys and $target/self::*[contains(@class,' topic/topic ')]">
           <xsl:apply-templates select="$target/*[contains(@class, ' topic/title ')]/node()"/>
@@ -222,7 +225,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
       </xsl:choose>
     </xsl:param>
-    <xsl:variable name="topicref" select="key('map-id', substring(@href, 2))"/>
+    <xsl:variable name="topicref" select="key('map-id', substring(@href, 2))[1]" as="element()?"/>
     <xsl:choose>
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref term">
@@ -443,7 +446,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Gets navigation title of current topic, used for bookmarks/TOC -->
     <xsl:template name="getNavTitle">
-        <xsl:variable name="topicref" select="key('map-id', @id)[1]"/>
+        <xsl:variable name="topicref" select="key('map-id', @id)[1]" as="element()?"/>
         <xsl:choose>
             <xsl:when test="$topicref/@locktitle='yes' and
                             $topicref/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]">
@@ -743,7 +746,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/prolog ')]
             //opentopic-index:index.entry[not(parent::opentopic-index:index.entry) and not(@end-range = 'true')]"/>
       <!-- index ranges from map -->
-      <xsl:variable name="topicref" select="key('map-id', @id)"/>
+      <xsl:variable name="topicref" select="key('map-id', @id)[1]" as="element()?"/>
       <xsl:apply-templates select="$topicref/
                                      *[contains(@class, ' map/topicmeta ')]/
                                        *[contains(@class, ' topic/keywords ')]/
@@ -757,7 +760,7 @@ See the accompanying LICENSE file for applicable license.
                                          descendant::opentopic-index:index.entry[not(parent::opentopic-index:index.entry) and
                                                                                  @end-range = 'true']"/>
       <!-- index ranges from map -->
-      <xsl:variable name="topicref" select="key('map-id', @id)"/>
+      <xsl:variable name="topicref" select="key('map-id', @id)[1]" as="element()?"/>
       <xsl:apply-templates select="$topicref/
                                      *[contains(@class, ' map/topicmeta ')]/
                                        *[contains(@class, ' topic/keywords ')]/
@@ -1132,7 +1135,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="keys" select="@keyref" as="attribute()?"/>
     <xsl:param name="contents" as="node()*">
       <!-- Current node can be preprocessed and may not be part of source document, check for root() to ensure key() is resolvable -->
-      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2)) else ()" as="element()?"/>
+      <xsl:variable name="target" select="if (exists(root()) and @href) then key('id', substring(@href, 2))[1] else ()" as="element()?"/>
       <xsl:choose>
         <xsl:when test="not(normalize-space(.)) and $keys and $target/self::*[contains(@class,' topic/topic ')]">
           <xsl:apply-templates select="$target/*[contains(@class, ' topic/title ')]/node()"/>
@@ -1142,7 +1145,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
       </xsl:choose>
     </xsl:param>
-    <xsl:variable name="topicref" select="key('map-id', substring(@href, 2))"/>
+    <xsl:variable name="topicref" select="key('map-id', substring(@href, 2))[1]" as="element()?"/>
     <xsl:choose>
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref">


### PR DESCRIPTION
Corrects a failure in 3.2.1 where a reference to a glossary entry that is referenced through an intermediate keyref caused an XSLT runtime failure.

Signed-off-by: Eliot Kimber <ekimber@contrext.com>