### PR TITLE
Fix footnote-by-reference link text

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1111,11 +1111,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <a name="fnsrc_{$fnid}" href="#fntarg_{$fnid}">
-      <sup>
-        <xsl:value-of select="$convergedcallout"/>
-      </sup>
-    </a>
+    <sup class="+ topic/ph hi-d/sup ">
+      <xsl:value-of select="$convergedcallout"/>
+    </sup>
   </xsl:template>
 
   <!-- Getting text from a dlentry target: use the contents of the term -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes `topicpull` processing for footnotes-by-reference.

## Motivation and Context

It looks like at some point HTML based code was copy/pasted into `topicpull` for setting link text for referenced footnotes. It is adding `<a href="#fnid"><sup>`callout`</sup></a>` which is not valid -- the output of `topicpull` needs to be valid DITA to go into the next step. Currently I'm getting "Invalid class attribute" errors from HTML and "Broken link to unique_NN" from PDF when I get to the final rendering steps (this comes from extra validation plugins I've got).

The actual cross reference is still valid after `topicpull`, this is just extra noise added around the link text; the callout inside the elements is also valid. We just need to remove the HTML `<a>` element and add a valid DITA class to `<sup>`.

## How Has This Been Tested?

Add this to any topic and format to HTML; check the file after `topicpull` runs and you'll see normal DITA markup with the HTML `<a><sup>` in the middle:
`<xref href="#./fn"/><fn id="id">This is my referenced footnote</fn>`

Before this fix, the output generally works for html/pdf (but might not for other formats). The HTML markup falls through, and PDF ignores the link text from `topicpull` in order to set the link text on its own.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
