### PR TITLE
Fix for Saxon crash when calculating row headers

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -151,7 +151,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="ctx" as="element()"/>
     <xsl:choose>
       <xsl:when test="$ctx/@nameend">
-        <xsl:value-of select="xs:integer(count(table:get-ending-colspec($ctx)/preceding-sibling::*[contains(@class, ' topic/colspec ')])+1)"/>
+        <xsl:value-of select="xs:integer(table:get-ending-colspec($ctx)/@colnum)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="xs:integer($ctx/@dita-ot:x)"/>

--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -151,10 +151,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="ctx" as="element()"/>
     <xsl:choose>
       <xsl:when test="$ctx/@nameend">
-        <xsl:value-of select="xs:integer(table:get-ending-colspec($ctx)/@colnum)"/>
+        <xsl:sequence select="xs:integer(table:get-ending-colspec($ctx)/@colnum)"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="xs:integer($ctx/@dita-ot:x)"/>
+        <xsl:sequence select="xs:integer($ctx/@dita-ot:x)"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
@@ -166,7 +166,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="entryend" as="xs:integer"/>
     <xsl:param name="headerstart" as="xs:integer"/>
     <xsl:param name="headerend" as="xs:integer"/>
-    <xsl:sequence select="if ($entryend lt $headerstart or $entrystart gt $headerend) then (false()) else (true())"/>
+    <xsl:sequence select="not($entryend lt $headerstart or $entrystart gt $headerend)"/>
   </xsl:function>
   
   <xsl:function name="table:get-matching-thead-headers" as="xs:string*">

--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -105,6 +105,15 @@ See the accompanying LICENSE file for applicable license.
       [@colname eq $entry/@colname]
     "/>
   </xsl:function>
+  
+  <xsl:function name="table:get-ending-colspec" as="element()?">
+    <xsl:param name="entry" as="element()"/>
+    
+    <xsl:sequence select="
+      table:get-current-tgroup($entry)/*[contains(@class, ' topic/colspec ')]
+      [@colname eq $entry/@nameend]
+      "/>
+  </xsl:function>
 
   <xsl:function name="table:get-entry-align" as="attribute(align)?">
     <xsl:param name="el" as="element()"/>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -328,7 +328,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="number($startCurrentRow) > number($endMatchRow)"/>
       <!-- Otherwise, the column-1 cell is aligned with the tbody cell, so save the ID and continue -->
       <xsl:otherwise>
-        <xsl:value-of select="generate-id(.)"/><xsl:text> </xsl:text>
+        <xsl:value-of select="if(@id) then dita-ot:generate-html-id(.) else generate-id(.)"/>
+        <xsl:text> </xsl:text>
         <!-- If we are not at the end of the tbody cell, and more rows exist, continue testing column 1 -->
         <xsl:if test="number($endCurrentRow) &lt; number($endMatchRow) and
                       parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -272,11 +272,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="startmatch" select="1"/>  <!-- start column of the tbody cell -->
     <xsl:param name="endmatch" select="1"/>    <!-- end column of the tbody cell -->
     <xsl:variable name="entrystartpos" select="@dita-ot:x"/>         <!-- start column of this thead cell -->
-    <xsl:variable name="entryendpos">           <!-- end column of this thead cell -->
-      <xsl:call-template name="find-entry-end-position">
+    <xsl:variable name="entryendpos" select="table:find-entry-end-column(.)"/>           <!-- end column of this thead cell -->
+      <!--<xsl:call-template name="find-entry-end-position">
         <xsl:with-param name="startposition" select="$entrystartpos"/>
-      </xsl:call-template>
-    </xsl:variable>
+      </xsl:call-template>-->
+    <!--</xsl:variable>-->
     <!-- The test cell can be any of the following:
          * completely before the header range (ignore id)
          * completely after the header range (ignore id)
@@ -349,42 +349,52 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="entrystartpos" select="@dita-ot:x">
     </xsl:variable>
     <!-- Determine the end column for the current cell -->
-    <xsl:variable name="entryendpos">
-      <xsl:call-template name="find-entry-end-position">
-        <xsl:with-param name="startposition" select="$entrystartpos"/>
-      </xsl:call-template>
-    </xsl:variable>
-    <!-- Find the IDs of headers that are aligned above this cell. This is done by applying
-         templates on all headers, using mode=findmatch; matching IDs are returned. -->
+    <xsl:variable name="entryendpos" select="table:find-entry-end-column(.)"/>
+    <!-- Find the IDs of all headers that are aligned above this cell. May contain duplicates due to spanning cells. -->
+    <xsl:variable name="all-thead-headers" select="table:get-matching-thead-headers(.)" as="xs:string*"/>
     <xsl:variable name="hdrattr">
+      <xsl:for-each select="distinct-values($all-thead-headers)">
+        <xsl:value-of select="concat(.,' ')"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <!-- Row header should be 0 or 1 today, but future updates may allow multiple -->
+    <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>
+    <xsl:variable name="rowheader">
+      <xsl:for-each select="distinct-values($all-row-headers)">
+        <xsl:value-of select="concat(.,' ')"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <!--<xsl:variable name="hdrattr">
       <xsl:apply-templates select="../../../*[contains(@class, ' topic/thead ')]/
                                             *[contains(@class, ' topic/row ')]/
                                             *[contains(@class, ' topic/entry ')]" mode="findmatch">
         <xsl:with-param name="startmatch" select="$entrystartpos"/>
         <xsl:with-param name="endmatch" select="$entryendpos"/>
       </xsl:apply-templates>
-    </xsl:variable>
-    <!-- Find the IDs of headers in the first column, which are aligned with this cell -->
-    <xsl:variable name="rowheader">
-      <!-- If this entry is not in the first column or in thead, and @rowheader=firstcol on table -->
+    </xsl:variable>-->
+    <!-- Find the ID of header in the first column, which is aligned with this cell -->
+    <!--<xsl:variable name="rowheader">
+      <!-\- If this entry is not in the first column or in thead, and @rowheader=firstcol on table -\->
       <xsl:if test="not(number($entrystartpos) = 1) and
                     not(parent::*/parent::*[contains(@class, ' topic/thead ')]) and
                     ../../../../@rowheader = 'firstcol'">
