### PR TITLE
Fix preprocess clean with resource that have different URI scheme

### DIFF
--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -135,7 +135,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
         final Collection<FileInfo> fis = job.getFileInfo();
         for (final FileInfo fi : fis) {
             final URI res = fi.result.resolve(".");
-            baseDir = getCommonBase(baseDir, res);
+            baseDir = Optional.ofNullable(getCommonBase(baseDir, res)).orElse(baseDir);
         }
 
         return baseDir;
@@ -146,7 +146,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
         assert left.isAbsolute();
         assert right.isAbsolute();
         if (!left.getScheme().equals(right.getScheme())) {
-            throw new IllegalArgumentException("Argument schemes do not match");
+            return null;
         }
         final URI l = left.resolve(".");
         final URI r = right.resolve(".");

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -28,6 +28,7 @@ public class CleanPreprocessModuleTest {
         assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/a"), create("file:/foo/bar/b")));
         assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/b")));
         assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/baz/b")));
+        assertEquals(null, module.getCommonBase(create("file:/foo/bar/a"), create("https://example.com/baz/b")));
     }
 
     @Test
@@ -41,6 +42,22 @@ public class CleanPreprocessModuleTest {
         job.add(new Builder()
                 .uri(create("topics/topic.dita"))
                 .result(create("file:/foo/bar/topics/topic.dita"))
+                .build());
+        module.setJob(job);
+        assertEquals(create("file:/foo/bar/"), module.getBaseDir());
+    }
+
+    @Test
+    public void getBaseDirExternal() throws Exception {
+        final Job job = new Job(new File("").getAbsoluteFile());
+        job.setInputDir(URI.create("file:/foo/bar/"));
+        job.add(new Builder()
+                .uri(create("map.ditamap"))
+                .result(create("file:/foo/bar/map.ditamap"))
+                .build());
+        job.add(new Builder()
+                .uri(create("topics/topic.dita"))
+                .result(create("https://example.com/topics/bar/topics/topic.dita"))
                 .build());
         module.setJob(job);
         assertEquals(create("file:/foo/bar/"), module.getBaseDir());


### PR DESCRIPTION
Preprocess clean module fails when input set has resources with different URI scheme, e.g. local files and external HTTPS files. This ignores the difference when calculating base directory.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>