### PR TITLE
Fix empty docinfo when authorInfo has no name

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -163,7 +163,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="$authorinformation/descendant::*[contains(@class, ' xnal-d/organizationname ')]" mode="dita-ot:text-only"/>
         </xsl:value-of>
       </xsl:when>
-      <xsl:when test="exists($map/*[contains(@class, ' bookmap/bookmeta ')]/*[contains(@class, ' topic/author ')])">
+      <xsl:when test="exists($map/*[contains(@class, ' bookmap/bookmeta ')]/*[contains(@class, ' topic/author ') and not(contains(@class,' xnal-d/authorinformation '))])">
         <xsl:value-of>
           <xsl:apply-templates select="$map/*[contains(@class, ' bookmap/bookmeta ')]/*[contains(@class, ' topic/author ')]" mode="dita-ot:text-only"/>
         </xsl:value-of>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes XSL-FO document info when a bookmap contains `<authorInformation>` but does not have a person name or an organization name.

Encountered in a customer document that had author information containing only an email address. The current test assumes that `<authorInformation>` will have either a person name or an organization name, but breaks down with that situation:

1. If there is a person name, use that as the document author
2. Otherwise if there is an organization name, use that as the document author
3. Otherwise if there is a general `<author>`, use that. This breaks with the condition above because `authorInformation` is specialized from `<author>`, so it gets processed. All of the sub-components are specialized from `<data>`, so when processed in text-only mode, it ends up returning white space and newlines.

The fix modifies the third check for `<author>` to ensure it's not `authorInformation` -- if using a bookmap with `authorInformation`, the author needs to come from one of the first two checks.

## Motivation and Context

Hit this with the condition described above (test case attached). When processing with AXF it results in the following error:
```
      [ahf] Error Code  : 10764 (2A0C)
      [ahf] Missing required property value: 'value' on axf:document-info.
      [ahf] Line 1, Col 571, C:\Users\ROBERT~1\AppData\Local\Temp\temp20190813155600496\topic.fo
```

## How Has This Been Tested?

Tested with the attached case.
[docInfo.zip](https://github.com/dita-ot/dita-ot/files/3498906/docInfo.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

