### PR TITLE
Fix conkeyref with temp file scheme that flattens the directory structure

### DIFF
--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -61,8 +61,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     private Mode processingMode;
     /** Generate {@code xtrf} and {@code xtrc} attributes */
     private boolean genDebugInfo;
-    /** Absolute input map path. */
-    private URI inputMap;
     private boolean setSystemId;
     /** Profiling is enabled. */
     private boolean profilingEnabled;
@@ -309,13 +307,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         genDebugInfo = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
         final String mode = input.getAttribute(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
         processingMode = mode != null ? Mode.valueOf(mode.toUpperCase()) : Mode.LAX;
-
-        // Absolute input directory path
-        URI inputDir = job.getInputDir();
-        if (!inputDir.isAbsolute()) {
-            inputDir = baseDir.toURI().resolve(inputDir);
-        }
-        inputMap = inputDir.resolve(job.getInputMap());
     }
 
 
@@ -355,7 +346,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
                 }
                 if (children != null) {
                     for (final URI childpath: children) {
-                        final Document childRoot = builder.parse(inputMap.resolve(childpath.getPath()).toString());
+                        final Document childRoot = builder.parse(job.getInputFile().resolve(childpath.getPath()).toString());
                         mergeScheme(parentRoot, childRoot);
                         generateScheme(new File(job.tempDir, childpath.getPath() + SUBJECT_SCHEME_EXTENSION), childRoot);
                     }

--- a/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
+++ b/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
@@ -91,7 +91,10 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
      */
     private URI getRelativePath(final URI href) {
         final URI keyValue;
-        final URI inputMap = job.getInputMap();
+        final URI inputMap = job.getFileInfo(fi -> fi.isInput).stream()
+                .map(fi -> fi.uri)
+                .findFirst()
+                .orElse(null);
         if (inputMap != null) {
             final URI tmpMap = job.tempDirURI.resolve(inputMap);
             keyValue = tmpMap.resolve(stripFragment(href));

--- a/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
@@ -156,6 +156,42 @@ public class ConkeyrefFilterTest {
     }
 
     @Test
+    public void testRelativePathsWithUplevels_flat() throws SAXException, IOException {
+        job.setInputDir(new File(".").getCanonicalFile().toURI());
+        job.add(new Job.FileInfo.Builder()
+                .src(srcDir.resolve("maps/root.map"))
+                .uri(URI.create("ROOT.map"))
+                .format(ATTR_FORMAT_VALUE_DITAMAP)
+                .isInput(true)
+                .build());
+        job.add(new Job.FileInfo.Builder()
+                .src(srcDir.resolve("product/topic.dita"))
+                .uri(URI.create("THIS.dita"))
+                .format(ATTR_FORMAT_VALUE_DITA)
+                .hasConref(true)
+                .build());
+        job.add(new Job.FileInfo.Builder()
+                .src(srcDir.resolve("common/library.dita"))
+                .uri(URI.create("LIBRARY.dita"))
+                .format(ATTR_FORMAT_VALUE_DITA)
+                .build());
+
+        final ConkeyrefFilter f = getConkeyrefFilter();
+        f.setCurrentFile(job.tempDirURI.resolve("topic.dita"));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", URI.create("LIBRARY.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, URI.create("main.ditamap"), null))));
+        f.setContentHandler(new DefaultHandler() {
+            @Override
+            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+                assertEquals("LIBRARY.dita", atts.getValue(ATTRIBUTE_NAME_CONREF));
+            }
+        });
+
+            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
+                .add(ATTRIBUTE_NAME_CONKEYREF, "foo")
+                .build());
+    }
+
+    @Test
     public void testMissingKey() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setKeyDefinitions(createKeyScope(Collections.emptyMap()));


### PR DESCRIPTION
## Description
Fix conkeyref processing to work correctly with temporary file scheme that doesn't generate matching directory structure, e.g. one that flattens the structure.

## Motivation and Context
Fixes issue with conkeyref.

## How Has This Been Tested?
Additional unit tests were added.
## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_