### PR TITLE
Refactor property declarations with isset guards to plain declarations

### DIFF
--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -88,11 +88,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- begin to init required parameters -->
     
-    <condition property="filter-stage" value="early">
-      <not>
-        <isset property="filter-stage"/>
-      </not>
-    </condition>
+    <property name="filter-stage" value="early"/>
     <condition property="filter-on-parse" value="true">
       <and>
         <equals arg1="${filter-stage}" arg2="early"/>
@@ -115,19 +111,8 @@ See the accompanying LICENSE file for applicable license.
       </and>
     </condition>
 
-    <condition property="args.grammar.cache"
-          value="yes">
-            <not>
-              <isset property="args.grammar.cache" />
-            </not>
-    </condition>
-
-    <condition property="args.xml.systemid.set"
-          value="yes">
-            <not>
-              <isset property="args.xml.systemid.set" />
-            </not>
-    </condition>
+    <property name="args.grammar.cache" value="yes"/>
+    <property name="args.xml.systemid.set" value="yes"/>    
     <!-- end to init required parameters -->
 
     <!-- create required directories -->
@@ -135,18 +120,10 @@ See the accompanying LICENSE file for applicable license.
     <delete dir="${dita.temp.dir}" quiet="false"/>
     <mkdir dir="${dita.temp.dir}" />
 
-    <condition property="args.logdir" value="${output.dir}">
-      <not>
-        <isset property="args.logdir" />
-      </not>
-    </condition>
+    <property name="args.logdir" value="${output.dir}"/>
 
     <!-- Validate the xml file or not,default is validation(true)-->
-    <condition property="validate" value="true">
-       <not>
-       <isset property="validate" />
-       </not>
-    </condition>
+    <property name="validate" value="true"/>
     
     <!-- Related links to output: none, all, nofamily -->
     <condition property="include.rellinks" value="">
@@ -169,17 +146,9 @@ See the accompanying LICENSE file for applicable license.
     </condition>
 
     <!--solution for the output control-->
-    <condition property="generate.copy.outer" value="1">
-       <not>
-       <isset property="generate.copy.outer" />
-       </not>
-    </condition>
+    <property name="generate.copy.outer" value="1"/>
 
-    <condition property="onlytopic.in.map" value="false">
-       <not>
-       <isset property="onlytopic.in.map" />
-       </not>
-  </condition>
+    <property name="onlytopic.in.map" value="false"/>
 
     <property name="link-crawl" value="topic"/>
     
@@ -189,11 +158,7 @@ See the accompanying LICENSE file for applicable license.
   warn  :1b) Complete if files will be generated/copied outside, but log a warning
   quiet  :1c) Quietly finish with only those files (no warning or error)
     -->
-    <condition property="outer.control" value="warn">
-       <not>
-       <isset property="outer.control" />
-       </not>
-    </condition>
+    <property name="outer.control" value="warn"/>
 
     <condition property="inner.transform">
         <equals arg1="${generate.copy.outer}" arg2="1"/>
@@ -203,9 +168,7 @@ See the accompanying LICENSE file for applicable license.
       <equals arg1="${generate.copy.outer}" arg2="3"></equals>
     </condition>
     
-    <condition property="conserve-memory" value="false">
-      <not><isset property="conserve-memory"/></not>
-    </condition>
+    <property name="conserve-memory" value="false"/>
   </target>
   
   <target name="log-arg">

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -27,9 +27,7 @@ See the accompanying LICENSE file for applicable license.
                   {depend.preprocess.post}">
     <dirname property="_dita.map.output.dir" file="${dita.output.dir}/${user.input.file}" />
     <dirname property="_dita.map.temp.dir" file="${dita.temp.dir}/${user.input.file}" />
-    <condition property="uplevels" value="">
-      <not><isset property="uplevels"/></not>
-    </condition>
+    <property name="uplevels" value=""/>
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
     <!-- Deprecated since 2.4 -->
     <property name="user.input.file.listfile" value="usr.input.file.list"/>
