### PR TITLE
Fix duplicate conref target message

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -353,7 +353,9 @@ See the accompanying LICENSE file for applicable license.
                            <xsl:with-param name="original-attributes" select="$original-attributes"/>
                          </xsl:apply-templates>
                          <xsl:if test="$target[2]">
-                           <xsl:apply-templates select="." mode="ditamsg:duplicateConrefTarget"/>
+                           <xsl:for-each select="$current-element">
+                             <xsl:apply-templates select="." mode="ditamsg:duplicateConrefTarget"/>
+                           </xsl:for-each>
                          </xsl:if>
                         </xsl:otherwise>
                       </xsl:choose>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Currently, if there are two possible targets when processing `@conref`, DITA-OT throws this error:
`   [conref] file:/C:/DITA-OT/dita-ot-3.2.1/docsrc/samples/concepts/garageconceptsoverview.xml:12:23: [DOTX011W][WARN]: There is more than one possible target for the reference conref="". Only the first will be used. Removethe duplicate id in the referenced file.`

The actual conref value is missing because at some point in a past release, the context from which this error is called changed. The context in this pull request is `$target-doc`, which is the root element of the document that contains the target of the conref. 

This update fixes the message by moving the context back to the `$current-element` context that already exists, so the message includes the conref value again:
`   [conref] file:/C:/DITA-OT/dita-ot-3.2.1/docsrc/samples/concepts/garageconceptsoverview.xml:12:23: [DOTX011W][WARN]: There is more than one possible target for the reference conref="#taskconcept/p". Only the first will be used. Removethe duplicate id in the referenced file.`