-        <!-- Find the start row for this entry -->
-        <xsl:variable name="startrow" select="number(count(parent::*/preceding-sibling::*[contains(@class, ' topic/row ')])+1)"/>
-        <!-- Find the end row for this entry -->
+        <xsl:value-of select="table:get-matching-row-headers(.)"/>
+        <xsl:text> </xsl:text>
+        <!-\- Find the start row for this entry -\->
+        <!-\-<xsl:variable name="startrow" select="number(count(parent::*/preceding-sibling::*[contains(@class, ' topic/row ')])+1)"/>
+        <!-\\- Find the end row for this entry -\\->
         <xsl:variable name="endrow">
           <xsl:if test="@morerows"><xsl:value-of select="number($startrow) + number(@morerows)"/></xsl:if>
           <xsl:if test="not(@morerows)"><xsl:value-of select="$startrow"/></xsl:if>
         </xsl:variable>
-        <!-- Scan first-column entries for ones that align with this cell, starting with
-             the first entry in the first row -->
+        <!-\\- Scan first-column entries for ones that align with this cell, starting with
+             the first entry in the first row -\\->
         <xsl:apply-templates select="../../*[contains(@class, ' topic/row ')][1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
           <xsl:with-param name="startMatchRow" select="$startrow"/>
           <xsl:with-param name="endMatchRow" select="$endrow"/>
-        </xsl:apply-templates>
+        </xsl:apply-templates>-\->
       </xsl:if>
-    </xsl:variable>
+    </xsl:variable>-->
      <xsl:if test="string-length($rowheader) > 0 or string-length($hdrattr) > 0">
       <xsl:attribute name="headers" select="concat($rowheader, $hdrattr)"/>
     </xsl:if>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -255,6 +255,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Find the end column of a cell. If the cell does not span any columns,
        the end position is the same as the start position. -->
+  <!-- DEPRECATED: use table:find-entry-end-column -->
   <xsl:template name="find-entry-end-position">
     <xsl:param name="startposition" select="0"/>
     <xsl:choose>
