### PR TITLE
Removed othermeta from the `cascadeset` as it should not cascade

### DIFF
--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -47,7 +47,6 @@ public final class MapMetaReader extends AbstractDomFilter {
     private static final Set<String> cascadeSet = Collections.unmodifiableSet(new HashSet<>(asList(
             TOPIC_AUDIENCE.matcher,
             TOPIC_AUTHOR.matcher,
-            TOPIC_SOURCE.matcher,
             TOPIC_CATEGORY.matcher,
             TOPIC_COPYRIGHT.matcher,
             TOPIC_CRITDATES.matcher,

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -53,7 +53,6 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_CRITDATES.matcher,
             TOPIC_PERMISSIONS.matcher,
             TOPIC_PRODINFO.matcher,
-            TOPIC_OTHERMETA.matcher,
             TOPIC_PUBLISHER.matcher
     )));
     private static final Set<String> metaSet = Collections.unmodifiableSet(new HashSet<>(asList(
@@ -307,7 +306,7 @@ public final class MapMetaReader extends AbstractDomFilter {
                     } else {
                         if (TOPIC_NAVTITLE.matches(classValue)) {
                             //Add locktitle value to navtitle so we know whether it should be pushed to topics
-                            final String locktitleAttr =  ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE) != null ? 
+                            final String locktitleAttr =  ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE) != null ?
                                                           ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE).getNodeValue() : "no";
                             elem.setAttributeNS(DITA_OT_NS, DITA_OT_NS_PREFIX + ":" + ATTRIBUTE_NAME_LOCKTITLE, locktitleAttr);
                         }

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -50,6 +50,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_CATEGORY.matcher,
             TOPIC_COPYRIGHT.matcher,
             TOPIC_CRITDATES.matcher,
+            TOPIC_METADATA.matcher,
             TOPIC_PERMISSIONS.matcher,
             TOPIC_PRODINFO.matcher,
             TOPIC_PUBLISHER.matcher

--- a/src/test/resources/MapMetaReaderTest/exp/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/exp/test.ditamap
@@ -96,7 +96,6 @@
   <topicref class="- map/topicref " href="b.xml">
     <topicmeta class="- map/topicmeta ">
       <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
-      <pluf/>
       <author class="- topic/author ">topicref author</author>
       <author class="- topic/author ">map author</author>
       <source class="- topic/source ">topicref source</source>

--- a/src/test/resources/MapMetaReaderTest/exp/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/exp/test.ditamap
@@ -1,413 +1,414 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-  class="- map/map "
-  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
-  title="test" ditaarch:DITAArchVersion="1.2">
-  <topicmeta class="- map/topicmeta ">
-    <navtitle class="- topic/navtitle ">map navtitle</navtitle>
-    <linktext class="- map/linktext ">map linktext</linktext>
-    <searchtitle class="- map/searchtitle ">map searchtitle</searchtitle>
-    <shortdesc class="- map/shortdesc ">map shortdesc</shortdesc>
-    <author class="- topic/author ">map author</author>
-    <source class="- topic/source ">map source</source>
-    <publisher class="- topic/publisher ">map publisher</publisher>
-    <copyright class="- topic/copyright ">
-      <copyryear class="- topic/copyryear " year="2010"/>
-      <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-    </copyright>
-    <critdates class="- topic/critdates ">
-      <created class="- topic/created " date="2010"/>
-      <revised class="- topic/revised " modified="2010"/>
-    </critdates>
-    <permissions class="- topic/permissions " view="map permissins"/>
-    <metadata class="- topic/metadata ">
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <keywords class="- topic/keywords ">
-        <keyword class="- topic/keyword ">map keyword</keyword>
-      </keywords>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <data class="- topic/data ">map data</data>
-      <data-about class="- topic/data-about ">
-        <data class="- topic/data ">map data</data>
-      </data-about>
-      <foreign class="- topic/foreign ">map foreign</foreign>
-      <unknown class="- topic/unknown ">map unknown</unknown>
-    </metadata>
-    <audience class="- topic/audience "/>
-    <category class="- topic/category ">map category</category>
-    <keywords class="- topic/keywords ">
-      <keyword class="- topic/keyword ">map keyword</keyword>
-    </keywords>
-    <exportanchors class="+ topic/keywords delay-d/exportanchors ">
-      <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="map anchorkey"/>
-    </exportanchors>
-    <prodinfo class="- topic/prodinfo ">
-      <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-      <vrmlist class="- topic/vrmlist ">
-        <vrm class="- topic/vrm " version="1.0"/>
-      </vrmlist>
-    </prodinfo>
-    <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-    <resourceid class="- topic/resourceid " id="foo"/>
-    <data class="- topic/data ">map datafoo</data>
-    <data-about class="- topic/data-about ">
-      <data class="- topic/data ">map datafoo</data>
-    </data-about>
-    <foreign class="- topic/foreign ">map foreign</foreign>
-    <unknown class="- topic/unknown ">map unknown</unknown>
-  </topicmeta>
-  <topicref class="- map/topicref " href="a.xml">
+    class="- map/map "
+    domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+    title="test" ditaarch:DITAArchVersion="1.2">
     <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
+        <navtitle class="- topic/navtitle ">map navtitle</navtitle>
+        <linktext class="- map/linktext ">map linktext</linktext>
+        <searchtitle class="- map/searchtitle ">map searchtitle</searchtitle>
+        <shortdesc class="- map/shortdesc ">map shortdesc</shortdesc>
+        <author class="- topic/author ">map author</author>
+        <source class="- topic/source ">map source</source>
+        <publisher class="- topic/publisher ">map publisher</publisher>
+        <copyright class="- topic/copyright ">
+            <copyryear class="- topic/copyryear " year="2010"/>
+            <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+        </copyright>
+        <critdates class="- topic/critdates ">
+            <created class="- topic/created " date="2010"/>
+            <revised class="- topic/revised " modified="2010"/>
+        </critdates>
+        <permissions class="- topic/permissions " view="map permissins"/>
+        <metadata class="- topic/metadata ">
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <keywords class="- topic/keywords ">
+                <keyword class="- topic/keyword ">map keyword</keyword>
+            </keywords>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+            <data class="- topic/data ">map data</data>
+            <data-about class="- topic/data-about ">
+                <data class="- topic/data ">map data</data>
+            </data-about>
+            <foreign class="- topic/foreign ">map foreign</foreign>
+            <unknown class="- topic/unknown ">map unknown</unknown>
+        </metadata>
+        <audience class="- topic/audience "/>
+        <category class="- topic/category ">map category</category>
+        <keywords class="- topic/keywords ">
+            <keyword class="- topic/keyword ">map keyword</keyword>
+        </keywords>
+        <exportanchors class="+ topic/keywords delay-d/exportanchors ">
+            <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="map anchorkey"/>
+        </exportanchors>
+        <prodinfo class="- topic/prodinfo ">
+            <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+            <vrmlist class="- topic/vrmlist ">
+                <vrm class="- topic/vrm " version="1.0"/>
+            </vrmlist>
+        </prodinfo>
+        <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+        <resourceid class="- topic/resourceid " id="foo"/>
+        <data class="- topic/data ">map datafoo</data>
+        <data-about class="- topic/data-about ">
+            <data class="- topic/data ">map datafoo</data>
+        </data-about>
+        <foreign class="- topic/foreign ">map foreign</foreign>
+        <unknown class="- topic/unknown ">map unknown</unknown>
     </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="b.xml">
-    <topicmeta class="- map/topicmeta ">
-      <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
-      <author class="- topic/author ">topicref author</author>
-      <author class="- topic/author ">map author</author>
-      <source class="- topic/source ">topicref source</source>
-      <publisher class="- topic/publisher ">topicref publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2011"/>
-        <copyrholder class="- topic/copyrholder ">topicref copyrholder</copyrholder>
-      </copyright>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2011"/>
-        <revised class="- topic/revised " modified="2011"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="topicref permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">topicref category</category>
-      <category class="- topic/category ">topicref category</category>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <keywords class="- topic/keywords ">
-        <keyword class="- topic/keyword ">topicref keyword</keyword>
-      </keywords>
-      <keywords class="- topic/keywords ">
-        <keyword class="- topic/keyword ">topicref keyword</keyword>
-      </keywords>
-      <exportanchors class="+ topic/keywords delay-d/exportanchors ">
-        <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="topicref anchorkey"/>
-      </exportanchors>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="2.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="2.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <resourceid class="- topic/resourceid " id="foo"/>
-      <data class="- topic/data ">topicref data</data>
-      <data class="- topic/data ">topicref datafoo</data>
-      <data-about class="- topic/data-about ">
-        <data class="- topic/data ">topicref data</data>
-      </data-about>
-      <data-about class="- topic/data-about ">
-        <data class="- topic/data ">topicref datafoo</data>
-      </data-about>
-      <foreign class="- topic/foreign ">topicref foreign</foreign>
-      <foreign class="- topic/foreign ">topicref foreign</foreign>
-      <unknown class="- topic/unknown ">topicref unknown</unknown>
-      <unknown class="- topic/unknown ">topicref unknown</unknown>
-      <linktext class="- map/linktext ">topicref linktext</linktext>
-      <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
-      <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="c.xml">
-    <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="d.xml">
-    <topicmeta class="- map/topicmeta ">
-      <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
-      <author class="- topic/author ">topicref author</author>
-      <author class="- topic/author ">map author</author>
-      <source class="- topic/source ">topicref source</source>
-      <publisher class="- topic/publisher ">topicref publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2011"/>
-        <copyrholder class="- topic/copyrholder ">topicref copyrholder</copyrholder>
-      </copyright>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2011"/>
-        <revised class="- topic/revised " modified="2011"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="topicref permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">topicref category</category>
-      <category class="- topic/category ">topicref category</category>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <keywords class="- topic/keywords ">
-        <keyword class="- topic/keyword ">topicref keyword</keyword>
-      </keywords>
-      <keywords class="- topic/keywords ">
-        <keyword class="- topic/keyword ">topicref keyword</keyword>
-      </keywords>
-      <exportanchors class="+ topic/keywords delay-d/exportanchors ">
-        <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="topicref anchorkey"/>
-      </exportanchors>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="2.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="2.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <resourceid class="- topic/resourceid " id="foo"/>
-      <data class="- topic/data ">topicref data</data>
-      <data class="- topic/data ">topicref datafoo</data>
-      <data-about class="- topic/data-about ">
-        <data class="- topic/data ">topicref data</data>
-      </data-about>
-      <data-about class="- topic/data-about ">
-        <data class="- topic/data ">topicref datafoo</data>
-      </data-about>
-      <foreign class="- topic/foreign ">topicref foreign</foreign>
-      <foreign class="- topic/foreign ">topicref foreign</foreign>
-      <unknown class="- topic/unknown ">topicref unknown</unknown>
-      <unknown class="- topic/unknown ">topicref unknown</unknown>
-      <linktext class="- map/linktext ">topicref linktext</linktext>
-      <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
-      <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="nest.xml">
-    <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="nest.xml#first">
-    <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="nest.xml#second">
-    <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-    </topicmeta>
-  </topicref>
-  <topicref class="- map/topicref " href="nest.xml#nest">
-    <topicmeta class="- map/topicmeta ">
-      <author class="- topic/author ">map author</author>
-      <publisher class="- topic/publisher ">map publisher</publisher>
-      <copyright class="- topic/copyright ">
-        <copyryear class="- topic/copyryear " year="2010"/>
-        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-      </copyright>
-      <critdates class="- topic/critdates ">
-        <created class="- topic/created " date="2010"/>
-        <revised class="- topic/revised " modified="2010"/>
-      </critdates>
-      <permissions class="- topic/permissions " view="map permissins"/>
-      <audience class="- topic/audience "/>
-      <audience class="- topic/audience "/>
-      <category class="- topic/category ">map category</category>
-      <category class="- topic/category ">map category</category>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-      <prodinfo class="- topic/prodinfo ">
-        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
-        <vrmlist class="- topic/vrmlist ">
-          <vrm class="- topic/vrm " version="1.0"/>
-        </vrmlist>
-      </prodinfo>
-    </topicmeta>
-  </topicref>
+    <topicref class="- map/topicref " href="a.xml">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="b.xml">
+        <topicmeta class="- map/topicmeta ">
+            <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
+            <author class="- topic/author ">topicref author</author>
+            <author class="- topic/author ">map author</author>
+            <source class="- topic/source ">topicref source</source>
+            <publisher class="- topic/publisher ">topicref publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2011"/>
+                <copyrholder class="- topic/copyrholder ">topicref copyrholder</copyrholder>
+            </copyright>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2011"/>
+                <revised class="- topic/revised " modified="2011"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="topicref permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">topicref category</category>
+            <category class="- topic/category ">topicref category</category>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <keywords class="- topic/keywords ">
+                <keyword class="- topic/keyword ">topicref keyword</keyword>
+            </keywords>
+            <keywords class="- topic/keywords ">
+                <keyword class="- topic/keyword ">topicref keyword</keyword>
+            </keywords>
+            <exportanchors class="+ topic/keywords delay-d/exportanchors ">
+                <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="topicref anchorkey"/>
+            </exportanchors>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="2.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="2.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
+            <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
+            <resourceid class="- topic/resourceid " id="foo"/>
+            <data class="- topic/data ">topicref data</data>
+            <data class="- topic/data ">topicref datafoo</data>
+            <data-about class="- topic/data-about ">
+                <data class="- topic/data ">topicref data</data>
+            </data-about>
+            <data-about class="- topic/data-about ">
+                <data class="- topic/data ">topicref datafoo</data>
+            </data-about>
+            <foreign class="- topic/foreign ">topicref foreign</foreign>
+            <foreign class="- topic/foreign ">topicref foreign</foreign>
+            <unknown class="- topic/unknown ">topicref unknown</unknown>
+            <unknown class="- topic/unknown ">topicref unknown</unknown>
+            <linktext class="- map/linktext ">topicref linktext</linktext>
+            <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+            <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
+        </topicmeta>
+
+    </topicref>
+    <topicref class="- map/topicref " href="c.xml">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="d.xml">
+        <topicmeta class="- map/topicmeta ">
+            <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
+            <author class="- topic/author ">topicref author</author>
+            <author class="- topic/author ">map author</author>
+            <source class="- topic/source ">topicref source</source>
+            <publisher class="- topic/publisher ">topicref publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2011"/>
+                <copyrholder class="- topic/copyrholder ">topicref copyrholder</copyrholder>
+            </copyright>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2011"/>
+                <revised class="- topic/revised " modified="2011"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="topicref permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">topicref category</category>
+            <category class="- topic/category ">topicref category</category>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <keywords class="- topic/keywords ">
+                <keyword class="- topic/keyword ">topicref keyword</keyword>
+            </keywords>
+            <keywords class="- topic/keywords ">
+                <keyword class="- topic/keyword ">topicref keyword</keyword>
+            </keywords>
+            <exportanchors class="+ topic/keywords delay-d/exportanchors ">
+                <anchorkey class="+ topic/keyword delay-d/anchorkey " keyref="topicref anchorkey"/>
+            </exportanchors>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="2.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">topicref prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="2.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
+            <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
+            <resourceid class="- topic/resourceid " id="foo"/>
+            <data class="- topic/data ">topicref data</data>
+            <data class="- topic/data ">topicref datafoo</data>
+            <data-about class="- topic/data-about ">
+                <data class="- topic/data ">topicref data</data>
+            </data-about>
+            <data-about class="- topic/data-about ">
+                <data class="- topic/data ">topicref datafoo</data>
+            </data-about>
+            <foreign class="- topic/foreign ">topicref foreign</foreign>
+            <foreign class="- topic/foreign ">topicref foreign</foreign>
+            <unknown class="- topic/unknown ">topicref unknown</unknown>
+            <unknown class="- topic/unknown ">topicref unknown</unknown>
+            <linktext class="- map/linktext ">topicref linktext</linktext>
+            <shortdesc class="- map/shortdesc ">topicref shortdesc</shortdesc>
+            <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="nest.xml">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="nest.xml#first">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="nest.xml#second">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
+    <topicref class="- map/topicref " href="nest.xml#nest">
+        <topicmeta class="- map/topicmeta ">
+            <author class="- topic/author ">map author</author>
+            <publisher class="- topic/publisher ">map publisher</publisher>
+            <copyright class="- topic/copyright ">
+                <copyryear class="- topic/copyryear " year="2010"/>
+                <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+            </copyright>
+            <critdates class="- topic/critdates ">
+                <created class="- topic/created " date="2010"/>
+                <revised class="- topic/revised " modified="2010"/>
+            </critdates>
+            <permissions class="- topic/permissions " view="map permissins"/>
+            <audience class="- topic/audience "/>
+            <audience class="- topic/audience "/>
+            <category class="- topic/category ">map category</category>
+            <category class="- topic/category ">map category</category>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+            <prodinfo class="- topic/prodinfo ">
+                <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+                <vrmlist class="- topic/vrmlist ">
+                    <vrm class="- topic/vrm " version="1.0"/>
+                </vrmlist>
+            </prodinfo>
+        </topicmeta>
+    </topicref>
 </map>

--- a/src/test/resources/MapMetaReaderTest/exp/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/exp/test.ditamap
@@ -1,4 +1,5 @@
-<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- map/map "
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  class="- map/map "
   domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
   title="test" ditaarch:DITAArchVersion="1.2">
   <topicmeta class="- map/topicmeta ">
@@ -64,7 +65,6 @@
   <topicref class="- map/topicref " href="a.xml">
     <topicmeta class="- map/topicmeta ">
       <author class="- topic/author ">map author</author>
-      <source class="- topic/source ">map source</source>
       <publisher class="- topic/publisher ">map publisher</publisher>
       <copyright class="- topic/copyright ">
         <copyryear class="- topic/copyryear " year="2010"/>
@@ -91,13 +91,12 @@
           <vrm class="- topic/vrm " version="1.0"/>
         </vrmlist>
       </prodinfo>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
     </topicmeta>
   </topicref>
   <topicref class="- map/topicref " href="b.xml">
     <topicmeta class="- map/topicmeta ">
       <searchtitle class="- map/searchtitle ">topicref searchtitle</searchtitle>
+      <pluf/>
       <author class="- topic/author ">topicref author</author>
       <author class="- topic/author ">map author</author>
       <source class="- topic/source ">topicref source</source>
@@ -157,9 +156,6 @@
         </vrmlist>
       </prodinfo>
       <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
       <resourceid class="- topic/resourceid " id="foo"/>
       <data class="- topic/data ">topicref data</data>
       <data class="- topic/data ">topicref datafoo</data>
@@ -181,7 +177,6 @@
   <topicref class="- map/topicref " href="c.xml">
     <topicmeta class="- map/topicmeta ">
       <author class="- topic/author ">map author</author>
-      <source class="- topic/source ">map source</source>
       <publisher class="- topic/publisher ">map publisher</publisher>
       <copyright class="- topic/copyright ">
         <copyryear class="- topic/copyryear " year="2010"/>
@@ -208,8 +203,6 @@
           <vrm class="- topic/vrm " version="1.0"/>
         </vrmlist>
       </prodinfo>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
     </topicmeta>
   </topicref>
   <topicref class="- map/topicref " href="d.xml">
@@ -274,9 +267,6 @@
         </vrmlist>
       </prodinfo>
       <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="topicref othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
       <resourceid class="- topic/resourceid " id="foo"/>
       <data class="- topic/data ">topicref data</data>
       <data class="- topic/data ">topicref datafoo</data>
@@ -295,140 +285,130 @@
       <navtitle class="- topic/navtitle " dita-ot:locktitle="no">topicref navtitle</navtitle>
     </topicmeta>
   </topicref>
-<topicref class="- map/topicref " href="nest.xml">
-<topicmeta class="- map/topicmeta ">
-<author class="- topic/author ">map author</author>
-<source class="- topic/source ">map source</source>
-<publisher class="- topic/publisher ">map publisher</publisher>
-<copyright class="- topic/copyright ">
-<copyryear class="- topic/copyryear " year="2010"/>
-<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-</copyright>
-<critdates class="- topic/critdates ">
-<created class="- topic/created " date="2010"/>
-<revised class="- topic/revised " modified="2010"/>
-</critdates>
-<permissions class="- topic/permissions " view="map permissins"/>
-<audience class="- topic/audience "/>
-<audience class="- topic/audience "/>
-<category class="- topic/category ">map category</category>
-<category class="- topic/category ">map category</category>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-</topicmeta>
-</topicref>
-<topicref class="- map/topicref " href="nest.xml#first">
-<topicmeta class="- map/topicmeta ">
-<author class="- topic/author ">map author</author>
-<source class="- topic/source ">map source</source>
-<publisher class="- topic/publisher ">map publisher</publisher>
-<copyright class="- topic/copyright ">
-<copyryear class="- topic/copyryear " year="2010"/>
-<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-</copyright>
-<critdates class="- topic/critdates ">
-<created class="- topic/created " date="2010"/>
-<revised class="- topic/revised " modified="2010"/>
-</critdates>
-<permissions class="- topic/permissions " view="map permissins"/>
-<audience class="- topic/audience "/>
-<audience class="- topic/audience "/>
-<category class="- topic/category ">map category</category>
-<category class="- topic/category ">map category</category>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-</topicmeta>
-</topicref>
-<topicref class="- map/topicref " href="nest.xml#second">
-<topicmeta class="- map/topicmeta ">
-<author class="- topic/author ">map author</author>
-<source class="- topic/source ">map source</source>
-<publisher class="- topic/publisher ">map publisher</publisher>
-<copyright class="- topic/copyright ">
-<copyryear class="- topic/copyryear " year="2010"/>
-<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-</copyright>
-<critdates class="- topic/critdates ">
-<created class="- topic/created " date="2010"/>
-<revised class="- topic/revised " modified="2010"/>
-</critdates>
-<permissions class="- topic/permissions " view="map permissins"/>
-<audience class="- topic/audience "/>
-<audience class="- topic/audience "/>
-<category class="- topic/category ">map category</category>
-<category class="- topic/category ">map category</category>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-</topicmeta>
-</topicref>
-<topicref class="- map/topicref " href="nest.xml#nest">
-<topicmeta class="- map/topicmeta ">
-<author class="- topic/author ">map author</author>
-<source class="- topic/source ">map source</source>
-<publisher class="- topic/publisher ">map publisher</publisher>
-<copyright class="- topic/copyright ">
-<copyryear class="- topic/copyryear " year="2010"/>
-<copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
-</copyright>
-<critdates class="- topic/critdates ">
-<created class="- topic/created " date="2010"/>
-<revised class="- topic/revised " modified="2010"/>
-</critdates>
-<permissions class="- topic/permissions " view="map permissins"/>
-<audience class="- topic/audience "/>
-<audience class="- topic/audience "/>
-<category class="- topic/category ">map category</category>
-<category class="- topic/category ">map category</category>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<prodinfo class="- topic/prodinfo ">
-<prodname class="- topic/prodname ">map prodnamefoo</prodname>
-<vrmlist class="- topic/vrmlist ">
-<vrm class="- topic/vrm " version="1.0"/>
-</vrmlist>
-</prodinfo>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-<othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
-</topicmeta>
-</topicref>
+  <topicref class="- map/topicref " href="nest.xml">
+    <topicmeta class="- map/topicmeta ">
+      <author class="- topic/author ">map author</author>
+      <publisher class="- topic/publisher ">map publisher</publisher>
+      <copyright class="- topic/copyright ">
+        <copyryear class="- topic/copyryear " year="2010"/>
+        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+      </copyright>
+      <critdates class="- topic/critdates ">
+        <created class="- topic/created " date="2010"/>
+        <revised class="- topic/revised " modified="2010"/>
+      </critdates>
+      <permissions class="- topic/permissions " view="map permissins"/>
+      <audience class="- topic/audience "/>
+      <audience class="- topic/audience "/>
+      <category class="- topic/category ">map category</category>
+      <category class="- topic/category ">map category</category>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+    </topicmeta>
+  </topicref>
+  <topicref class="- map/topicref " href="nest.xml#first">
+    <topicmeta class="- map/topicmeta ">
+      <author class="- topic/author ">map author</author>
+      <publisher class="- topic/publisher ">map publisher</publisher>
+      <copyright class="- topic/copyright ">
+        <copyryear class="- topic/copyryear " year="2010"/>
+        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+      </copyright>
+      <critdates class="- topic/critdates ">
+        <created class="- topic/created " date="2010"/>
+        <revised class="- topic/revised " modified="2010"/>
+      </critdates>
+      <permissions class="- topic/permissions " view="map permissins"/>
+      <audience class="- topic/audience "/>
+      <audience class="- topic/audience "/>
+      <category class="- topic/category ">map category</category>
+      <category class="- topic/category ">map category</category>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+    </topicmeta>
+  </topicref>
+  <topicref class="- map/topicref " href="nest.xml#second">
+    <topicmeta class="- map/topicmeta ">
+      <author class="- topic/author ">map author</author>
+      <publisher class="- topic/publisher ">map publisher</publisher>
+      <copyright class="- topic/copyright ">
+        <copyryear class="- topic/copyryear " year="2010"/>
+        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+      </copyright>
+      <critdates class="- topic/critdates ">
+        <created class="- topic/created " date="2010"/>
+        <revised class="- topic/revised " modified="2010"/>
+      </critdates>
+      <permissions class="- topic/permissions " view="map permissins"/>
+      <audience class="- topic/audience "/>
+      <audience class="- topic/audience "/>
+      <category class="- topic/category ">map category</category>
+      <category class="- topic/category ">map category</category>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+      <othermeta class="- topic/othermeta " content="map othermeta" name="othermeta"/>
+    </topicmeta>
+  </topicref>
+  <topicref class="- map/topicref " href="nest.xml#nest">
+    <topicmeta class="- map/topicmeta ">
+      <author class="- topic/author ">map author</author>
+      <publisher class="- topic/publisher ">map publisher</publisher>
+      <copyright class="- topic/copyright ">
+        <copyryear class="- topic/copyryear " year="2010"/>
+        <copyrholder class="- topic/copyrholder ">map copyrholder</copyrholder>
+      </copyright>
+      <critdates class="- topic/critdates ">
+        <created class="- topic/created " date="2010"/>
+        <revised class="- topic/revised " modified="2010"/>
+      </critdates>
+      <permissions class="- topic/permissions " view="map permissins"/>
+      <audience class="- topic/audience "/>
+      <audience class="- topic/audience "/>
+      <category class="- topic/category ">map category</category>
+      <category class="- topic/category ">map category</category>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+      <prodinfo class="- topic/prodinfo ">
+        <prodname class="- topic/prodname ">map prodnamefoo</prodname>
+        <vrmlist class="- topic/vrmlist ">
+          <vrm class="- topic/vrm " version="1.0"/>
+        </vrmlist>
+      </prodinfo>
+    </topicmeta>
+  </topicref>
 </map>

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/MatadataInheritance_source.ditamap
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/MatadataInheritance_source.ditamap
@@ -19,9 +19,6 @@
         <navtitle class="- topic/navtitle ">batcaring</navtitle>
         <?ditaot gentext?>
         <linktext class="- map/linktext ">batcaring</linktext>
-        <source class="- topic/source ">
-    source2
-  </source>
       </topicmeta>
     </topicref>
   </topicref>
@@ -30,9 +27,6 @@
       <navtitle class="- topic/navtitle ">batfeeding</navtitle>
       <?ditaot gentext?>
       <linktext class="- map/linktext ">batfeeding</linktext>
-      <source class="- topic/source ">
-    source
-  </source>
     </topicmeta>
   </topicref>
 </map>

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/batcaring.dita
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/batcaring.dita
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="batcaring" xml:lang="en-us" ditaarch:DITAArchVersion="1.2" domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)" class="- topic/topic ">
   <title class="- topic/title ">batcaring</title>
-  <prolog class="- topic/prolog ">
-    <source class="- topic/source ">
-    source2
-  </source>
-  </prolog>
   <body class="- topic/body ">
     <p class="- topic/p ">The ANT tasks are refactored so that developers can easily find the targets
       they need and make their own extensions. Developers can still use Java Command

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/batfeeding.dita
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source/batfeeding.dita
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="batfeeding" xml:lang="en-us" ditaarch:DITAArchVersion="1.2" domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)" class="- topic/topic ">
   <title class="- topic/title ">batfeeding</title>
