### PR TITLE
Avoid Ant error about time stamps

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -429,7 +429,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="copy-image2"
           unless="preprocess.copy-image.skip"
           description="Copy image files">
-    <copy todir="${dita.output.dir}" failonerror="false">
+    <copy todir="${dita.output.dir}" failonerror="false" overwrite="true">
       <ditafileset format="image" />
     </copy>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -550,7 +550,7 @@ See the accompanying LICENSE file for applicable license.
     <condition property="copy-image.todir" value="${_dita.map.output.dir}/${uplevels}" else="${dita.output.dir}">
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
-    <copy todir="${copy-image.todir}" failonerror="false">
+    <copy todir="${copy-image.todir}" failonerror="false" overwrite="true">
       <ditafileset format="image" />
     </copy>
   </target>
@@ -563,7 +563,7 @@ See the accompanying LICENSE file for applicable license.
     <condition property="copy-html.todir" value="${_dita.map.output.dir}/${uplevels}" else="${dita.output.dir}">
       <equals arg1="${generate.copy.outer}" arg2="1"/>      
     </condition>
-    <copy todir="${copy-html.todir}" failonerror="false">
+    <copy todir="${copy-html.todir}" failonerror="false" overwrite="true">
       <ditafileset>
         <excludes format="dita"/>
         <excludes format="ditamap"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Resolves an edge case where source files zipped up and then processed on a different machine produce invalid warnings from Ant.

## Motivation and Context

In our environment, the build process is often:
1. Zip source files
2. Send zip to cloud / server / other machine
3. Content is unzipped and built with DITA-OT

When this happens, and the machine processing the files is in a time zone _earlier in the day_ than the location where the zip was created, an HTML5 build results in this message for every referenced image:

`[copy] Warning: filepath/img/<image_name>.jpg modified in the future.`

It does not matter if the image exists at the target location (which it never does in our context). If the time stamp of the source image is in the future, the log will include this warning from Ant.

By setting `overwrite="true"` on the Ant copy task, we prevent Ant from writing out the "modified in future" message.

The potential down side I see is that if you have a lot of images, and they already exist (copied during a previous build), we will spend time copying them again. I don't think there is any other way to bypass the time-zone issue though.

## How Has This Been Tested?

1. Zip created in Europe
2. Zip sent to machine in US
3. Unzipped, with referenced images that had time stamps several hours in the future
4. Building without this update gives one "modified in the future" message for every image. Building with this update has no warnings in the log, and the files are still copied.

In trying to think of ways this could cause problems - the only thing I can think of is if

- You have source images (or HTML files) referenced by your DITA,
- Which are copied to the output directory,
- And you've edited the "output" copies (rather than the source)
- Such that setting overwrite="true" will overwrite the updated copies

That seems like a bad setup for many reasons, but I think that could potentially be affected here?

## Type of Changes

A bit hard to categorize but calling it a bug fix, because today we'll end up with invalid warnings.
