### PR TITLE
Fix table numbering when draft excluded

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -914,4 +914,20 @@ See the accompanying LICENSE file for applicable license.
       <xsl:sequence select="$topicType"/>
     </xsl:function>
 
+    <xsl:function name="dita-ot:notExcludedByDraftElement" as="xs:boolean">
+      <xsl:param name="ctx" as="element()"/>
+      <xsl:choose>
+        <xsl:when test="$publishRequiredCleanup='yes' or $DRAFT='yes'">
+            <xsl:sequence select="true()"/>
+        </xsl:when>
+        <xsl:when test="$ctx/ancestor::*[contains(@class,' topic/draft-comment ') or 
+                                         contains(@class,' topic/required-cleanup ')]">
+            <xsl:sequence select="false()"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:sequence select="true()"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:function>
+
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -21,27 +21,31 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:variable name="tableset">
     <xsl:for-each select="//*[contains (@class, ' topic/table ')][*[contains(@class, ' topic/title ' )]]">
-      <xsl:copy>
-        <xsl:copy-of select="@*"/>
-        <xsl:if test="not(@id)">
-          <xsl:attribute name="id">
-            <xsl:call-template name="get-id"/>
-          </xsl:attribute>
-        </xsl:if>
-      </xsl:copy>
+      <xsl:if test="dita-ot:notExcludedByDraftElement(.)">
+        <xsl:copy>
+          <xsl:copy-of select="@*"/>
+          <xsl:if test="not(@id)">
+            <xsl:attribute name="id">
+              <xsl:call-template name="get-id"/>
+            </xsl:attribute>
+          </xsl:if>
+        </xsl:copy>
+      </xsl:if>
     </xsl:for-each>
   </xsl:variable>
   
   <xsl:variable name="figureset">
     <xsl:for-each select="//*[contains (@class, ' topic/fig ')][*[contains(@class, ' topic/title ' )]]">
-      <xsl:copy>
-        <xsl:copy-of select="@*"/>
-        <xsl:if test="not(@id)">
-          <xsl:attribute name="id">
-            <xsl:call-template name="get-id"/>
-          </xsl:attribute>
-        </xsl:if>
-      </xsl:copy>
+      <xsl:if test="dita-ot:notExcludedByDraftElement(.)">
+        <xsl:copy>
+          <xsl:copy-of select="@*"/>
+          <xsl:if test="not(@id)">
+            <xsl:attribute name="id">
+              <xsl:call-template name="get-id"/>
+            </xsl:attribute>
+          </xsl:if>
+        </xsl:copy>
+      </xsl:if>
     </xsl:for-each>
   </xsl:variable>
   
@@ -57,7 +61,10 @@ See the accompanying LICENSE file for applicable license.
           <fo:block start-indent="0in">
             <xsl:call-template name="createLOTHeader"/>
             
-            <xsl:apply-templates select="//*[contains (@class, ' topic/table ')][child::*[contains(@class, ' topic/title ' )]]" mode="list.of.tables"/>
+            <xsl:apply-templates select="//*[contains (@class, ' topic/table ')]
+                                            [child::*[contains(@class, ' topic/title ' )]]
+                                            [dita-ot:notExcludedByDraftElement(.)]"
+                                 mode="list.of.tables"/>
           </fo:block>
         </fo:flow>
         
@@ -143,7 +150,10 @@ See the accompanying LICENSE file for applicable license.
             <fo:block start-indent="0in">
               <xsl:call-template name="createLOFHeader"/>
 
-              <xsl:apply-templates select="//*[contains (@class, ' topic/fig ')][child::*[contains(@class, ' topic/title ' )]]" mode="list.of.figures"/>
+              <xsl:apply-templates select="//*[contains (@class, ' topic/fig ')]
+                                              [child::*[contains(@class, ' topic/title ' )]]
+                                              [dita-ot:notExcludedByDraftElement(.)]"
+                                   mode="list.of.figures"/>
             </fo:block>
           </fo:flow>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -312,7 +312,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
   
   <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]" mode="table.title-number">
-    <xsl:value-of select="count(key('enumerableByClass', 'topic/table')[. &lt;&lt; current()])"/>
+    <xsl:value-of select="count(key('enumerableByClass', 'topic/table')[. &lt;&lt; current()][dita-ot:notExcludedByDraftElement(.)])"/>
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tgroup ')]" name="tgroup">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -183,7 +183,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
   
   <xsl:template match="*[contains(@class,' topic/fig ')]/*[contains(@class,' topic/title ')]" mode="fig.title-number">
-    <xsl:value-of select="count(key('enumerableByClass', 'topic/fig')[. &lt;&lt; current()])"/>
+    <xsl:value-of select="count(key('enumerableByClass', 'topic/fig')[. &lt;&lt; current()][dita-ot:notExcludedByDraftElement(.)])"/>
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tm ')]">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

Currently, when tables or figures are included in a `<draft-comment>` or `<required-cleanup>`, and DRAFT output is not active, the PDF has a number of problems:

- Table / figure numbering is based on all tables / figures in the doc. So if tables 1 and 3 are included but table 2 is within `<required-cleanup>` and hidden, the captions still read **Table 1** and **Table 3**
- Links to the tables have the same problem (the number for the reference is calculated using the same XSLT mode)
- If using a bookmap, and a list of tables / list of figures is included, the hidden items still appear in the list, with page number 0 and a broken link. (This is actually how I became aware of the problem, with the FO processor reporting a broken link).

This pull request fixes all of the issues with a number of small updates:

- A new utility function checks if an element is inside of a draft-comment or required-cleanup element that will be excluded (used for all of the following updates)
- Hidden elements are now excluded from the `tableset` and `figureset` variables used to count numbers for the lists
- When creating the lists, tables and figures inside of hidden sections are not counted
- When calculating the number for inline content or cross references, hidden sections are now excluded form the count

Tested with and without draft by adding a minor update to the `taskbook.ditamap` sample -- adding figure/table lists, and adding tables/figures that will be hidden such that with draft there 6 of each, but without draft only the first and fourth appear (numbered 1 and 2). Samples attached.
[taskbook.zip](https://github.com/dita-ot/dita-ot/files/2933526/taskbook.zip)
