### PR TITLE
Drop TOC bookmark when TOC suppressed

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
@@ -102,13 +102,15 @@ See the accompanying LICENSE file for applicable license.
                 <xsl:when test="$map//*[contains(@class,' bookmap/toc ')][@href]"/>
                 <xsl:when test="$map//*[contains(@class,' bookmap/toc ')]
                               | /*[contains(@class,' map/map ')][not(contains(@class,' bookmap/bookmap '))]">
-                    <fo:bookmark internal-destination="{$id.toc}">
-                        <fo:bookmark-title>
-                            <xsl:call-template name="getVariable">
-                                <xsl:with-param name="id" select="'Table of Contents'"/>
-                            </xsl:call-template>
-                        </fo:bookmark-title>
-                    </fo:bookmark>
+                    <xsl:if test="$generate-toc">
+                        <fo:bookmark internal-destination="{$id.toc}">
+                            <fo:bookmark-title>
+                                <xsl:call-template name="getVariable">
+                                    <xsl:with-param name="id" select="'Table of Contents'"/>
+                                </xsl:call-template>
+                            </fo:bookmark-title>
+                        </fo:bookmark>
+                    </xsl:if>
                 </xsl:when>
             </xsl:choose>
             <xsl:for-each select="/*/*[contains(@class, ' topic/topic ')] |


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description / Motivation

Minor fix to the bookmarks.

The PDF2 code has a variable `$generate.toc` which can be used to disable the TOC. When set to `false()` the TOC will not be included (otherwise it is there by default for non-book maps, and when you include `<toc>` for bookmaps).

For a specific style need we set the variable to `false()`, which works to remove the TOC for all types of map, but the current code still keeps **Contents** in the bookmarks as a broken link.

This update removes the link from bookmarks when the TOC is suppressed.

## How Has This Been Tested?

Tested with non-book map and bookmap; when default is still `true()` the bookmark link is still there and correct, when set to `false()` the broken link is removed.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
