### PR TITLE
Provide meaningful warning for conref=""

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -397,6 +397,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Use plugin configuration '%1' instead.</response>
   </message>
 
+  <message id="DOTJ081W" type="WARN">
+    <reason>Ignoring empty conref attribute conref="".</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -651,22 +651,26 @@ public final class GenListModuleReader extends AbstractXMLFilter {
     private void parseConrefAttr(final Attributes atts) throws SAXException {
         String attrValue = atts.getValue(ATTRIBUTE_NAME_CONREF);
         if (attrValue != null) {
-            hasConRef = true;
-
-            URI filename;
-            final URI target = toURI(attrValue);
-            if (isAbsolute(target)) {
-                filename = target;
-            } else if (attrValue.startsWith(SHARP)) {
-                filename = currentFile;
+            if (attrValue.isEmpty()) {
+                logger.warn(MessageUtils.getMessage("DOTJ081W").setLocation(atts).toString());
             } else {
-                filename = currentDir.resolve(target);
-            }
-            filename = stripFragment(filename);
+                hasConRef = true;
 
-            // Collect only conref target topic files
-            conrefTargets.add(filename);
-            toOutFile(filename, atts);
+                URI filename;
+                final URI target = toURI(attrValue);
+                if (isAbsolute(target)) {
+                    filename = target;
+                } else if (attrValue.startsWith(SHARP)) {
+                    filename = currentFile;
+                } else {
+                    filename = currentDir.resolve(target);
+                }
+                filename = stripFragment(filename);
+
+                // Collect only conref target topic files
+                conrefTargets.add(filename);
+                toOutFile(filename, atts);
+            }
         }
     }
 

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -332,7 +332,7 @@ public class IntegrationTest extends AbstractIntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("lang-common1.dita"))
                 .put("validate", "false")
-                .warnCount(1)
+                .warnCount(2)
                 .test();
     }
     

--- a/src/test/resources/conref/exp/preprocess/lang-common0.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common0.dita
@@ -38,6 +38,7 @@
       </metadata>
     </prolog>
     <body class="- topic/body ">
+      <p class="- topic/p " conref="">Invalid conref, ignore the attribute</p>
       <p class="- topic/p ">Xref to the another file: <xref class="- topic/xref " href="lang-concept.dita"/>. Now do it again, <xref class="- topic/xref " href="lang-concept.dita">with link text</xref>.</p>
       <p class="- topic/p ">Xref to fig in another file's topic: <xref class="- topic/xref " href="lang-concept.dita#lang-concept"/>. Now do it again, <xref class="- topic/xref " href="lang-concept.dita#lang-concept">with link text</xref>.</p>
       <p class="- topic/p ">Xref to fig in another file: <xref class="- topic/xref " href="lang-concept.dita#lang-concept/fig"/>. Now do it again, <xref class="- topic/xref " href="lang-concept.dita#lang-concept/fig">with link text</xref>.</p>

--- a/src/test/resources/conref/exp/preprocess/lang-common1.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common1.dita
@@ -43,6 +43,7 @@
       </metadata>
     </prolog>
     <body class="- topic/body ">
+      <p class="- topic/p " conref="">Invalid conref, ignore the attribute</p>
       <p class="- topic/p ">Xref to the another file: <xref class="- topic/xref "
           href="lang-concept.dita" type="concept"><?ditaot gentext?>Concept for language
             test<?ditaot genshortdesc?><desc class="- topic/desc ">this is the related

--- a/src/test/resources/conref/src/lang-common0.dita
+++ b/src/test/resources/conref/src/lang-common0.dita
@@ -42,6 +42,7 @@
       </metadata>
     </prolog>
     <body class="- topic/body ">
+      <p class="- topic/p " conref="">Invalid conref, ignore the attribute</p>
       <p class="- topic/p ">Xref to the another file: <xref class="- topic/xref "
           href="lang-concept.dita"/>. Now do it again, <xref class="- topic/xref "
           href="lang-concept.dita">with link text</xref>.</p>

--- a/src/test/resources/messages.xml
+++ b/src/test/resources/messages.xml
@@ -443,6 +443,41 @@
     <response></response>
   </message>
 
