### PR TITLE
Fix plugin param types

### DIFF
--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -140,7 +140,7 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="output.dir" desc="Specifies the name and location of the output directory." type="dir"/>
     <param name="root-chunk-override" desc="Override for map chunk attribute value." type="string"/>
-    <param name="transtype" desc="Specifies the output format (transformation type)." type="file" required="true"/>
+    <param name="transtype" desc="Specifies the output format (transformation type)." type="string" required="true"/>
     <param name="validate" desc="Specifies whether DITA-OT validates the content." type="enum">
       <val default="true">true</val>
       <val>false</val>

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -23,9 +23,9 @@ See the accompanying LICENSE file for applicable license.
       <val>yes</val>
       <val default="true">no</val>
     </param>
-    <param name="args.css" desc="Specifies the name of a custom .css file." type="file"/>
-    <param name="args.csspath" desc="Specifies the location of a copied .css file relative to the output directory." type="file"/>
-    <param name="args.cssroot" desc="Specifies the directory that contains the custom .css file." type="file"/>
+    <param name="args.css" desc="Specifies the name of a custom .css file." type="string"/>
+    <param name="args.csspath" desc="Specifies the location of a copied .css file relative to the output directory." type="string"/>
+    <param name="args.cssroot" desc="Specifies the directory that contains the custom .css file." type="string"/>
     <param name="args.dita.locale" desc="Specifies the language locale file to use for sorting index entries." type="string"/>
     <param name="args.ftr" desc="Specifies an XML file that contains content for a running footer." type="file"/>
     <param name="args.gen.default.meta" desc="Specifies whether to generate extra metadata that targets parental control scanners, meta elements with name=&#34;security&#34; and name=&#34;Robots&#34;." type="enum">

--- a/src/main/plugins/org.dita.xhtml/plugin.xml
+++ b/src/main/plugins/org.dita.xhtml/plugin.xml
@@ -24,9 +24,9 @@ See the accompanying LICENSE file for applicable license.
       <val>yes</val>
       <val default="true">no</val>
     </param>
-    <param name="args.css" desc="Specifies the name of a custom .css file." type="file"/>
-    <param name="args.csspath" desc="Specifies the location of a copied .css file relative to the output directory." type="file"/>
-    <param name="args.cssroot" desc="Specifies the directory that contains the custom .css file." type="file"/>
+    <param name="args.css" desc="Specifies the name of a custom .css file." type="string"/>
+    <param name="args.csspath" desc="Specifies the location of a copied .css file relative to the output directory." type="string"/>
+    <param name="args.cssroot" desc="Specifies the directory that contains the custom .css file." type="string"/>
     <param name="args.dita.locale" desc="Specifies the language locale file to use for sorting index entries." type="string"/>
     <param name="args.ftr" desc="Specifies an XML file that contains content for a running footer." type="file"/>
     <param name="args.gen.default.meta"


### PR DESCRIPTION
Fix param types in plugin configuration where type `file` is incorrectly used. The type `file` should only be applied to arguments that are system paths that take either an absolute path, or relative path that can be made absolute by resolving with some base base that is not part of input set. The same restriction applies to `dir` type. For params that represent paths but are e.g. relative to input set or output set, should use `string` type.