### PR TITLE
Preserve xml:lang when processing links

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
@@ -81,6 +81,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="links" as="node()*"/>
         <xsl:if test="exists($links)">
           <linklist class="- topic/linklist " outputclass="relinfo relref">
+            <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
             <xsl:sequence select="$links"/>
           </linklist>
         </xsl:if>

--- a/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
@@ -81,7 +81,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="links" as="node()*"/>
         <xsl:if test="exists($links)">
           <linklist class="- topic/linklist " outputclass="relinfo relref">
-            <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+            <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
             <xsl:sequence select="$links"/>
           </linklist>
         </xsl:if>

--- a/src/main/plugins/org.dita.html5/xsl/concept.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/concept.xsl
@@ -32,7 +32,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
-      <title class="- topic/title ">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related concepts'"/>
           </xsl:call-template>

--- a/src/main/plugins/org.dita.html5/xsl/concept.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/concept.xsl
@@ -32,7 +32,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related concepts'"/>

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -308,7 +308,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -308,6 +308,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -279,7 +279,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>
@@ -580,8 +580,9 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--linklists-->
   <xsl:template match="*[contains(@class, ' topic/linklist ')]/@xml:lang" priority="100">
-    <xsl:if test="(empty(parent::*/ancestor::*[@xml:lang][1]/@xml:lang) and .!=$DEFAULTLANG) or
-                  .!=parent::*/ancestor::*[@xml:lang][1]/@xml:lang">
+    <xsl:variable name="ancestorLang" select="parent::*/ancestor::*[@xml:lang][1]/@xml:lang" as="attribute()?"/>
+    <xsl:if test="(empty($ancestorLang) and .!=$DEFAULTLANG) or
+                  .!=$ancestorLang">
       <xsl:next-match/>
     </xsl:if>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -279,6 +279,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>
@@ -578,6 +579,12 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
   </xsl:template>
 
   <!--linklists-->
+  <xsl:template match="*[contains(@class, ' topic/linklist ')]/@xml:lang" priority="100">
+    <xsl:if test="(empty(parent::*/ancestor::*[@xml:lang][1]/@xml:lang) and .!=$DEFAULTLANG) or
+                  .!=parent::*/ancestor::*[@xml:lang][1]/@xml:lang">
+      <xsl:next-match/>
+    </xsl:if>
+  </xsl:template>
   <xsl:template match="*[contains(@class, ' topic/linklist ')]" name="topic.linklist">
     <xsl:choose>
       <!-- if this is a first-level linklist with no child links in it, put it in a div (flush left)-->

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -679,7 +679,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -679,6 +679,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -727,6 +727,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>
@@ -757,6 +758,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related concepts'"/>
@@ -787,6 +789,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>
@@ -817,6 +820,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -727,7 +727,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>
@@ -758,7 +758,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related concepts'"/>
@@ -789,7 +789,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>
@@ -820,7 +820,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
@@ -31,12 +31,13 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="links" as="node()*"/>
         <xsl:if test="normalize-space(string-join($links, ''))">
           <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
+            <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
             <title class="- topic/title ">
-                  <xsl:call-template name="getVariable">
-                      <xsl:with-param name="id" select="'Related concepts'"/>
-                  </xsl:call-template>
-              </title>
-              <xsl:copy-of select="$links"/>
+              <xsl:call-template name="getVariable">
+                <xsl:with-param name="id" select="'Related concepts'"/>
+              </xsl:call-template>
+            </title>
+            <xsl:copy-of select="$links"/>
           </linklist>
         </xsl:if>
     </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
@@ -31,7 +31,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="links" as="node()*"/>
         <xsl:if test="normalize-space(string-join($links, ''))">
           <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
-            <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+            <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
             <title class="- topic/title ">
               <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Related concepts'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
@@ -373,6 +373,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
@@ -373,7 +373,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo relref">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related reference'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -293,6 +293,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>
@@ -600,6 +601,12 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
   </xsl:template>
 
   <!--linklists-->
+  <xsl:template match="*[contains(@class, ' topic/linklist ')]/@xml:lang" priority="100">
+    <xsl:if test="(empty(parent::*/ancestor::*[@xml:lang][1]/@xml:lang) and .!=$DEFAULTLANG) or
+      .!=parent::*/ancestor::*[@xml:lang][1]/@xml:lang">
+      <xsl:next-match/>
+    </xsl:if>
+  </xsl:template>
   <xsl:template match="*[contains(@class, ' topic/linklist ')]" name="topic.linklist">
     <xsl:value-of select="$newline"/>
     <xsl:choose>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -293,7 +293,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
       <linklist class="- topic/linklist " outputclass="relinfo">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related information'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -742,6 +742,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
+        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -742,7 +742,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " outputclass="relinfo reltasks">
-        <xsl:sequence select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
+        <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Related tasks'"/>

