### PR TITLE
Change registry to use HTTPS

### DIFF
--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -14,7 +14,7 @@ cli.color = true
 plugindirs = plugins;demo
 plugin.ignores =
 plugin.order = org.dita.base org.oasis-open.dita.v1_3 org.oasis-open.dita.v1_2
-registry = http://plugins.dita-ot.org/
+registry = https://plugins.dita-ot.org/
 
 # PDF2 defaults
 org.dita.pdf2.i18n.enabled = true


### PR DESCRIPTION
Use HTTPS to access registry for improved security.

This requires Java 8u101 because that contains IdenTrust CA roots in the Java's CA trust store. Java can be update from e.g. https://adoptopenjdk.net/index.html