### PR TITLE
Re-lint HTML5 Sass code

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/.scss-lint.yml
+++ b/src/main/plugins/org.dita.html5/sass/.scss-lint.yml
@@ -67,7 +67,7 @@ linters:
     ignore_single_line_blocks: false
 
   EmptyRule:
-    enabled: true
+    enabled: false
 
   ExtendDirective:
     enabled: false
@@ -168,7 +168,7 @@ linters:
     max_depth: 3
 
   SelectorFormat:
-    enabled: true
+    enabled: false
     convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
 #   class_convention: '^(?:u|is|has)\-[a-z][a-zA-Z0-9]*$|^(?!u|is|has)[a-zA-Z][a-zA-Z0-9]*(?:\-[a-z][a-zA-Z0-9]*)?(?:\-\-[a-z][a-zA-Z0-9]*)?$'
 

--- a/src/main/plugins/org.dita.html5/sass/_variables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_variables.scss
@@ -13,14 +13,14 @@
 //
 //## Gray and brand colors
 
-$gray-base:              #000 !default;
-$gray-darker:            lighten($gray-base, 13.5%) !default; // #222
-$gray-dark:              lighten($gray-base, 20%) !default;   // #333
-$gray:                   lighten($gray-base, 33.5%) !default; // #555
-$gray-light:             lighten($gray-base, 46.7%) !default; // #777
-$gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+$gray-base:             #000 !default;
+$gray-darker:           lighten($gray-base, 13.5%) !default; // #222
+$gray-dark:             lighten($gray-base, 20%) !default;   // #333
+$gray:                  lighten($gray-base, 33.5%) !default; // #555
+$gray-light:            lighten($gray-base, 46.7%) !default; // #777
+$gray-lighter:          lighten($gray-base, 93.5%) !default; // #eee
 