@@ -268,6 +269,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <!-- Check <thead> entries, and return IDs for those which match the desired column -->
+  <!-- DEPRECATED: use table:get-matching-thead-headers -->
   <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="findmatch">
     <xsl:param name="startmatch" select="1"/>  <!-- start column of the tbody cell -->
     <xsl:param name="endmatch" select="1"/>    <!-- end column of the tbody cell -->
@@ -301,6 +303,7 @@ See the accompanying LICENSE file for applicable license.
        Any entries that line up need to have the header saved. This template is first
        called with the first entry of the first row in <tbody>. It is called from here
        on the next cell in column one.            -->
+  <!-- DEPRECATED: use table:get-matching-row-headers -->
   <xsl:template match="*[contains(@class, ' topic/entry ')]" mode="check-first-column">
     <xsl:param name="startMatchRow" select="1"/>   <!-- First row of the tbody cell we are matching -->
     <xsl:param name="endMatchRow" select="1"/>     <!-- Last row of the tbody cell we are matching -->
@@ -345,58 +348,19 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Add @headers to cells in the body of a table. -->
   <xsl:template name="add-headers-attribute">
-    <!-- Determine the start column for the current cell -->
-    <xsl:variable name="entrystartpos" select="@dita-ot:x">
-    </xsl:variable>
-    <!-- Determine the end column for the current cell -->
-    <xsl:variable name="entryendpos" select="table:find-entry-end-column(.)"/>
     <!-- Find the IDs of all headers that are aligned above this cell. May contain duplicates due to spanning cells. -->
     <xsl:variable name="all-thead-headers" select="table:get-matching-thead-headers(.)" as="xs:string*"/>
-    <xsl:variable name="hdrattr">
-      <xsl:for-each select="distinct-values($all-thead-headers)">
-        <xsl:value-of select="concat(.,' ')"/>
-      </xsl:for-each>
-    </xsl:variable>
     <!-- Row header should be 0 or 1 today, but future updates may allow multiple -->
     <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>
-    <xsl:variable name="rowheader">
-      <xsl:for-each select="distinct-values($all-row-headers)">
-        <xsl:value-of select="concat(.,' ')"/>
-      </xsl:for-each>
-    </xsl:variable>
-    <!--<xsl:variable name="hdrattr">
-      <xsl:apply-templates select="../../../*[contains(@class, ' topic/thead ')]/
-                                            *[contains(@class, ' topic/row ')]/
-                                            *[contains(@class, ' topic/entry ')]" mode="findmatch">
-        <xsl:with-param name="startmatch" select="$entrystartpos"/>
-        <xsl:with-param name="endmatch" select="$entryendpos"/>
-      </xsl:apply-templates>
-    </xsl:variable>-->
-    <!-- Find the ID of header in the first column, which is aligned with this cell -->
-    <!--<xsl:variable name="rowheader">
-      <!-\- If this entry is not in the first column or in thead, and @rowheader=firstcol on table -\->
-      <xsl:if test="not(number($entrystartpos) = 1) and
-                    not(parent::*/parent::*[contains(@class, ' topic/thead ')]) and
-                    ../../../../@rowheader = 'firstcol'">
-        <xsl:value-of select="table:get-matching-row-headers(.)"/>
-        <xsl:text> </xsl:text>
-        <!-\- Find the start row for this entry -\->
-        <!-\-<xsl:variable name="startrow" select="number(count(parent::*/preceding-sibling::*[contains(@class, ' topic/row ')])+1)"/>
-        <!-\\- Find the end row for this entry -\\->
-        <xsl:variable name="endrow">
-          <xsl:if test="@morerows"><xsl:value-of select="number($startrow) + number(@morerows)"/></xsl:if>
-          <xsl:if test="not(@morerows)"><xsl:value-of select="$startrow"/></xsl:if>
-        </xsl:variable>
-        <!-\\- Scan first-column entries for ones that align with this cell, starting with
-             the first entry in the first row -\\->
-        <xsl:apply-templates select="../../*[contains(@class, ' topic/row ')][1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
-          <xsl:with-param name="startMatchRow" select="$startrow"/>
-          <xsl:with-param name="endMatchRow" select="$endrow"/>
-        </xsl:apply-templates>-\->
-      </xsl:if>
-    </xsl:variable>-->
-     <xsl:if test="string-length($rowheader) > 0 or string-length($hdrattr) > 0">
-      <xsl:attribute name="headers" select="concat($rowheader, $hdrattr)"/>
+    <xsl:if test="exists($all-row-headers) or exists($all-thead-headers)">
+       <xsl:attribute name="headers">
+         <xsl:for-each select="distinct-values($all-row-headers)">
+           <xsl:value-of select="concat(.,' ')"/>
+         </xsl:for-each>
+        <xsl:for-each select="distinct-values($all-thead-headers)">
+          <xsl:value-of select="concat(.,' ')"/>
+        </xsl:for-each>
+      </xsl:attribute>
     </xsl:if>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -574,6 +574,9 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[table:is-tbody-entry(.)]" mode="headers">
