### PR TITLE
Support different DITA-OT installation volume and temp volume

### DIFF
--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -128,7 +128,7 @@ public final class PluginInstallTask extends Task {
                         throw new BuildException(new IllegalStateException(String.format("Plug-in %s already installed: %s", name, pluginDir)));
                     }
                 }
-                Files.move(tempPluginDir.toPath(), pluginDir.toPath());
+                FileUtils.moveDirectory(tempPluginDir, pluginDir);
             }
         } catch (IOException e) {
             throw new BuildException(e.getMessage(), e);


### PR DESCRIPTION
If DITA-OT installation directory and temporary directory are not on the same volume, simple Files.move will fail. Use Apache Commons IO to move directories.

Fixes #3162

Closes  #3238