### PR TITLE
Simplify input configuration in project files

### DIFF
--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,13 +74,11 @@ public class Project {
                 context.name,
                 context.id,
                 context.idref,
-                context.inputs != null
-                        ? new Deliverable.Inputs(
-                        context.inputs.stream()
-                                .map(input -> new Deliverable.Inputs.Input(resolve(input, base)))
-                                .collect(Collectors.toList())
-                )
-                        : null,
+                Optional.ofNullable(context.input)
+                        .map(input -> new Deliverable.Inputs.Input(resolve(input, base)))
+                        .map(Collections::singletonList)
+                        .map(Deliverable.Inputs::new)
+                        .orElse(null),
                 context.profiles != null
                         ? new Deliverable.Profile(
                         context.profiles.ditavals.stream()

--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -68,19 +68,19 @@ public class ProjectBuilder {
         public String name;
         public String id;
         public String idref;
-        public List<URI> inputs;
+        public URI input;
         public Deliverable.Profile profiles;
 
         @JsonCreator
         public Context(@JsonProperty("name") String name,
                        @JsonProperty("id") String id,
                        @JsonProperty("idref") String idref,
-                       @JsonProperty("inputs") List<URI> inputs,
+                       @JsonProperty("input") URI input,
                        @JsonProperty("profiles") Deliverable.Profile profiles) {
             this.name = name;
             this.id = id;
             this.idref = idref;
-            this.inputs = inputs;
+            this.input = input;
             this.profiles = profiles;
         }
     }

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -50,7 +50,6 @@ public class XmlReader {
     public static final String ELEM_DITAVAL = "ditaval";
     public static final String ELEM_INCLUDE = "include";
     public static final String ELEM_INPUT = "input";
-    public static final String ELEM_INPUTS = "inputs";
     public static final String ELEM_OUTPUT = "output";
     public static final String ELEM_PARAM = "param";
     public static final String ELEM_PROFILE = "profile";
@@ -182,14 +181,11 @@ public class XmlReader {
                 getValue(context, ATTR_NAME),
                 getValue(context, ATTR_ID),
                 getValue(context, ATTR_IDREF),
-                getChildElement(context, ELEM_INPUTS)
-                        .map(inputs -> getChildElements(inputs, ELEM_INPUT).stream()
-                                .map(this::getHref)
-                                .filter(Optional::isPresent)
-                                .map(Optional::get)
-                                .collect(Collectors.toList())
-                        )
-                        .orElse(null),
+                getChildElements(context, ELEM_INPUT).stream()
+                        .map(this::getHref)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.toList()),
                 getChildElement(context, ELEM_PROFILE)
                         .map(inputs -> getChildElements(inputs, ELEM_DITAVAL).stream()
                                 .map(this::getHref)

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -181,11 +181,9 @@ public class XmlReader {
                 getValue(context, ATTR_NAME),
                 getValue(context, ATTR_ID),
                 getValue(context, ATTR_IDREF),
-                getChildElements(context, ELEM_INPUT).stream()
-                        .map(this::getHref)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(Collectors.toList()),
+                getChildElement(context, ELEM_INPUT)
+                        .flatMap(this::getHref)
+                        .orElse(null),
                 getChildElement(context, ELEM_PROFILE)
                         .map(inputs -> getChildElements(inputs, ELEM_DITAVAL).stream()
                                 .map(this::getHref)

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -21,7 +21,7 @@ context =
   element context {
     attribute name { text }?,
     attribute id { xsd:ID }?,
-    inputs,
+    input,
     profile
   }
 

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -32,7 +32,7 @@ public class XmlReaderTest {
             assertEquals("Site", deliverable.context.name);
             assertEquals("site", deliverable.context.id);
             assertEquals(null, deliverable.context.idref);
-            assertEquals(1, deliverable.context.inputs.size());
+            assertNotNull(deliverable.context.input);
             assertEquals(1, deliverable.context.profiles.ditavals.size());
             assertEquals("./site", deliverable.output.toString());
             final ProjectBuilder.Publication publication = deliverable.publication;

--- a/src/test/resources/org/dita/dost/project/common.json
+++ b/src/test/resources/org/dita/dost/project/common.json
@@ -22,9 +22,7 @@
     {
       "name": "Site",
       "id": "site",
-      "inputs": [
-        "site.ditamap"
-      ],
+      "input": "site.ditamap",
       "profiles": {
         "ditavals": [
           "site.ditaval"

--- a/src/test/resources/org/dita/dost/project/common.xml
+++ b/src/test/resources/org/dita/dost/project/common.xml
@@ -6,9 +6,7 @@
     <param name="args.rellinks" value="noparent"/>
   </publication>
   <context name="Site" id="site">
-    <inputs>
-      <input href="site.ditamap"/>
-    </inputs>
+    <input href="site.ditamap"/>
     <profile>
       <ditaval href="site.ditaval"/>
     </profile>

--- a/src/test/resources/org/dita/dost/project/common.yaml
+++ b/src/test/resources/org/dita/dost/project/common.yaml
@@ -11,8 +11,7 @@ publications:
 contexts:
 - name: "Site"
   id: "site"
-  inputs:
-  - "site.ditamap"
+  input: "site.ditamap"
   profiles:
     ditavals:
     - "site.ditaval"

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -5,9 +5,7 @@
       "context": {
         "name": "Site",
         "id": "site",
-        "inputs": [
-          "site.ditamap"
-        ],
+        "input": "site.ditamap",
         "profiles": {
           "ditavals": [
             "site.ditaval"

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -3,9 +3,7 @@
 <project>
   <deliverable name="name">
     <context name="Site" id="site">
-      <inputs>
-        <input href="site.ditamap"/>
-      </inputs>
+      <input href="site.ditamap"/>
       <profile>
         <ditaval href="site.ditaval"/>
       </profile>

--- a/src/test/resources/org/dita/dost/project/simple.yaml
+++ b/src/test/resources/org/dita/dost/project/simple.yaml
@@ -4,8 +4,7 @@ deliverables:
   context:
     name: "Site"
     id: "site"
-    inputs:
-    - "site.ditamap"
+    input: "site.ditamap"
     profiles:
       ditavals:
       - "site.ditaval"


### PR DESCRIPTION
Since DITA-OT is able to use only one input resource at a time, simplify the project file configuration to only allow a single input resource.