-  <prolog class="- topic/prolog ">
-    <source class="- topic/source ">
-    source
-  </source>
-  </prolog>
   <body class="- topic/body ">
     <p class="- topic/p ">In DITA 1.1, you can use new element, &lt;data&gt;. This element and the content
       inside it is ignored in the transformation process of DITA files.<note rev="r5" class="- topic/note "><ul class="- topic/ul "><li class="- topic/li ">Because OASIS DITA 1.1 is not yet an approved standard as of the release

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/MatadataInheritance_source_replace.ditamap
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/MatadataInheritance_source_replace.ditamap
@@ -19,9 +19,6 @@
         <navtitle class="- topic/navtitle ">batcaring</navtitle>
         <?ditaot gentext?>
         <linktext class="- map/linktext ">batcaring</linktext>
-        <source class="- topic/source ">
-    source2
-  </source>
       </topicmeta>
     </topicref>
   </topicref>
@@ -30,9 +27,6 @@
       <navtitle class="- topic/navtitle ">Programming elements</navtitle>
       <?ditaot gentext?>
       <linktext class="- map/linktext ">Programming elements</linktext>
-      <source class="- topic/source ">
-    source
-  </source>
     </topicmeta>
   </topicref>
 </map>

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/batcaring.dita
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/batcaring.dita
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="batcaring" xml:lang="en-us" ditaarch:DITAArchVersion="1.2" domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)" class="- topic/topic ">
   <title class="- topic/title ">batcaring</title>