@@ -79,9 +77,7 @@ See the accompanying LICENSE file for applicable license.
                   {depend.preprocess.post}">
     <dirname property="_dita.map.output.dir" file="${dita.output.dir}/${user.input.file}" />
     <dirname property="_dita.map.temp.dir" file="${dita.temp.dir}/${user.input.file}" />
-    <condition property="uplevels" value="">
-      <not><isset property="uplevels"/></not>
-    </condition>
+    <property name="uplevels" value=""/>
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
     <!-- Deprecated since 2.4 -->
     <property name="user.input.file.listfile" value="usr.input.file.list"/>
@@ -157,9 +153,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="map-mapref"
           unless="preprocess.mapref.skip"
           description="Resolve mapref in ditamap">
-    <condition property="dita.preprocess.reloadstylesheet.mapref" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.mapref"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.mapref" value="${dita.preprocess.reloadstylesheet}"/>
     <dirname property="mapref.workdir" file="${dita.temp.dir}/${user.input.file}" />
     <pipeline message="Resolve mapref in ditamap" taskname="mapref">
       <module class="org.dita.dost.module.MaprefModule">
@@ -209,9 +203,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="map-conref"
     unless="preprocess.conref.skip"
     description="Resolve conref in input map files">
-    <condition property="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.conref"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}"/>
     <makeurl property="exportfile.url" file="${dita.temp.dir}/export.xml" validate="false"/>
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
@@ -310,9 +302,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="topic-conref"
           unless="preprocess.conref.skip"
           description="Resolve conref in input files">
-    <condition property="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.conref"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}"/>
     <makeurl property="exportfile.url" file="${dita.temp.dir}/export.xml" validate="false"/>
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
@@ -389,9 +379,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="topic-maplink"
     unless="preprocess.maplink.skip"
     description="Find and generate related link information">
-    <condition property="dita.preprocess.reloadstylesheet.maplink" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.maplink"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.maplink" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Move related links" taskname="maplink">
       <module class="org.dita.dost.module.MoveLinksModule">
         <param name="style" location="${dita.plugin.org.dita.base.dir}/xsl/preprocess/maplink.xsl"/>
@@ -404,9 +392,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="topic-topicpull"
     unless="preprocess.topicpull.skip"
     description="Pull metadata for link and xref element">
-    <condition property="dita.preprocess.reloadstylesheet.topicpull" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.topicpull"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.topicpull" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Pull metadata for link and xref element" taskname="topicpull">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
@@ -425,9 +411,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="map-clean-map" 
           unless="preprocess.clean-map-check.skip"
           description="Clean ditamap">
-    <condition property="dita.preprocess.reloadstylesheet.clean-map" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.clean-map"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.clean-map" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Clean ditamap" taskname="clean-map">
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.clean-map}"

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -271,9 +271,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.conref.skip"
     description="Resolve conref in input files">
-    <condition property="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.conref"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}"/>
     <makeurl property="exportfile.url" file="${dita.temp.dir}/export.xml" validate="false"/>
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
@@ -326,9 +324,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.mapref.skip"
     description="Resolve mapref in ditamap">
-    <condition property="dita.preprocess.reloadstylesheet.mapref" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.mapref"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.mapref" value="${dita.preprocess.reloadstylesheet}"/>
     <dirname property="mapref.workdir" file="${dita.temp.dir}/${user.input.file}" />
     <pipeline message="Resolve mapref in ditamap" taskname="mapref">
       <module class="org.dita.dost.module.MaprefModule">
@@ -437,9 +433,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.maplink.skip"
     description="Find and generate related link information">
-    <condition property="dita.preprocess.reloadstylesheet.maplink" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.maplink"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.maplink" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Move related links" taskname="maplink"
               inputmap="${user.input.file}">
       <module class="org.dita.dost.module.MoveLinksModule">
@@ -463,9 +457,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.topicpull.skip"
     description="Pull metadata for link and xref element">
-    <condition property="dita.preprocess.reloadstylesheet.topicpull" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.topicpull"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.topicpull" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Pull metadata for link and xref element" taskname="topicpull">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
@@ -494,9 +486,7 @@ See the accompanying LICENSE file for applicable license.
           depends="clean-map-check"
           unless="preprocess.clean-map-check.skip"
           description="Clean ditamap">
