### PR TITLE
Add support for context of input and profile sets

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -795,7 +795,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         final org.dita.dost.project.Project project = readProjectFile();
 
         project.deliverables.forEach(deliverable -> {
-            final String input = base.resolve(deliverable.inputs.inputs.get(0).href).toString();
+            final Deliverable.Context context = deliverable.context;
+            final String input = base.resolve(context.inputs.inputs.get(0).href).toString();
             definedProps.put("args.input", input);
             final URI outputDir = new File(definedProps.get("output.dir").toString()).toURI();
             final String output = Paths.get(outputDir.resolve(deliverable.output)).toString();
@@ -821,7 +822,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     definedProps.put(param.name, value);
                 }
             });
-            final String filters = deliverable.profiles.ditavals.stream()
+            final String filters = context.profiles.ditavals.stream()
                     .map(ditaVal -> Paths.get(base.resolve(ditaVal.href)).toString())
                     .collect(Collectors.joining(File.pathSeparator));
             definedProps.put("args.filter", filters);

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -556,8 +556,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      * @since Ant 1.6
      */
     private void processArgs(final String[] arguments) {
-        String searchForThis = null;
-        boolean searchForFile = false;
         PrintStream logTo = null;
 
         // cycle through given args
@@ -613,11 +611,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 handleArgInputHandler(args);
             } else if (isLongForm(arg, "-emacs") || arg.equals("-e")) {
                 emacsMode = true;
-            } else if (isLongForm(arg, "-find") || arg.equals("-s")) {
-                searchForFile = true;
-                args.pop();
-                // eat up next arg if present, default to build.xml
-                searchForThis = args.peek();
             } else if (isLongForm(arg, "-propertyfile")) {
                 handleArgPropertyFile(arg, args);
             } else if (arg.equals("-k") || isLongForm(arg, "-keep-going")) {
@@ -720,58 +713,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             handleProject();
         }
 
-        // if buildFile was not specified on the command line,
-        if (buildFile == null) {
-            // but --find then search for it
-            if (searchForFile) {
-                if (searchForThis != null) {
-                    buildFile = findBuildFile(System.getProperty("user.dir"), searchForThis);
-                    if (buildFile == null) {
-                        throw new BuildException("Could not locate a build file!");
-                    }
-                } else {
-                    // no search file specified: so search an existing default
-                    // file
-                    final Iterator<ProjectHelper> it = ProjectHelperRepository.getInstance().getHelpers();
-                    do {
-                        final ProjectHelper helper = it.next();
-                        searchForThis = helper.getDefaultBuildFile();
-                        if (msgOutputLevel >= Project.MSG_VERBOSE) {
-                            System.out.println("Searching the default build file: " + searchForThis);
-                        }
-                        buildFile = findBuildFile(System.getProperty("user.dir"), searchForThis);
-                    } while (buildFile == null && it.hasNext());
-                    if (buildFile == null) {
-                        throw new BuildException("Could not locate a build file!");
-                    }
-                }
-            } else {
-                // no build file specified: so search an existing default file
-                final Iterator<ProjectHelper> it = ProjectHelperRepository.getInstance().getHelpers();
-                do {
-                    final ProjectHelper helper = it.next();
-                    buildFile = new File(helper.getDefaultBuildFile());
-                    if (msgOutputLevel >= Project.MSG_VERBOSE) {
-                        System.out.println("Trying the default build file: " + buildFile);
-                    }
-                } while (!buildFile.exists() && it.hasNext());
-            }
-        }
-
         // make sure buildfile exists