+    <xsl:if test="table:is-row-header(.)">
+      <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>
+    </xsl:if>
     <xsl:call-template name="add-headers-attribute"/>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -255,7 +255,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Find the end column of a cell. If the cell does not span any columns,
        the end position is the same as the start position. -->
-  <!-- DEPRECATED: use table:find-entry-end-column -->
+  <!-- DEPRECATED since 3.3: use table:find-entry-end-column -->
   <xsl:template name="find-entry-end-position">
     <xsl:param name="startposition" select="0"/>
     <xsl:choose>
@@ -269,16 +269,12 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <!-- Check <thead> entries, and return IDs for those which match the desired column -->
-  <!-- DEPRECATED: use table:get-matching-thead-headers -->
+  <!-- DEPRECATED since 3.3: use table:get-matching-thead-headers -->
   <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="findmatch">
     <xsl:param name="startmatch" select="1"/>  <!-- start column of the tbody cell -->
     <xsl:param name="endmatch" select="1"/>    <!-- end column of the tbody cell -->
     <xsl:variable name="entrystartpos" select="@dita-ot:x"/>         <!-- start column of this thead cell -->
     <xsl:variable name="entryendpos" select="table:find-entry-end-column(.)"/>           <!-- end column of this thead cell -->
-      <!--<xsl:call-template name="find-entry-end-position">
-        <xsl:with-param name="startposition" select="$entrystartpos"/>
-      </xsl:call-template>-->
-    <!--</xsl:variable>-->
     <!-- The test cell can be any of the following:
          * completely before the header range (ignore id)
          * completely after the header range (ignore id)
@@ -303,7 +299,7 @@ See the accompanying LICENSE file for applicable license.
        Any entries that line up need to have the header saved. This template is first
        called with the first entry of the first row in <tbody>. It is called from here
        on the next cell in column one.            -->
-  <!-- DEPRECATED: use table:get-matching-row-headers -->
+  <!-- DEPRECATED since 3.3: use table:get-matching-row-headers -->
   <xsl:template match="*[contains(@class, ' topic/entry ')]" mode="check-first-column">
     <xsl:param name="startMatchRow" select="1"/>   <!-- First row of the tbody cell we are matching -->
     <xsl:param name="endMatchRow" select="1"/>     <!-- Last row of the tbody cell we are matching -->
@@ -353,14 +349,9 @@ See the accompanying LICENSE file for applicable license.
     <!-- Row header should be 0 or 1 today, but future updates may allow multiple -->
     <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>
     <xsl:if test="exists($all-row-headers) or exists($all-thead-headers)">
-       <xsl:attribute name="headers">
-         <xsl:for-each select="distinct-values($all-row-headers)">
-           <xsl:value-of select="concat(.,' ')"/>
-         </xsl:for-each>
-        <xsl:for-each select="distinct-values($all-thead-headers)">
-          <xsl:value-of select="concat(.,' ')"/>
-        </xsl:for-each>
-      </xsl:attribute>
+      <xsl:attribute name="headers"
+        select="distinct-values($all-row-headers), distinct-values($all-thead-headers)"
+        separator=" "/>
     </xsl:if>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2016 Eero Helenius
