### PR TITLE
Fix uplevels when topic has uplevels and map does not #3333

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -469,6 +469,9 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             updateUplevels(target);
 
         }
+        for (final URI file: listFilter.getNonTopicrefReferenceSet()) {
+            updateUplevels(file);
+        }
         schemeSet.addAll(listFilter.getSchemeRefSet());
 
         // collect key definitions

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -831,6 +831,25 @@ public class IntegrationTest extends AbstractIntegrationTest {
     }
     
     @Test
+    public void testuplevelslink() throws Throwable {
+        builder().name("uplevelslink")
+                .transtype(PREPROCESS)
+                .input(Paths.get("main/uplevel-in-topic.ditamap"))
+                .put("outer.control", "quiet")
+                .test();
+    }
+    
+    @Test
+    public void testuplevelslinkOnlytopic() throws Throwable {
+        builder().name("uplevelslink")
+                .transtype(PREPROCESS)
+                .input(Paths.get("main/uplevel-in-topic.ditamap"))
+                .put("outer.control", "quiet")
+                .put("onlytopic.in.map", "true")
+                .test();
+    }
+    
+    @Test
     public void testmappull_topicid() throws Throwable {
         builder().name("mappull-topicid")
                 .transtype(PREPROCESS)

--- a/src/test/resources/uplevelslink/exp/preprocess/main/justthis.dita
+++ b/src/test/resources/uplevelslink/exp/preprocess/main/justthis.dita
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?workdir /C:\jira119\content\temp\content?>
+<?workdir-uri file:/C:/jira119/content/temp/content/?>
+<?path2project?>
+<?path2project-uri ./?>
+<?path2rootmap-uri ./?>
+<?doctype-public -//OASIS//DTD DITA Topic//EN?>
+<?doctype-system topic.dtd?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" id="justthis" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" class="- topic/topic " xtrf="file:/C:/jira119/content/justthis.dita" xtrc="topic:1;3:22">
+    <title class="- topic/title " xtrf="file:/C:/jira119/content/justthis.dita" xtrc="title:1;4:12">Just this topic</title>
+    <body class="- topic/body " xtrf="file:/C:/jira119/content/justthis.dita" xtrc="body:1;5:11">
+        <p class="- topic/p " xtrf="file:/C:/jira119/content/justthis.dita" xtrc="p:1;6:12">But link up and over: <xref href="../peer/upandover.dita" class="- topic/xref " xtrf="file:/C:/jira119/content/justthis.dita" xtrc="xref:1;6:71" type="topic"><?ditaot gentext?>I'm up and over!</xref></p>
+    </body>
+</topic>

--- a/src/test/resources/uplevelslink/exp/preprocess/main/uplevel-in-topic.ditamap
+++ b/src/test/resources/uplevelslink/exp/preprocess/main/uplevel-in-topic.ditamap
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?workdir /C:\jira119\content\temp\content?>
+<?workdir-uri file:/C:/jira119/content/temp/content/?>
+<?path2project?>
+<?path2project-uri ./?>
+<?path2rootmap-uri ./?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" cascade="nomerge" class="- map/map " ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" xml:lang="en-us" xtrc="map:1;3:23" xtrf="file:/C:/jira119/content/uplevel-in-topic.ditamap">
+    <title class="- topic/title " xtrc="title:1;3:30" xtrf="file:/C:/jira119/content/uplevel-in-topic.ditamap">Topic has up and over, map does not</title>
+<topicref class="- map/topicref " xtrc="topicref:1;4:33" xtrf="file:/C:/jira119/content/uplevel-in-topic.ditamap" href="justthis.dita" type="topic">
+    <topicmeta class="- map/topicmeta ">
+        <navtitle class="- topic/navtitle ">Just this topic</navtitle>
+        <?ditaot gentext?>
+        <linktext class="- map/linktext ">Just this topic</linktext>
+    </topicmeta>
+</topicref>
+</map>

--- a/src/test/resources/uplevelslink/exp/preprocess/peer/upandover.dita
+++ b/src/test/resources/uplevelslink/exp/preprocess/peer/upandover.dita
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?workdir /C:\jira119\content\temp\peer?>
+<?workdir-uri file:/C:/jira119/content/temp/peer/?>
+<?path2project ..\out\?>
+<?path2project-uri ../out/?>
+<?path2rootmap-uri ../content/?>
+<?doctype-public -//OASIS//DTD DITA Topic//EN?><?doctype-system topic.dtd?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" id="upandover" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)" class="- topic/topic " xtrf="file:/C:/jira119/peer/upandover.dita" xtrc="topic:1;3:23">
+    <title class="- topic/title " xtrf="file:/C:/jira119/peer/upandover.dita" xtrc="title:1;4:12">I'm up and over!</title>
+    <body class="- topic/body " xtrf="file:/C:/jira119/peer/upandover.dita" xtrc="body:1;5:11">
+        <p class="- topic/p " xtrf="file:/C:/jira119/peer/upandover.dita" xtrc="p:1;6:12">That's it</p>
+    </body>
+</topic>

--- a/src/test/resources/uplevelslink/src/main/justthis.dita
+++ b/src/test/resources/uplevelslink/src/main/justthis.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="justthis">
+    <title>Just this topic</title>
+    <body>
+        <p>But link up and over: <xref href="../peer/upandover.dita"/></p>
+    </body>
+</topic>

--- a/src/test/resources/uplevelslink/src/main/uplevel-in-topic.ditamap
+++ b/src/test/resources/uplevelslink/src/main/uplevel-in-topic.ditamap
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map xml:lang="en-us">
+    <title>Topic has up and over, map does not</title>
+    <!--Addresses: https://github.com/dita-ot/dita-ot/issues/3333-->
+    <topicref href="justthis.dita"/>
+</map>

--- a/src/test/resources/uplevelslink/src/peer/upandover.dita
+++ b/src/test/resources/uplevelslink/src/peer/upandover.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="upandover">
+    <title>I'm up and over!</title>
+    <body>
+        <p>That's it</p>
+    </body>
+</topic>


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

We run a method called `updateUplevels(URI)` over each linked DITA file when processing topics and maps; this ensures the temp directory can handle references to peer directories. This runs on all references from the map.

When `onlytopic.in.map=true` and local topics are linked from a topic (not from the map), they go into a different set, holding topics that are processed as resources in some way but will be excluded from a lot of other processing and will not generate output. These topics go into the `nonTopicrefReferenceSet`.

Currently uplevels processing only operates on sets that contain references from a map. As a result, when 1) a map only has references within the map directory (no uplevels), 2) a topic *does* have uplevels, and 3) `onlytopic.in.map=true`, DITA-OT's Job ends up using the _source_ file for the link target. Our link filters change the relative URI to refer to that source file.

For example, as in #3333, if a topic just has one `../peer/file.dita` reference, and the temp directory is `input/temp`, the URI is modified to `../../peer.dita` (referring to the original source). The result is a broken link in the output because we've corrupted the expected path; the broken path also means we do not pull link text, so the link just has a file name.

The fix here is a minor change to ensure files in the `nonTopicrefReferenceSet` are also checked to see if they result in changes to the `uplevels` count; with the fixed `uplevels` value, the Job is structured appropriately, so the link is processed correctly.

## Motivation and Context

Fixes #3333 which continues to come up in our customer source

## How Has This Been Tested?

Tested with original source.

Added a test case to our integrationTest with a very simple peer link that reproduces the problem. Set up the same test to run with both `onlytopic.in.map=false` (with the default) and with `onlytopic.in.map=true` -- both should have the same result coming out of `preprocess`. Before the test, default (`false`) passed and `true` failed; with the fix, both pass.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
