### PR TITLE
Drop duplicates when listing transform types

### DIFF
--- a/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
@@ -32,6 +32,7 @@ final class ListTranstypeAction extends ImportAction {
         final String separator = paramTable.getOrDefault("separator", "|");
         final List<String> v = valueSet.stream()
                 .map(fileValue -> fileValue.value)
+                .distinct()
                 .collect(Collectors.toList());
         Collections.sort(v);
         final StringBuilder retBuf = new StringBuilder();


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

When writing out a list of transform types, DITA-OT puts out a list of each declared transform type. In out-of-the-box DITA-OT, we have a base `pdf` transform type + three working extension plugins that all declare `pdf` as the transform type. When that list goes into the message template, it results in:
```
<message id="DOTA001F" type="FATAL">
    <reason>"%1" is not a recognized transformation type.</reason>
    <response>Supported transformation types are eclipsehelp, html5, htmlhelp, pdf, pdf, pdf, pdf, pdf2, xhtml.</response>
  </message>
```

Noticed this when I had a typo in my transform type using the `develop` branch, and got the error:
`Error: [DOTA001F][FATAL] "pfd" is not a recognized transformation type. Supported transformation types are eclipsehelp, html5, htmlhelp, pdf, pdf, pdf, pdf, pdf2, xhtml.`

This update just strips duplicates when writing out the list of transform types, resulting in a better message:
`Error: [DOTA001F][FATAL] "spfd" is not a recognized transformation type. Supported transformation types are eclipsehelp, html5, htmlhelp, pdf, pdf2, xhtml.`