### PR TITLE
Add support for including project files in project files

### DIFF
--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -22,10 +22,15 @@ public class Project {
     @JacksonXmlElementWrapper(useWrapping = false)
     @JacksonXmlProperty(localName = "deliverable")
     public final List<Deliverable> deliverables;
+    @JacksonXmlElementWrapper(useWrapping = false)
+    @JacksonXmlProperty(localName = "include")
+    public final List<ProjectRef> includes;
 
     @JsonCreator
-    public Project(@JsonProperty("deliverables") List<Deliverable> deliverables) {
+    public Project(@JsonProperty("deliverables") List<Deliverable> deliverables,
+                   @JsonProperty("includes") List<ProjectRef> includes) {
         this.deliverables = deliverables;
+        this.includes = includes;
     }
 
     public static class Deliverable {
@@ -171,6 +176,16 @@ public class Project {
                     this.href = href;
                 }
             }
+        }
+    }
+
+    public static class ProjectRef {
+        @JacksonXmlProperty(isAttribute = true)
+        public final URI href;
+
+        @JsonCreator
+        public ProjectRef(@JsonProperty("href") URI href) {
+            this.href = href;
         }
     }
 }

--- a/src/test/java/org/dita/dost/project/ProjectFactory.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactory.java
@@ -9,24 +9,37 @@
 package org.dita.dost.project;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class ProjectFactory {
 
+    private static final ObjectReader reader = new ObjectMapper().reader().forType(Project.class);
+
     public static Project load(final URI file) throws IOException {
-        final ObjectMapper mapper = new ObjectMapper();
         try {
-            return resolve(mapper.readValue(file.toURL(), Project.class), file);
+            return load(file, Collections.emptySet());
         } catch (IOException e) {
             throw new IOException("Failed to read project file: " + e.getMessage(), e);
         }
     }
 
-    private static Project resolve(final Project project, final URI base) throws IOException {
+    private static Project load(final URI file, final Set<URI> processed) throws IOException {
+        if (processed.contains(file)) {
+            throw new RuntimeException("Recursive project file import: " + file);
+        }
+        final Project project = reader.readValue(file.toURL());
+        return resolve(project, file, ImmutableSet.<URI>builder().addAll(processed).add(file).build());
+    }
+
+    private static Project resolve(final Project project, final URI base, final Set<URI> processed) throws IOException {
         if (project.includes == null || project.includes.isEmpty()) {
             return project;
         }
@@ -36,7 +49,7 @@ public class ProjectFactory {
         if (project.includes != null) {
             for (final Project.ProjectRef projectRef : project.includes) {
                 final URI href = projectRef.href.isAbsolute() ? projectRef.href : base.resolve(projectRef.href);
-                final Project ref = load(href);
+                final Project ref = load(href, processed);
                 res.addAll(ref.deliverables);
             }
         }

--- a/src/test/java/org/dita/dost/project/ProjectFactory.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactory.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.project;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProjectFactory {
+
+    public static Project load(final URI file) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        try {
+            return resolve(mapper.readValue(file.toURL(), Project.class), file);
+        } catch (IOException e) {
+            throw new IOException("Failed to read project file: " + e.getMessage(), e);
+        }
+    }
+
+    private static Project resolve(final Project project, final URI base) throws IOException {
+        if (project.includes == null || project.includes.isEmpty()) {
+            return project;
+        }
+        final List<Project.Deliverable> res = project.deliverables != null
+                ? new ArrayList(project.deliverables)
+                : new ArrayList();
+        if (project.includes != null) {
+            for (final Project.ProjectRef projectRef : project.includes) {
+                final URI href = projectRef.href.isAbsolute() ? projectRef.href : base.resolve(projectRef.href);
+                final Project ref = load(href);
+                res.addAll(ref.deliverables);
+            }
+        }
+        return new Project(res, project.includes);
+    }
+
+}

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -22,22 +22,45 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 
+import static org.junit.Assert.*;
+
 public class ProjectTest {
+
+    @Test
+    public void read() throws IOException, URISyntaxException {
+        final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/simple.json").toURI();
+        final Project project = ProjectFactory.load(file);
+        assertEquals(1, project.deliverables.size());
+        assertNull(project.includes);
+    }
 
     @Test
     public void deserializeXmlSimple() throws IOException {
         final ObjectMapper xmlMapper = new XmlMapper();
         final InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/simple.xml");
-        xmlMapper.readValue(in, Project.class);
+        final Project project = xmlMapper.readValue(in, Project.class);
+        assertNotNull(project.deliverables);
+        assertNull( project.includes);
     }
 
     @Test
     public void deserializeJsonSimple() throws IOException {
         final ObjectMapper xmlMapper = new ObjectMapper();
         final InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/simple.json");
-        xmlMapper.readValue(in, Project.class);
+        final Project project = xmlMapper.readValue(in, Project.class);
+        assertNotNull(project.deliverables);
+        assertNull(project.includes);
+    }
+
+    @Test
+    public void deserializeJsonRoot() throws IOException, URISyntaxException {
+        final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/root.json").toURI();
+        final Project project = ProjectFactory.load(input);
+        assertEquals(2, project.deliverables.size());
+        assertEquals(2, project.includes.size());
     }
 
     @Test
@@ -51,6 +74,13 @@ public class ProjectTest {
     public void serializeJsonSimple() throws IOException {
         final ObjectMapper xmlMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
         final Project project = getProject();
+        xmlMapper.writeValueAsString(project);
+    }
+
+    @Test
+    public void serializeJsonRoot() throws IOException {
+        final ObjectMapper xmlMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+        final Project project = new Project(null, Arrays.asList(new Project.ProjectRef(URI.create("simple.json"))));
         xmlMapper.writeValueAsString(project);
     }
 
@@ -70,6 +100,6 @@ public class ProjectTest {
                         new Publication.Param("args.gen.task.lbl", "YES", null),
                         new Publication.Param("args.rellinks", "noparent", null)
                 ))
-        )));
+        )), null);
     }
 }

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -43,7 +43,7 @@ public class ProjectTest {
         final InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/simple.xml");
         final Project project = xmlMapper.readValue(in, Project.class);
         assertNotNull(project.deliverables);
-        assertNull( project.includes);
+        assertNull(project.includes);
     }
 
     @Test