-        if (!buildFile.exists()) {
+        if (!buildFile.exists() || buildFile.isDirectory()) {
             System.out.println("Buildfile: " + buildFile + " does not exist!");
             throw new BuildException("Build failed");
-        }
-
-        if (buildFile.isDirectory()) {
-            final File whatYouMeant = new File(buildFile, "build.xml");
-            if (whatYouMeant.isFile()) {
-                buildFile = whatYouMeant;
-            } else {
-                System.out.println("What? Buildfile: " + buildFile + " is a dir!");
-                throw new BuildException("Build failed");
-            }
         }
 
         // Normalize buildFile for re-import detection
@@ -1478,10 +1423,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // msg.append("                         on failed target(s)" + lSep);
         // msg.append("  -inputhandler <class>  the class which will handle input requests"
         // + lSep);
-        // msg.append("  -find <file>           (s)earch for buildfile towards the root of"
-        // + lSep);
-        // msg.append("    -s  <file>           the filesystem and use it" +
-        // lSep);
         // msg.append("  -nice  number          A niceness value for the main thread:"
         // + lSep
         // +

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -133,14 +133,22 @@ public class Project {
 
         public static class Publication {
             @JacksonXmlProperty(isAttribute = true)
+            public final String name;
+            @JacksonXmlProperty(isAttribute = true)
+            public final String id;
+            @JacksonXmlProperty(isAttribute = true)
             public final String transtype;
             @JacksonXmlElementWrapper(useWrapping = false)
             @JacksonXmlProperty(localName = "param")
             public final List<Param> params;
 
             @JsonCreator
-            public Publication(@JsonProperty("transtype") String transtype,
+            public Publication(@JsonProperty("name") String name,
+                               @JsonProperty("id") String id,
+                               @JsonProperty("transtype") String transtype,
                                @JsonProperty("params") List<Param> params) {
+                this.name = name;
+                this.id = id;
                 this.transtype = transtype;
                 this.params = params;
             }

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -51,10 +51,10 @@ public class Project {
         }
 
         public static class Context {
-            //            @JacksonXmlProperty(isAttribute = true)
-//            public final String name;
-//            @JacksonXmlProperty(isAttribute = true)
-//            public final String ref;
+            @JacksonXmlProperty(isAttribute = true)
+            public final String name;
+            @JacksonXmlProperty(isAttribute = true)
+            public final String id;
             @JacksonXmlElementWrapper(useWrapping = false)
             public final Inputs inputs;
             @JacksonXmlProperty(localName = "profile")
@@ -62,12 +62,12 @@ public class Project {
             public final Profile profiles;
 
             @JsonCreator
-            public Context(//@JsonProperty("name") String name,
-//                          @JsonProperty("ref") String ref,
+            public Context(@JsonProperty("name") String name,
+                           @JsonProperty("id") String id,
                            @JsonProperty("inputs") Inputs inputs,
                            @JsonProperty("profiles") Profile profiles) {
-//                this.name = name;
-//                this.ref = ref;
+                this.name = name;
+                this.id = id;
                 this.inputs = inputs;
                 this.profiles = profiles;
             }
@@ -103,7 +103,7 @@ public class Project {
         }
 
         public static class Profile {
-//            @JacksonXmlProperty(isAttribute = true)
+            //            @JacksonXmlProperty(isAttribute = true)
 //            public final String name;
 //            @JacksonXmlProperty(isAttribute = true)
 //            public final String ref;

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -13,15 +13,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import org.dita.dost.invoker.Main;
 
-import java.io.File;
 import java.net.URI;
-import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @JacksonXmlRootElement(localName = "project")
 public class Project {
@@ -37,32 +31,50 @@ public class Project {
     public static class Deliverable {
         @JacksonXmlProperty(isAttribute = true)
         public final String name;
-        @JacksonXmlElementWrapper(useWrapping = false)
-        public final Inputs inputs;
+        @JacksonXmlElementWrapper(localName = "context")
+        public final Context context;
         @JacksonXmlElementWrapper(localName = "output")
         public final URI output;
-        @JacksonXmlProperty(localName = "profile")
-        @JacksonXmlElementWrapper(useWrapping = false)
-        public final Profile profiles;
         @JacksonXmlProperty(localName = "publication")
         @JacksonXmlElementWrapper(useWrapping = false)
         public final Publication publications;
 
         @JsonCreator
         public Deliverable(@JsonProperty("name") String name,
-                           @JsonProperty("inputs") Inputs inputs,
+                           @JsonProperty("context") Context context,
                            @JsonProperty("output") URI output,
-                           @JsonProperty("profiles") Profile profiles,
                            @JsonProperty("publications") Publication publications) {
             this.name = name;
-            this.inputs = inputs;
+            this.context = context;
             this.output = output;
-            this.profiles = profiles;
             this.publications = publications;
         }
 
-        public static class Inputs {
+        public static class Context {
+            //            @JacksonXmlProperty(isAttribute = true)
+//            public final String name;
 //            @JacksonXmlProperty(isAttribute = true)
+//            public final String ref;
+            @JacksonXmlElementWrapper(useWrapping = false)
+            public final Inputs inputs;
+            @JacksonXmlProperty(localName = "profile")
+            @JacksonXmlElementWrapper(useWrapping = false)
+            public final Profile profiles;
+
+            @JsonCreator
+            public Context(//@JsonProperty("name") String name,
+//                          @JsonProperty("ref") String ref,
+                           @JsonProperty("inputs") Inputs inputs,
+                           @JsonProperty("profiles") Profile profiles) {
+//                this.name = name;
+//                this.ref = ref;
+                this.inputs = inputs;
+                this.profiles = profiles;
+            }
+        }
+
+        public static class Inputs {
+            //            @JacksonXmlProperty(isAttribute = true)
 //            public final String name;
 //            @JacksonXmlProperty(isAttribute = true)
 //            public final String ref;
@@ -74,7 +86,7 @@ public class Project {
             public Inputs(//@JsonProperty("name") String name,
 //                          @JsonProperty("ref") String ref,
                           @JsonProperty("inputs") List<Input> inputs) {
-                //this.name = name;
+//                this.name = name;
 //                this.ref = ref;
                 this.inputs = inputs;
             }

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -7,6 +7,7 @@ project =
     # | profile-set
     # | publication-set
     # *
+    
   }
 
 ## Project deliverable
@@ -63,8 +64,8 @@ prop =
 ## Publication
 publication =
   element publication {
-    # (attribute ref { text }
-    # | attribute name { text })?,
+    attribute name { text }?,
+    attribute id { xsd:ID }?,
     attribute transtype { text },
     # (transtype, param*)
     param*

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -18,7 +18,13 @@ deliverable =
   }
 
 ## Context
-context = element context { inputs, profile }
+context =
+  element context {
+    attribute name { text }?,
+    attribute id { xsd:ID }?,
+    inputs,
+    profile
+  }
 
 ## Input resources
 inputs =

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -1,25 +1,29 @@
 
 ## Publication project
-project = element project {
-  (deliverable
-   #| input-set
-   #| profile-set
-   #| publication-set
-   )#*
-}
+project =
+  element project {
+    deliverable
+    # | input-set
+    # | profile-set
+    # | publication-set
+    # *
+  }
 
 ## Project deliverable
 deliverable =
   element deliverable {
     attribute name { text }?,
-    #(inputs* & output & profile* & publication*)
-    (inputs, output, profile, publication)
+    # (inputs* & output & profile* & publication*)
+    (context, output, publication)
   }
+
+## Context
+context = element context { inputs, profile }
 
 ## Input resources
 inputs =
   element inputs {
-    #(attribute ref { text }
+    # (attribute ref { text }
     # | attribute name { text })?,
     input*
   }
@@ -29,15 +33,12 @@ input =
   }
 
 ## Output directory
-output =
-  element output {
-    text
-  }
+output = element output { text }
 
 ## Filter and highligh profile
 profile =
   element profile {
-    #(attribute ref { text }
+    # (attribute ref { text }
     # | attribute name { text })?,
     (ditaval | prop)*
   }
@@ -56,7 +57,7 @@ prop =
 ## Publication
 publication =
   element publication {
-    #(attribute ref { text }
+    # (attribute ref { text }
     # | attribute name { text })?,
     attribute transtype { text },
     # (transtype, param*)

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -11,7 +11,7 @@ package org.dita.dost.project;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.google.common.collect.ImmutableMap;
+import org.dita.dost.project.Project.Deliverable.Context;
 import org.dita.dost.project.Project.Deliverable.Inputs;
 import org.dita.dost.project.Project.Deliverable.Inputs.Input;
 import org.dita.dost.project.Project.Deliverable.Profile;
@@ -19,15 +19,10 @@ import org.dita.dost.project.Project.Deliverable.Profile.DitaVal;
 import org.dita.dost.project.Project.Deliverable.Publication;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import static junit.framework.TestCase.assertEquals;
 
 public class ProjectTest {
 
@@ -62,13 +57,15 @@ public class ProjectTest {
     private Project getProject() {
         return new Project(Arrays.asList(new Project.Deliverable(
                 "name",
-                new Inputs(//"inputs-name",
+                new Context(
+                        new Inputs(//"inputs-name",
 //                        "inputs-ref",
-                        Arrays.asList(new Input(URI.create("site.ditamap")))),
-                URI.create("./site"),
-                new Profile(//"profile-name",
+                                Arrays.asList(new Input(URI.create("site.ditamap")))),
+                        new Profile(//"profile-name",
 //                        "profile-ref",
-                        Arrays.asList(new DitaVal(URI.create("site.ditaval")))),
+                                Arrays.asList(new DitaVal(URI.create("site.ditaval"))))
+                ),
+                URI.create("./site"),
                 new Publication("html5", Arrays.asList(
                         new Publication.Param("args.gen.task.lbl", "YES", null),
                         new Publication.Param("args.rellinks", "noparent", null)

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -57,7 +57,7 @@ public class ProjectTest {
     private Project getProject() {
         return new Project(Arrays.asList(new Project.Deliverable(
                 "name",
-                new Context(
+                new Context("Site", "site",
                         new Inputs(//"inputs-name",
 //                        "inputs-ref",
                                 Arrays.asList(new Input(URI.create("site.ditamap")))),

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -66,7 +66,7 @@ public class ProjectTest {
                                 Arrays.asList(new DitaVal(URI.create("site.ditaval"))))
                 ),
                 URI.create("./site"),
-                new Publication("html5", Arrays.asList(
+                new Publication("Site", "site", "html5", Arrays.asList(
                         new Publication.Param("args.gen.task.lbl", "YES", null),
                         new Publication.Param("args.rellinks", "noparent", null)
                 ))

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -23,6 +23,8 @@
       "output": "./site",
       "publications": {
         "transtype": "html5",
+        "id": "sitePub",
+        "name": "Site",
         "params": [
           {
             "name": "args.gen.task.lbl",

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -3,6 +3,8 @@
     {
       "name": "name",
       "context": {
+        "name": "Site",
+        "id": "site",
         "inputs": {
           "inputs": [
             {

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -2,21 +2,23 @@
   "deliverables": [
     {
       "name": "name",
-      "inputs": {
-        "inputs": [
-          {
-            "href": "site.ditamap"
-          }
-        ]
+      "context": {
+        "inputs": {
+          "inputs": [
+            {
+              "href": "site.ditamap"
+            }
+          ]
+        },
+        "profiles": {
+          "ditavals": [
+            {
+              "href": "site.ditaval"
+            }
+          ]
+        }
       },
       "output": "./site",
-      "profiles": {
-        "ditavals": [
-          {
-            "href": "site.ditaval"
-          }
-        ]
-      },
       "publications": {
         "transtype": "html5",
         "params": [

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -2,7 +2,7 @@
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
 <project>
   <deliverable name="name">
-    <context>
+    <context name="Site" id="site">
       <inputs>
         <input href="site.ditamap"/>
       </inputs>

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -11,7 +11,7 @@
       </profile>
     </context>
     <output>./site</output>
-    <publication transtype="html5">
+    <publication transtype="html5" id="sitePub" name="Site">
       <param name="args.gen.task.lbl" value="YES"/>
       <param name="args.rellinks" value="noparent"/>
     </publication>

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -2,13 +2,15 @@
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
 <project>
   <deliverable name="name">
-    <inputs>
-      <input href="site.ditamap"/>
-    </inputs>
+    <context>
+      <inputs>
+        <input href="site.ditamap"/>
+      </inputs>
+      <profile>
+        <ditaval href="site.ditaval"/>
+      </profile>
+    </context>
     <output>./site</output>
-    <profile>
-      <ditaval href="site.ditaval"/>
-    </profile>
     <publication transtype="html5">
       <param name="args.gen.task.lbl" value="YES"/>
       <param name="args.rellinks" value="noparent"/>


### PR DESCRIPTION
Add support for input and profile set context. This abstraction is not strictly required by publishing engine, but is a logical unit for editors and CMSs.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>