-$brand-primary:          darken(#428bca, 6.5%) !default; // #337ab7
+$brand-primary:         darken(#428bca, 6.5%) !default; // #337ab7
 
 // Hazard statement colors
 //
@@ -116,15 +116,15 @@ $border-radius-small:       3px !default;
 //
 //##
 
-$code-color:                  $gray-light !default;
-$code-bg:                     transparent !default;
+$code-color:            $gray-light !default;
+$code-bg:               transparent !default;
 
-$kbd-color:                   #fff !default;
-$kbd-bg:                      #333 !default;
+$kbd-color:             #fff !default;
+$kbd-bg:                #333 !default;
 
-$pre-bg:                      #f5f5f5 !default;
-$pre-color:                   $gray-dark !default;
-$pre-border-color:            #ccc !default;
+$pre-bg:                #f5f5f5 !default;
+$pre-color:             $gray-dark !default;
+$pre-border-color:      #ccc !default;
 
 $screen-bg:             $pre-border-color;
 
@@ -133,4 +133,4 @@ $screen-bg:             $pre-border-color;
 //##
 
 //** Text muted color
-$text-muted:                  $gray-light !default;
+$text-muted:            $gray-light !default;

--- a/src/main/plugins/org.dita.html5/sass/_variables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_variables.scss
@@ -22,6 +22,21 @@ $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
 
 $brand-primary:          darken(#428bca, 6.5%) !default; // #337ab7
 
+// Hazard statement colors
+//
+// Source: https://www.nema.org/Standards/ComplimentaryDocuments/ANSI%20Z535_1-2017%20CONTENTS%20AND%20SCOPE.pdf
+$hazard-ansi-red:       #c8102e; // danger
+$hazard-ansi-orange:    #ff8200; // warning
+$hazard-ansi-yellow:    #ffd100; // caution
+$hazard-ansi-green:     #007b5f;
+$hazard-ansi-blue:      #0072ce; // note
+$hazard-ansi-purple:    #6d2077;
+
+// Source: https://en.wikipedia.org/wiki/ISO_3864
+$hazard-iso-red:        #9b2423;
+$hazard-iso-yellow:     #f9a800;
+$hazard-iso-green:      #237f52;
+$hazard-iso-blue:       #005387;
 
 //== Scaffolding
 //
@@ -111,6 +126,7 @@ $pre-bg:                      #f5f5f5 !default;
 $pre-color:                   $gray-dark !default;
 $pre-border-color:            #ccc !default;
 
+$screen-bg:             $pre-border-color;
 
 //== Type
 //

--- a/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_abbreviated-form.scss
@@ -4,6 +4,6 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// inline 
+// inline
 .abbreviated-form {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_bookmap.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .abbrevlist {
 }
 
@@ -155,7 +155,7 @@
 .volume {
 }
 
-// inline 
+// inline
 .booklibrary {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_classification.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .subjectCell {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_concept.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .conbody {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_equation-d.scss
@@ -4,14 +4,14 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .equation-block {
 }
 
 .equation-figure {
 }
 
-// inline 
+// inline
 .equation-inline {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossentry.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .glossAbbreviation {
 }
 
@@ -44,7 +44,7 @@
 .glossUsage {
 }
 
-// inline 
+// inline
 .glossAlternateFor {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossgroup.scss
@@ -4,6 +4,6 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .glossgroup {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_glossref.scss
@@ -4,6 +4,6 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .glossref {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -9,7 +9,13 @@
 }
 
 .hazardstatement {
-  &--caution {
+  &--caution,
+  &--fastpath,
+  &--important,
+  &--other,
+  &--remember,
+  &--restriction,
+  &--tip {
     background-color: $hazard-ansi-yellow;
   }
 
@@ -25,15 +31,6 @@
   &--note,
   &--notice {
     background-color: $hazard-ansi-blue;
-  }
-
-  &--fastpath,
-  &--important,
-  &--other,
-  &--remember,
-  &--restriction,
-  &--tip {
-    @extend .hazardstatement--caution;
   }
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -33,10 +33,17 @@
   &--warning {
     background-color: $hazard-ansi-orange;
   }
-  &--attention, &--note, &--notice {
+  &--attention,
+  &--note,
+  &--notice {
     background-color: $hazard-ansi-blue;
   }
-  &--fastpath, &--important, &--other, &--remember, &--restriction, &--tip {
+  &--fastpath,
+  &--important,
+  &--other,
+  &--remember,
+  &--restriction,
+  &--tip {
     @extend .hazardstatement--caution;
   }
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -25,16 +25,16 @@
 
 .hazardstatement {
   &--caution {
-    background-color: #FFD100;
+    background-color: $hazard-ansi-yellow;
   }
   &--danger {
-    background-color: #C8102E;
+    background-color: $hazard-ansi-red;
   }
   &--warning {
-    background-color: #FF8200;
+    background-color: $hazard-ansi-orange;
   }
   &--attention, &--note, &--notice {
-    background-color: #0072CE;
+    background-color: $hazard-ansi-blue;
   }
   &--fastpath, &--important, &--other, &--remember, &--restriction, &--tip {
     @extend .hazardstatement--caution;

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -9,21 +9,6 @@
 }
 
 .hazardstatement {
-}
-
-.hazardsymbol {
-}
-
-.howtoavoid {
-}
-
-.messagepanel {
-}
-
-.typeofhazard {
-}
-
-.hazardstatement {
   &--caution {
     background-color: $hazard-ansi-yellow;
   }
@@ -50,4 +35,16 @@
   &--tip {
     @extend .hazardstatement--caution;
   }
+}
+
+.hazardsymbol {
+}
+
+.howtoavoid {
+}
+
+.messagepanel {
+}
+
+.typeofhazard {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -27,17 +27,21 @@
   &--caution {
     background-color: $hazard-ansi-yellow;
   }
+
   &--danger {
     background-color: $hazard-ansi-red;
   }
+
   &--warning {
     background-color: $hazard-ansi-orange;
   }
+
   &--attention,
   &--note,
   &--notice {
     background-color: $hazard-ansi-blue;
   }
+
   &--fastpath,
   &--important,
   &--other,

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .consequence {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// inline 
+// inline
 .b {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_indexing-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .index-see {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .lcAnswerContent {
 }
 
@@ -173,7 +173,7 @@
 .lcTrueFalse2 {
 }
 
-// inline 
+// inline
 .lcAreaCoords {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learning.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .lcLom {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningAssessment.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningAssessment {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningBase.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .lcAudience {
 }
 
@@ -62,7 +62,7 @@
 .learningBasebody {
 }
 
-// inline 
+// inline
 .lcObjectivesStem {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningContent.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningContent {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningOverview.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningOverview {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningPlan.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .lcAge {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningSummary.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningSummary {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmapdomain.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningContentRef {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_learningmaps.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .learningGroupMap {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_map.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_map.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .linktext {
 }
 
@@ -37,7 +37,7 @@
 
 .topicref {
 }
-// inline 
+// inline
 .anchor {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_mapgroup-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .anchorref {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_markup-d.scss
@@ -4,6 +4,6 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// inline 
+// inline
 .markupname {
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .codeblock {
   font-family: monospace;
 }
@@ -42,7 +42,7 @@
 .syntaxdiagram {
 }
 
-// inline 
+// inline
 .apiname {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_reference.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .propdesc {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_subject.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .defaultSubject {
 }
 
@@ -56,7 +56,7 @@
 .subjectScheme {
 }
 
-// block 
+// block
 .attributedef {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_sw-d.scss
@@ -4,11 +4,11 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .msgblock {
 }
 
-// inline 
+// inline
 .cmdname {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_task.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_task.scss
@@ -5,8 +5,8 @@
 // See the accompanying LICENSE file for applicable license.
 
 div.tasklabel {
-  margin-top: 1em;
   margin-bottom: 1em;
+  margin-top: 1em;
 }
 
 h2.tasklabel,

--- a/src/main/plugins/org.dita.html5/sass/domains/_task.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_task.scss
@@ -17,7 +17,7 @@ h6.tasklabel {
   font-size: 100%;
 }
 
-// block 
+// block
 .chdesc {
 }
 
@@ -90,7 +90,7 @@ h6.tasklabel {
 .tasktroubleshooting {
 }
 
-// inline 
+// inline
 .cmd {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_task.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_task.scss
@@ -4,17 +4,10 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-div.tasklabel {
+.tasklabel {
+  font-size: 100%;
   margin-bottom: 1em;
   margin-top: 1em;
-}
-
-h2.tasklabel,
-h3.tasklabel,
-h4.tasklabel,
-h5.tasklabel,
-h6.tasklabel {
-  font-size: 100%;
 }
 
 // block

--- a/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_taskreq.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .closereqs {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .abstract {
 }
 
@@ -275,7 +275,7 @@
 .vrmlist {
 }
 
-// inline 
+// inline
 .boolean {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_troubleshooting.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .cause {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -8,7 +8,7 @@
 .screen {
   padding: 5px 5px 5px 5px;
   border: outset;
-  background-color: #CCCCCC;
+  background-color: $screen-bg;
   margin-top: 2px;
   margin-bottom: 2px;
   white-space: pre;

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -6,7 +6,7 @@
 
 // block
 .screen {
-  padding: 5px 5px 5px 5px;
+  padding: 5px;
   border: outset;
   background-color: $screen-bg;
   margin-top: 2px;

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -6,11 +6,11 @@
 
 // block
 .screen {
-  padding: 5px;
-  border: outset;
   background-color: $screen-bg;
-  margin-top: 2px;
+  border: outset;
   margin-bottom: 2px;
+  margin-top: 2px;
+  padding: 5px;
   white-space: pre;
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ui-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .screen {
   padding: 5px 5px 5px 5px;
   border: outset;
@@ -14,7 +14,7 @@
   white-space: pre;
 }
 
-// inline 
+// inline
 .menucascade {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_ut-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .area {
 }
 
@@ -14,7 +14,7 @@
 .sort-as {
 }
 
-// inline 
+// inline
 .coords {
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
@@ -7,7 +7,7 @@
 // Sass partial for DITA 1.3 XML mention domain
 
 $code-fonts: Menlo, Monaco, Consolas, "Courier New", monospace;
-$markup-color: #663399;
+$markup-color: #639;
 
 @mixin markupname {
   color: $markup-color;

--- a/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xml-d.scss
@@ -14,7 +14,7 @@ $markup-color: #663399;
   font-family: $code-fonts;
 }
 
-// inline 
+// inline
 .numcharref {
   @include markupname;
 }

--- a/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_xnal-d.scss
@@ -4,7 +4,7 @@
 //
 // See the accompanying LICENSE file for applicable license.
 
-// block 
+// block
 .addressdetails {
 }
 


### PR DESCRIPTION
When we switched to Sass for HTML5 styling back in 2016 for 2.3, we created an [scss-lint](https://github.com/brigade/scss-lint/) configuration [file](https://github.com/dita-ot/dita-ot/blob/develop/src/main/plugins/org.dita.html5/sass/.scss-lint.yml) based on [recommendations](http://sass-guidelin.es/#scss-lint) from the [Sass Guidelines](http://sass-guidelin.es) project to ensure Sass code is formatted consistently.

## Hazard Domain

Running that configuration on `_hazard.scss` reveals several issues that are easy to fix:

    scss-lint src/main/plugins/org.dita.html5/sass/domains/_hazard.scss \
     --config src/main/plugins/org.dita.html5/sass/.scss-lint.yml \
     --format Stats

Results

    7  SingleLinePerSelector         (across 1 files)
     6  EmptyRule                     (across 1 files)
     4  EmptyLineBetweenBlocks        (across 1 files)
     4  HexNotation                   (across 1 files)
     4  ColorVariable                 (across 1 files)
     1  PlaceholderInExtend           (across 1 files)
     1  MergeableSelector             (across 1 files)
     1  TrailingWhitespace            (across 1 files)
    --  ----------------------        ----------------
    28  total                         (across 1 files)

## Sass folder

Running the same configuration over the entire `sass/` folder shows this is not the only file with issues:

    scss-lint src/main/plugins/org.dita.html5/sass/domains \
     --config src/main/plugins/org.dita.html5/sass/.scss-lint.yml \
     --format Stats

Results:

    588  EmptyRule                     (across 38 files)
    213  SelectorFormat                (across 14 files)
     49  TrailingWhitespace            (across 36 files)
      7  SingleLinePerSelector         (across  1 files)
      6  QualifyingElement             (across  1 files)
      5  ColorVariable                 (across  2 files)
      5  HexNotation                   (across  2 files)
      4  EmptyLineBetweenBlocks        (across  1 files)
      2  PropertySortOrder             (across  2 files)
      2  Shorthand                     (across  1 files)
      2  HexLength                     (across  2 files)
      1  PlaceholderInExtend           (across  1 files)
      1  MergeableSelector             (across  1 files)
    ---  ----------------------        -----------------
    885  total                         (across 39 files)


Most issues are due to the empty placeholder rules we create so people know where to extend the styling for all DITA elements, and the mixed-case selectors we're stuck with to match the unfortunately named learning & training domain elements.

If we disable those linter rules to reduce the noise, we're left with a reasonable number of exceptions that are easily resolved.

This PR adjusts the config accordingly and makes the necessary changes to ensure the code style is consistent.

## Questions for review

1. Can we simplify the [`.tasklabel` rules](https://github.com/dita-ot/dita-ot/blob/develop/src/main/plugins/org.dita.html5/sass/domains/_task.scss#L7-L18) to drop the qualifying element selector, or is there some funtional reason those remain separate?

```diff

-div.tasklabel {
+.tasklabel {
+  font-size: 100%;
   margin-bottom: 1em;
   margin-top: 1em;
 }
 
-h2.tasklabel,
-h3.tasklabel,
-h4.tasklabel,
-h5.tasklabel,
-h6.tasklabel {
-  font-size: 100%;
-}

```

2. Why use the `@extend` directive with `.hazardstatement--caution`?

```scss

.hazardstatement {
  &--caution {
    background-color: $hazard-ansi-yellow;
  }

  &--fastpath,
  &--important,
  &--other,
  &--remember,
  &--restriction,
  &--tip {
    @extend .hazardstatement--caution;
  }
}
```

_Shouldn't we use the simpler approach chosen for `attention/note/notice`, where we just have multiple selectors in the same rule?_

```scss
  &--attention,
  &--note,
  &--notice {
    background-color: $hazard-ansi-blue;
  }
```