--- a/src/test/resources/lang/exp/xhtml/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-areg.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>الموضوع التالي:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>المفاهيم المتعلقة</strong><br />
+<div xml:lang="ar-eg" lang="ar-eg" class="linklist linklist relinfo relconcepts"><strong>المفاهيم المتعلقة</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>المهام المتعلقة</strong><br />
+<div xml:lang="ar-eg" lang="ar-eg" class="linklist linklist relinfo reltasks"><strong>المهام المتعلقة</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>المرجع المتعلق</strong><br />
+<div xml:lang="ar-eg" lang="ar-eg" class="linklist linklist relinfo relref"><strong>المرجع المتعلق</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>المعلومات المتعلقة</strong><br />
+<div xml:lang="ar-eg" lang="ar-eg" class="linklist linklist relinfo"><strong>المعلومات المتعلقة</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml/lang-beby.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Наступная тэма:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Адпаведныя канцэпцыі</strong><br />
+<div xml:lang="be-by" lang="be-by" class="linklist linklist relinfo relconcepts"><strong>Адпаведныя канцэпцыі</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Адпаведныя задачы</strong><br />
+<div xml:lang="be-by" lang="be-by" class="linklist linklist relinfo reltasks"><strong>Адпаведныя задачы</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Адпаведная спасылка</strong><br />
+<div xml:lang="be-by" lang="be-by" class="linklist linklist relinfo relref"><strong>Адпаведная спасылка</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Адпаведная інфармацыя</strong><br />
+<div xml:lang="be-by" lang="be-by" class="linklist linklist relinfo"><strong>Адпаведная інфармацыя</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-bgbg.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Следваща тема:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Свързани понятия</strong><br />
+<div xml:lang="bg-bg" lang="bg-bg" class="linklist linklist relinfo relconcepts"><strong>Свързани понятия</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Свързани дейности</strong><br />
+<div xml:lang="bg-bg" lang="bg-bg" class="linklist linklist relinfo reltasks"><strong>Свързани дейности</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Свързани справки</strong><br />
+<div xml:lang="bg-bg" lang="bg-bg" class="linklist linklist relinfo relref"><strong>Свързани справки</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Свързана информация</strong><br />
+<div xml:lang="bg-bg" lang="bg-bg" class="linklist linklist relinfo"><strong>Свързана информация</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml/lang-caes.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Tema següent:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Conceptes relacionats</strong><br />
+<div xml:lang="ca-es" lang="ca-es" class="linklist linklist relinfo relconcepts"><strong>Conceptes relacionats</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tasques relacionades</strong><br />
+<div xml:lang="ca-es" lang="ca-es" class="linklist linklist relinfo reltasks"><strong>Tasques relacionades</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Referència relacionada</strong><br />
+<div xml:lang="ca-es" lang="ca-es" class="linklist linklist relinfo relref"><strong>Referència relacionada</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informació relacionada</strong><br />
+<div xml:lang="ca-es" lang="ca-es" class="linklist linklist relinfo"><strong>Informació relacionada</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml/lang-cscz.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Následující téma:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Související pojmy</strong><br />
+<div xml:lang="cs-cz" lang="cs-cz" class="linklist linklist relinfo relconcepts"><strong>Související pojmy</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Související úlohy</strong><br />
+<div xml:lang="cs-cz" lang="cs-cz" class="linklist linklist relinfo reltasks"><strong>Související úlohy</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Související odkazy</strong><br />
+<div xml:lang="cs-cz" lang="cs-cz" class="linklist linklist relinfo relref"><strong>Související odkazy</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Související informace</strong><br />
+<div xml:lang="cs-cz" lang="cs-cz" class="linklist linklist relinfo"><strong>Související informace</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dadk.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Næste emne:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Beslægtede begreber</strong><br />
+<div xml:lang="da-dk" lang="da-dk" class="linklist linklist relinfo relconcepts"><strong>Beslægtede begreber</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Beslægtede opgaver</strong><br />
+<div xml:lang="da-dk" lang="da-dk" class="linklist linklist relinfo reltasks"><strong>Beslægtede opgaver</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Beslægtet reference</strong><br />
+<div xml:lang="da-dk" lang="da-dk" class="linklist linklist relinfo relref"><strong>Beslægtet reference</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Beslægtede oplysninger</strong><br />
+<div xml:lang="da-dk" lang="da-dk" class="linklist linklist relinfo"><strong>Beslægtede oplysninger</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Nächstes Thema:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
+<div xml:lang="de-ch" lang="de-ch" class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
+<div xml:lang="de-ch" lang="de-ch" class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
+<div xml:lang="de-ch" lang="de-ch" class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
+<div xml:lang="de-ch" lang="de-ch" class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Nächstes Thema:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
+<div xml:lang="de-de" lang="de-de" class="linklist linklist relinfo relconcepts"><strong>Zugehörige Konzepte</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
+<div xml:lang="de-de" lang="de-de" class="linklist linklist relinfo reltasks"><strong>Zugehörige Tasks</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
+<div xml:lang="de-de" lang="de-de" class="linklist linklist relinfo relref"><strong>Zugehörige Verweise</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
+<div xml:lang="de-de" lang="de-de" class="linklist linklist relinfo"><strong>Zugehörige Informationen</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-elgr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Επόμενο θέμα:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Συναφείς έννοιες</strong><br />
+<div xml:lang="el-gr" lang="el-gr" class="linklist linklist relinfo relconcepts"><strong>Συναφείς έννοιες</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Συναφείς εργασίες</strong><br />
+<div xml:lang="el-gr" lang="el-gr" class="linklist linklist relinfo reltasks"><strong>Συναφείς εργασίες</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Συναφής αναφορά</strong><br />
+<div xml:lang="el-gr" lang="el-gr" class="linklist linklist relinfo relref"><strong>Συναφής αναφορά</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Συναφείς πληροφορίες</strong><br />
+<div xml:lang="el-gr" lang="el-gr" class="linklist linklist relinfo"><strong>Συναφείς πληροφορίες</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enca.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Next topic:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
+<div xml:lang="en-ca" lang="en-ca" class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
+<div xml:lang="en-ca" lang="en-ca" class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
+<div xml:lang="en-ca" lang="en-ca" class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Related information</strong><br />
+<div xml:lang="en-ca" lang="en-ca" class="linklist linklist relinfo"><strong>Related information</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml/lang-engb.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Next topic:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
+<div xml:lang="en-gb" lang="en-gb" class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
+<div xml:lang="en-gb" lang="en-gb" class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
+<div xml:lang="en-gb" lang="en-gb" class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Related information</strong><br />
+<div xml:lang="en-gb" lang="en-gb" class="linklist linklist relinfo"><strong>Related information</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enus.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Next topic:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
+<div xml:lang="en-us" lang="en-us" class="linklist linklist relinfo relconcepts"><strong>Related concepts</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
+<div xml:lang="en-us" lang="en-us" class="linklist linklist relinfo reltasks"><strong>Related tasks</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
+<div xml:lang="en-us" lang="en-us" class="linklist linklist relinfo relref"><strong>Related reference</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Related information</strong><br />
+<div xml:lang="en-us" lang="en-us" class="linklist linklist relinfo"><strong>Related information</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml/lang-eses.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Tema siguiente:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Conceptos relacionados</strong><br />
+<div xml:lang="es-es" lang="es-es" class="linklist linklist relinfo relconcepts"><strong>Conceptos relacionados</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tareas relacionadas</strong><br />
+<div xml:lang="es-es" lang="es-es" class="linklist linklist relinfo reltasks"><strong>Tareas relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Referencia relacionada</strong><br />
+<div xml:lang="es-es" lang="es-es" class="linklist linklist relinfo relref"><strong>Referencia relacionada</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Información relacionada</strong><br />
+<div xml:lang="es-es" lang="es-es" class="linklist linklist relinfo"><strong>Información relacionada</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml/lang-etee.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Järgmine teema:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Seostuvad mõisted</strong><br />
+<div xml:lang="et-ee" lang="et-ee" class="linklist linklist relinfo relconcepts"><strong>Seostuvad mõisted</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Seostuvad tegevused</strong><br />
+<div xml:lang="et-ee" lang="et-ee" class="linklist linklist relinfo reltasks"><strong>Seostuvad tegevused</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Seostuv viide</strong><br />
+<div xml:lang="et-ee" lang="et-ee" class="linklist linklist relinfo relref"><strong>Seostuv viide</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Seostuv teave</strong><br />
+<div xml:lang="et-ee" lang="et-ee" class="linklist linklist relinfo"><strong>Seostuv teave</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-fifi.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Seuraava aihe:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Aiheeseen liittyviä käsitteitä</strong><br />
+<div xml:lang="fi-fi" lang="fi-fi" class="linklist linklist relinfo relconcepts"><strong>Aiheeseen liittyviä käsitteitä</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Aiheeseen liittyviä tehtäviä</strong><br />
+<div xml:lang="fi-fi" lang="fi-fi" class="linklist linklist relinfo reltasks"><strong>Aiheeseen liittyviä tehtäviä</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Aiheeseen liittyviä tietolähteitä</strong><br />
+<div xml:lang="fi-fi" lang="fi-fi" class="linklist linklist relinfo relref"><strong>Aiheeseen liittyviä tietolähteitä</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Aiheeseen liittyviä tietoja</strong><br />
+<div xml:lang="fi-fi" lang="fi-fi" class="linklist linklist relinfo"><strong>Aiheeseen liittyviä tietoja</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frbe.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Sujet suivant :</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
+<div xml:lang="fr-be" lang="fr-be" class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
+<div xml:lang="fr-be" lang="fr-be" class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
+<div xml:lang="fr-be" lang="fr-be" class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Information associée</strong><br />
+<div xml:lang="fr-be" lang="fr-be" class="linklist linklist relinfo"><strong>Information associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frca.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Sujet suivant :</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
+<div xml:lang="fr-ca" lang="fr-ca" class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
+<div xml:lang="fr-ca" lang="fr-ca" class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
+<div xml:lang="fr-ca" lang="fr-ca" class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Information associée</strong><br />
+<div xml:lang="fr-ca" lang="fr-ca" class="linklist linklist relinfo"><strong>Information associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frch.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Sujet suivant :</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
+<div xml:lang="fr-ch" lang="fr-ch" class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
+<div xml:lang="fr-ch" lang="fr-ch" class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
+<div xml:lang="fr-ch" lang="fr-ch" class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Information associée</strong><br />
+<div xml:lang="fr-ch" lang="fr-ch" class="linklist linklist relinfo"><strong>Information associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frfr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Sujet suivant :</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
+<div xml:lang="fr-fr" lang="fr-fr" class="linklist linklist relinfo relconcepts"><strong>Concepts associés</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
+<div xml:lang="fr-fr" lang="fr-fr" class="linklist linklist relinfo reltasks"><strong>Tâches associées</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
+<div xml:lang="fr-fr" lang="fr-fr" class="linklist linklist relinfo relref"><strong>Référence associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Information associée</strong><br />
+<div xml:lang="fr-fr" lang="fr-fr" class="linklist linklist relinfo"><strong>Information associée</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml/lang-heil.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>הנושא הבא:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>מושגים קשורים</strong><br />
+<div xml:lang="he-il" lang="he-il" class="linklist linklist relinfo relconcepts"><strong>מושגים קשורים</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>משימות קשורות</strong><br />
+<div xml:lang="he-il" lang="he-il" class="linklist linklist relinfo reltasks"><strong>משימות קשורות</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>תיעוד קשור</strong><br />
+<div xml:lang="he-il" lang="he-il" class="linklist linklist relinfo relref"><strong>תיעוד קשור</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>מידע קשור</strong><br />
+<div xml:lang="he-il" lang="he-il" class="linklist linklist relinfo"><strong>מידע קשור</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hiin.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>अगला विषय:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>संबंधित अवधारणाए</strong><br />
+<div xml:lang="hi-in" lang="hi-in" class="linklist linklist relinfo relconcepts"><strong>संबंधित अवधारणाए</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>संबंधित कार्य</strong><br />
+<div xml:lang="hi-in" lang="hi-in" class="linklist linklist relinfo reltasks"><strong>संबंधित कार्य</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>संबंधित संदर्भ</strong><br />
+<div xml:lang="hi-in" lang="hi-in" class="linklist linklist relinfo relref"><strong>संबंधित संदर्भ</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>संबंधित जानकारी</strong><br />
+<div xml:lang="hi-in" lang="hi-in" class="linklist linklist relinfo"><strong>संबंधित जानकारी</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hrhr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Slijedeće poglavlje:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Srodni koncepti</strong><br />
+<div xml:lang="hr-hr" lang="hr-hr" class="linklist linklist relinfo relconcepts"><strong>Srodni koncepti</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Srodni zadaci</strong><br />
+<div xml:lang="hr-hr" lang="hr-hr" class="linklist linklist relinfo reltasks"><strong>Srodni zadaci</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Srodne reference</strong><br />
+<div xml:lang="hr-hr" lang="hr-hr" class="linklist linklist relinfo relref"><strong>Srodne reference</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Srodne informacije</strong><br />
+<div xml:lang="hr-hr" lang="hr-hr" class="linklist linklist relinfo"><strong>Srodne informacije</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml/lang-huhu.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Következő téma:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Kapcsolódó fogalmak</strong><br />
+<div xml:lang="hu-hu" lang="hu-hu" class="linklist linklist relinfo relconcepts"><strong>Kapcsolódó fogalmak</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Kapcsolódó feladatok</strong><br />
+<div xml:lang="hu-hu" lang="hu-hu" class="linklist linklist relinfo reltasks"><strong>Kapcsolódó feladatok</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Kapcsolódó hivatkozás</strong><br />
+<div xml:lang="hu-hu" lang="hu-hu" class="linklist linklist relinfo relref"><strong>Kapcsolódó hivatkozás</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Kapcsolódó tájékoztatás</strong><br />
+<div xml:lang="hu-hu" lang="hu-hu" class="linklist linklist relinfo"><strong>Kapcsolódó tájékoztatás</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml/lang-isis.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Næsti kafli:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Skyld hugtök</strong><br />
+<div xml:lang="is-is" lang="is-is" class="linklist linklist relinfo relconcepts"><strong>Skyld hugtök</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Skyld verkefni</strong><br />
+<div xml:lang="is-is" lang="is-is" class="linklist linklist relinfo reltasks"><strong>Skyld verkefni</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Skyld tilvísun</strong><br />
+<div xml:lang="is-is" lang="is-is" class="linklist linklist relinfo relref"><strong>Skyld tilvísun</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Skyldar upplýsingar</strong><br />
+<div xml:lang="is-is" lang="is-is" class="linklist linklist relinfo"><strong>Skyldar upplýsingar</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itch.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Argomento successivo:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
+<div xml:lang="it-ch" lang="it-ch" class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
+<div xml:lang="it-ch" lang="it-ch" class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
+<div xml:lang="it-ch" lang="it-ch" class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
+<div xml:lang="it-ch" lang="it-ch" class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itit.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Argomento successivo:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
+<div xml:lang="it-it" lang="it-it" class="linklist linklist relinfo relconcepts"><strong>Concetti correlati</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
+<div xml:lang="it-it" lang="it-it" class="linklist linklist relinfo reltasks"><strong>Attività correlate</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
+<div xml:lang="it-it" lang="it-it" class="linklist linklist relinfo relref"><strong>Riferimenti correlati</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
+<div xml:lang="it-it" lang="it-it" class="linklist linklist relinfo"><strong>Informazioni correlate</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-jajp.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>次のトピック:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>関連概念</strong><br />
+<div xml:lang="ja-jp" lang="ja-jp" class="linklist linklist relinfo relconcepts"><strong>関連概念</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>関連タスク</strong><br />
+<div xml:lang="ja-jp" lang="ja-jp" class="linklist linklist relinfo reltasks"><strong>関連タスク</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>関連資料</strong><br />
+<div xml:lang="ja-jp" lang="ja-jp" class="linklist linklist relinfo relref"><strong>関連資料</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>関連情報</strong><br />
+<div xml:lang="ja-jp" lang="ja-jp" class="linklist linklist relinfo"><strong>関連情報</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-kokr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>다음 주제:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>관련 개념</strong><br />
+<div xml:lang="ko-kr" lang="ko-kr" class="linklist linklist relinfo relconcepts"><strong>관련 개념</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>관련 태스크</strong><br />
+<div xml:lang="ko-kr" lang="ko-kr" class="linklist linklist relinfo reltasks"><strong>관련 태스크</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>관련 참조</strong><br />
+<div xml:lang="ko-kr" lang="ko-kr" class="linklist linklist relinfo relref"><strong>관련 참조</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>관련 정보</strong><br />
+<div xml:lang="ko-kr" lang="ko-kr" class="linklist linklist relinfo"><strong>관련 정보</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ltlt.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Paskesnė tema:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Susijusios sąvokos</strong><br />
+<div class="linklist linklist relinfo relconcepts" xml:lang="lt-lt" lang="lt-lt"><strong>Susijusios sąvokos</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Susijusios užduotys</strong><br />
+<div class="linklist linklist relinfo reltasks" xml:lang="lt-lt" lang="lt-lt"><strong>Susijusios užduotys</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Susijusi nuoroda</strong><br />
+<div class="linklist linklist relinfo relref" xml:lang="lt-lt" lang="lt-lt"><strong>Susijusi nuoroda</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Susijusi informacija</strong><br />
+<div class="linklist linklist relinfo" xml:lang="lt-lt" lang="lt-lt"><strong>Susijusi informacija</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml/lang-lvlv.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Nākamā tēma:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Saistītās koncepcijas</strong><br />
+<div xml:lang="lv-lv" lang="lv-lv" class="linklist linklist relinfo relconcepts"><strong>Saistītās koncepcijas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Saistītie uzdevumi</strong><br />
+<div xml:lang="lv-lv" lang="lv-lv" class="linklist linklist relinfo reltasks"><strong>Saistītie uzdevumi</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Saistītā atsauce</strong><br />
+<div xml:lang="lv-lv" lang="lv-lv" class="linklist linklist relinfo relref"><strong>Saistītā atsauce</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Saistītā informācija</strong><br />
+<div xml:lang="lv-lv" lang="lv-lv" class="linklist linklist relinfo"><strong>Saistītā informācija</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-mkmk.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Следна тема:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
+<div xml:lang="mk-mk" lang="mk-mk" class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Сродни задачи</strong><br />
+<div xml:lang="mk-mk" lang="mk-mk" class="linklist linklist relinfo reltasks"><strong>Сродни задачи</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Сродни референци</strong><br />
+<div xml:lang="mk-mk" lang="mk-mk" class="linklist linklist relinfo relref"><strong>Сродни референци</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Сродни информации</strong><br />
+<div xml:lang="mk-mk" lang="mk-mk" class="linklist linklist relinfo"><strong>Сродни информации</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlbe.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Volgend onderwerp:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
+<div xml:lang="nl-be" lang="nl-be" class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
+<div xml:lang="nl-be" lang="nl-be" class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
+<div xml:lang="nl-be" lang="nl-be" class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
+<div xml:lang="nl-be" lang="nl-be" class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlnl.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Volgend onderwerp:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
+<div xml:lang="nl-nl" lang="nl-nl" class="linklist linklist relinfo relconcepts"><strong>Verwante onderwerpen</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
+<div xml:lang="nl-nl" lang="nl-nl" class="linklist linklist relinfo reltasks"><strong>Verwante taken</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
+<div xml:lang="nl-nl" lang="nl-nl" class="linklist linklist relinfo relref"><strong>Verwante verwijzing</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
+<div xml:lang="nl-nl" lang="nl-nl" class="linklist linklist relinfo"><strong>Verwante informatie</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nono.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Neste emne:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Beslektede begreper</strong><br />
+<div xml:lang="no-no" lang="no-no" class="linklist linklist relinfo relconcepts"><strong>Beslektede begreper</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Beslektede oppgaver</strong><br />
+<div xml:lang="no-no" lang="no-no" class="linklist linklist relinfo reltasks"><strong>Beslektede oppgaver</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Beslektet referanse</strong><br />
+<div xml:lang="no-no" lang="no-no" class="linklist linklist relinfo relref"><strong>Beslektet referanse</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Beslektet informasjon</strong><br />
+<div xml:lang="no-no" lang="no-no" class="linklist linklist relinfo"><strong>Beslektet informasjon</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-plpl.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Następny temat:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Pojęcia pokrewne</strong><br />
+<div xml:lang="pl-pl" lang="pl-pl" class="linklist linklist relinfo relconcepts"><strong>Pojęcia pokrewne</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Zadania pokrewne</strong><br />
+<div xml:lang="pl-pl" lang="pl-pl" class="linklist linklist relinfo reltasks"><strong>Zadania pokrewne</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Odsyłacze pokrewne</strong><br />
+<div xml:lang="pl-pl" lang="pl-pl" class="linklist linklist relinfo relref"><strong>Odsyłacze pokrewne</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informacje pokrewne</strong><br />
+<div xml:lang="pl-pl" lang="pl-pl" class="linklist linklist relinfo"><strong>Informacje pokrewne</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptbr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Próximo tópico:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
+<div xml:lang="pt-br" lang="pt-br" class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
+<div xml:lang="pt-br" lang="pt-br" class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
+<div xml:lang="pt-br" lang="pt-br" class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
+<div xml:lang="pt-br" lang="pt-br" class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptpt.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Tópico seguinte:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
+<div xml:lang="pt-pt" lang="pt-pt" class="linklist linklist relinfo relconcepts"><strong>Conceitos relacionados</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
+<div xml:lang="pt-pt" lang="pt-pt" class="linklist linklist relinfo reltasks"><strong>Tarefas relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
+<div xml:lang="pt-pt" lang="pt-pt" class="linklist linklist relinfo relref"><strong>Referências relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
+<div xml:lang="pt-pt" lang="pt-pt" class="linklist linklist relinfo"><strong>Informações relacionadas</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml/lang-roro.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Subiect următor:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Concepte înrudite</strong><br />
+<div xml:lang="ro-ro" lang="ro-ro" class="linklist linklist relinfo relconcepts"><strong>Concepte înrudite</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Operaţii înrudite</strong><br />
+<div xml:lang="ro-ro" lang="ro-ro" class="linklist linklist relinfo reltasks"><strong>Operaţii înrudite</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Referinţe înrudite</strong><br />
+<div xml:lang="ro-ro" lang="ro-ro" class="linklist linklist relinfo relref"><strong>Referinţe înrudite</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Informaţii înrudite</strong><br />
+<div xml:lang="ro-ro" lang="ro-ro" class="linklist linklist relinfo"><strong>Informaţii înrudite</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ruru.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Следующая тема:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Понятия, связанные с данным</strong><br />
+<div xml:lang="ru-ru" lang="ru-ru" class="linklist linklist relinfo relconcepts"><strong>Понятия, связанные с данным</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Задачи, связанные с данной</strong><br />
+<div xml:lang="ru-ru" lang="ru-ru" class="linklist linklist relinfo reltasks"><strong>Задачи, связанные с данной</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Ссылки, связанные с данной</strong><br />
+<div xml:lang="ru-ru" lang="ru-ru" class="linklist linklist relinfo relref"><strong>Ссылки, связанные с данной</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Информация, связанная с данной</strong><br />
+<div xml:lang="ru-ru" lang="ru-ru" class="linklist linklist relinfo"><strong>Информация, связанная с данной</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-sksk.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Nasledujúca téma:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Súvisiace koncepty</strong><br />
+<div xml:lang="sk-sk" lang="sk-sk" class="linklist linklist relinfo relconcepts"><strong>Súvisiace koncepty</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Súvisiace úlohy</strong><br />
+<div xml:lang="sk-sk" lang="sk-sk" class="linklist linklist relinfo reltasks"><strong>Súvisiace úlohy</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Súvisiaci odkaz</strong><br />
+<div xml:lang="sk-sk" lang="sk-sk" class="linklist linklist relinfo relref"><strong>Súvisiaci odkaz</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Súvisiace informácie</strong><br />
+<div xml:lang="sk-sk" lang="sk-sk" class="linklist linklist relinfo"><strong>Súvisiace informácie</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-slsi.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Naslednja tema:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>S tem povezani pojmi</strong><br />
+<div xml:lang="sl-si" lang="sl-si" class="linklist linklist relinfo relconcepts"><strong>S tem povezani pojmi</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>S tem povezana opravila</strong><br />
+<div xml:lang="sl-si" lang="sl-si" class="linklist linklist relinfo reltasks"><strong>S tem povezana opravila</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>S tem povezane povezave</strong><br />
+<div xml:lang="sl-si" lang="sl-si" class="linklist linklist relinfo relref"><strong>S tem povezane povezave</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>S tem povezane informacije</strong><br />
+<div xml:lang="sl-si" lang="sl-si" class="linklist linklist relinfo"><strong>S tem povezane informacije</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-srsp.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Следећа тема:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
+<div xml:lang="sr-sp" lang="sr-sp" class="linklist linklist relinfo relconcepts"><strong>Сродни концепти</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Сродни задаци</strong><br />
+<div xml:lang="sr-sp" lang="sr-sp" class="linklist linklist relinfo reltasks"><strong>Сродни задаци</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Сродна референца</strong><br />
+<div xml:lang="sr-sp" lang="sr-sp" class="linklist linklist relinfo relref"><strong>Сродна референца</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Сродна информација</strong><br />
+<div xml:lang="sr-sp" lang="sr-sp" class="linklist linklist relinfo"><strong>Сродна информација</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml/lang-svse.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Nästa avsnitt:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Närliggande begrepp</strong><br />
+<div xml:lang="sv-se" lang="sv-se" class="linklist linklist relinfo relconcepts"><strong>Närliggande begrepp</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Närliggande uppgifter</strong><br />
+<div xml:lang="sv-se" lang="sv-se" class="linklist linklist relinfo reltasks"><strong>Närliggande uppgifter</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Närliggande referens</strong><br />
+<div xml:lang="sv-se" lang="sv-se" class="linklist linklist relinfo relref"><strong>Närliggande referens</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Närliggande information</strong><br />
+<div xml:lang="sv-se" lang="sv-se" class="linklist linklist relinfo"><strong>Närliggande information</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml/lang-thth.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>หัวข้อถัดไป:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>หลักการที่เกี่ยวข้อง</strong><br />
+<div xml:lang="th-th" lang="th-th" class="linklist linklist relinfo relconcepts"><strong>หลักการที่เกี่ยวข้อง</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>งานที่เกี่ยวข้อง</strong><br />
+<div xml:lang="th-th" lang="th-th" class="linklist linklist relinfo reltasks"><strong>งานที่เกี่ยวข้อง</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>สิ่งอ้างอิงที่เกี่ยวข้อง</strong><br />
+<div xml:lang="th-th" lang="th-th" class="linklist linklist relinfo relref"><strong>สิ่งอ้างอิงที่เกี่ยวข้อง</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>ข้อมูลที่เกี่ยวข้อง</strong><br />
+<div xml:lang="th-th" lang="th-th" class="linklist linklist relinfo"><strong>ข้อมูลที่เกี่ยวข้อง</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-trtr.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Sonraki:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>İlgili kavramlar</strong><br />
+<div xml:lang="tr-tr" lang="tr-tr" class="linklist linklist relinfo relconcepts"><strong>İlgili kavramlar</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>İlgili görevler</strong><br />
+<div xml:lang="tr-tr" lang="tr-tr" class="linklist linklist relinfo reltasks"><strong>İlgili görevler</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>İlgili başvurular</strong><br />
+<div xml:lang="tr-tr" lang="tr-tr" class="linklist linklist relinfo relref"><strong>İlgili başvurular</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>İlgili bilgiler</strong><br />
+<div xml:lang="tr-tr" lang="tr-tr" class="linklist linklist relinfo"><strong>İlgili bilgiler</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ukua.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>Наступна тема:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>Споріднені ідеї</strong><br />
+<div xml:lang="uk-ua" lang="uk-ua" class="linklist linklist relinfo relconcepts"><strong>Споріднені ідеї</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>Пов'язані задачі</strong><br />
+<div xml:lang="uk-ua" lang="uk-ua" class="linklist linklist relinfo reltasks"><strong>Пов'язані задачі</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>Відповідні посилання</strong><br />
+<div xml:lang="uk-ua" lang="uk-ua" class="linklist linklist relinfo relref"><strong>Відповідні посилання</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>Інформація з пов'язаних питань</strong><br />
+<div xml:lang="uk-ua" lang="uk-ua" class="linklist linklist relinfo"><strong>Інформація з пов'язаних питань</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-urpk.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>اگلا موضوع:</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>متعلقہ خیالات</strong><br />
+<div xml:lang="ur-pk" lang="ur-pk" class="linklist linklist relinfo relconcepts"><strong>متعلقہ خیالات</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>متعلقہ کام</strong><br />
+<div xml:lang="ur-pk" lang="ur-pk" class="linklist linklist relinfo reltasks"><strong>متعلقہ کام</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>متعلقہ حوالہ</strong><br />
+<div xml:lang="ur-pk" lang="ur-pk" class="linklist linklist relinfo relref"><strong>متعلقہ حوالہ</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>متعلقہ معلومات</strong><br />
+<div xml:lang="ur-pk" lang="ur-pk" class="linklist linklist relinfo"><strong>متعلقہ معلومات</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhcn.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>下一主题：</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>相关概念</strong><br />
+<div xml:lang="zh-cn" lang="zh-cn" class="linklist linklist relinfo relconcepts"><strong>相关概念</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>相关任务</strong><br />
+<div xml:lang="zh-cn" lang="zh-cn" class="linklist linklist relinfo reltasks"><strong>相关任务</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>相关参考</strong><br />
+<div xml:lang="zh-cn" lang="zh-cn" class="linklist linklist relinfo relref"><strong>相关参考</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>相关信息</strong><br />
+<div xml:lang="zh-cn" lang="zh-cn" class="linklist linklist relinfo"><strong>相关信息</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -117,19 +117,19 @@
 <div class="nextlink"><strong>下一個主題：</strong> <a class="link" href="lang-next.html" title="This is the next topic in the language tests">Next topic link</a></div>
 </div>
 