-    <condition property="dita.preprocess.reloadstylesheet.clean-map" value="${dita.preprocess.reloadstylesheet}">
-      <not><isset property="dita.preprocess.reloadstylesheet.clean-map"/></not>
-    </condition>
+    <property name="dita.preprocess.reloadstylesheet.clean-map" value="${dita.preprocess.reloadstylesheet}"/>
     <pipeline message="Clean ditamap" taskname="clean-map">
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.clean-map}"

--- a/src/main/plugins/org.dita.base/build_template.xml
+++ b/src/main/plugins/org.dita.base/build_template.xml
@@ -25,9 +25,7 @@ See the accompanying LICENSE file for applicable license.
       </condition>
       <param name="1" value="${transtype}"/>
     </dita-ot-fail>
-    <condition property="clean.temp" value="true">
-      <not><isset property="clean.temp"/></not>
-    </condition>
+    <property name="clean.temp" value="true"/>
     <condition property="clean-temp.skip">
       <isfalse value="${clean.temp}"/>
     </condition>

--- a/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
+++ b/src/main/plugins/org.dita.eclipsehelp/build_dita2eclipsehelp_template.xml
@@ -10,20 +10,14 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="dita.eclipsehelp.init">
     <property name="html-version" value="xhtml"/>
-    <condition property="args.xsl" value="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/dita2xhtml_eclipsehelp.xsl">
-      <not>
-        <isset property="args.xsl" />
-      </not>
-    </condition>
+    <property name="args.xsl" value="${dita.plugin.org.dita.eclipsehelp.dir}/xsl/dita2xhtml_eclipsehelp.xsl"/>
     <condition property="temp.output.dir.name" value="temp_jar_dir">
       <isset property="args.eclipsehelp.jar.name"/>
     </condition>
   </target>
 
      <target name="dita.index.eclipsehelp.init">
-        <condition property="dita.eclipsehelp.index.class" value="org.dita.dost.writer.EclipseIndexWriter">
-            <not><isset property="dita.eclipsehelp.index.class"></isset></not>
-        </condition>
+       <property name="dita.eclipsehelp.index.class" value="org.dita.dost.writer.EclipseIndexWriter"/>
      </target>
 
 
@@ -51,11 +45,7 @@ See the accompanying LICENSE file for applicable license.
 
     <target name="dita.map.eclipse.plugin.init"
             description="Init properties for EclipseHelp">
-        <condition property="out.ext" value=".html">
-            <not>
-                <isset property="out.ext" />
-            </not>
-        </condition>
+      <property name="out.ext" value=".html"/>
         <condition property="noPlugin">
             <equals arg1="${dita.eclipse.plugin}" arg2="no" />
         </condition>
@@ -94,11 +84,7 @@ See the accompanying LICENSE file for applicable license.
           </not>
         </and>
       </condition>
-      <condition property="args.eclipsehelp.indexsee" value="false">
-          <not>
-            <isset property="args.eclipsehelp.indexsee"></isset>
-          </not>
-      </condition>
+      <property name="args.eclipsehelp.indexsee" value="false"/>
     </target>
 
     <target name="dita.map.eclipse.toc" unless="noMap"

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -20,11 +20,7 @@ See the accompanying LICENSE file for applicable license.
                    html5.css"/>
 
   <target name="html5.init">
-    <condition property="args.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/dita2html5.xsl">
-      <not>
-        <isset property="args.xsl"/>
-      </not>
-    </condition>
+    <property name="args.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/dita2html5.xsl"/>
     <condition property="html5.nav-toc" value="${nav-toc}" else="none">
       <isset property="nav-toc"/>
     </condition>
@@ -104,11 +100,7 @@ See the accompanying LICENSE file for applicable license.
     </condition>
     <!-- Set to "true" if you get out-of-memory errors during preprocess
     while processing very large (thousands of files) document sets. -->
-    <condition property="dita.html5.reloadstylesheet" value="false">
-      <not>
-        <isset property="dita.html5.reloadstylesheet"/>
-      </not>
-    </condition>
+    <property name="dita.html5.reloadstylesheet" value="false"/>
   </target>
 
   <target name="html5.topic"
