### PR TITLE
Add default support for note type=trouble

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/strings-ar-eg.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ar-eg.xml
@@ -41,6 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">خطر</str>
   <str name="Remember">تذكر</str>
   <str name="Restriction">ممنوع</str>
+  <str name="Trouble">المشكلة</str>
   <str name="Warning">تحذﻳر</str>
   <str name="Contents">المحتويات</str>
   <str name="Related concepts">المفاهيم المتعلقة</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-be-by.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-be-by.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">НЕБЯСПЕКА</str> 
   <str name="Remember">Напамін</str> 
   <str name="Restriction">Абмежаванне</str> 
+  <str name="Trouble">Непаладка</str>
   <str name="Warning">Папярэджанне</str>  
   <str name="Contents">Змест</str> 
   <str name="Related concepts">Адпаведныя канцэпцыі</str> 

--- a/src/main/plugins/org.dita.base/xsl/common/strings-bg-bg.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-bg-bg.xml
@@ -41,6 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">ОПАСНО</str>
   <str name="Remember">Запомнете</str>
   <str name="Restriction">Ограничение</str>
+  <str name="Trouble">Проблем</str>
   <str name="Warning">Предупреждение</str>
   <str name="Contents">Съдържание</str>
   <str name="Related concepts">Свързани понятия</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-bs-ba.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-bs-ba.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">OPASNOST</str>
   <str name="Remember">Zapamtite</str>
   <str name="Restriction">Ograničenje</str>
+   <str name="Trouble">Problem</str>
   <str name="Warning">Upozorenje</str>
   <str name="Trouble">Trouble</str> <!--TODO:Trouble-->
   <str name="Contents">Sadržaj</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ca-es.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ca-es.xml
@@ -41,6 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PERILL</str>
   <str name="Remember">Recordeu</str>
   <str name="Restriction">Restricció</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Avís</str>
   <str name="Contents">Contingut</str>
   <str name="Related concepts">Conceptes relacionats</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-cs-cz.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-cs-cz.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">NEBEZPEČÍ</str>
   <str name="Remember">Zapamatujte si</str>
   <str name="Restriction">Omezení</str>
+  <str name="Trouble">Problém</str>
   <str name="Warning">Upozornění</str>
   <str name="Contents">Obsah</str>
   <str name="Related concepts">Související pojmy</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-da-dk.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-da-dk.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">Fare!</str>
   <str name="Remember">Husk</str>
   <str name="Restriction">Begrænsning</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Advarsel</str>
   <str name="Contents">Indholdsfortegnelse</str>
   <str name="Related concepts">Beslægtede begreber</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-de-ch.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-de-ch.xml
@@ -40,7 +40,8 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">GEFAHR</str>
   <str name="Remember">Hinweis</str>
   <str name="Restriction">Einschränkung</str>
-  <str name="Warning">Warnung</str>
+  <str name="Trouble">Problem</str>
+<str name="Warning">Warnung</str>
   <str name="Contents">Inhaltsverzeichnis</str>
   <str name="Related concepts">Zugehörige Konzepte</str>
   <str name="Related tasks">Zugehörige Tasks</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-de-de.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-de-de.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">GEFAHR</str>
   <str name="Remember">Hinweis</str>
   <str name="Restriction">Einschränkung</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Warnung</str>
   <str name="Contents">Inhaltsverzeichnis</str>
   <str name="Related concepts">Zugehörige Konzepte</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-el-gr.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-el-gr.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">ΚΙΝΔΥΝΟΣ</str>
   <str name="Remember">Υπενθύμιση</str>
   <str name="Restriction">Περιορισμός</str>
