### PR TITLE
Sync hazard statement presentation

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_variables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_variables.scss
@@ -38,6 +38,9 @@ $hazard-iso-yellow:     #f9a800;
 $hazard-iso-green:      #237f52;
 $hazard-iso-blue:       #005387;
 
+// Text color for hazard statements with dark backgrounds: danger (red), note (blue)
+$hazard-heading-light:  #fff;
+
 //== Scaffolding
 //
 //## Settings for some of the most global styles.

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -43,6 +43,7 @@
   &--notice {
     background-color: $hazard-ansi-blue;
     color: $hazard-heading-light;
+    font-style: italic;
   }
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -14,6 +14,10 @@
     padding: 0.5rem;
   }
 
+  th {
+    text-align: center;
+  }
+
   &--caution,
   &--fastpath,
   &--important,

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -9,6 +9,11 @@
 }
 
 .hazardstatement {
+  td,
+  th {
+    padding: 0.5rem;
+  }
+
   &--caution,
   &--fastpath,
   &--important,

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -26,6 +26,7 @@
 
   &--danger {
     background-color: $hazard-ansi-red;
+    color: $hazard-heading-light;
   }
 
   &--warning {
@@ -36,6 +37,7 @@
   &--note,
   &--notice {
     background-color: $hazard-ansi-blue;
+    color: $hazard-heading-light;
   }
 }
 

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -16,6 +16,7 @@
 
   th {
     text-align: center;
+    text-transform: uppercase;
   }
 
   &--caution,

--- a/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hazard.scss
@@ -19,13 +19,7 @@
     text-transform: uppercase;
   }
 
-  &--caution,
-  &--fastpath,
-  &--important,
-  &--other,
-  &--remember,
-  &--restriction,
-  &--tip {
+  &--caution {
     background-color: $hazard-ansi-yellow;
   }
 
@@ -39,8 +33,14 @@
   }
 
   &--attention,
+  &--fastpath,
+  &--important,
   &--note,
-  &--notice {
+  &--notice,
+  &--other,
+  &--remember,
+  &--restriction,
+  &--tip {
     background-color: $hazard-ansi-blue;
     color: $hazard-heading-light;
     font-style: italic;

--- a/src/main/plugins/org.dita.xhtml/resource/commonltr.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonltr.css
@@ -246,18 +246,28 @@ h6.tasklabel {
 .warningtitle {
   font-weight: bold;
 }
-.hazardstatement--caution, .hazardstatement--fastpath, .hazardstatement--important, .hazardstatement--other,
-.hazardstatement--remember, .hazardstatement--restriction, .hazardstatement--tip {
-  background-color: #FFD100;
+.hazardstatement td,
+.hazardstatement th {
+  padding: 0.5rem;
+}
+.hazardstatement th {
+  text-align: center;
+  text-transform: uppercase;
+}
+.hazardstatement--caution {
+  background-color: #ffd100;
 }
 .hazardstatement--danger {
-  background-color: #C8102E;
+  background-color: #c8102e;
+  color: #fff;
 }
 .hazardstatement--warning {
-  background-color: #FF8200;
+  background-color: #ff8200;
 }
-.hazardstatement--attention, .hazardstatement--note, .hazardstatement--notice {
-  background-color: #0072CE;
+.hazardstatement--attention, .hazardstatement--fastpath, .hazardstatement--important, .hazardstatement--note, .hazardstatement--notice, .hazardstatement--other, .hazardstatement--remember, .hazardstatement--restriction, .hazardstatement--tip {
+  background-color: #0072ce;
+  color: #fff;
+  font-style: italic;
 }
 /* Simple lists do not get a bullet */
 ul.simple {

--- a/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
@@ -250,18 +250,28 @@ h6.tasklabel {
 .warningtitle {
   font-weight: bold;
 }
-.hazardstatement--caution, .hazardstatement--fastpath, .hazardstatement--important, .hazardstatement--other,
-.hazardstatement--remember, .hazardstatement--restriction, .hazardstatement--tip {
-  background-color: #FFD100;
+.hazardstatement td,
+.hazardstatement th {
+  padding: 0.5rem;
+}
+.hazardstatement th {
+  text-align: center;
+  text-transform: uppercase;
+}
+.hazardstatement--caution {
+  background-color: #ffd100;
 }
 .hazardstatement--danger {
-  background-color: #C8102E;
+  background-color: #c8102e;
+  color: #fff;
 }
 .hazardstatement--warning {
-  background-color: #FF8200;
+  background-color: #ff8200;
 }
-.hazardstatement--attention, .hazardstatement--note, .hazardstatement--notice {
-  background-color: #0072CE;
+.hazardstatement--attention, .hazardstatement--fastpath, .hazardstatement--important, .hazardstatement--note, .hazardstatement--notice, .hazardstatement--other, .hazardstatement--remember, .hazardstatement--restriction, .hazardstatement--tip {
+  background-color: #0072ce;
+  color: #fff;
+  font-style: italic;
 }
 /* Simple lists do not get a bullet */
 ul.simple {


### PR DESCRIPTION
The default HTML5 output for hazard statements from #3207 currently differs from the PDF style in several ways:

1. No padding in the table cells, so the text content nearly touches the borders
2. Poor contrast with black text in the blue & red header rows 
   _(PDF uses white text in these cases)_
3. Header rows are left-aligned, whereas PDF centers them
4. PDF uses all caps for _all_ header rows, whereas HTML only does that for CAUTION & DANGER.
5. PDF italicizes header text for notes & related variants
6. Colors differ for the following types _(blue in PDF, yellow in HTML)_:
   - fastpath
   - important
   - other
   - remember
   - restriction
   - tip

- [x] Sync header variants with PDF attribute sets
- [x] Sync Sass-generated CSS from HTML5 to XHTML
 
## HTML state on `develop` vs. this PR branch

| Before | After |
| ------ | -----
| ![html-hazards-develop](https://user-images.githubusercontent.com/129995/53134311-fb4c3780-3576-11e9-8eaa-67ca5d9424fb.png) | ![html-hazards-new](https://user-images.githubusercontent.com/129995/53134354-1ae36000-3577-11e9-8c15-d5051d3992a8.png) |

## PDF

<img width="530" alt="pdf-hazards" src="https://user-images.githubusercontent.com/129995/53134459-8a594f80-3577-11e9-9a8f-4d5b11cae490.png">