@@ -155,16 +147,8 @@ See the accompanying LICENSE file for applicable license.
                    html5.map.toc"/>
 
   <target name="html5.map.init" unless="noMap">
-    <condition property="args.html5.toc.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/map2html5-cover.xsl">
-      <not>
-        <isset property="args.html5.toc.xsl"/>
-      </not>
-    </condition>
-    <condition property="args.html5.toc" value="index">
-      <not>
-        <isset property="args.html5.toc"/>
-      </not>
-    </condition>
+    <property name="args.html5.toc.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/map2html5-cover.xsl"/>
+    <property name="args.html5.toc" value="index"/>
   </target>
 
   <target name="html5.map.toc" unless="noMap" description="Build HTML5 TOC file">

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -71,11 +71,7 @@ See the accompanying LICENSE file for applicable license.
                    compile.HTML.Help"/> 
 
   <target name="dita.map.htmlhelp.init" description="Init properties for HTMLHelp">
-    <condition property="out.ext" value=".html">
-      <not>
-        <isset property="out.ext"/>
-      </not>
-    </condition>
+    <property name="out.ext" value=".html"/>
     <property name="args.output.base" value="${dita.map.filename.root}"/>
   </target>
 

--- a/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
@@ -30,9 +30,7 @@ See the accompanying LICENSE file for applicable license.
       </and>
     </condition>
     <!-- default output format -->
-    <condition property="axf.formatter.output-format" value="@PDF">
-      <not><isset property="axf.formatter.output-format"/></not>
-    </condition>
+    <property name="axf.formatter.output-format" value="@PDF"/>
     <!-- output file extension -->
     <condition property="xsl.formatter.ext" value=".ps">
       <and>
@@ -189,9 +187,7 @@ See the accompanying LICENSE file for applicable license.
       </condition>
     </fail>
     
-    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
-      <not><isset property="outputFile"/></not>
-    </condition>
+    <property name="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}"/>
     <mkdir dir="${dita.output.dir}"/>
     
     <antcall target="transform.fo2pdf.ah.nooption"/>

--- a/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/build_fop.xml
@@ -21,11 +21,7 @@ See the accompanying LICENSE file for applicable license.
       <equals arg1="${pdf.formatter}" arg2="fop"/>
     </condition>
     
-    <condition property="args.fo.userconfig" value="${fop.home}/cfg/fop.xconf">
-      <not>
-        <isset property="args.fo.userconfig"/>
-      </not>
-    </condition>
+    <property name="args.fo.userconfig" value="${fop.home}/cfg/fop.xconf"/>
     
     <condition property="temp.transformation.file" value="${dita.plugin.org.dita.pdf2.fop.dir}/xsl/fo/topic2fo_shell_fop.xsl">
       <and>
@@ -37,9 +33,7 @@ See the accompanying LICENSE file for applicable license.
     <property name="fop.failOnError" value="true"/>
     
     <!-- default output format -->
-    <condition property="fop.formatter.output-format" value="application/pdf">
-      <not><isset property="fop.formatter.output-format"/></not>
-    </condition>
+    <property name="fop.formatter.output-format" value="application/pdf"/>
     <!-- output file extension -->
     <condition property="xsl.formatter.ext" value=".mif">
       <and>
@@ -143,9 +137,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="transform.fo2pdf.fop" if="use.fop.pdf.formatter">
     <taskdef name="fop" classname="org.apache.fop.tools.anttasks.Fop"/>
     
-    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
-      <not><isset property="outputFile"/></not>
-    </condition>
+    <property name="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}"/>
     <mkdir dir="${dita.output.dir}"/>
     
     <fop format="${fop.formatter.output-format}" fofile="${pdf2.temp.dir}/topic.fo" basedir="${pdf2.temp.dir}"

--- a/src/main/plugins/org.dita.pdf2.xep/build_xep.xml
+++ b/src/main/plugins/org.dita.pdf2.xep/build_xep.xml
@@ -102,9 +102,7 @@ See the accompanying LICENSE file for applicable license.
     </condition>
     
     <!-- default output format -->