+  <str name="Trouble">πρόβλημα</str>
   <str name="Warning">Προειδοποίηση</str>
   <str name="Contents">Περιεχόμενα</str>
   <str name="Related concepts">Συναφείς έννοιες</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-en-ca.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-en-ca.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">Remember</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Trouble</str>
   <str name="Warning">Warning</str>
   <str name="Contents">Contents</str>
   <str name="Related concepts">Related concepts</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-en-gb.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-en-gb.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">Remember</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Trouble</str>
   <str name="Warning">Warning</str>
   <str name="Contents">Contents</str>
   <str name="Related concepts">Related concepts</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-es-es.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-es-es.xml
@@ -41,6 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PELIGRO</str>
   <str name="Remember">Recuerde</str>
   <str name="Restriction">Restricción</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Aviso</str>
   <str name="Contents">Contenido</str>
   <str name="Related concepts">Conceptos relacionados</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-et-ee.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-et-ee.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">OHT</str>
   <str name="Remember">Pidage meeles</str>
   <str name="Restriction">Piirang</str>
+  <str name="Trouble">Probleem</str>
   <str name="Warning">Hoiatus</str>
   <str name="Contents">Sisukord</str>
   <str name="Related concepts">Seostuvad mõisted</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-fi-fi.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-fi-fi.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">VAARA</str>
   <str name="Remember">Muistutus</str>
   <str name="Restriction">Rajoitus</str>
+  <str name="Trouble">Ongelma</str>
   <str name="Warning">Varoitus</str>
   <str name="Contents">Sisältö</str>
   <str name="Related concepts">Aiheeseen liittyviä käsitteitä</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-fr-be.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-fr-be.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">A faire</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Incident</str>
   <str name="Warning">Avertissement</str>
   <str name="Contents">Table des matières</str>
   <str name="Related concepts">Concepts associés</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-fr-ca.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-fr-ca.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">A faire</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Incident</str>
   <str name="Warning">Avertissement</str>
   <str name="Contents">Table des matières</str>
   <str name="Related concepts">Concepts associés</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-fr-ch.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-fr-ch.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">A faire</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Incident</str>
   <str name="Warning">Avertissement</str>
   <str name="Contents">Table des matières</str>
   <str name="Related concepts">Concepts associés</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-fr-fr.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-fr-fr.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">DANGER</str>
   <str name="Remember">A faire</str>
   <str name="Restriction">Restriction</str>
+  <str name="Trouble">Incident</str>
   <str name="Warning">Avertissement</str>
   <str name="Contents">Table des matières</str>
   <str name="Related concepts">Concepts associés</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-he-il.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-he-il.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">סכנה</str>
   <str name="Remember">נא לזכור</str>
   <str name="Restriction">מגבלה</str>
+  <str name="Trouble">בעיה</str>
   <str name="Warning">אזהרה</str>
   <str name="Contents">תוכן</str>
   <str name="Related concepts">מושגים קשורים</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-hi-in.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-hi-in.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">खतरा</str>
   <str name="Remember">याद करना</str>
   <str name="Restriction">प्रतिबंध</str>
+  <str name="Trouble">समस्या</str>
   <str name="Warning">चेतावनी</str>
   <str name="Contents">सामग्री</str>
   <str name="Related concepts">संबंधित अवधारणाए</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-hr-hr.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-hr-hr.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">OPASNOST</str>
   <str name="Remember">Zapamtite</str>
   <str name="Restriction">Ograničenje</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Upozorenje</str>
   <str name="Contents">Sadržaj</str>
   <str name="Related concepts">Srodni koncepti</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-hu-hu.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-hu-hu.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">VESZÉLY!</str>
   <str name="Remember">Ne feledje</str>
   <str name="Restriction">Korlátozás</str>
+  <str name="Trouble">Hiba</str>
   <str name="Warning">Figyelmeztetés</str>
   <str name="Contents">Tartalom</str>
   <str name="Related concepts">Kapcsolódó fogalmak</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-id-id.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-id-id.xml
@@ -39,6 +39,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Caution">PERINGATAN</str>
   <str name="Danger">BAHAYA</str>
   <str name="Remember">Ingat</str>