+  <message id="DOTJ075W" type="WARN">
+    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
+    <response>Using 'scope' attribute value 'external'.</response>
+  </message>
+  
+  <message id="DOTJ076W" type="WARN">
+    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
+    <response></response>
+  </message>
+  
+  <message id="DOTJ077F" type="FATAL">
+    <reason>Invalid action attribute '%1' on DITAVAL property.</reason>
+    <response></response>
+  </message>
+  
+  <message id="DOTJ078F" type="FATAL">
+    <reason>Input file '%1' could not be loaded.</reason>
+    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+  </message>
+  
+  <message id="DOTJ079E" type="ERROR">
+    <reason>File '%1' could not be loaded.</reason>
+    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+  </message>
+  
+  <message id="DOTJ080W" type="WARN">
+    <reason>Integrator configuration '%1' has been deprecated.</reason>
+    <response>Use plugin configuration '%1' instead.</response>
+  </message>
+  
+  <message id="DOTJ081W" type="WARN">
+    <reason>Ignoring empty conref attribute conref="".</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -6,11 +6,13 @@ DOTX064W=The copy-to attribute [copy-to\="{0}"] uses the name of a file that alr
 DOTX025E=Missing linktext and navtitle for non-DITA resource "{0}". References must provide a local navigation title when the target is not a local DITA resource.
 PDFX012E=Found a table row with more entries than allowed.
 DOTX005E=Unable to find navigation title for reference to ''{0}''. The build will use ''{0}'' as the title in the Eclipse Table of Contents.
+DOTA014W=Attribute @{0} is deprecated. Use attribute @{1} instead.
 DOTJ043W=The conref push function is trying to replace an element that does not exist (element "{0}" in file "{1}").
 DOTX044E=The area element in an image map does not specify a link target. Please add an xref element with a link target to the area element.
 PDFX007W=Found an index term with end\="{0}", but no starting term was found for this entry.
 DOTJ063E=The cols attibute is "{0}" but number of colspec elements was {1}.
 DOTA069W=Target "{0}" is deprecated. Remove references to this target from your custom XSLT or plug-ins.
+DOTJ079E=File ''{0}'' could not be loaded. Ensure that grammar files for this document type are referenced and installed properly.
 DOTX063W=The dita document ''{0}'' is linked to from your content, but is not referenced by a topicref tag in the ditamap file. Include the topic in your map to avoid a broken link.
 DOTX024E=Missing linktext and navtitle for peer topic "{0}". References must provide a local navigation title when the target is not a local DITA resource.
 PDFX011E=The index term ''{1}'' uses both an index-see element and {0} element. Convert the index-see element to index-see-also.
@@ -25,7 +27,9 @@ DOTX043I=The link to ''{0}'' may appear more than once in ''{1}''.
 DOTX019W=The type attribute on a topicref was set to ''{0}'', but the topicref references a ''{1}'' topic. This may cause your links to sort incorrectly in the output. Note that the type attribute cascades in maps, so the value ''{0}'' may come from an ancestor topicref.
 DOTJ062E=Invalid {0} attribute value "{1}".
 DOTA013F=Cannot find the specified DITAVAL ''{0}''.
+DOTJ078F=Input file ''{0}'' could not be loaded. Ensure that grammar files for this document type are referenced and installed properly.
 DOTA068W=Ignoring index-see-also ''{0}'' inside parent index entry ''{1}'' because the parent indexterm contains indexterm children.
+DOTJ081W=Ignoring empty conref attribute conref\="".
 DOTX003I=The anchorref attribute should either reference another dita map or an Eclipse XML TOC file. The value ''{0}'' does not appear to reference either.
 DOTJ042E=Two elements both use conref push to replace the target "{0}". Please delete one of the duplicate "replace" actions.
 DOTJ058E=Both {0} and {1} attributes defined. A single element may not contain both generalized and specialized values for the same attribute.
@@ -43,8 +47,10 @@ DOTJ021W=File ''{0}'' will not generate output since it is invalid or all of its
 DOTJ037W=The XML schema and DTD validation function of the parser is turned off. Please make sure the input is normalized DITA with class attributes included, otherwise it will not be processed correctly.
 DOTJ061E=Topic reference target is a DITA map but format attribute has not been set. Set format attribute value to "ditamap".
 DOTX038I=The longdescref attribute on tag ''{0}'' will be ignored. Accessibility for object elements needs to be handled another way.
