### PR TITLE
Preserve flags for generated links

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -596,9 +596,9 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
   
-  <xsl:template match="@*|*|text()" mode="add-props-to-link">
+  <xsl:template match="@*|node()" mode="add-props-to-link">
     <xsl:copy>
-      <xsl:apply-templates select="@*|*|text()" mode="add-props-to-link"/>
+      <xsl:apply-templates select="@*|node()" mode="add-props-to-link"/>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="@imageref" mode="add-props-to-link">

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -575,6 +575,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:attribute name="otherrole" select="$otherrole"/>
         </xsl:if>
         <!--figure out the linktext and desc-->
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="add-props-to-link"/>
         <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
           <!--Do not output linktext when The final output type is PDF or IDD
             The target of the HREF is a local DITA file
@@ -590,8 +591,19 @@ See the accompanying LICENSE file for applicable license.
           <!-- add desc node and text -->
           <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]"/>
         </xsl:if>
+        <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="add-props-to-link"/>
       </link>
     </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="@*|*|text()" mode="add-props-to-link">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|*|text()" mode="add-props-to-link"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="@imageref" mode="add-props-to-link">
+    <xsl:param name="pathBackToMapDirectory" as="xs:string" tunnel="yes"/>
+    <xsl:attribute name="imageref" select="concat($pathBackToMapDirectory,.)"/>    
   </xsl:template>
   
   <!-- create a template to get child nodes and text -->

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -55,6 +55,7 @@ with those set forth herein.
     </dita-ot-fail>
     
     <property name="preprocess.copy-image.skip" value="true"/>
+    <property name="preprocess.copy-flag.skip" value="true"/>
     <property name="clean-preprocess.use-result-filename" value="false"/>
     <condition property="preprocess.chunk.skip" value="true">
       <isfalse value="${org.dita.pdf2.chunk.enabled}"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Preserves style / image flagging for generated links. These worked in a previous release but was lost when filter/flag processing moved to the start of pre-processing.

In 2.x, flagging was done at the end of preprocess, after links were already added to topics. Generated links contained all flagging property attributes, so they were flagged at that point.

Now that flagging moved early in the pipeline, the flag information is added before links are created. Any flags associated with the attributes are present in the `<topicref>` that generates the link, but are ignored. This update copies any flag associated with the `<topicref>` into generated links to that `<topciref>`.

## Motivation and Context

Some customers rely heavily on flagging to help identify relevant links. This disappeared with our upgrade form 2.5 to 3.3.

## How Has This Been Tested?

Same test case attached to #3316 

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
