### PR TITLE
Enable dynamic registration of collation URI resolvers

### DIFF
--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -7,6 +7,7 @@
  */
 package org.dita.dost.module;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.sf.saxon.jaxp.SaxonTransformerFactory;
 import net.sf.saxon.lib.CollationURIResolver;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
@@ -255,7 +256,8 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         this.extension = extension.startsWith(".") ? extension : ("." + extension);
     }
 
-    private void configureExtensions(TransformerFactory tf) {
+    @VisibleForTesting
+    void configureExtensions(TransformerFactory tf) {
         if (tf instanceof SaxonTransformerFactory) {
             configureSaxonExtensions((SaxonTransformerFactory) tf);
         }
@@ -286,7 +288,8 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
      * 
      * @param tf The transformer factory to configure.
      */
-    private void configureCollationResolvers(TransformerFactory tf) {
+    @VisibleForTesting
+    void configureCollationResolvers(TransformerFactory tf) {
         if (tf instanceof SaxonTransformerFactory) {
             configureSaxonCollationResolvers((SaxonTransformerFactory) tf);
         }

--- a/src/main/java/org/dita/dost/module/saxon/DelegatingCollationUriResolver.java
+++ b/src/main/java/org/dita/dost/module/saxon/DelegatingCollationUriResolver.java
@@ -1,0 +1,23 @@
+package org.dita.dost.module.saxon;
+
+import net.sf.saxon.lib.CollationURIResolver;
+
+/**
+ * Enables dynamic configuration of Collation URI resolvers by the Open Toolkit
+ * by providing the Collator's URI.
+ * @since 3.3
+ *
+ */
+public interface DelegatingCollationUriResolver extends CollationURIResolver {
+  
+  /**
+   * Sets the base resolver to delegate to if the resolver does not
+   * handle the specified URI. This allows multiple plugins to 
+   * contribute collation URI resolvers.
+   * 
+   * @param baseResolver The resolver to delegate to.
+   */
+  public void setBaseResolver(CollationURIResolver baseResolver);
+  
+
+}

--- a/src/test/java/org/dita/dost/module/DelegatingCollationUriResolverTest.java
+++ b/src/test/java/org/dita/dost/module/DelegatingCollationUriResolverTest.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.module;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.lib.CollationURIResolver;
+import net.sf.saxon.lib.StringCollator;
+import net.sf.saxon.trans.XPathException;
+import org.dita.dost.module.saxon.DelegatingCollationUriResolver;
+
+public class DelegatingCollationUriResolverTest implements DelegatingCollationUriResolver {
+
+    @Override
+    public void setBaseResolver(CollationURIResolver baseResolver) {
+
+    }
+
+    @Override
+    public StringCollator resolve(String collationURI, Configuration config) throws XPathException {
+        return null;
+    }
+}

--- a/src/test/java/org/dita/dost/module/ExtensionFunctionDefinitionTest.java
+++ b/src/test/java/org/dita/dost/module/ExtensionFunctionDefinitionTest.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.module;
+
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.value.SequenceType;
+
+public class ExtensionFunctionDefinitionTest extends ExtensionFunctionDefinition {
+    @Override
+    public StructuredQName getFunctionQName() {
+        return new StructuredQName("x", "y", "z");
+    }
+
+    @Override
+    public SequenceType[] getArgumentTypes() {
+        return new SequenceType[0];
+    }
+
+    @Override
+    public SequenceType getResultType(SequenceType[] suppliedArgumentTypes) {
+        return null;
+    }
+
+    @Override
+    public ExtensionFunctionCall makeCallExpression() {
+        return null;
+    }
+}

--- a/src/test/java/org/dita/dost/module/XsltModuleTest.java
+++ b/src/test/java/org/dita/dost/module/XsltModuleTest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.module;
+
+import net.sf.saxon.functions.FunctionLibraryList;
+import net.sf.saxon.jaxp.SaxonTransformerFactory;
+import net.sf.saxon.lib.CollationURIResolver;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.SymbolicName;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.xml.transform.TransformerFactory;
+
+import static org.junit.Assert.*;
+
+public class XsltModuleTest {
+
+    private XsltModule xsltModule;
+    private SaxonTransformerFactory tf;
+
+    @Before
+    public void setUp() {
+        xsltModule = new XsltModule();
+        tf = (SaxonTransformerFactory) TransformerFactory.newInstance("net.sf.saxon.jaxp.SaxonTransformerFactory", getClass().getClassLoader());
+    }
+
+    @Test
+    public void configureCollationResolvers() {
+        xsltModule.configureCollationResolvers(tf);
+        final CollationURIResolver collationURIResolver = tf.getConfiguration().getCollationURIResolver();
+        assertTrue(collationURIResolver.getClass().isAssignableFrom(DelegatingCollationUriResolverTest.class));
+    }
+
+    @Test
+    public void configureExtensions() {
+        xsltModule.configureExtensions(tf);
+        final SymbolicName.F functionName = new SymbolicName.F(new StructuredQName("x", "y", "z"), 0);
+        assertTrue(tf.getConfiguration().getIntegratedFunctionLibrary().isAvailable(functionName));
+    }
+}

--- a/src/test/resources/META-INF/services/net.sf.saxon.lib.ExtensionFunctionDefinition
+++ b/src/test/resources/META-INF/services/net.sf.saxon.lib.ExtensionFunctionDefinition
@@ -1,0 +1,1 @@
+org.dita.dost.module.ExtensionFunctionDefinitionTest

--- a/src/test/resources/META-INF/services/org.dita.dost.module.saxon.DelegatingCollationUriResolver
+++ b/src/test/resources/META-INF/services/org.dita.dost.module.saxon.DelegatingCollationUriResolver
@@ -1,0 +1,1 @@
+org.dita.dost.module.DelegatingCollationUriResolverTest


### PR DESCRIPTION
Enable dynamic registration of collation URI resolvers by plugins analogous to extension functions.

Also fixes a bug in the extension function registration that caused it to fail on subclasses of TransformerFactoryImpl

Tested with org.dita-community.i18n plugin.

Have prepared supporting documentation as a separate pull request for the docs.

Signed-off-by: Eliot Kimber <ekimber@contrext.com>