+DOTJ077F=Invalid action attribute ''{0}'' on DITAVAL property.
 DOTA067W=Ignoring index-see ''{0}'' inside parent index entry ''{1}'' because the parent indexterm contains indexterm children.
 DOTX061W=ID ''{0}'' was used in topicref tag but did not reference a topic element. The href attribute on a topicref element should only reference topic level elements.
+DOTJ080W=Integrator configuration ''{0}'' has been deprecated. Use plugin configuration ''{0}'' instead.
 DOTJ041E=The attribute conref\="{0}" uses invalid syntax. The value should contain ''\#'' followed by a topic or map ID, optionally followed by ''/elemID'' for a sub-topic element.
 DOTX018I=The type attribute on a topicref was set to ''{0}'', but the topicref references a more specific ''{1}'' topic. Note that the type attribute cascades in maps, so the value ''{0}'' may come from an ancestor topicref.
 XEPJ003E={0}
@@ -55,6 +61,7 @@ DOTX057W=The link or cross reference target ''{0}'' cannot be found, which may c
 DOTJ060W=Key "{0}" was used in conkeyref but is not bound to a DITA topic or map. Cannot resolve conkeyref value "{1}" as a valid conref reference.
 PDFX005F=The topic reference href\="{0}" could not be found. Please correct the reference, or set the scope or format attribute if the target is not a local DITA topic.
 DOTA011W=Argument "{0}" is deprecated. This argument is no longer supported in the toolkit.
+DOTJ076W=Absolute link ''{0}'' without correct ''scope'' attribute.
 DOTX037W=No title found for this document; using "***" in XHTML title bar.
 DOTX001W=No string named ''{0}'' was found for language ''{1}''. Using the default language ''{2}''. Add a mapping between default language and desired language for the string ''{0}''.
 DOTJ020W=At least one plug-in in ''{0}'' is required by plug-in ''{1}''. Plug-in ''{1}'' cannot be loaded. Check and see whether all prerequisite plug-ins are installed in toolkit.
@@ -73,11 +80,13 @@ DOTJ076W=Absolute link ''{0}'' without correct ''scope'' attribute.
 DOTA066F=Cannot find the user specified XSLT stylesheet ''{0}''.
 XEPJ001W={0}
 PDFJ003I=Index entry ''{0}'' will be sorted under the "Special characters" heading.
+DOTX076E=A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints "{0}". The current constrained document may only reuse content from documents with equivalent constraints.
 DOTA006W=Absolute paths on the local file system are not supported for the CSSPATH parameter. Please use a relative path or full URI instead.
 DOTX040I=Draft comment area found. To remove this message and hide the comments, build your content without using the DRAFT parameter.
 DOTX016W=A reference to "{1}" appears to reference a DITA document, but the format attribute has inherited a value of "{0}". The document will not be processed as DITA.
 PDFX003W=There are multiple index entries found to close the index range for "{0}". Ensure that any index term with start\="{0}" has only one matching end term with end\="{0}".
 DOTX020E=Missing navtitle attribute or element for peer topic "{0}". References must provide a local navigation title when the target is not a local DITA resource.
+DOTX075W=A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in "{0}".
 DOTX036E=Unable to generate link text for a cross reference to a dlentry (the dlentry or term could not be found)\: ''{0}''
 DOTJ055E=Invalid key name "{0}".
 DOTX055W=Customized stylesheet uses deprecated template "flagit". Conditional processing is no longer supported using this template. Please update your stylesheet to use template "start-flagit" instead of deprecated template "flagit".
@@ -85,6 +94,7 @@ DOTJ035F=The file "{0}" is outside the scope of the input dita/map directory. If
 DOTJ074W=Rev attribute cannot be used with prop filter.
 PDFJ002E=The build failed due to problems encountered when sorting the PDF index. Please address any messages located earlier in the log.
 PDFX002W=There are multiple index terms specified with start\="{0}", but there is only one term to end this range, or the ranges for this term overlap. Ensure that each term with this start value has a matching end value, and that the specified ranges for this value do not overlap
+DOTX074W=No formatting defined for unknown class attribute value "{0}".
 DOTX035E=Unable to generate the correct number for a cross reference to a footnote\: ''{0}''
 DOTJ014W=Found an indexterm element with no content. Setting the term to ***.
 DOTJ054E=Unable to parse invalid {0} attribute value "{1}"
