### PR TITLE
Add property to skip HTML5 TOC file generation

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
       </filterchain>
     </loadfile>
     <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}"/>
-    <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>    
+    <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>
   </target>
 
   <target name="html5.image-metadata"
@@ -146,12 +146,19 @@ See the accompanying LICENSE file for applicable license.
           depends="html5.map.init,
                    html5.map.toc"/>
 
-  <target name="html5.map.init" unless="noMap">
+  <target name="html5.map.init">
     <property name="args.html5.toc.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/map2html5-cover.xsl"/>
     <property name="args.html5.toc" value="index"/>
+
+    <condition property="_html5.toc.skip" value="true">
+      <or>
+        <isset property="noMap"/>
+        <istrue value="${html5.toc.skip}"/>
+      </or>
+    </condition>
   </target>
 
-  <target name="html5.map.toc" unless="noMap" description="Build HTML5 TOC file">
+  <target name="html5.map.toc" unless="_html5.toc.skip" description="Build HTML5 TOC file">
     <html5.map>
       <dita:extension id="dita.conductor.html5.toc.param" behavior="org.dita.dost.platform.InsertAction"/>
     </html5.map>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -149,11 +149,11 @@ See the accompanying LICENSE file for applicable license.
   <target name="html5.map.init">
     <property name="args.html5.toc.xsl" value="${dita.plugin.org.dita.html5.dir}/xsl/map2html5-cover.xsl"/>
     <property name="args.html5.toc" value="index"/>
-
+    <property name="html5.toc.generate" value="true"/>
     <condition property="_html5.toc.skip" value="true">
       <or>
         <isset property="noMap"/>
-        <istrue value="${html5.toc.skip}"/>
+        <isfalse value="${html5.toc.generate}"/>
       </or>
     </condition>
   </target>

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -45,6 +45,10 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.html5.contenttarget" desc="Specifies the value of the @target attribute on the &lt;base&gt; element in the TOC file." type="string">
       <val default="true">contentwin</val>
     </param>
+    <param name="html5.toc.skip" desc="Disable TOC generation from DITA map." type="enum">
+      <val>yes</val>
+      <val default="true">no</val>
+    </param>
     <param name="args.html5.toc" desc="Specifies the base name of the TOC file." type="string">
       <val default="true">index</val>
     </param>

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -45,9 +45,9 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.html5.contenttarget" desc="Specifies the value of the @target attribute on the &lt;base&gt; element in the TOC file." type="string">
       <val default="true">contentwin</val>
     </param>
-    <param name="html5.toc.skip" desc="Disable TOC generation from DITA map." type="enum">
-      <val>yes</val>
-      <val default="true">no</val>
+    <param name="html5.toc.generate" desc="Generate TOC file from the DITA map." type="enum">
+      <val default="true">yes</val>
+      <val>no</val>
     </param>
     <param name="args.html5.toc" desc="Specifies the base name of the TOC file." type="string">
       <val default="true">index</val>


### PR DESCRIPTION
Add `html5.toc.skip` property to disable separate TOC file generation in HTML5.

## Usage

Disable `index.html` generation.

```bash
$ dita -i root.ditamap -f html5 --html5.toc.skip=yes
```

