### PR TITLE
Fix indentation of Swiss German warning string

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/strings-de-ch.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-de-ch.xml
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
   <str name="Remember">Hinweis</str>
   <str name="Restriction">Einschränkung</str>
   <str name="Trouble">Problem</str>
-<str name="Warning">Warnung</str>
+  <str name="Warning">Warnung</str>
   <str name="Contents">Inhaltsverzeichnis</str>
   <str name="Related concepts">Zugehörige Konzepte</str>
   <str name="Related tasks">Zugehörige Tasks</str>


### PR DESCRIPTION
Trivial tweak to 04318ae. _(Sorry I missed this earlier while #3322 was open for review.)_

Signed-off-by: Roger Sheen <roger@infotexture.net>
