### PR TITLE
Handle relative paths in peer or non-DITA key references

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -553,8 +553,16 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 }
                             } else {
                                 valid = true;
-                                final URI targetOutput = normalizeHrefValue(href, elementId);
-                                XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
+                                if (href.isAbsolute() || 
+                                        (keyDef.scope != null && keyDef.scope.equals(ATTR_SCOPE_VALUE_EXTERNAL))) {
+                                    final URI targetOutput = normalizeHrefValue(href, elementId);
+                                    XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
+                                } else { //Adjust path for peer or local references with relative path
+                                    final URI target = keyDef.source.resolve(href);
+                                    final URI relativeTarget = URLUtils.getRelativePath(currentFile, target);
+                                    final URI targetOutput = normalizeHrefValue(relativeTarget, elementId);
+                                    XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());
+                                }
 
                                 if (keyDef.scope != null && !keyDef.scope.equals(ATTR_SCOPE_VALUE_LOCAL)) {
                                     XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_SCOPE, keyDef.scope);

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -82,6 +82,20 @@ public class KeyrefPaserTest {
         assertXMLEqual(new InputSource(new File(expDir, "a.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "a.xml").toURI().toString()));
     }
+    
+    @Test
+    public void testTopicWriteSubdir() throws Exception {
+        final KeyrefPaser parser = new KeyrefPaser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(tempDir));
+        parser.setKeyDefinition(keyDefinition);
+        final String tempSubDir = tempDir + File.separator + "subdir";
+        parser.setCurrentFile(new File(tempSubDir, "subdirtopic.xml").toURI());
+        parser.write(new File(tempSubDir, "subdirtopic.xml"));
+
+        assertXMLEqual(new InputSource(new File(expDir + File.separator + "subdir", "subdirtopic.xml").toURI().toString()),
+                new InputSource(new File(tempSubDir, "subdirtopic.xml").toURI().toString()));
+    }
 
     @Test
     public void testFragment() throws Exception {

--- a/src/test/resources/KeyrefPaserTest/exp/subdir/subdirtopic.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/subdir/subdirtopic.xml
@@ -1,0 +1,18 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)"
+  id="subdirtopic" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Keyref in subdir</title>
+    <body class="- topic/body ">
+      <object class="- topic/object " datakeyref="localmp4" data="../movie.mp4" format="mp4"/>
+      <image class="- topic/image " keyref="localsvg" href="../example.svg" format="svg"><alt class="- topic/alt ">SVG in main directory</alt></image>
+      <p class="- topic/p ">
+        <xref class="- topic/xref " keyref="xref_link" href="../a.xml"><keyword class="- topic/keyword ">xref keyword</keyword>
+          <keyword class="- topic/keyword ">xref keyword B</keyword></xref>
+        <xref class="- topic/xref " keyref="peerdita" href="../../peer/peer-in-subdir.dita" scope="peer">Peer DITA topic with relative path to be adjusted</xref>
+        <xref class="- topic/xref " keyref="localpdf" href="../pdffile.pdf" format="pdf">PDF in main directory</xref>
+        <xref class="- topic/xref " keyref="localmp4" href="../movie.mp4" format="mp4">mp4 in main directory</xref>
+        <xref class="- topic/xref " keyref="externalunknown" href="foo.bar" format="unknown" scope="external">external unknown, do not adjust path even if appears relative</xref>
+        <xref class="- topic/xref " keyref="peerabsolute" href="https://example.com/peer.pdf" format="pdf" scope="peer">Peer PDF but absolute path</xref>
+      </p>
+    </body>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/keys.ditamap
@@ -995,4 +995,36 @@
   </keydef>
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="nondita_use_href" href="http://www.dita-ot.org/2.5/" scope="external" format="html"/>  
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="copy" href="a.xml" copy-to="a-copy.xml" processing-role="resource-only"/>
+
+  <!-- Tests for local+peer relative paths referenced from subdir -->
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="peerdita" href="../peer/peer-in-subdir.dita" processing-role="resource-only" scope="peer">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">Peer DITA topic with relative path to be adjusted</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="localpdf" href="pdffile.pdf" processing-role="resource-only" format="pdf">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">PDF in main directory</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="localmp4" href="movie.mp4" processing-role="resource-only" format="mp4">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">mp4 in main directory</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="localsvg" href="example.svg" processing-role="resource-only" format="svg">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">SVG in main directory</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="externalunknown" href="foo.bar" processing-role="resource-only" format="unknown" scope="external">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">external unknown, do not adjust path even if appears relative</linktext>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="peerabsolute" href="https://example.com/peer.pdf" processing-role="resource-only" format="pdf" scope="peer">
+    <topicmeta class="- map/topicmeta ">
+      <linktext class="- map/linktext ">Peer PDF but absolute path</linktext>
+    </topicmeta>
+  </keydef>
 </map>

--- a/src/test/resources/KeyrefPaserTest/src/subdir/subdirtopic.xml
+++ b/src/test/resources/KeyrefPaserTest/src/subdir/subdirtopic.xml
@@ -1,0 +1,17 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)"
+  id="subdirtopic" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Keyref in subdir</title>
+    <body class="- topic/body ">
+      <object class="- topic/object " datakeyref="localmp4"/>
+      <image class="- topic/image " keyref="localsvg"/>
+      <p class="- topic/p ">
+        <xref class="- topic/xref " keyref="xref_link"/>
+        <xref class="- topic/xref " keyref="peerdita"/>
+        <xref class="- topic/xref " keyref="localpdf"/>
+        <xref class="- topic/xref " keyref="localmp4"/>
+        <xref class="- topic/xref " keyref="externalunknown"/>
+        <xref class="- topic/xref " keyref="peerabsolute"/>
+      </p>
+    </body>
+</topic>


### PR DESCRIPTION
Fixes #2620, #2581, #2250, and #1951 (recently closed by probot).

Currently, when a key definition uses a relative path, references to that key are evaluated as follows:

- If the key reference is on `<image>`, adjust relative path based on location of the key definition / key references
- Else if it is for a local DITA topic, adjust relative path based on location of the key definition / key references
- Else use the path as-is. If the key is defined with a relative path, but referenced from a different directory, this breaks all of the following cases (as reported in the various issues above):
 - Keys for peer DITA topics like `../peer/some.dita`, when referenced from a directory different from the map, are no longer valid
 - Keys for local non-DITA file, such as `example.pdf`, are also not adjusted based on the directory
 - This has been reported several times for `@datakeyref` on `<object>`, which will break if the key definition refers to a local file but the key reference is in a different directory
 - If images are referenced by link (rather than from `<image>`), the same issue comes up, because the special handling for images only works on `<image>` element.

This fix corrects all of those cases by testing the `@href` value on the key definition:

- If the path is absolute, OR if `scope="external"`, leave it as-is (no change from today)
- Otherwise, it is a relative path and either local or peer, so adjust the path as needed to stay valid in any referencing location

Also updated keyref unit tests to cover all of these conditions, to ensure that we test for keys defined in one directory but referenced from a topic in a different directory.