### PR TITLE
Reference individual deliverable

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -797,10 +797,12 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                             props.put(param.name, value);
                         }
                     });
-                    final String filters = context.profiles.ditavals.stream()
-                            .map(ditaVal -> Paths.get(base.resolve(ditaVal.href)).toString())
-                            .collect(Collectors.joining(File.pathSeparator));
-                    props.put("args.filter", filters);
+                    if (!context.profiles.ditavals.isEmpty()) {
+                        final String filters = context.profiles.ditavals.stream()
+                                .map(ditaVal -> Paths.get(base.resolve(ditaVal.href)).toString())
+                                .collect(Collectors.joining(File.pathSeparator));
+                        props.put("args.filter", filters);
+                    }
 
                     return props;
                 })

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -457,7 +457,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      */
     @Override
     public void startAnt(final String[] args, final Properties additionalUserProperties, final ClassLoader coreLoader) {
-
         try {
             processArgs(args);
         } catch (final BuildException exc) {
@@ -474,6 +473,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             handleLogfile();
             printMessage(exc);
             exit(1);
+            return;
+        }
+
+        if (!readyToRun) {
             return;
         }
 
@@ -958,7 +961,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 .reduce(Integer::max)
                 .orElse(0);
         for (Map.Entry<String, String> pair : pairs) {
-            System.out.println(Strings.padEnd(pair.getKey(), length, ' ') + "  " + pair.getValue());
+            System.out.println(Strings.padEnd(pair.getKey(), length, ' ')
+                    + (pair.getValue() != null ? ("  " + pair.getValue()) : ""));
         }
     }
 
@@ -1208,18 +1212,13 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      * Executes the build. If the constructor for this instance failed (e.g.
      * returned after issuing a warning), this method returns immediately.
      *
