### PR TITLE
Add Docker configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ stages:
     if: repo = dita-ot/dita-ot AND branch = develop AND type != pull_request
   - name: release
     if: repo = dita-ot/dita-ot AND tag IS present AND type != pull_request
+  - name: deploy
+    if: repo = dita-ot/dita-ot AND tag IS present AND type != pull_request
 jobs:
   include:
     # Test
@@ -88,6 +90,20 @@ jobs:
         - provider: script
           script: bash .travis/registry.sh
           skip_cleanup: true
+          on:
+            tags: true
+            repo: dita-ot/dita-ot
+    # Deployment
+    - state: deploy
+      name: "Deploy Docker"
+      install: skip
+      script: skip
+      deploy:
+        - provider: script
+          script: |-
+            docker login docker.pkg.github.com -u $GITHUB_USER -p $GITHUB_PACKAGE_REGISTRY
+            TAG=${TRAVIS_TAG} docker build -t docker.pkg.github.com/dita-ot/dita-ot/dita-ot:${TRAVIS_TAG} --build-arg VERSION=${TRAVIS_TAG} .
+            TAG=${TRAVIS_TAG} docker push docker.pkg.github.com/dita-ot/dita-ot/dita-ot:${TRAVIS_TAG}
           on:
             tags: true
             repo: dita-ot/dita-ot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM adoptopenjdk/openjdk11:jdk-11.0.4_11-slim
+
+RUN apt-get update \
+    && apt-get install -y unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+RUN curl -sLo /tmp/dita-ot-$VERSION.zip https://github.com/dita-ot/dita-ot/releases/download/$VERSION/dita-ot-$VERSION.zip && \
+    unzip /tmp/dita-ot-$VERSION.zip -d /tmp/ && \
+    rm /tmp/dita-ot-$VERSION.zip && \
+    mkdir -p /opt/app/ && \
+    mv /tmp/dita-ot-$VERSION/bin /opt/app/bin && \
+    chmod 755 /opt/app/bin/dita && \
+    mv /tmp/dita-ot-$VERSION/config /opt/app/config && \
+    mv /tmp/dita-ot-$VERSION/lib /opt/app/lib && \
+    mv /tmp/dita-ot-$VERSION/plugins /opt/app/plugins && \
+    mv /tmp/dita-ot-$VERSION/build.xml /opt/app/build.xml && \
+    mv /tmp/dita-ot-$VERSION/integrator.xml /opt/app/integrator.xml && \
+    rm -r /tmp/dita-ot-$VERSION && \
+    /opt/app/bin/dita --install
+
+RUN useradd -ms /bin/bash dita-ot && \
+    chown -R dita-ot:dita-ot /opt/app
+USER dita-ot
+
+ENV DITA_HOME=/opt/app
+ENV PATH=${PATH}:${DITA_HOME}/bin
+WORKDIR $DITA_HOME
+ENTRYPOINT ["/opt/app/bin/dita"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.4_11-slim
+FROM adoptopenjdk:11-jre-hotspot
 
 RUN apt-get update \
     && apt-get install -y unzip \


### PR DESCRIPTION
Add DITA-OT Docker image.

This image is not based on [dita-ot-project-docker](https://github.com/dita-community/dita-ot-project-docker), but instead is a independent image for DITA-OT that is under the [dita-ot organization](https://github.com/dita-ot).

The image will be published into [GitHub Package Registry](https://help.github.com/en/articles/about-github-package-registry) instead of [Docker Hub](https://hub.docker.com/).

## Documentation

Documentation stubs for using DITA-OT via Docker image:

### Running

```bash
docker run -it \
  -v /Volumes/tmp:/src docker.pkg.github.com/dita-ot/dita-ot/dita-ot:3.3.4 \
  -i /src/topic.dita -o /src/out -f html5 -v
```

Where you map your local `/Volumes/tmp` to the container’s `/src` directory. Then you pass it the `dita` command arguments, so that you reference files in the containers `/src` directory.

### Extending

Custom plug-ins can be installed by creating a new Docker image that's based on the DITA-OT image:

```Dockerfile
FROM docker.pkg.github.com/dita-ot/dita-ot/dita-ot:3.3.4

RUN dita --install https://example.com/plugin.zip
RUN dita --install from-plugin-registry
```