-<div class="linklist linklist relinfo relconcepts"><strong>相關概念</strong><br />
+<div xml:lang="zh-tw" lang="zh-tw" class="linklist linklist relinfo relconcepts"><strong>相關概念</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-concept.html" title="this is the related concept">Concept for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo reltasks"><strong>相關工作</strong><br />
+<div xml:lang="zh-tw" lang="zh-tw" class="linklist linklist relinfo reltasks"><strong>相關工作</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-task.html" title="Description of the related task">Task for related link</a></li></ul></div>
 
-<div class="linklist linklist relinfo relref"><strong>相關參考</strong><br />
+<div xml:lang="zh-tw" lang="zh-tw" class="linklist linklist relinfo relref"><strong>相關參考</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="lang-reference.html" title="Reference for the related link">Reference link for language test</a></li></ul></div>
 
-<div class="linklist linklist relinfo"><strong>相關資訊</strong><br />
+<div xml:lang="zh-tw" lang="zh-tw" class="linklist linklist relinfo"><strong>相關資訊</strong><br />
 <ul class="linklist">
 <li class="linklist"><a class="link" href="http://www.ibm.com/" target="_blank">http://www.ibm.com/</a></li></ul></div>
 </div>


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Ensures that the active `@xml:lang` value is still available when processing links.