+  <str name="Trouble">Masalah</str>
   <str name="Warning">Peringatan</str>
   <str name="Restriction">Pembatasan</str>
   <str name="Contents">Isi</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-is-is.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-is-is.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">HÆTTA</str>
   <str name="Remember">Mundu</str>
   <str name="Restriction">Takmörkun</str>
+  <str name="Trouble">Vandamál</str>
   <str name="Warning">Viðvörun</str>
   <str name="Contents">Efnisyfirlit</str>
   <str name="Related concepts">Skyld hugtök</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-it-ch.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-it-ch.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">Pericolo</str>
   <str name="Remember">Attenzione</str>
   <str name="Restriction">Limitazione</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Avvertenza</str>
   <str name="Contents">Indice</str>
   <str name="Related concepts">Concetti correlati</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-it-it.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-it-it.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">Pericolo</str>
   <str name="Remember">Attenzione</str>
   <str name="Restriction">Limitazione</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Avvertenza</str>
   <str name="Contents">Indice</str>
   <str name="Related concepts">Concetti correlati</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ja-jp.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ja-jp.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">危険</str>
   <str name="Remember">要確認</str>
   <str name="Restriction">制約事項</str>
+  <str name="Trouble">問題</str>
   <str name="Warning">警告</str>
   <str name="Contents">目次</str>
   <str name="Related concepts">関連概念</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-kk-kz.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-kk-kz.xml
@@ -39,6 +39,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Caution">АБАЙЛАҢЫЗ</str>
   <str name="Danger">ҚАУІП</str>
   <str name="Remember">Есте сақтаңыз</str>
+  <str name="Trouble">Қиындық</str>
   <str name="Warning">Ескерту</str>
   <str name="Restriction">Шектеу</str>
   <str name="Contents">Мазмұны</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ko-kr.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ko-kr.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">위험</str>
   <str name="Remember">알아두기</str>
   <str name="Restriction">제한사항</str>
+  <str name="Trouble">문제점</str>
   <str name="Warning">경고</str>
   <str name="Contents">목차</str>
   <str name="Related concepts">관련 개념</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-lt-lt.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-lt-lt.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PAVOJINGA</str>
   <str name="Remember">Atminkite</str>
   <str name="Restriction">APRIBOJIMAS</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Įspėjimas</str>
   <str name="Contents">Turinys</str>
   <str name="Related concepts">Susijusios sąvokos</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-lv-lv.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-lv-lv.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">BĪSTAMI</str>
   <str name="Remember">Atcerieties</str>
   <str name="Restriction">Ierobežojums</str>
+  <str name="Trouble">Problēma</str>
   <str name="Warning">Brīdinājums</str>
   <str name="Contents">Saturs</str>
   <str name="Related concepts">Saistītās koncepcijas</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-mk-mk.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-mk-mk.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">ОПАСНОСТ</str>
   <str name="Remember">Запаметете</str>
   <str name="Restriction">Ограничување</str>
+  <str name="Trouble">Проблем</str>
   <str name="Warning">Предупредување</str>
   <str name="Contents">Содржина</str>
   <str name="Related concepts">Сродни концепти</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ms-my.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ms-my.xml
@@ -39,6 +39,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Caution">AWAS</str>
   <str name="Danger">BAHAYA</str>
   <str name="Remember">Ingat</str>
+  <str name="Trouble">Masalah</str>
   <str name="Warning">Amaran</str>
   <str name="Restriction">Sekatan</str>
   <str name="Contents">Kandungan</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-nl-be.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-nl-be.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">GEVAAR!</str>
   <str name="Remember">Let op</str>
   <str name="Restriction">Beperking</str>
+  <str name="Trouble">Probleem</str>
   <str name="Warning">Waarschuwing</str>
   <str name="Contents">Inhoudsopgave</str>
   <str name="Related concepts">Verwante concepten</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-nl-nl.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-nl-nl.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">Gevaar!</str>
   <str name="Remember">Let op</str>
   <str name="Restriction">Beperking</str>