-    <condition property="xep.formatter.output-format" value="PDF">
-      <not><isset property="xep.formatter.output-format"/></not>
-    </condition>
+    <property name="xep.formatter.output-format" value="PDF"/>
     <!-- output file extension -->
     <condition property="xsl.formatter.ext" value=".ps">
       <and>
@@ -182,9 +180,7 @@ See the accompanying LICENSE file for applicable license.
 
     <property name="xep.failOnError" value="true"/>
     
-    <condition property="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}">
-      <not><isset property="outputFile"/></not>
-    </condition>
+    <property name="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}"/>
     <mkdir dir="${dita.output.dir}"/>
     
     <echo level="info" taskname="xep">Processing ${pdf2.temp.dir}/topic.fo to ${outputFile}</echo>

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -60,9 +60,7 @@ with those set forth herein.
       <isfalse value="${org.dita.pdf2.chunk.enabled}"/>
     </condition>
     
-    <condition property="args.rellinks" value="nofamily">
-      <not><isset property="args.rellinks"/></not>
-    </condition>
+    <property name="args.rellinks" value="nofamily"/>
   </target>
 
   <target name="dita2pdf" depends="dita2pdf2"/>
@@ -104,9 +102,7 @@ with those set forth herein.
       <os family="unix"/>
     </condition>
     
-    <condition property="file.protocol.prefix" value="file:/">
-      <not><isset property="file.protocol.prefix"/></not>
-    </condition>
+    <property name="file.protocol.prefix" value="file:/"/>
     
     <path id="xml.catalog.path">
       <pathelement location="${customization.dir}/catalog.xml"/>
@@ -204,29 +200,19 @@ with those set forth herein.
       <available file="${variable.file}" />
     </condition>
 
-    <condition property="document.locale" value="${default.locale}">
-      <not><isset property="document.locale"/></not>
-    </condition>
+    <property name="document.locale" value="${default.locale}"/>
 
     <!-- WS runtime properties -->
     <property file="${cfg.common.dir}/properties/${document.locale}.properties"/>
 
-    <condition property="document.language" value="${default.language}">
-      <not><isset property="document.language"/></not>
-    </condition>
+    <property name="document.language" value="${default.language}"/>
     <echo level="info">Using document.locale=${document.locale}</echo>
 
-    <condition property="args.bookmark.style" value="">
-      <not><isset property="args.bookmark.style"/></not>
-    </condition>
+    <property name="args.bookmark.style" value=""/>
 
-    <condition property="args.chapter.layout" value="">
-      <not><isset property="args.chapter.layout"/></not>
-    </condition>
+    <property name="args.chapter.layout" value=""/>
 
-    <condition property="args.draft" value="no">
-      <not><isset property="args.draft"/></not>
-    </condition>
+    <property name="args.draft" value="no"/>
 
     <condition property="publish.required.cleanup" value="${args.draft}">
       <and>
@@ -235,9 +221,7 @@ with those set forth herein.
       </and>
     </condition>
 
-    <condition property="args.gen.task.lbl" value="">
-      <not><isset property="args.gen.task.lbl"/></not>
-    </condition>
+    <property name="args.gen.task.lbl" value=""/>
     <!-- use customized xsl file for pdf transform.-->
     <condition property="temp.transformation.file" value="${args.xsl.pdf}">
       <and>
@@ -252,16 +236,9 @@ with those set forth herein.
       </and>
     </condition>
     
-    <condition property="args.bookmap-order" value="discard">
-      <not><isset property="args.bookmap-order"/></not>
-    </condition>
-
-    <condition property="args.figurelink.style" value="NUMTITLE">
-        <not><isset property="args.figurelink.style"/></not>
-    </condition>
-    <condition property="args.tablelink.style" value="NUMTITLE">
-        <not><isset property="args.tablelink.style"/></not>
-    </condition>
+    <property name="args.bookmap-order" value="discard"/>
+    <property name="args.figurelink.style" value="NUMTITLE"/>
+    <property name="args.tablelink.style" value="NUMTITLE"/>
   </target>
 
   <target name="transform.topic2fo.index">
