### PR TITLE
Use open JDK for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 env:
   global:
   - JAVA_OPTS="-Xmx2048M"


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

Switches Travis builds from using `oraclejdk8` to `openjdk8` -- all of our Travis tests are failing immediately with Oracle JDK 8, with this message:

`The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .`

Switching from Oracle to Open fixes the issue and seems like a good way to get our tests running again, while staying with a Java 8 implementation.
