### PR TITLE
Change file key to path for improved readability

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -406,13 +406,13 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                                 if (param.href != null) {
                                     value = Paths.get(base.resolve(param.href)).toString();
                                 } else {
-                                    value = Paths.get(base).resolve(param.file).toString();
+                                    value = Paths.get(base).resolve(param.path).toString();
                                 }
                             } else {
                                 if (param.href != null) {
                                     value = param.href.toString();
                                 } else {
-                                    value = URLUtils.toFile(param.file.toString()).toString();
+                                    value = URLUtils.toFile(param.path.toString()).toString();
                                 }
                             }
                             props.put(param.name, value);

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -75,7 +75,7 @@ public class Project {
                                 param.name,
                                 param.value,
                                 resolveURI(param.href, base),
-                                resolvePath(param.file, base))
+                                resolvePath(param.path, base))
                         )
                         .collect(Collectors.toList())
         );
@@ -225,20 +225,20 @@ public class Project {
             public final String name;
             public final String value;
             public final URI href;
-            public final Path file;
+            public final Path path;
 
             public Param(
                     String name,
                     String value,
                     URI href,
-                    Path file) {
+                    Path path) {
                 this.name = Objects.requireNonNull(name);
-                if (value == null && href == null && file == null) {
+                if (value == null && href == null && path == null) {
                     throw new NullPointerException();
                 }
                 this.value = value;
                 this.href = href;
-                this.file = file;
+                this.path = path;
             }
         }
     }

--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -113,18 +113,18 @@ public class ProjectBuilder {
             public String name;
             public String value;
             public URI href;
-            public URI file;
+            public URI path;
 
             @JsonCreator
             public Param(
                     @JsonProperty("name") String name,
                     @JsonProperty("value") String value,
                     @JsonProperty("href") URI href,
-                    @JsonProperty("file") URI file) {
+                    @JsonProperty("file") URI path) {
                 this.name = name;
                 this.value = value;
                 this.href = href;
-                this.file = file;
+                this.path = path;
             }
         }
     }

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -44,7 +44,7 @@ public class XmlReader {
     public static final String NS = "https://www.dita-ot.org/project";
 
     public static final String ATTR_HREF = "href";
-    public static final String ATTR_FILE = "file";
+    public static final String ATTR_PATH = "path";
     public static final String ATTR_ID = "id";
     public static final String ATTR_IDREF = "idref";
     public static final String ATTR_NAME = "name";
@@ -219,7 +219,7 @@ public class XmlReader {
     }
 
     private Optional<URI> getFile(final Element elem) {
-        return getAttribute(elem, ATTR_FILE).map(this::toUri);
+        return getAttribute(elem, ATTR_PATH).map(this::toUri);
     }
 
     private Optional<String> getAttribute(final Element elem, final String attrName) {

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -75,7 +75,7 @@ param =
   element param {
     attribute name { text }?,
     (attribute href { xsd:anyURI }
-     | attribute file { xsd:anyURI }
+     | attribute path { xsd:anyURI }
      | attribute value { text })
   }
 start = project

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -41,7 +41,7 @@ public class XmlReaderTest {
             assertEquals("sitePub", publication.id);
             assertEquals(null, publication.idref);
             assertEquals("html5", publication.transtype);
-            assertEquals(2, publication.params.size());
+            assertEquals(4, publication.params.size());
             assertEquals("args.gen.task.lbl", publication.params.get(0).name);
             assertEquals("YES", publication.params.get(0).value);
             assertEquals(null, publication.params.get(0).href);

--- a/src/test/resources/org/dita/dost/project/common.xml
+++ b/src/test/resources/org/dita/dost/project/common.xml
@@ -4,7 +4,7 @@
   <publication transtype="html5" id="common-sitePub2" name="Site">
     <param name="args.gen.task.lbl" value="YES"/>
     <param name="args.rellinks" value="noparent"/>
-    <param name="args.cssroot" file="../../resources"/>
+    <param name="args.cssroot" path="../../resources"/>
   </publication>
   <context name="Site" id="site">
     <input href="site.ditamap"/>

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -26,6 +26,14 @@
             "name": "args.rellinks",
             "value": "noparent",
             "href": null
+          },
+          {
+            "name": "args.uri",
+            "href": "foo%20bar"
+          },
+          {
+            "name": "args.rellinks",
+            "path": "baz+qux"
           }
         ]
       }

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -12,6 +12,8 @@
     <publication transtype="html5" id="sitePub" name="Site">
       <param name="args.gen.task.lbl" value="YES"/>
       <param name="args.rellinks" value="noparent"/>
+      <param name="args.uri" href="foo%20bar"/>
+      <param name="args.path" path="baz+qux"/>
     </publication>
   </deliverable>
 </project>

--- a/src/test/resources/org/dita/dost/project/simple.yaml
+++ b/src/test/resources/org/dita/dost/project/simple.yaml
@@ -18,3 +18,7 @@ deliverables:
       value: "YES"
     - name: "args.rellinks"
       value: "noparent"
+    - name: "args.uri"
+      href: "foo%20bar"
+    - name: "args.path"
+      path: "baz+qux"


### PR DESCRIPTION
Change `file` key on `param` to `path` because the value may be either a file or a directory path.