+  <str name="Trouble">Probleem</str>
   <str name="Warning">Attentie</str>
   <str name="Contents">Inhoudsopgave</str>
   <str name="Related concepts">Verwante onderwerpen</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-no-no.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-no-no.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">FARE!</str>
   <str name="Remember">Husk</str>
   <str name="Restriction">Begrensning</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">ADVARSEL</str>
   <str name="Contents">Innhold</str>
   <str name="Related concepts">Beslektede begreper</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-pl-pl.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-pl-pl.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">NIEBEZPIECZEŃSTWO</str>
   <str name="Remember">Zapamiętaj</str>
   <str name="Restriction">Ograniczenie</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Ostrzeżenie</str>
   <str name="Contents">Spis treści</str>
   <str name="Related concepts">Pojęcia pokrewne</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-pt-br.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-pt-br.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PERIGO</str>
   <str name="Remember">Lembre-se</str>
   <str name="Restriction">Restrição</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Aviso</str>
   <str name="Contents">Conteúdo</str>
   <str name="Related concepts">Conceitos relacionados</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-pt-pt.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-pt-pt.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PERIGO</str>
   <str name="Remember">Lembre-se</str>
   <str name="Restriction">Restrição</str>
+  <str name="Trouble">Problema</str>
   <str name="Warning">Aviso</str>
   <str name="Contents">Índice</str>
   <str name="Related concepts">Conceitos relacionados</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ro-ro.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ro-ro.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">PERICOL</str>
   <str name="Remember">De reţinut</str>
   <str name="Restriction">Restricţie</str>
+  <str name="Trouble">Problemă</str>
   <str name="Warning">Avertisment</str>
   <str name="Contents">Cuprins</str>
   <str name="Related concepts">Concepte înrudite</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ru-ru.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ru-ru.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">ОПАСНО</str>
   <str name="Remember">Напоминание</str>
   <str name="Restriction">Ограничение</str>
+  <str name="Trouble">Неполадка</str>
   <str name="Warning">Внимание</str>
   <str name="Contents">Содержание</str>
   <str name="Related concepts">Понятия, связанные с данным</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sk-sk.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sk-sk.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">NEBEZPEČENSTVO</str>
   <str name="Remember">Zapamätajte si</str>
   <str name="Restriction">Obmedzenie</str>
+  <str name="Trouble">Problém</str>
   <str name="Warning">Varovanie</str>
   <str name="Contents">Obsah</str>
   <str name="Related concepts">Súvisiace koncepty</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sl-si.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sl-si.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">NEVARNOST</str>
   <str name="Remember">Pomnite</str>
   <str name="Restriction">Omejitev</str>
+  <str name="Trouble">Težava</str>
   <str name="Warning">Opozorilo</str>
   <str name="Contents">Kazalo</str>
   <str name="Related concepts">S tem povezani pojmi</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sr-latn-me.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sr-latn-me.xml
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Remember">Zapamtite</str>
   <str name="Restriction">Ograničenje</str>
   <str name="Warning">Upozorenje</str>
-  <str name="Trouble">Trouble</str>  <!-- TODO:Trouble -->
+  <str name="Trouble">Problem</str>
   <str name="Contents">Sadržaj</str>
   <str name="Related concepts">Srodni koncepti</str>
   <str name="Related tasks">Srodni zadaci</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sr-latn-rs.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sr-latn-rs.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">OPASNOST</str>
   <str name="Remember">Zapamtite</str>
   <str name="Restriction">Ograničenje</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Upozorenje</str>
   <str name="Contents">Sadržaj</str>
   <str name="Related concepts">Srodni koncepti</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sr-sp.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sr-sp.xml
@@ -42,6 +42,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">ОПАСНОСТ</str>
   <str name="Remember">Запамтите</str>
   <str name="Restriction">Ограничење</str>