@@ -133,6 +143,7 @@ DOTJ051E=Unable to load target for coderef "{0}".
 DOTJ067E=No id attribute on topic type element {0}.
 DOTJ031I=No specified rule for ''{0}'' was found in the ditaval file. This value will use the default action, or a parent prop action if specified. To remove this message, you can specify a rule for ''{0}'' in the ditaval file.
 DOTX028E=Link or cross reference must contain a valid href or keyref attribute; no link target is specified.
+DOTJ007W=Duplicate condition in filter file for rule ''{0}''. The first encountered condition will be used.
 DOTJ047I=Unable to find key definition for key reference "{0}" in root scope. The href attribute may be used as fallback if it exists
 DOTX047W=Area coordinates are blank. Coordinate points for the shape need to be specified.
 DOTX008E=File ''{0}'' does not exist or cannot be loaded.
@@ -145,7 +156,7 @@ DOTX067E=No string named ''{0}'' was found for language ''{1}''. Add a mapping f
 DOTJ007E=Duplicate condition in filter file for rule ''{0}''. The first encountered condition will be used.
 DOTX070W=Target "{0}" is deprecated. Remove references to this target from your custom Ant files.
 DOTX031E=The file {0} is not available to resolve link information.
-DOTA001F="{0}" is not a recognized transformation type. Supported transformation types are docx, eclipsehelp, html5, htmlhelp, markdown, markdown_gitbook, markdown_github, org.dita-ot.html, pdf, pdf2, tocjs, troff, xhtml.
+DOTA001F="{0}" is not a recognized transformation type. Supported transformation types are eclipsehelp, html5, htmlhelp, pdf, pdf, pdf, pdf, pdf2, xhtml.
 DOTX050W=Default id "org.sample.help.doc" is used for Eclipse plug-in. If you want to use your own plug-in id, please specify it using the id attribute on your map.
 DOTJ066E=No id attribute on topic type element {0}. Using generated id {1}.
 DOTJ030I=No ''class'' attribute for was found for element ''<{0}>''. The element will be processed as an unknown or non-DITA element.
@@ -159,7 +170,8 @@ DOTX026W=Unable to retrieve linktext from target\: ''{0}''. Using navigation tit
 DOTJ065I=Branch filter generated topic {0} used more than once. Renaming {0} to {1}.
 DOTX010E=Unable to find target for conref\="{0}".
 DOTX065W=Two unique source files each specify copy-to\="{1}", which results in a collision. The value associated with href\="{0}" is ignored.
-DOTJ045I=The key "{0}" is defined more than once in the same map file. The reference href\="{1}" is ignored.
+DOTJ045I=The key "{0}" is defined more than once in the same map file.
+PDFX013F=The PDF file ''{0}'' could not be generated.
 DOTX045W=The area element in an image map should specify link text for greater accessibility. Link text should be specified directly when the target is not a local DITA resource.
 DOTX006E=Unknown file extension in href\="{0}". References to non-DITA resources should set the format attribute to match the resource (for example, ''txt'', ''pdf'', or ''html'').
 DOTJ064W=Chunk attribute uses both "to-content" and "by-topic" that conflict with each other. Ignoring "by-topic" token.


### PR DESCRIPTION
When I have `conref=""` in my source files, the Gen List step + the `map-reader` and `topic-reader` steps treat the attribute as a valid reference. They try to read the "file" referenced by `@conref`, which the operating system interprets as an attempt to read the directory, resulting in the following error:

` [gen-list] [DOTJ013E][ERROR] Failed to parse the referenced file 'file:/C:/DITA-OT/TESTGITHUB/emptyconref/'.: file:/C:/DITA-OT/TESTGITHUB/emptyconref/ Line 1:Content is not allowed in prolog.`

I've encountered this in a lot of different documents over the last few weeks. The current message is meaningless for an author who has not encountered this recently, and does not even list the source file, resulting in a lot of difficult debugging for most people.

This update checks for an empty value. If the attribute is empty, it generates a new (better) warning message, and ignores the reference so that we do not try to read the directory. (The conref processing already knows to skip an empty value.) With this update, the build now reports a more useful message:
` [gen-list] file:/C:/DITA-OT/TESTGITHUB/emptyconref/emptyconref.dita:10:15: [DOTJ081W][WARN] Ignoring empty conref attribute (conref="").`