### PR TITLE
Use OASIS namespace for generating catalog-dita.xml

### DIFF
--- a/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
@@ -7,6 +7,8 @@
  */
 package org.dita.dost.platform;
 
+import static org.dita.dost.util.Constants.OASIS_CATALOG_NAMESPACE;
+
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
@@ -24,10 +26,10 @@ final class ImportCatalogActionRelative extends ImportAction {
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
         for (final Value value: valueSet) {
-            buf.startElement("urn:oasis:names:tc:entity:xmlns:xml:catalog", "nextCatalog", "nextCatalog", new AttributesBuilder()
+            buf.startElement(OASIS_CATALOG_NAMESPACE, "nextCatalog", "nextCatalog", new AttributesBuilder()
                 .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value.value))
                 .build());
-            buf.endElement("urn:oasis:names:tc:entity:xmlns:xml:catalog", "nextCatalog", "nextCatalog");
+            buf.endElement(OASIS_CATALOG_NAMESPACE, "nextCatalog", "nextCatalog");
         }
     }
 

--- a/src/main/java/org/dita/dost/platform/ImportPluginCatalogAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportPluginCatalogAction.java
@@ -7,7 +7,6 @@
  */
 package org.dita.dost.platform;
 
-import static javax.xml.XMLConstants.NULL_NS_URI;
 import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
@@ -55,11 +54,11 @@ final class ImportPluginCatalogAction extends ImportAction {
             if (location.length() > 0 && !location.substring(location.length() - 1).equals(UNIX_SEPARATOR)) {
                 location.append(UNIX_SEPARATOR);
             }
-            buf.startElement(NULL_NS_URI, "rewriteURI", "rewriteURI", new AttributesBuilder()
+            buf.startElement(OASIS_CATALOG_NAMESPACE, "rewriteURI", "rewriteURI", new AttributesBuilder()
                 .add("uriStartString", name)
                 .add("rewritePrefix", location.toString())
                 .build());
-            buf.endElement(NULL_NS_URI, "rewriteURI", "rewriteURI");
+            buf.endElement(OASIS_CATALOG_NAMESPACE, "rewriteURI", "rewriteURI");
         }
     }
 

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1100,6 +1100,10 @@ public final class Constants {
     public static final String ANT_REFERENCE_JOB = "job";
     /** Temporary directory Ant property name. */
     public static final String ANT_TEMP_DIR = "dita.temp.dir";
+
+    /** OASIS catalog file namespace. */
+    public static final String OASIS_CATALOG_NAMESPACE = "urn:oasis:names:tc:entity:xmlns:xml:catalog";
+    
     /** Deprecated since 2.3 */
     @Deprecated
     public static final String PI_PATH2PROJ_TARGET = "path2project";


### PR DESCRIPTION
---
name: Use OASIS namspace for generating catalog-dita.xml
about: Fix #3284 

---

## Description
Use OASIS namspace "urn:oasis:names:tc:entity:xmlns:xml:catalog" when generating catalog-dita.xml from catalog-dita_template.xml.

## Motivation and Context
Fix #3284 

## How Has This Been Tested?
Using DITA-OT 3.3.1 & Saxon-HE 9.8.0.15.
The plugins/org.dita.base/catalog-dita.xml has normally generated.

## Type of Changes
- Breaking change _(Use OASIS namespace instead of javax.xml.XMLConstants.NULL_NS_URI.)_

## Checklist
- My code follows the code style of this project.
- I have updated the unit tests to reflect the changes in my code.