@@ -292,9 +269,7 @@ with those set forth herein.
         <available file="${cfg.dir}/common/index/${document.language}.xml"/>
       </and>
     </condition>
-    <condition property="index.config.file" value="${cfg.dir}/common/index/${default.language}.xml">
-      <not><isset property="index.config.file"/></not>
-    </condition>
+    <property name="index.config.file" value="${cfg.dir}/common/index/${default.language}.xml"/>
 
     <index-preprocess input="${inputFile.url}" output="${dita.temp.dir}/stage1.xml"
                       indexConfig="${index.config.file}" locale="${document.locale}"
@@ -372,9 +347,7 @@ with those set forth herein.
         <available file="${cfg.fo.dir}/i18n/${document.language}.xml"/>
       </and>
     </condition>
-    <condition property="i18n.config.file" value="${cfg.fo.dir}/i18n/${default.language}.xml">
-      <not><isset property="i18n.config.file"/></not>
-    </condition>
+    <property name="i18n.config.file" value="${cfg.fo.dir}/i18n/${default.language}.xml"/>
 
     <i18n-preprocess input="${dita.temp.dir}/stage2.fo" output="${pdf2.temp.dir}/topic.fo"
                      config="${i18n.config.file}"

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -28,16 +28,8 @@ See the accompanying LICENSE file for applicable license.
             depends="dita.map.xhtml.init, dita.map.xhtml.toc" />
 
     <target name="dita.map.xhtml.init" unless="noMap">
-      <condition property="args.xhtml.toc.xsl" value="${dita.plugin.org.dita.xhtml.dir}/xsl/map2${html-version}-cover.xsl">
-        <not>
-          <isset property="args.xhtml.toc.xsl" />
-        </not>
-      </condition>
-        <condition property="args.xhtml.toc" value="index">
-            <not>
-                <isset property="args.xhtml.toc" />
-            </not>
-        </condition>
+      <property name="args.xhtml.toc.xsl" value="${dita.plugin.org.dita.xhtml.dir}/xsl/map2${html-version}-cover.xsl"/>
+      <property name="args.xhtml.toc" value="index"/>
     </target>
     
 

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -65,11 +65,7 @@ See the accompanying LICENSE file for applicable license.
         <isset property="args.csspath.absolute" />
       </or>
     </condition>
-    <condition property="user.csspath" value="${args.csspath}/">
-      <not>
-        <isset property="user.csspath" />
-      </not>
-    </condition>
+    <property name="user.csspath" value="${args.csspath}/"/>
     <condition property="args.css.real" value="${args.cssroot}${file.separator}${args.css}">
       <isset property="args.cssroot" />
     </condition>
@@ -87,27 +83,13 @@ See the accompanying LICENSE file for applicable license.
       </or>
     </condition>
     <!-- end to check and init css relevant parameters -->
-    <condition property="out.ext" value=".html">
-      <not>
-        <isset property="out.ext" />
-      </not>
-    </condition>
-    <condition property="html-version" value="xhtml">
-      <not>
-        <isset property="html-version"/>
-      </not>
-    </condition>
-    <condition property="args.xsl" value="${dita.plugin.org.dita.xhtml.dir}/xsl/dita2${html-version}.xsl">
-      <not>
-        <isset property="args.xsl" />
-      </not>
-    </condition>
+    <property name="out.ext" value=".html"/>
+    <property name="html-version" value="xhtml"/>
+    <property name="args.xsl" value="${dita.plugin.org.dita.xhtml.dir}/xsl/dita2${html-version}.xsl"/>
     <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>
     <!-- Set to "true" if you get out-of-memory errors during preprocess
     while processing very large (thousands of files) document sets. -->
-    <condition property="dita.xhtml.reloadstylesheet" value="false">
-      <not><isset property="dita.xhtml.reloadstylesheet"/></not>
-    </condition>
+    <property name="dita.xhtml.reloadstylesheet" value="false"/>
     <antcall target="output-css-warn-message"/>
   </target>
   


### PR DESCRIPTION
Replace `<contains>` guards to set properties with plain `<property>` declaration for simplicity.

Replaces part of #2987