### PR TITLE
Fix generated string 'continued'

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/bs.xml
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
   <variable id="Table of Contents">Sadržaj</variable>
-  <variable id="Index Continued String">continued</variable>
+  <variable id="Index Continued String">nastavak</variable>
   <variable id="Index See String">, Vidi </variable>
   <variable id="Index See Also String">Vidi takođe </variable>
   <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/da.xml
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Preface odd header"><param ref-name="prodname"/> | Forord | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Forord | <param ref-name="prodname"/></variable>
   <variable id="Table of Contents">Indholdsfortegnelse</variable>
-  <variable id="Index Continued String"></variable>
+  <variable id="Index Continued String">fortsat</variable>
   <variable id="Index See String">, Se </variable>
   <variable id="Index See Also String">Se også </variable>
   <variable id="Table of Contents Chapter">Kapitel <param ref-name="number"/>: </variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/sr-latn-me.xml
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Preface odd header"><param ref-name="prodname"/> | Predgovor | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Predgovor | <param ref-name="prodname"/></variable>
   <variable id="Table of Contents">Sadržaj</variable>
-  <variable id="Index Continued String">continued</variable><!--TODO:Index Continued String-->
+  <variable id="Index Continued String">nastavak</variable>
   <variable id="Index See String">, Vidi </variable>
   <variable id="Index See Also String">Vidi takođe </variable>
   <variable id="Table of Contents Chapter">Poglavlje <param ref-name="number"/>: </variable>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/vi.xml
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   <variable id="Preface odd header"><param ref-name="prodname"/> | Lời nói đầu | <param ref-name="pagenum"/></variable>
   <variable id="Preface even header"><param ref-name="pagenum"/> | Lời nói đầu | <param ref-name="prodname"/></variable>
   <variable id="Table of Contents">Nội dung</variable>
-  <variable id="Index Continued String"></variable>
+  <variable id="Index Continued String">tiếp tục</variable>
   <variable id="Index See String">, xem </variable>
   <variable id="Index See Also String">Xem thêm </variable>
   <variable id="Table of Contents Chapter">Chương <param ref-name="number"/>: </variable>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes two TODO instances where a set of translated strings each has English for the string "continued"; also adds the string "continued" for the two remaining sets that have no translation for that string.

## Motivation and Context

We recently started using this string in our PDF styles, and found it was broken / empty for these four languages. 

## How Has This Been Tested?

Validated as part of our own style - with these updates in place, the "continued" string appears correctly for all languages.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

