### PR TITLE
Corrected spelling of KeyrefPaser to KeyrefParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Eclipse
+.settings/
+.classpath
+.project

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -37,7 +37,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.KeyrefReader;
 import org.dita.dost.writer.ConkeyrefFilter;
-import org.dita.dost.writer.KeyrefPaser;
+import org.dita.dost.writer.KeyrefParser;
 
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
@@ -350,7 +350,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
         filters.add(topicFragmentFilter);
 
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(logger);
         parser.setJob(job);
         parser.setKeyDefinition(r.scope);

--- a/src/main/java/org/dita/dost/writer/KeyrefParser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefParser.java
@@ -37,7 +37,7 @@ import org.xml.sax.helpers.AttributesImpl;
  * Filter for processing key reference elements in DITA files.
  * Instances are reusable but not thread-safe.
  */
-public final class KeyrefPaser extends AbstractXMLFilter {
+public final class KeyrefParser extends AbstractXMLFilter {
 
     /**
      * Set of attributes which should not be copied from
@@ -174,7 +174,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     /**
      * Constructor.
      */
-    public KeyrefPaser() {
+    public KeyrefParser() {
         keyrefLevel = 0;
         definitionMaps = new ArrayDeque<>();
         keyrefLevalStack = new ArrayDeque<>();

--- a/src/test/java/org/dita/dost/writer/KeyrefParserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefParserTest.java
@@ -48,9 +48,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 import org.dita.dost.TestUtils;
 
-public class KeyrefPaserTest {
+public class KeyrefParserTest {
 
-    private static final File resourceDir = TestUtils.getResourceDir(KeyrefPaserTest.class);
+    private static final File resourceDir = TestUtils.getResourceDir(KeyrefParserTest.class);
     private static final File srcDir = new File(resourceDir, "src");
     private static final File expDir = new File(resourceDir, "exp");
 
@@ -59,7 +59,7 @@ public class KeyrefPaserTest {
 
     @Before
     public void setUp() throws Exception {
-        tempDir = createTempDir(KeyrefPaserTest.class);
+        tempDir = createTempDir(KeyrefParserTest.class);
         TestUtils.copy(srcDir, tempDir);
 
         keyDefinition = readKeyMap(Paths.get("keys.ditamap"));
@@ -72,7 +72,7 @@ public class KeyrefPaserTest {
 
     @Test
     public void testTopicWrite() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
@@ -85,7 +85,7 @@ public class KeyrefPaserTest {
 
     @Test
     public void testFragment() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
@@ -98,7 +98,7 @@ public class KeyrefPaserTest {
     
     @Test
     public void testFallback() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
@@ -111,7 +111,7 @@ public class KeyrefPaserTest {
 
     @Test
     public void testMapWrite() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
@@ -124,7 +124,7 @@ public class KeyrefPaserTest {
 
     @Test
     public void testUpLevelMapWrite() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(readKeyMap(Paths.get("subdir", "c.ditamap")));
@@ -137,7 +137,7 @@ public class KeyrefPaserTest {
 
     @Test
     public void testMapWithKeyScopes() throws Exception {
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir));
         parser.setKeyDefinition(keyDefinition);
@@ -172,10 +172,10 @@ public class KeyrefPaserTest {
         final TransformerHandler h = f.newTransformerHandler();
         h.setResult(r);
         
-        final KeyrefPaser parser = new KeyrefPaser();
+        final KeyrefParser parser = new KeyrefParser();
         parser.setContentHandler(h);
         
-        final Method m = KeyrefPaser.class.getDeclaredMethod("domToSax", Element.class, boolean.class);
+        final Method m = KeyrefParser.class.getDeclaredMethod("domToSax", Element.class, boolean.class);
         m.setAccessible(true);
         
         h.startDocument();


### PR DESCRIPTION
Signed-off-by: Eliot Kimber <ekimber@contrext.com>