### PR TITLE
Support passthrough without @att and @val

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1718,13 +1718,35 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="." mode="set-output-class">
       <xsl:with-param name="default" select="$default-output-class"/>
     </xsl:apply-templates>
-    <xsl:if test="exists($passthrough-attrs)">
-      <xsl:for-each select="@*">
-        <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
+    <xsl:choose>
+      <xsl:when test="exists($passthrough-attrs[empty(@att) and empty(@value)])">
+        <xsl:variable name="specializations" as="xs:string*">
+          <xsl:for-each select="ancestor-or-self::*[@domains][1]/@domains">
+            <xsl:analyze-string select="normalize-space(.)" regex="a\(props (.+?)\)">
+              <xsl:matching-substring>
+                <xsl:sequence select="tokenize(regex-group(1), '\s+')"/>
+              </xsl:matching-substring>
+            </xsl:analyze-string>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:for-each select="@props |
+                              @audience |
+                              @platform |
+                              @product |
+                              @otherprops |
+                              @deliveryTarget |
+                              @*[local-name() = $specializations]">
           <xsl:attribute name="data-{name()}" select="."/>
-        </xsl:if>
-      </xsl:for-each>
-    </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:when test="exists($passthrough-attrs)">
+        <xsl:for-each select="@*">
+          <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
+            <xsl:attribute name="data-{name()}" select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+    </xsl:choose>
   </xsl:template>
   
   <!-- Set the class attribute on the resulting output element. The default for a class of elements

--- a/src/test/java/org/dita/dost/IntegrationTestHtml5.java
+++ b/src/test/java/org/dita/dost/IntegrationTestHtml5.java
@@ -86,4 +86,16 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
                 .test();
     }
 
+    @Test
+    public void html5_ditaval_passthrough_all() throws Throwable {
+        final File srcDir = new File(resourceDir, "html5_ditaval" + File.separator + "src");
+        builder().name("html5_ditaval")
+                .transtype(HTML5)
+                .input(Paths.get("all.ditamap"))
+                .put("validate", "no")
+                .put("dita.input.valfile", new File(srcDir, "all.ditaval").getAbsolutePath())
+                .warnCount(1)
+                .test();
+    }
+
 }

--- a/src/test/resources/html5_ditaval/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval/exp/html5/all.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html
+    SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2019">
+  <meta name="DC.rights.owner" content="(C) Copyright 2019">
+  <meta name="DC.type" content="topic">
+  <meta name="DC.format" content="HTML5">
+  <meta name="DC.identifier" content="topic-1">
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <title>Topic title</title></head>
+<body id="topic-1">
+<main role="main">
+  <article role="article" aria-labelledby="ariaid-title1">
+    <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
+    <div class="body">
+      <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel" data-product="notepad"
+         data-os="win"></p>
+      <p class="p" data-props="audience(expert) deliveryTarget(print) platform(intel) product(notepad) os(win)"></p>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5_ditaval/exp/html5/index.html
+++ b/src/test/resources/html5_ditaval/exp/html5/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html
+    SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2019">
+  <meta name="DC.rights.owner" content="(C) Copyright 2019">
+  <meta name="DC.type" content="map">
+  <meta name="DC.format" content="HTML5"><link rel="stylesheet" type="text/css" href="commonltr.css"><title></title></head>
+<body>
+<nav xmlns:dita="http://dita-ot.sourceforge.net">
+  <ul class="map">
+    <li class="topicref"><a href="all.html">Topic title</a></li>
+  </ul>
+</nav>
+</body>
+</html>

--- a/src/test/resources/html5_ditaval/src/all.dita
+++ b/src/test/resources/html5_ditaval/src/all.dita
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic-1"
+       domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) a(props os) (topic markup-d xml-d)">
+  <title>Topic title</title>
+  <body>
+    <p audience="expert"
+       deliveryTarget="print"
+       platform="intel"
+       product="notepad"
+       os="win"/>
+    <p props="audience(expert) deliveryTarget(print) platform(intel) product(notepad) os(win)"/>
+  </body>
+</topic>

--- a/src/test/resources/html5_ditaval/src/all.ditamap
+++ b/src/test/resources/html5_ditaval/src/all.ditamap
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <topicref href="all.dita"/>
+</map>

--- a/src/test/resources/html5_ditaval/src/all.ditaval
+++ b/src/test/resources/html5_ditaval/src/all.ditaval
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="passthrough"/>
+</val>


### PR DESCRIPTION
## Description
Allow DITAVAL `passthrough` action to work in HTML5 without `@att` and `@val` matcher attributes.

## Motivation and Context
HTML5 only supports `passthrough` with `@att` matcher and the specification allows `passthrough` for all profiling attributes.

## How Has This Been Tested?
Added integration test `IntegrationTestHtml5#html5_ditaval_passthrough_all()`.
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