+
+See the accompanying LICENSE file for applicable license.
+
+Copied from HTML5 plugin to make table and simpletable functions available to XHTML.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+                xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
+                version="2.0"
+                exclude-result-prefixes="xs dita-ot table">
+
+  <xsl:function name="table:is-tbody-entry" as="xs:boolean">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      contains($el/@class, ' topic/entry ') and contains($el/../../@class, ' topic/tbody ')
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:is-thead-entry" as="xs:boolean">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      contains($el/@class, ' topic/entry ') and contains($el/../../@class, ' topic/thead ')
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-current-table" as="element()">
+    <xsl:param name="node" as="node()"/>
+
+    <xsl:sequence select="
+      $node/ancestor-or-self::*[contains(@class, ' topic/table ')][1]
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-current-tgroup" as="element()">
+    <xsl:param name="node" as="node()"/>
+
+    <xsl:sequence select="
+      $node/ancestor-or-self::*[contains(@class, ' topic/tgroup ')][1]
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:is-row-header" as="xs:boolean">
+    <xsl:param name="entry" as="element()"/>
+
+    <xsl:sequence select="
+      table:get-current-table($entry)/@rowheader eq 'firstcol'
+      and xs:integer($entry/@dita-ot:x) eq 1
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-entry-colspec" as="element()?">
+    <xsl:param name="entry" as="element()"/>
+
+    <xsl:sequence select="
+      table:get-current-tgroup($entry)/*[contains(@class, ' topic/colspec ')]
+      [@colname eq $entry/@colname]
+    "/>
+  </xsl:function>
+  
+  <xsl:function name="table:get-ending-colspec" as="element()?">
+    <xsl:param name="entry" as="element()"/>
+    
+    <xsl:sequence select="
+      table:get-current-tgroup($entry)/*[contains(@class, ' topic/colspec ')]
+      [@colname eq $entry/@nameend]
+      "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-entry-align" as="attribute(align)?">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      ($el/@align,
+       table:get-current-tgroup($el)/@align,
+       table:get-entry-colspec($el)/@align)[1]
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-entry-colsep" as="attribute(colsep)?">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      ($el/@colsep,
+       table:get-entry-colspec($el)/@colsep,
+       table:get-current-table($el)/@colsep,
+       table:get-current-tgroup($el)/@colsep)[1]
+    "/>
+  </xsl:function>
+
+  <xsl:function name="table:get-entry-rowsep" as="attribute(rowsep)?">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      ($el/@rowsep,
+       table:get-entry-colspec($el)/@rowsep,
+       table:get-current-table($el)/@rowsep,
+       table:get-current-tgroup($el)/@rowsep)[1]
+    "/>
+  </xsl:function>
+  
+  <xsl:function name="table:find-entry-end-column" as="xs:integer">
+    <xsl:param name="ctx" as="element()"/>
+    <xsl:choose>
+      <xsl:when test="$ctx/@nameend">
+        <xsl:value-of select="xs:integer(table:get-ending-colspec($ctx)/@colnum)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="xs:integer($ctx/@dita-ot:x)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  
+  <!-- Return true if an entry is entirely within the X or Y span of the header.
+       If entry ends before the header, or starts after the header, no match, otherwise there is overlap. -->
+  <xsl:function name="table:entry-within-range" as="xs:boolean">
+    <xsl:param name="entrystart" as="xs:integer"/>
+    <xsl:param name="entryend" as="xs:integer"/>
+    <xsl:param name="headerstart" as="xs:integer"/>
+    <xsl:param name="headerend" as="xs:integer"/>
+    <xsl:sequence select="if ($entryend lt $headerstart or $entrystart gt $headerend) then (false()) else (true())"/>
+  </xsl:function>
+  
+  <xsl:function name="table:get-matching-thead-headers" as="xs:string*">
+    <xsl:param name="ctx" as="element()"/>
+    <xsl:variable name="startposition" select="xs:integer($ctx/@dita-ot:x)"/>
+    <xsl:variable name="endposition" select="table:find-entry-end-column($ctx)"/>
+    <xsl:for-each select="$ctx/../../../*[contains(@class,' topic/thead ')]/*[contains(@class,' topic/row ')]/*[contains(@class,' topic/entry ')]">
+      <xsl:variable name="headstart" select="xs:integer(@dita-ot:x)"/>
+      <xsl:variable name="headend" select="table:find-entry-end-column(.)"/>
+      <xsl:if test="table:entry-within-range($startposition, $endposition, $headstart, $headend)">
+        <xsl:value-of select="dita-ot:generate-html-id(.)"/>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:function>
+  
+  <xsl:function name="table:get-matching-row-headers" as="xs:string*">
+    <xsl:param name="ctx" as="element()"/>
+    <xsl:if test="table:get-current-table($ctx)/@rowheader='firstcol' and 
+      $ctx/@dita-ot:x != '1' and
+      not(table:is-thead-entry($ctx))">
+      <xsl:variable name="startposition" select="xs:integer($ctx/@dita-ot:y)"/>
+      <xsl:variable name="endposition" select="if ($ctx/@morerows) then ($startposition + xs:integer($ctx/@morerows)) else $startposition"/>
+      <xsl:choose>
+        <xsl:when test="($startposition = $endposition) and $ctx/preceding-sibling::*[contains(@class,' topic/entry ')][@dita-ot:x = '1']">
+          <!-- Quick result for common simplest case: no spanning and first-col row header is in this row -->
+          <xsl:value-of select="dita-ot:generate-html-id($ctx/preceding-sibling::*[contains(@class,' topic/entry ')][@dita-ot:x ='1'])"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="$ctx/../../*[contains(@class,' topic/row ')]/*[contains(@class,' topic/entry ')][@dita-ot:x='1']">
+            <xsl:variable name="headstart" select="xs:integer(@dita-ot:y)"/>
+            <xsl:variable name="headend" select="if (@morerows) then ($headstart + xs:integer(@morerows)) else $headstart"/>
+            <xsl:if test="table:entry-within-range($startposition, $endposition, $headstart, $headend)">
+              <xsl:value-of select="dita-ot:generate-html-id(.)"/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+
+  <xsl:function name="simpletable:is-body-entry" as="xs:boolean">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      contains($el/@class, ' topic/stentry ') and contains($el/../@class, ' topic/strow ')
+    "/>
+  </xsl:function>
+
+  <xsl:function name="simpletable:is-head-entry" as="xs:boolean">
+    <xsl:param name="el" as="element()"/>
+
+    <xsl:sequence select="
+      contains($el/@class, ' topic/stentry ') and contains($el/../@class, ' topic/sthead ')
+    "/>
+  </xsl:function>
+
+  <xsl:function name="simpletable:get-current-table" as="element()">
+    <xsl:param name="node" as="node()"/>
+
+    <xsl:sequence select="
+      $node/ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]
+    "/>
+  </xsl:function>
+
+  <xsl:function name="simpletable:is-keycol-entry" as="xs:boolean">
+    <xsl:param name="entry" as="element()"/>
+
+    <xsl:variable name="table" as="element()"
+      select="simpletable:get-current-table($entry)"/>
+
+    <xsl:sequence select="
+      $table/@keycol and xs:integer($table/@keycol) eq count($entry/preceding-sibling::*) + 1
+    "/>
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
@@ -126,7 +126,7 @@ Copied from HTML5 plugin to make table and simpletable functions available to XH
     <xsl:param name="entryend" as="xs:integer"/>
     <xsl:param name="headerstart" as="xs:integer"/>
     <xsl:param name="headerend" as="xs:integer"/>
-    <xsl:sequence select="if ($entryend lt $headerstart or $entrystart gt $headerend) then (false()) else (true())"/>
+    <xsl:sequence select="not($entryend lt $headerstart or $entrystart gt $headerend)"/>
   </xsl:function>
   
   <xsl:function name="table:get-matching-thead-headers" as="xs:string*">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -10,9 +10,12 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                exclude-result-prefixes="xs dita-ot dita2html ditamsg">
+                exclude-result-prefixes="xs dita-ot dita2html ditamsg table">
+  
+  <xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/tablefunctions.xsl"/>
 
 <!-- =========== CALS (OASIS) TABLE =========== -->
   
@@ -551,6 +554,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Find the end column of a cell. If the cell does not span any columns,
      the end position is the same as the start position. -->
+<!-- DEPRECATED: use table:find-entry-end-column -->  
 <xsl:template name="find-entry-end-position">
   <xsl:param name="startposition" select="0"/>
   <xsl:choose>
@@ -564,6 +568,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <!-- Check <thead> entries, and return IDs for those which match the desired column -->
+<!-- DEPRECATED: use table:get-matching-thead-headers -->
 <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="findmatch">
   <xsl:param name="startmatch" select="1"/>  <!-- start column of the tbody cell -->
   <xsl:param name="endmatch" select="1"/>    <!-- end column of the tbody cell -->
@@ -597,6 +602,7 @@ See the accompanying LICENSE file for applicable license.
      Any entries that line up need to have the header saved. This template is first
      called with the first entry of the first row in <tbody>. It is called from here
      on the next cell in column one.            -->
+<!-- DEPRECATED: use table:get-matching-row-headers -->
 <xsl:template match="*[contains(@class, ' topic/entry ')]" mode="check-first-column">
   <xsl:param name="startMatchRow" select="1"/>   <!-- First row of the tbody cell we are matching -->
   <xsl:param name="endMatchRow" select="1"/>     <!-- Last row of the tbody cell we are matching -->
@@ -641,48 +647,19 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Add @headers to cells in the body of a table. -->
 <xsl:template name="add-headers-attribute">
-  <!-- Determine the start column for the current cell -->
-  <xsl:variable name="entrystartpos" select="@dita-ot:x">
-  </xsl:variable>
-  <!-- Determine the end column for the current cell -->
-  <xsl:variable name="entryendpos">
-    <xsl:call-template name="find-entry-end-position">
-      <xsl:with-param name="startposition" select="$entrystartpos"/>
-    </xsl:call-template>
-  </xsl:variable>
-  <!-- Find the IDs of headers that are aligned above this cell. This is done by applying
-       templates on all headers, using mode=findmatch; matching IDs are returned. -->
-  <xsl:variable name="hdrattr">
-    <xsl:apply-templates select="../../../*[contains(@class, ' topic/thead ')]/
-                                          *[contains(@class, ' topic/row ')]/
-                                          *[contains(@class, ' topic/entry ')]" mode="findmatch">
-      <xsl:with-param name="startmatch" select="$entrystartpos"/>
-      <xsl:with-param name="endmatch" select="$entryendpos"/>
-    </xsl:apply-templates>
-  </xsl:variable>
-  <!-- Find the IDs of headers in the first column, which are aligned with this cell -->
-  <xsl:variable name="rowheader">
-    <!-- If this entry is not in the first column or in thead, and @rowheader=firstcol on table -->
-    <xsl:if test="not(number($entrystartpos) = 1) and
-                  not(parent::*/parent::*[contains(@class, ' topic/thead ')]) and
-                  ../../../../@rowheader = 'firstcol'">
-      <!-- Find the start row for this entry -->
-      <xsl:variable name="startrow" select="number(count(parent::*/preceding-sibling::*[contains(@class, ' topic/row ')])+1)"/>
-      <!-- Find the end row for this entry -->
-      <xsl:variable name="endrow">
-        <xsl:if test="@morerows"><xsl:value-of select="number($startrow) + number(@morerows)"/></xsl:if>
-        <xsl:if test="not(@morerows)"><xsl:value-of select="$startrow"/></xsl:if>
-      </xsl:variable>
-      <!-- Scan first-column entries for ones that align with this cell, starting with
-           the first entry in the first row -->
-      <xsl:apply-templates select="../../*[contains(@class, ' topic/row ')][1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
-        <xsl:with-param name="startMatchRow" select="$startrow"/>
-        <xsl:with-param name="endMatchRow" select="$endrow"/>
-      </xsl:apply-templates>
-    </xsl:if>
-  </xsl:variable>
-   <xsl:if test="string-length($rowheader) > 0 or string-length($hdrattr) > 0">
-    <xsl:attribute name="headers" select="concat($rowheader, $hdrattr)"/>
+  <!-- Find the IDs of all headers that are aligned above this cell. May contain duplicates due to spanning cells. -->
+  <xsl:variable name="all-thead-headers" select="table:get-matching-thead-headers(.)" as="xs:string*"/>
+  <!-- Row header should be 0 or 1 today, but future updates may allow multiple -->
+  <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>
+  <xsl:if test="exists($all-row-headers) or exists($all-thead-headers)">
+    <xsl:attribute name="headers">
+      <xsl:for-each select="distinct-values($all-row-headers)">
+        <xsl:value-of select="concat(.,' ')"/>
+      </xsl:for-each>
+      <xsl:for-each select="distinct-values($all-thead-headers)">
+        <xsl:value-of select="concat(.,' ')"/>
+      </xsl:for-each>
+    </xsl:attribute>
   </xsl:if>
 </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -554,7 +554,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Find the end column of a cell. If the cell does not span any columns,
      the end position is the same as the start position. -->