@@ -61,6 +61,12 @@ public class ProjectTest {
         final Project project = ProjectFactory.load(input);
         assertEquals(2, project.deliverables.size());
         assertEquals(2, project.includes.size());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void deserializeJsonRecursive() throws IOException, URISyntaxException {
+        final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/recursive.json").toURI();
+        ProjectFactory.load(input);
     }
 
     @Test

--- a/src/test/resources/org/dita/dost/project/common.json
+++ b/src/test/resources/org/dita/dost/project/common.json
@@ -1,0 +1,43 @@
+{
+  "deliverables": [
+    {
+      "name": "common-name",
+      "context": {
+        "name": "common-Site",
+        "id": "common-site",
+        "inputs": {
+          "inputs": [
+            {
+              "href": "site.ditamap"
+            }
+          ]
+        },
+        "profiles": {
+          "ditavals": [
+            {
+              "href": "site.ditaval"
+            }
+          ]
+        }
+      },
+      "output": "./site",
+      "publications": {
+        "transtype": "html5",
+        "id": "common-sitePub",
+        "name": "common-Site",
+        "params": [
+          {
+            "name": "args.gen.task.lbl",
+            "value": "YES",
+            "href": null
+          },
+          {
+            "name": "args.rellinks",
+            "value": "noparent",
+            "href": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/dita/dost/project/recursive.json
+++ b/src/test/resources/org/dita/dost/project/recursive.json
@@ -1,0 +1,7 @@
+{
+  "includes": [
+    {
+      "href": "recursive.json"
+    }
+  ]
+}

--- a/src/test/resources/org/dita/dost/project/root.json
+++ b/src/test/resources/org/dita/dost/project/root.json
@@ -1,0 +1,10 @@
+{
+  "includes": [
+    {
+      "href": "common.json"
+    },
+    {
+      "href": "simple.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Add support for import/include functionality to compose project files.

## Motivation and Context
Being able to import/include common project file components into a project files enables project file reuse.