### PR TITLE
Remove TocJS plugin from default distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,6 @@ def bundled = [
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.3.0/org.lwdita-2.3.0.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
         "troff": "https://github.com/dita-ot/org.dita.troff/archive/3.1.1.zip",
-        "tocjs": "https://github.com/dita-ot/com.sophos.tocjs/archive/2.5.zip",
         "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip"
 ]
 


### PR DESCRIPTION
Remove [TocJS plug-in](https://github.com/dita-ot/com.sophos.tocjs/) from default DITA-OT distribution package.