-<!-- DEPRECATED: use table:find-entry-end-column -->  
+<!-- DEPRECATED since 3.3: use table:find-entry-end-column -->  
 <xsl:template name="find-entry-end-position">
   <xsl:param name="startposition" select="0"/>
   <xsl:choose>
@@ -568,7 +568,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <!-- Check <thead> entries, and return IDs for those which match the desired column -->
-<!-- DEPRECATED: use table:get-matching-thead-headers -->
+<!-- DEPRECATED since 3.3: use table:get-matching-thead-headers -->
 <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]" mode="findmatch">
   <xsl:param name="startmatch" select="1"/>  <!-- start column of the tbody cell -->
   <xsl:param name="endmatch" select="1"/>    <!-- end column of the tbody cell -->
@@ -602,7 +602,7 @@ See the accompanying LICENSE file for applicable license.
      Any entries that line up need to have the header saved. This template is first
      called with the first entry of the first row in <tbody>. It is called from here
      on the next cell in column one.            -->
-<!-- DEPRECATED: use table:get-matching-row-headers -->
+<!-- DEPRECATED since 3.3: use table:get-matching-row-headers -->
 <xsl:template match="*[contains(@class, ' topic/entry ')]" mode="check-first-column">
   <xsl:param name="startMatchRow" select="1"/>   <!-- First row of the tbody cell we are matching -->
   <xsl:param name="endMatchRow" select="1"/>     <!-- Last row of the tbody cell we are matching -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -624,7 +624,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:when test="number($startCurrentRow) > number($endMatchRow)"/>
     <!-- Otherwise, the column-1 cell is aligned with the tbody cell, so save the ID and continue -->
     <xsl:otherwise>
