### PR TITLE
Fix processing errors for data objects

### DIFF
--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -482,7 +482,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
 
     private void parseObject(final Attributes atts) {
         URI attrValue = toURI(atts.getValue(ATTRIBUTE_NAME_DATA));
-        if (attrValue == null) {
+        if (attrValue == null || attrValue.isAbsolute()) {
             return;
         }
 
@@ -500,7 +500,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         filename = stripFragment(filename);
         assert filename.isAbsolute();
 
-        nonConrefCopytoTargets.add(new Reference(filename, ATTR_FORMAT_VALUE_HTML));
+        nonConrefCopytoTargets.add(new Reference(filename, ATTR_FORMAT_VALUE_NONDITA));
     }
 
     private void handleSubjectScheme(final Attributes atts) {

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1001,6 +1001,8 @@ public final class Constants {
     public static final String ATTR_FORMAT_VALUE_DITAVAL = "ditaval";
     public static final String ATTR_FORMAT_VALUE_IMAGE = "image";
     public static final String ATTR_FORMAT_VALUE_HTML = "html";
+    /** ATTR_FORMAT_VALUE_NONDITA = format unknown, but not DITA **/
+    public static final String ATTR_FORMAT_VALUE_NONDITA = "nondita";
     /**ATTRIBUTE_NAME_DITAARCHVERSION.*/
     public static final String ATTRIBUTE_NAME_DITAARCHVERSION = "DITAArchVersion";
     /**ATTRIBUTE_PREFIX_DITAARCHVERSION.*/

--- a/src/test/resources/keyref/exp/preprocess/a.xml
+++ b/src/test/resources/keyref/exp/preprocess/a.xml
@@ -30,6 +30,8 @@
       </dlentry>
     </dl>
     <lq keyref="lq" class="- topic/lq " href="b.xml" scope="peer"><keyword class="- topic/keyword ">lq keyword</keyword></lq>
+    <object class="- topic/object " datakeyref="object" data="https://example.com" format="html" scope="external"/>
+    <object class="- topic/object " data="https://example.com/fake-media-link"><desc class="- topic/desc ">Link to youtube or similar</desc></object>
   </body>
   <related-links class="- topic/related-links ">
     <link keyref="link" class="- topic/link " href="b.xml" scope="peer"><?ditaot usertext?><linktext class="- topic/linktext "><keyword class="- topic/keyword ">link keyword</keyword></linktext></link>

--- a/src/test/resources/keyref/exp/preprocess/test.ditamap
+++ b/src/test/resources/keyref/exp/preprocess/test.ditamap
@@ -211,4 +211,10 @@
       </keywords>
     </topicmeta>
   </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="object" href="https://example.com" scope="external" format="html" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Object test</navtitle>
+      <linktext class="- map/linktext ">Object test</linktext>
+    </topicmeta>
+  </keydef>
 </map>

--- a/src/test/resources/keyref/src/a.xml
+++ b/src/test/resources/keyref/src/a.xml
@@ -32,6 +32,8 @@
       </dlentry>
     </dl>
     <lq keyref="lq"></lq>
+    <object datakeyref="object"/>
+    <object data="https://example.com/fake-media-link"><desc>Link to youtube or similar</desc></object>
   </body>
   <related-links>
     <link keyref="link"/>

--- a/src/test/resources/keyref/src/test.ditamap
+++ b/src/test/resources/keyref/src/test.ditamap
@@ -157,4 +157,9 @@
       </keywords>
     </topicmeta>
   </keydef>
+  <keydef keys="object" href="https://example.com" scope="external" format="html">
+    <topicmeta>
+      <navtitle>Object test</navtitle>
+    </topicmeta>
+  </keydef>
 </map>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Fixes two issues with processing for `object` elements:

- With local files referenced by `object/@data`, we set a default of `format="html"` in our job configuration. Out of the box DITA-OT 3.3.1 treats anything referenced with `format="html"` as lightweight DITA, and tries to parse the file, so we automatically parse (and presumably fail) on any local media object referenced by `object/@data`. To fix this, I've changed the default format for media objects from `html` to `nondita`, which still copies it to the output directory but avoids trying to parse it for any HTML processing. Tested with `<object data="local-video.mp4"/>` which results in failures from `html2dita.xsl`
- With absolute external URLs, we treat the object referenced by `@data` as a local file. The way I see to work around this is by moving the value to a key and using `@datakeyref` but that should not be necessary - we should recognize that the URL is absolute and avoid treating it as a local (html) file. If the `org.lwdita` plugin is disabled so that we do not try and parse the file, it still fails later when we try to copy this as a local HTML file. To correct this, I've added a test for `attrValue.isAbsolute()` which avoids further processing of the `@data` target when it is an absolute reference. Tested with the following, which also fails in `html2dita.xsl`: `<object data="https://www.youtube.com/embed/BaUjhYw8IK4">`

## Motivation and Context

Ran in to both of these failures with DITA-OT 3.3.1 and `object` elements.

## How Has This Been Tested?

Tested with each of the values above. Zip file:
[object.zip](https://github.com/dita-ot/dita-ot/files/3173964/object.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
