### PR TITLE
Replace pixelated warning icon with SVG image

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
@@ -117,13 +117,13 @@ See the accompanying LICENSE file for applicable license.
   <!-- Image path to use for a note of "notice" type. -->
   <variable id="notice Note Image Path"></variable>
   <!-- Image path to use for a note of "attention" type. -->
-  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <variable id="attention Note Image Path">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
   <!-- Image path to use for a note of "caution" type. -->
-  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <variable id="caution Note Image Path">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
   <!-- Image path to use for a note of "danger" type. -->
-  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <variable id="danger Note Image Path">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
   <!-- Image path to use for a note of "warning" type. -->
-  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <variable id="warning Note Image Path">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
   <!-- Image path to use for a note of "fastpath" type. -->
   <variable id="fastpath Note Image Path"></variable>
   <!-- Image path to use for a note of "important" type. -->
@@ -135,7 +135,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Image path to use for a note of "tip" type. -->
   <variable id="tip Note Image Path"></variable>
   <!-- Image path to use for a note of "troubleshooting" type. -->
-  <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/warning.gif</variable>
+  <variable id="trouble Note Image Path">Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg</variable>
   <!-- Image path to use for a note of "other" type. -->
   <variable id="other Note Image Path"></variable>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -933,7 +933,10 @@ See the accompanying LICENSE file for applicable license.
                         <fo:table-row>
                                 <fo:table-cell xsl:use-attribute-sets="note__image__entry">
                                     <fo:block>
-                                        <fo:external-graphic src="url('{concat($artworkPrefix, $noteImagePath)}')" xsl:use-attribute-sets="image"/>
+                                        <fo:external-graphic src="url('{concat($artworkPrefix, $noteImagePath)}')" 
+                                                             content-height="2em" padding-right="3pt"
+                                                             vertical-align="middle"
+                                                             baseline-shift="baseline"/>
                                     </fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell xsl:use-attribute-sets="note__text__entry">


### PR DESCRIPTION
## Description

The SVG image added for the PDF implementation of the hazard domain in #3039 for 3.2 is a vector representation of the warning icon used by other note types.

This PR replaces the old jaggy bitmap icon with the vector image used in hazard statements.

## How Has This Been Tested?

Built distribution docs PDF to verify results:

![dita-ot-warning-icon-changes](https://user-images.githubusercontent.com/129995/57605619-5afb2300-7567-11e9-9a61-f0e9163f57ee.gif)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