-      <xsl:value-of select="generate-id(.)"/><xsl:text> </xsl:text>
+      <xsl:value-of select="if(@id) then dita-ot:generate-html-id(.) else generate-id(.)"/>
+      <xsl:text> </xsl:text>
       <!-- If we are not at the end of the tbody cell, and more rows exist, continue testing column 1 -->
       <xsl:if test="number($endCurrentRow) &lt; number($endMatchRow) and
                     parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Table entries in XHTML and HTML5 currently add `@headers` attributes for accessibility purposes - it explicitly identifies header cells to help screen readers.

This pull request refactors code as part of fixing several problems:

- If an entry in the first column is a header today, and it specifies `@id`, the `@headers` value refers to a generated ID rather than to the explicit ID. This is fixed for XHTML and HTML5.
- Finding the appropriately aligned row header is horribly inefficient. It uses recursion to check every table entry for spanning, to ensure the correct position of the current entry is known, and then uses similar recursion to find header entries that line up. Last week a customer had a table with nearly 1,500 lines, which crashed Saxon due to too many recursive calls as part of this calculation. The old method is now replaced with much simpler, non-recursive tests that make use of `@dita-ot:x` and `@dita-ot:y`, which were added by `preprocess` long ago.
- Finding the appropriately aligned `thead` headers was not as bad because those headers never reach that size, but it has also been refactored to make use of `x`/`y` values.
- To reuse this logic as much as possible (without creating dependencies between XHTML and HTML5), the functions were added to existing HTML5 table functions, and those (table-only) functions were copied to XHTML for use in that code.

If this were for a major release, I'd remove the obsolete functions that used recursion. This is intended as a hotfix for a problem in the current release so I've left them in (marked deprecated) to avoid any compatibility issues.

## Motivation and Context

Fixes the crash that results from inefficient processing, and fixes smaller defects noticed while pursuing that bug.

## How Has This Been Tested?

Topic that includes tables with no headers, just row headers, just `thead` headers, and a 1,500 row table with spanning rows, columns, and headers.
[longtable.zip](https://github.com/dita-ot/dita-ot/files/3234191/longtable.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

Need to add `xspec` tests for the new table functions in HTML5 but wanted to open this first to get the  started on the pull request.
