### PR TITLE
Fix plug-in installation with multiple plug-ins #3294

### DIFF
--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -128,7 +128,7 @@ public final class PluginInstallTask extends Task {
                         throw new BuildException(new IllegalStateException(String.format("Plug-in %s already installed: %s", name, pluginDir)));
                     }
                 }
-                FileUtils.moveDirectory(tempPluginDir, pluginDir);
+                FileUtils.copyDirectory(tempPluginDir, pluginDir);
             }
         } catch (IOException e) {
             throw new BuildException(e.getMessage(), e);
@@ -211,7 +211,7 @@ public final class PluginInstallTask extends Task {
             }
         }
         if (res == null) {
-            throw new BuildException("Unable to find plugin " + pluginFile);
+            throw new BuildException("Unable to find plugin " + pluginFile + " in any configured registry.");
         }
 
         Set<Registry> results = new HashSet<>();


### PR DESCRIPTION
Replace moveDirectory() with copyDirectory() to resolve not-found failure when installing dependencies. Fixes #3294

Signed-off-by: Eliot Kimber <ekimber@contrext.com>

---
name: Pull request
about: Correct #3294 bug in installation of dependencies.

---

## Description

Use copyDirectory() not moveDirectory()

## Motivation and Context

Fixes #3294

## How Has This Been Tested?

Tested interactively through Eclipse on macOS to install org.dita-community.glossary.preprocess plugin from the registry.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

