### PR TITLE
Drop phrase IDs from title marker

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -213,10 +213,12 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*" mode="insertTopicHeaderMarker">
     <xsl:param name="marker-class-name" as="xs:string">current-header</xsl:param>
-
-    <fo:marker marker-class-name="{$marker-class-name}">
-      <xsl:apply-templates select="." mode="insertTopicHeaderMarkerContents"/>
-    </fo:marker>
+      <xsl:variable name="headerContent" as="node()*">
+        <xsl:apply-templates select="." mode="insertTopicHeaderMarkerContents"/>
+      </xsl:variable>
+      <fo:marker marker-class-name="{$marker-class-name}">
+        <xsl:apply-templates select="$headerContent" mode="dropCopiedIds"/>
+      </fo:marker>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="insertTopicHeaderMarkerContents">


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Topic title content is generated within the title, but also within the `<fo:marker>` element ahead of the rendered title. The same content is used for both. If an ID is used on a phrase element inside of the title, that ID will appear in both the marker and in the normal content -- for example, if `<ph id="test">` is used in a title, then the FO will have an ID similar to `<fo:inline id="unique_2_Connect_42_test"` that appears in both the marker and in the content.

We've had this problem before for duplicated content in short descriptions, which is why there is already a mode `dropCopiedIds`. The fix puts the marker content into a variable and then uses the existing mode to drop any ID from the marker, so that any links to the ID resolve properly to the heading.

## Motivation and Context

The duplicate ID is technically invalid; we had some content several hundred titles that contain IDs, resulting in a lot of noise about duplicate IDs from the FO rendering step. If the first instance is used for links, it resolves to the marker, which doesn't make sense; the only instance of the ID should be the one in the actual title.

## How Has This Been Tested?

Can be tested by putting `<ph id="test">` around any topic title, and building to PDF -- if you look at the `topic.fo` file you'll find two instances of the same ID that ends in `_test"`. (You can also run in verbose mode and check for warnings from the formatter).

With this fix, the problem is corrected.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that changes existing functionality)_