### PR TITLE
Turn warning into info for duplicate ditaval condition

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -62,6 +62,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
   
+  <message id="DOTJ007I" type="INFO">
+    <reason>Duplicate condition in filter file for rule '%1'.</reason>
+    <response>The first encountered condition will be used.</response>
+  </message>
+  
   <message id="DOTJ007W" type="WARN">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -388,7 +388,7 @@ public final class DitaValReader implements AbstractReader {
         if (filterMap.get(key) == null) {
             filterMap.put(key, action);
         } else {
-            logger.warn(MessageUtils.getMessage("DOTJ007W", key.toString()).toString());
+            logger.info(MessageUtils.getMessage("DOTJ007I", key.toString()).toString());
         }
     }
 


### PR DESCRIPTION
If a DITAVAL file has a duplicate condition, we currently generate a warning:
` [gen-list] [DOTJ007W][WARN] Duplicate condition in filter file for rule 'platform=test'. The first encountered condition will be used.`

This was changed from an error to a warning in #2958, but really should have been changed to informational. I see this regularly with content that is managed using a combination of DITAVAL files, where the conditions for a specific job are set in the first file(s) but a common set of all valid conditions is set to "include" to avoid any messages about unknown values.

This update downgrades the message further to Info level; this is actually a good example of a purely informational message that should not have been treated as a warning (something likely wrong) or error (something broken):
` [gen-list] [DOTJ007I][INFO] Duplicate condition in filter file for rule 'platform=test'. The first encountered condition will be used.`

The older message number is left in the message template for historical reasons (as with previous downgrade to warning).