### PR TITLE
Update to LwDITA 2.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
                    "develop" :
                    "${project.version}"
 def bundled = [
-        "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.2.0/org.lwdita-2.2.0.zip",
+        "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.3.0/org.lwdita-2.3.0.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
         "troff": "https://github.com/dita-ot/org.dita.troff/archive/3.1.1.zip",
         "tocjs": "https://github.com/dita-ot/com.sophos.tocjs/archive/2.5.zip",


### PR DESCRIPTION
Update bundled LwDITA plugin to version 2.3.0

-   Fixes whitespace generation in mixed content for Markdown output.
-   Disable html as HDITA format.
-   Use HDITA reader for `hdita` format
-   Update dependencies