### PR TITLE
Change bar on table/fig should also appear in booklist

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -13,9 +13,10 @@ See the accompanying LICENSE file for applicable license.
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
     xmlns:opentopic="http://www.idiominc.com/opentopic"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
-    exclude-result-prefixes="opentopic opentopic-index dita2xslfo ot-placeholder"
+    exclude-result-prefixes="dita-ot opentopic opentopic-index dita2xslfo ot-placeholder"
     version="2.0">
   
   <xsl:variable name="tableset">
@@ -87,6 +88,10 @@ See the accompanying LICENSE file for applicable license.
           <xsl:attribute name="internal-destination">
             <xsl:call-template name="get-id"/>
           </xsl:attribute>
+
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop[@changebar]" mode="changebar">
+            <xsl:with-param name="changebar-id" select="concat(dita-ot:generate-changebar-id(.),'-toc')"/>
+          </xsl:apply-templates>
           
           <fo:inline xsl:use-attribute-sets="__lotf__title">
             <xsl:call-template name="getVariable">
@@ -116,6 +121,10 @@ See the accompanying LICENSE file for applicable license.
               </xsl:attribute>
             </fo:page-number-citation>
           </fo:inline>
+
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop[@changebar]" mode="changebar">
+            <xsl:with-param name="changebar-id" select="concat(dita-ot:generate-changebar-id(.),'-toc')"/>
+          </xsl:apply-templates>
           
         </fo:basic-link>
       </fo:block>
@@ -165,6 +174,10 @@ See the accompanying LICENSE file for applicable license.
           <xsl:attribute name="internal-destination">
             <xsl:call-template name="get-id"/>
           </xsl:attribute>
+
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop[@changebar]" mode="changebar">
+            <xsl:with-param name="changebar-id" select="concat(dita-ot:generate-changebar-id(.),'-toc')"/>
+          </xsl:apply-templates>
           
           <fo:inline xsl:use-attribute-sets="__lotf__title">
             <xsl:call-template name="getVariable">
@@ -194,6 +207,10 @@ See the accompanying LICENSE file for applicable license.
               </xsl:attribute>
             </fo:page-number-citation>
           </fo:inline>
+
+          <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]/revprop[@changebar]" mode="changebar">
+            <xsl:with-param name="changebar-id" select="concat(dita-ot:generate-changebar-id(.),'-toc')"/>
+          </xsl:apply-templates>
           
         </fo:basic-link>
       </fo:block>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

This matches a change in 3.2 that added change bar support for revised topics in the TOC. #3100 

This update does the same thing for tables and figures:


- When a revision is specified on a table (or figure), AND
- When that revision uses a change bar in the DITAVAL, AND
- When that table (or figure)appears in a generated table list (or figure list),
- The table (or figure) should be marked with that change bar in the table list (or figure list)