The code that processes links uses variables to group them into generated `<linklist>` elements, with locale-based headings such as "Related information". The context when generating those headings is the original document, so the closest set `@xml:lang` value is used to get that variable. However, the link elements themselves are processed from the context of the generated `<linklist>` element, which is the root of a variable -- any `xml:lang` setting on an ancestor element is unavailable. 

This update ensures that the closest `xml:lang` value is preserved on the generated `<linklist>`; in this way, processing any link _within_ those lists has access to the current language. (If the link itself sets an alternate language, that remains the active value.)

## Motivation and Context

We have generated variables for several types of links; in particular, every external link gets hover help like "Opens in a new tab or window". We recently noticed that for all non-English links, that text is broken -- it always comes out in the default language (English), because `getVariable` from that `xsl:variable` context never finds the right language.

Preserving the currently-active language on `linklist` ensures that any variable set from the `<link>` context uses the appropriate language.

## How Has This Been Tested?

Tested with the attached topic (and a few variations):

- Active language of Russian on the topic -- `getVariable` from the link context returns English variables in 3.3.2, but returns Russian for default links with this update
- Tested with alternate language set directly on `<link>` -- that language is used correctly in 3.3.2 and with this update
- Tested with a manually created `<linklist>` with its own language -- that language is used correctly in 3.3.2 and with this update

[jira413.zip](https://github.com/dita-ot/dita-ot/files/3279132/jira413.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.