### PR TITLE
Switch invalid-file error condition from warning to error

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -108,10 +108,15 @@ See the accompanying LICENSE file for applicable license.
     <response>Check and see whether all prerequisite plug-ins are installed in toolkit.</response>
   </message>
   
-  <!-- 2012-06-12: Still need to reproduce and edit this message -->
+  <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
     <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file.</reason>
     <response>Please check the file '%1' and the ditaval file to see if this is the intended result.</response>
+  </message>
+  
+  <message id="DOTJ021E" type="ERROR">
+    <reason>File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.</reason>
+    <response></response>
   </message>
   
   <message id="DOTJ022F" type="FATAL">

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -389,7 +389,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
                 processParseResult(currentFile);
                 categorizeCurrentFile(ref);
             } else if (!currentFile.equals(rootFile)) {
-                logger.warn(MessageUtils.getMessage("DOTJ021W", params).toString());
+                logger.error(MessageUtils.getMessage("DOTJ021E", params).toString());
                 failureList.add(currentFile);
             }
         } catch (final RuntimeException e) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -364,7 +364,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
                 processParseResult(currentFile);
                 categorizeCurrentFile(ref);
             } else if (!currentFile.equals(rootFile)) {
-                logger.warn(MessageUtils.getMessage("DOTJ021W", params).toString());
+                logger.error(MessageUtils.getMessage("DOTJ021E", params).toString());
                 failureList.add(currentFile);
             }
         } catch (final RuntimeException e) {


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Changes the following warning message `DOTJ021W`:
`File '%1' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file. Please check the file '%1' and the ditaval file to see if this is the intended result.`

To an updated error message `DOTJ021E`:
`File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.`

## Motivation and Context

We've had people run into this when filtering out everything from topics, and they did not understand the current version of the message. They also assumed that with a Warning (rather than error) the output might still be acceptable -- but there is no case in which this produces valid output, so it should be Error level instead of Warning.

The message has also been updated to start with the possibility that content has all been filtered out (most likely scenario), or that the content is explicitly not valid DITA.

## How Has This Been Tested?

Including test case with:

- One valid file
- One empty file (empty as source, can't be parsed); generates a different message so not affected
- One file with all content filtered out
- One file that is not valid DITA

[fixmsg.zip](https://github.com/dita-ot/dita-ot/files/3659649/fixmsg.zip)
