### PR TITLE
Fix for spaces in file/dir name #3213

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -172,5 +172,10 @@ See the accompanying LICENSE file for applicable license.
       $table/@keycol and xs:integer($table/@keycol) eq count($entry/preceding-sibling::*) + 1
     "/>
   </xsl:function>
+  
+  <xsl:function name="dita-ot:normalize-href" as="xs:string?">
+    <xsl:param name="href" as="xs:string"/>
+    <xsl:value-of select="replace(translate($href, '\', '/'), ' ', '%20')"/>
+  </xsl:function>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -54,7 +54,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
   
-  <xsl:variable name="current-file" select="translate(if ($FILEDIR = '.') then $FILENAME else concat($FILEDIR, '/', $FILENAME), '\', '/')" as="xs:string?"/>
+  <xsl:variable name="current-file" select="dita-ot:normalize-href(if ($FILEDIR = '.') then $FILENAME else concat($FILEDIR, '/', $FILENAME))" as="xs:string?"/>
   <xsl:variable name="current-topicrefs" select="$input.map//*[contains(@class, ' map/topicref ')][dita-ot:get-path($PATH2PROJ, .) = $current-file]" as="element()*"/>
   <xsl:variable name="current-topicref" select="$current-topicrefs[1]" as="element()?"/>
   

--- a/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
@@ -385,5 +385,20 @@
       <x:expect label="return false()" select="false()"/>
     </x:scenario>
   </x:scenario>
+  
+  <x:scenario label="Normalize path with space and backslash">
+    <x:call function="dita-ot:normalize-href">
+      <x:param name="href" select="'foo bar\this that.dita'"/>
+    </x:call>
+    
+    <x:expect label="path normalized with / and %20" select="'foo%20bar/this%20that.dita'"/>
+  </x:scenario>
+  <x:scenario label="Normalize path that doesn't need normalization">
+    <x:call function="dita-ot:normalize-href">
+      <x:param name="href" select="'foo%20bar/this%20that.dita'"/>
+    </x:call>
+    
+    <x:expect label="path not modified" select="'foo%20bar/this%20that.dita'"/>
+  </x:scenario>
 
 </x:description>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Fixes #3213 

When a TOC is added into the `<nav>` section of HTML5 output, it is done by matching the file name (passed into XSLT as `$FILENAME`) against `@href` values in the map. When the operating system passes in `$FILENAME` with backslashes, we already normalize those to `/` to match expected entries in the map.

When the file name (or directory name) contains spaces, `$FILENAME` or `$FILEDIR` can be passed in with a space value in place of `%20`, but the map uses the URI value `%20`, so we need to do the same normalization here.

I've updated the matching code so that `$current-file` adds an additional normalization for spaces to the existing normalization for `\`. Also moved this into a general function for HTML5 in case more normalization is needed in the future; this also makes it easy to set up an XSPEC test for normalization.