-  <prolog class="- topic/prolog ">
-    <source class="- topic/source ">
-    source2
-  </source>
-  </prolog>
   <body class="- topic/body ">
     <p class="- topic/p ">The ANT tasks are refactored so that developers can easily find the targets
       they need and make their own extensions. Developers can still use Java Command

--- a/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/bats.dita
+++ b/src/test/resources/MetadataInheritance/exp/preprocess/MatadataInheritance_source_replace/bats.dita
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="bats" xml:lang="en-us" ditaarch:DITAArchVersion="1.2" domains="(topic ui-d) (topic hi-d) (topic pr-d) (topic sw-d)                          (topic ut-d) (topic indexing-d)" class="- topic/topic ">
   <title class="- topic/title ">Programming elements</title>
-  <prolog class="- topic/prolog ">
-    <source class="- topic/source ">
-    source
-  </source>
-  </prolog>
   <body class="- topic/body ">
     <section class="- topic/section ">
       <p class="- topic/p ">The programming domains elements are used to define the syntax and to give


### PR DESCRIPTION
##  `othermeta` and `source` should not cascade
I removed `othermeta` and `source` from the `cascadeset` in MapMetaReader.java.

## Motivation and Context
Based on the official DITA 1.3 specs http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/archSpec/base/reconciling-topic-and-map-metadata.html#reconciling-topic-and-map-metadata
Fixes issue #1899 

## How Has This Been Tested?
Transformed a map heavy with `othermeta` and with some `source` declarations. Cascading behaves as expected.

## Type of Changes
- Bug fix

Signed-off-by: Lionel Moizeau <lionel.moizeau@gmail.com>
