### PR TITLE
Fix errors for href="-dita-use-conref-target"

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -565,6 +565,13 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         if (attrValue == null) {
             return;
         }
+
+        //Check if this attribute will be ignored due to conref
+        final String attrConref = atts.getValue(ATTRIBUTE_NAME_CONREF);
+        if (attrConref != null && !attrConref.isEmpty() && ATTR_VALUE_DITA_USE_CONREF_TARGET.equals(attrValue.toString())) {
+            return;
+        }
+
         final String attrClass = atts.getValue(ATTRIBUTE_NAME_CLASS);
         final String attrScope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
 

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1038,7 +1038,9 @@ public final class Constants {
     public static final String ATTR_CONACTION_VALUE_PUSHBEFORE = "pushbefore";
     /** Conaction push replace value */
     public static final String ATTR_CONACTION_VALUE_PUSHREPLACE = "pushreplace";
-
+    
+    /** Standard token for attribute to be ignored due to conref */
+    public static final String ATTR_VALUE_DITA_USE_CONREF_TARGET = "-dita-use-conref-target";
 
     /** constants for filtering or flagging. */
     public static final String DEFAULT_ACTION = "default";

--- a/src/test/resources/conref_with_xref/exp/xhtml/common/conref-with-xref.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml/common/conref-with-xref.html
@@ -24,6 +24,10 @@
 
     <p class="p" id="topic-1__p-with-keyref">This is a keyref xref to the target "XRef target topic": <a class="xref" href="../langref/xref-target-topic.html">keyref xref to xref-target-topic</a></p>
 
+    <p class="p">Now try conref on an actual xref, with -dita-use-conref-target
+      <a class="xref" href="https://www.dita-ot.org" target="_blank">project site</a>
+      <a class="xref" href="https://www.dita-ot.org" target="_blank">project site</a></p>
+    
   </div>
 
 </body>

--- a/src/test/resources/conref_with_xref/src/common/conref-with-xref.xml
+++ b/src/test/resources/conref_with_xref/src/common/conref-with-xref.xml
@@ -11,5 +11,8 @@
     <p
       id="p-with-keyref">This is a keyref xref to the target "XRef target topic": <xref
       keyref="xref-target-01">keyref xref to xref-target-topic</xref></p>
+    <p>Now try conref on an actual xref, with -dita-use-conref-target
+      <xref id="xref" href="https://www.dita-ot.org" format="html" scope="external">project site</xref>
+      <xref conref="#./xref" href="-dita-use-conref-target"/></p>
   </body>
 </topic>


### PR DESCRIPTION
The DITA specification defines the token [-dita-use-conref-target](http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part1-base/langRef/attributes/ditauseconreftarget.html#usingthe-dita-use-conref-targetvalue) as a way to specify an attribute that will be ignored when conref is going to replace that attribute. It's intended for use with required attributes but technically valid on any attribute.

I've just discovered some documents used in an older system that have thousands of images using syntax such as
`<image conref="some.dita#value/image" href="-dita-use-conref-target"/>`

The design pattern for these was established in DITA 1.0 when `@href` was required on images, but has carried on through habit and through the continued use of old files.

DITA-OT today treats `@href` as an actual file reference, and tries to evaluate it as a file, resulting in these errors; the rest of the build is fine because the attribute is evaluated correctly:
```
 [gen-list] [DOTX008E][ERROR] File 'file:/C:/temp/-dita-use-conref-target' doesnot exist or cannot be loaded.
File file:/C:/temp/-dita-use-conref-target not found
```

This update fixes the issue by skipping evaluation of `href="-dita-use-conref-target"` as a file when `@conref` is specified + non-empty. It also updates an existing integration test that uses conref + xref to show the issue and avoid regressions.

Note: yes, there are two obvious workarounds here -- removing the attribute (because the token is no longer needed) or switching to keys rather than conref for reuse (which would still require removing the href value). However, the markup is valid so we should allow it.