+  <str name="Trouble">Проблем</str>
   <str name="Warning">Упозорење</str>
   <str name="Contents">Садржај</str>
   <str name="Related concepts">Сродни концепти</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-sv-se.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-sv-se.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">Varning - livsfara</str>
   <str name="Remember">Glöm inte</str>
   <str name="Restriction">Begränsning</str>
+  <str name="Trouble">Problem</str>
   <str name="Warning">Varning - risk för maskinskada</str>
   <str name="Contents">Innehåll</str>
   <str name="Related concepts">Närliggande begrepp</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-th-th.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-th-th.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">อันตราย</str>
   <str name="Remember">เตือนความจำ</str>
   <str name="Restriction">ข้อจำกัด</str>
+  <str name="Trouble">ปัญหา</str>
   <str name="Warning">คำเตือน</str>
   <str name="Contents">สารบัญ</str>
   <str name="Related concepts">หลักการที่เกี่ยวข้อง</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-tr-tr.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-tr-tr.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">TEHLİKE</str>
   <str name="Remember">Unutmayın</str>
   <str name="Restriction">Sınırlama</str>
+  <str name="Trouble">Sorun</str>
   <str name="Warning">Uyarı</str>
   <str name="Contents">İçindekiler</str>
   <str name="Related concepts">İlgili kavramlar</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-uk-ua.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-uk-ua.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">НЕБЕЗПЕЧНО</str>
   <str name="Remember">Запам'ятайте</str>
   <str name="Restriction">Обмеження</str>
+  <str name="Trouble">Неполадка</str>
   <str name="Warning">Попередження</str>
   <str name="Contents">Зміст</str>
   <str name="Related concepts">Споріднені ідеї</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-ur-pk.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-ur-pk.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">خطرناک</str>
   <str name="Remember">یاد رکھیں</str>
   <str name="Restriction">پابندی</str>
+  <str name="Trouble">مشکل/پریشانی</str>
   <str name="Warning">انتباہ</str>
   <str name="Contents">فہرست</str>
   <str name="Related concepts">متعلقہ خیالات</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-vi-vn.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-vi-vn.xml
@@ -39,7 +39,7 @@ This file is part of the DITA Open Toolkit project.
   <str name="Remember">Ghi nhớ</str>
   <str name="Warning">Cảnh báo</str>
   <str name="Restriction">Hạn chế</str>
-  <str name="Trouble">Trouble</str>
+  <str name="Trouble">sự cố or vấn đề</str>
   <str name="Contents">Nội dung</str>
   <str name="Related concepts">Các khái niệm liên quan</str>
   <str name="Related tasks">Các tác vụ liên quan</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-zh-cn.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-zh-cn.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">危险</str>
   <str name="Remember">切记</str>
   <str name="Restriction">限制</str>
+  <str name="Trouble">故障</str>
   <str name="Warning">警告</str>
   <str name="Contents">内容</str>
   <str name="Related concepts">相关概念</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-zh-tw.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-zh-tw.xml
@@ -40,6 +40,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Danger">危險</str>
   <str name="Remember">記住</str>
   <str name="Restriction">限制</str>
+  <str name="Trouble">問題描述</str>
   <str name="Warning">警告</str>
   <str name="Contents">目錄</str>
   <str name="Related concepts">相關概念</str>


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Adds a default locale-based variable for use with `<note type="trouble">` for every language currently supported in DITA-OT.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, add a link to the issue number: Fixes #1234. -->

## How Has This Been Tested?

We ship a default translation for every other note type, so that if a document in one of our supported languages uses something like `<note type="caution">`, we have an appropriate locale-based string to use.

When DITA 1.3 added the note type `trouble`, we added a generated string `Trouble` for English, but did not gather translations for the other languages. We recently had some teams start to use this note type, and get build warnings due to the lack of support for anything other than English. 

While many (or most?) people translating their content will use their own custom strings for values like this, DITA-OT should at least have a default starting point for `type="trouble"` that is comparable to all of the other note types.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