-     * @param coreLoader The classloader to use to find core classes. May be
-     *                   <code>null</code>, in which case the system classloader is
-     *                   used.
+     * @param coreLoader   The classloader to use to find core classes. May be
+     *                     <code>null</code>, in which case the system classloader is
+     *                     used.
      * @param definedProps Set of properties that can be used by tasks.
      * @throws BuildException if the build fails
      */
     private void runBuild(final ClassLoader coreLoader, Map<String, Object> definedProps) throws BuildException {
-
-        if (!readyToRun) {
-            return;
-        }
-
         final Project project = new Project();
         project.setCoreLoader(coreLoader);
 

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -25,6 +25,7 @@ public class Project {
                 toStream(src.deliverables)
                         .map(deliverable -> new Deliverable(
                                 deliverable.name,
+                                deliverable.id,
                                 build(deliverable.context, base),
                                 deliverable.output,
                                 build(deliverable.publication, base)
@@ -107,16 +108,19 @@ public class Project {
 
     public static class Deliverable {
         public final String name;
+        public final String id;
         public final Context context;
         public final URI output;
         public final Publication publication;
 
         @JsonCreator
         public Deliverable(@JsonProperty("name") String name,
+                           @JsonProperty("id") String id,
                            @JsonProperty("context") Context context,
                            @JsonProperty("output") URI output,
                            @JsonProperty("publication") Publication publication) {
             this.name = name;
+            this.id = id;
             this.context = context;
             this.output = output;
             this.publication = publication;

--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -38,16 +38,19 @@ public class ProjectBuilder {
 
     public static class Deliverable {
         public String name;
+        public String id;
         public Context context;
         public URI output;
         public Publication publication;
 
         @JsonCreator
         public Deliverable(@JsonProperty("name") String name,
+                           @JsonProperty("id") String id,
                            @JsonProperty("context") Context context,
                            @JsonProperty("output") URI output,
                            @JsonProperty("publication") Publication publication) {
             this.name = name;
+            this.id = id;
             this.context = context;
             this.output = output;
             this.publication = publication;

--- a/src/main/java/org/dita/dost/project/ProjectFactory.java
+++ b/src/main/java/org/dita/dost/project/ProjectFactory.java
@@ -45,6 +45,7 @@ public class ProjectFactory {
                         src.deliverables.stream()
                                 .map(deliverable -> new Deliverable(
                                         deliverable.name,
+                                        deliverable.id,
                                         Optional.ofNullable(deliverable.context)
                                                 .flatMap(context -> Optional.ofNullable(context.idref))
                                                 .map(idref -> {

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -145,9 +145,9 @@ public class XmlReader {
     }
 
     private ProjectBuilder.Deliverable readDeliverable(final Element deliverable) {
-        final String name = getValue(deliverable, ATTR_NAME);
         return new ProjectBuilder.Deliverable(
-                name,
+                getValue(deliverable, ATTR_NAME),
+                getValue(deliverable, ATTR_ID),
                 getChildElement(deliverable, ELEM_CONTEXT)
                         .map(this::readContext)
                         .orElse(null),

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -9,6 +9,7 @@
 package org.dita.dost.project;
 
 import com.thaiopensource.relaxng.jaxp.CompactSyntaxSchemaFactory;
+import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -34,10 +35,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.dita.dost.util.XMLUtils.*;
+import static org.dita.dost.util.XMLUtils.getValue;
 
 public class XmlReader {
+
+    public static final String NS = "https://www.dita-ot.org/project";
 
     public static final String ATTR_HREF = "href";
     public static final String ATTR_ID = "id";
@@ -61,7 +65,9 @@ public class XmlReader {
 
     public XmlReader() {
         try {
-            documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            documentBuilder = factory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);
         }
@@ -98,18 +104,18 @@ public class XmlReader {
             final Document document = readDocument(in, file);
             final Element project = document.getDocumentElement();
             return new ProjectBuilder(
-                    getChildElements(project, ELEM_DELIVERABLE).stream()
+                    getChildren(project, ELEM_DELIVERABLE)
                             .map(this::readDeliverable)
                             .collect(Collectors.toList()),
-                    getChildElements(project, ELEM_INCLUDE).stream()
+                    getChildren(project, ELEM_INCLUDE)
                             .map(this::getHref)
                             .filter(Optional::isPresent)
                             .map(Optional::get)
                             .collect(Collectors.toList()),
-                    getChildElements(project, ELEM_PUBLICATION).stream()
+                    getChildren(project, ELEM_PUBLICATION)
                             .map(this::readPublication)
                             .collect(Collectors.toList()),
-                    getChildElements(project, ELEM_CONTEXT).stream()
+                    getChildren(project, ELEM_CONTEXT)
                             .map(this::readContext)
                             .collect(Collectors.toList())
             );
@@ -148,13 +154,13 @@ public class XmlReader {
         return new ProjectBuilder.Deliverable(
                 getValue(deliverable, ATTR_NAME),
                 getValue(deliverable, ATTR_ID),
-                getChildElement(deliverable, ELEM_CONTEXT)
+                getChild(deliverable, ELEM_CONTEXT)
                         .map(this::readContext)
                         .orElse(null),
-                getChildElement(deliverable, ELEM_OUTPUT)
+                getChild(deliverable, ELEM_OUTPUT)
                         .flatMap(this::getHref)
                         .orElse(null),
-                getChildElement(deliverable, ELEM_PUBLICATION)
+                getChild(deliverable, ELEM_PUBLICATION)
                         .map(this::readPublication)
                         .orElse(null)
         );
@@ -166,7 +172,7 @@ public class XmlReader {
                 getValue(publication, ATTR_ID),
                 getValue(publication, ATTR_IDREF),
                 getValue(publication, ATTR_TRANSTYPE),
-                getChildElements(publication, ELEM_PARAM).stream()
+                getChildren(publication, ELEM_PARAM)
                         .map(param -> new ProjectBuilder.Publication.Param(
                                 getValue(param, ATTR_NAME),
                                 getValue(param, ATTR_VALUE),
@@ -181,11 +187,11 @@ public class XmlReader {
                 getValue(context, ATTR_NAME),
                 getValue(context, ATTR_ID),
                 getValue(context, ATTR_IDREF),
-                getChildElement(context, ELEM_INPUT)
+                getChild(context, ELEM_INPUT)
                         .flatMap(this::getHref)
                         .orElse(null),
-                getChildElement(context, ELEM_PROFILE)
-                        .map(inputs -> getChildElements(inputs, ELEM_DITAVAL).stream()
+                getChild(context, ELEM_PROFILE)
+                        .map(inputs -> getChildren(inputs, ELEM_DITAVAL)
                                 .map(this::getHref)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
@@ -194,6 +200,14 @@ public class XmlReader {
                         .map(ProjectBuilder.Deliverable.Profile::new)
                         .orElse(null)
         );
+    }
+
+    private Optional<Element> getChild(final Element project, String localName) {
+        return XMLUtils.getChildElement(project, NS, localName);
+    }
+
+    private Stream<Element> getChildren(final Element project, String localName) {
+        return XMLUtils.getChildElements(project, NS, localName).stream();
     }
 
     private Optional<URI> getHref(final Element elem) {

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -113,15 +113,16 @@ public final class XMLUtils {
      * Get first child element by element name.
      *
      * @param elem root element
+     * @param ns namespace URI, {@code null} for empty namespace
      * @param name element name to match element
      * @return matching element
      */
-    public static Optional<Element> getChildElement(final Element elem, final String name) {
+    public static Optional<Element> getChildElement(final Element elem, final String ns, final String name) {
         final NodeList children = elem.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             final Node child = children.item(i);
             if (child.getNodeType() == Node.ELEMENT_NODE) {
-                if (name.equals(child.getNodeName()) || name.equals(child.getLocalName())) {
+                if (Objects.equals(child.getNamespaceURI(), ns) && name.equals(child.getLocalName())) {
                     return Optional.of((Element) child);
                 }
             }
@@ -150,17 +151,18 @@ public final class XMLUtils {
     /**
      * List child elements by element name.
      *
+     * @param ns namespace URL, {@code null} for empty namespace
      * @param elem root element
-     * @param name element name to match elements
+     * @param name element local name to match elements
      * @return list of matching elements
      */
-    public static List<Element> getChildElements(final Element elem, final String name) {
+    public static List<Element> getChildElements(final Element elem, final String ns, final String name) {
         final NodeList children =  elem.getChildNodes();
         final List<Element> res = new ArrayList<>(children.getLength());
         for (int i = 0; i < children.getLength(); i++) {
             final Node child = children.item(i);
             if (child.getNodeType() == Node.ELEMENT_NODE) {
-                if (name.equals(child.getLocalName()) || name.equals(child.getNodeName())) {
+                if (Objects.equals(child.getNamespaceURI(), ns) && name.equals(child.getLocalName())) {
                     res.add((Element) child);
                 }
             }

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -12,6 +12,7 @@ includes =
 deliverable =
   element deliverable {
     attribute name { text }?,
+    attribute id { text }?,
     # (inputs* & output & profile* & publication*)
     ((context | context-ref), output, (publication | publication-ref))
   }

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -2,7 +2,7 @@ default namespace = "https://www.dita-ot.org/project"
 
 
 ## Publication project
-project = element project { includes* & deliverable? & publication* & context* }
+project = element project { (includes | deliverable | publication | context)* }
 
 ## Include project file
 includes =
@@ -15,7 +15,6 @@ deliverable =
   element deliverable {
     attribute name { text }?,
     attribute id { xsd:NCName }?,
-    # (inputs* & output & profile* & publication*)
     ((context | context-ref), output, (publication | publication-ref))
   }
 
@@ -34,14 +33,6 @@ context-ref =
     attribute idref { xsd:NCName }
   }
 
-## Input resources
-inputs =
-  element inputs {
-    # (attribute ref { text }
-    # | attribute name { text })?,
-    input*
-  }
-
 ## Input resource
 input =
   element input {
@@ -55,22 +46,13 @@ output =
   }
 
 ## Filter and highligh profile
-profile =
-  element profile {
-    # (attribute ref { text }
-    # | attribute name { text })?,
-    (ditaval | prop)*
-  }
+profile = element profile { ditaval+ }
+
+## DITAVAL profile resource
 ditaval =
   element ditaval {
     attribute href { xsd:anyURI }?,
     text
-  }
-prop =
-  element prop {
-    attribute val { text }?,
-    attribute action { text }?,
-    attribute att { text }?
   }
 
 ## Publication
@@ -87,20 +69,12 @@ publication-ref =
   element publication {
     attribute idref { xsd:NCName }
   }
+
+## Publication parameter
 param =
   element param {
     attribute name { text }?,
     (attribute href { xsd:anyURI }
      | attribute value { text })
   }
-
-## Input set
-input-set = element input-set { inputs* }
-
-## Profile set 
-profile-set = element profile-set { profile* }
-
-## Publication set
-publication-set = element publication-set { publication* }
-
 start = project

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -1,3 +1,5 @@
+default namespace = "https://www.dita-ot.org/project"
+
 
 ## Publication project
 project = element project { includes* & deliverable? & publication* & context* }
@@ -12,7 +14,7 @@ includes =
 deliverable =
   element deliverable {
     attribute name { text }?,
-    attribute id { text }?,
+    attribute id { xsd:NCName }?,
     # (inputs* & output & profile* & publication*)
     ((context | context-ref), output, (publication | publication-ref))
   }
@@ -21,7 +23,7 @@ deliverable =
 context =
   element context {
     attribute name { text }?,
-    attribute id { xsd:ID }?,
+    attribute id { xsd:NCName }?,
     input,
     profile
   }
@@ -29,7 +31,7 @@ context =
 ## Publication reference
 context-ref =
   element context {
-    attribute idref { xsd:ID }
+    attribute idref { xsd:NCName }
   }
 
 ## Input resources
@@ -75,7 +77,7 @@ prop =
 publication =
   element publication {
     attribute name { text }?,
-    attribute id { xsd:ID }?,
+    attribute id { xsd:NCName }?,
     attribute transtype { text },
     param*
   }
@@ -83,7 +85,7 @@ publication =
 ## Publication reference
 publication-ref =
   element publication {
-    attribute idref { xsd:ID }
+    attribute idref { xsd:NCName }
   }
 param =
   element param {
@@ -100,4 +102,5 @@ profile-set = element profile-set { profile* }
 
 ## Publication set
 publication-set = element publication-set { publication* }
+
 start = project

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -24,7 +24,7 @@ context =
     attribute name { text }?,
     attribute id { xsd:NCName }?,
     input,
-    profile
+    profile?
   }
 
 ## Publication reference

--- a/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
@@ -30,7 +30,7 @@ public class ProjectBuilderTest {
     @Parameters(name = "{0}")
     public static Collection<String[]> data() {
         return Arrays.asList(new String[][]{
-                {"simple"}, {"common"}, {"product"}, {"root"}
+                {"simple"}, {"common"}, {"product"}, {"root"}, {"minimal"}
         });
     }
 

--- a/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
@@ -32,6 +32,7 @@ public class ProjectFactoryTest {
                                 null,
                                 null,
                                 null,
+                                null,
                                 new Publication(
                                         null,
                                         null,
@@ -59,6 +60,7 @@ public class ProjectFactoryTest {
         final Project src = new Project(
                 singletonList(
                         new Deliverable(
+                                null,
                                 null,
                                 new Context(
                                         null,
@@ -89,6 +91,7 @@ public class ProjectFactoryTest {
         final Project src = new Project(
                 singletonList(
                         new Deliverable(
+                                null,
                                 null,
                                 null,
                                 null,

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -46,6 +46,7 @@ public class ProjectTest {
     private Project getProject() {
         return new Project(Arrays.asList(new Project.Deliverable(
                 "name",
+                "id",
                 new Context("Site", "site", null,
                         new Inputs(//"inputs-name",
 //                        "inputs-ref",

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -27,7 +27,8 @@ public class XmlReaderTest {
             final ProjectBuilder project = xmlReader.read(in, URI.create("classpath:org/dita/dost/project/simple.xml"));
             assertEquals(1, project.deliverables.size());
             final ProjectBuilder.Deliverable deliverable = project.deliverables.get(0);
-            assertEquals("name", deliverable.name);
+            assertEquals("Name", deliverable.name);
+            assertEquals("site", deliverable.id);
             assertNotNull(deliverable.context);
             assertEquals("Site", deliverable.context.name);
             assertEquals("site", deliverable.context.id);

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -69,4 +69,12 @@ public class XmlReaderTest {
             assertEquals("common-sitePub2", project.deliverables.get(0).publication.idref);
         }
     }
+
+    @Test
+    public void deserializeXmlMinimal() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/minimal.xml")) {
+            final ProjectBuilder project = xmlReader.read(input, null);
+            assertEquals(1, project.deliverables.size());
+        }
+    }
 }

--- a/src/test/resources/org/dita/dost/project/common.xml
+++ b/src/test/resources/org/dita/dost/project/common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
-<project>
+<project xmlns="https://www.dita-ot.org/project">
   <publication transtype="html5" id="common-sitePub2" name="Site">
     <param name="args.gen.task.lbl" value="YES"/>
     <param name="args.rellinks" value="noparent"/>

--- a/src/test/resources/org/dita/dost/project/minimal.json
+++ b/src/test/resources/org/dita/dost/project/minimal.json
@@ -1,0 +1,13 @@
+{
+  "deliverables": [
+    {
+      "context": {
+        "input": "site.ditamap"
+      },
+      "output": "./site",
+      "publication": {
+        "transtype": "html5"
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/dita/dost/project/minimal.xml
+++ b/src/test/resources/org/dita/dost/project/minimal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
+<project xmlns="https://www.dita-ot.org/project">
+  <deliverable>
+    <context>
+      <input href="site.ditamap"/>
+    </context>
+    <output href="./site"/>
+    <publication transtype="html5"/>
+  </deliverable>
+</project>

--- a/src/test/resources/org/dita/dost/project/minimal.yaml
+++ b/src/test/resources/org/dita/dost/project/minimal.yaml
@@ -1,0 +1,7 @@
+---
+deliverables:
+- context:
+    input: "site.ditamap"
+  output: "./site"
+  publication:
+    transtype: "html5"

--- a/src/test/resources/org/dita/dost/project/product.xml
+++ b/src/test/resources/org/dita/dost/project/product.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
-<project>
+<project xmlns="https://www.dita-ot.org/project">
   <include href="common.xml"/>
   <deliverable name="name">
     <context idref="site"/>

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -1,7 +1,8 @@
 {
   "deliverables": [
     {
-      "name": "name",
+      "name": "Name",
+      "id": "site",
       "context": {
         "name": "Site",
         "id": "site",

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
-<project>
+<project xmlns="https://www.dita-ot.org/project">
   <deliverable name="Name" id="site">
     <context name="Site" id="site">
       <input href="site.ditamap"/>

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../../../../../../main/resources/project.rnc" type="application/relax-ng-compact-syntax"?>
 <project>
-  <deliverable name="name">
+  <deliverable name="Name" id="site">
     <context name="Site" id="site">
       <input href="site.ditamap"/>
       <profile>

--- a/src/test/resources/org/dita/dost/project/simple.yaml
+++ b/src/test/resources/org/dita/dost/project/simple.yaml
@@ -1,6 +1,7 @@
 ---
 deliverables:
-- name: "name"
+- name: "Name"
+  id: "site"
   context:
     name: "Site"
     id: "site"


### PR DESCRIPTION
Allow running project with only a given deliverable, defined by `--deliverable=<id>`. If no deliverable is defined, run all deliverables in the project. If a single deliverable fails, DITA-OT CLI exits and all remaining deliverables will skipped. All log messages will go to the same stream.

Deliverables in a project can be listed with `--deliverables`.

Added namespace `https://www.dita-ot.org/project` to XML syntax.

## Example

When `all.yaml` contains deliverable definitions for all deliverables, run only `project` deliverable:

``` bash
$ dita --project=all.yaml --deliverables
product-a  Product A name
product-b  Product B name
$ dita --project=all.yaml --deliverable=product-a
```