### PR TITLE
Fix index link when term has subterms #3320; fix index-see-also #3314

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -66,7 +66,7 @@ See the accompanying LICENSE file for applicable license.
               select="key('refid-by-value', @value)
                       [empty(ancestor-or-self::opentopic-index:index.entry[@end-range])]
                       [empty(ancestor::opentopic-index:index.groups)]
-                      [empty(opentopic-index:index.entry|opentopic-index:see-childs)]
+                      [empty(../opentopic-index:index.entry|../opentopic-index:see-childs)]
                       [empty(ancestor::*[@no-page eq 'true'])]
                       [ancestor::*[contains(@class,' topic/topic ')]]"/>
           </xsl:for-each>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -67,6 +67,7 @@ See the accompanying LICENSE file for applicable license.
                       [empty(ancestor-or-self::opentopic-index:index.entry[@end-range])]
                       [empty(ancestor::opentopic-index:index.groups)]
                       [empty(../opentopic-index:index.entry|../opentopic-index:see-childs)]
+                      [empty(ancestor::opentopic-index:see-also-childs|ancestor::opentopic-index:see-childs)]
                       [empty(ancestor::*[@no-page eq 'true'])]
                       [ancestor::*[contains(@class,' topic/topic ')]]"/>
           </xsl:for-each>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -66,6 +66,7 @@ See the accompanying LICENSE file for applicable license.
               select="key('refid-by-value', @value)
                       [empty(ancestor-or-self::opentopic-index:index.entry[@end-range])]
                       [empty(ancestor::opentopic-index:index.groups)]
+                      [empty(opentopic-index:index.entry|opentopic-index:see-childs)]
                       [empty(ancestor::*[@no-page eq 'true'])]
                       [ancestor::*[contains(@class,' topic/topic ')]]"/>
           </xsl:for-each>

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/index_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/index_xep.xsl
@@ -117,7 +117,7 @@ See the accompanying LICENSE file for applicable license.
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
                             <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm and exists(key('index-leaves',@value)))
-                              then (opentopic-index:refID)
+                              then opentopic-index:refID
                               else ()"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
                             <xsl:with-param name="no-page" select="$isNoPage"/>

--- a/src/main/plugins/org.dita.pdf2.xep/xsl/fo/index_xep.xsl
+++ b/src/main/plugins/org.dita.pdf2.xep/xsl/fo/index_xep.xsl
@@ -116,6 +116,9 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:variable>
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
+                            <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm and exists(key('index-leaves',@value)))
+                              then (opentopic-index:refID)
+                              else ()"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
                             <xsl:with-param name="no-page" select="$isNoPage"/>
                           </xsl:apply-templates>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -249,12 +249,17 @@ See the accompanying LICENSE file for applicable license.
                         <xsl:with-param name="id" select="'Index See String'"/>
                     </xsl:call-template>
                 </fo:inline>
-                <fo:basic-link>
-                    <xsl:attribute name="internal-destination">
-                        <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-destination"/>
-                    </xsl:attribute>
-                    <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
-                </fo:basic-link>
+                <xsl:for-each select="opentopic-index:index.entry">
+                    <xsl:if test="not(position() eq 1)">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                    <fo:basic-link>
+                        <xsl:attribute name="internal-destination">
+                            <xsl:apply-templates select="." mode="get-see-destination"/>
+                        </xsl:attribute>
+                        <xsl:apply-templates select="." mode="get-see-value"/>
+                    </fo:basic-link>
+                </xsl:for-each>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="output-message">
@@ -271,12 +276,17 @@ See the accompanying LICENSE file for applicable license.
                             <xsl:with-param name="id" select="'Index See Also String'"/>
                         </xsl:call-template>
                     </fo:inline>
-                    <fo:basic-link>
-                        <xsl:attribute name="internal-destination">
-                            <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-destination"/>
-                        </xsl:attribute>
-                        <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
-                    </fo:basic-link>
+                    <xsl:for-each select="opentopic-index:index.entry">
+                        <xsl:if test="not(position() eq 1)">
+                            <xsl:text>, </xsl:text>
+                        </xsl:if>
+                        <fo:basic-link>
+                            <xsl:attribute name="internal-destination">
+                                <xsl:apply-templates select="." mode="get-see-destination"/>
+                            </xsl:attribute>
+                            <xsl:apply-templates select="." mode="get-see-value"/>
+                        </fo:basic-link>
+                    </xsl:for-each>
                 </fo:block>
             </xsl:otherwise>
         </xsl:choose>
@@ -306,8 +316,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="opentopic-index:index.entry" mode="get-see-value">
         <fo:inline>
             <xsl:apply-templates select="opentopic-index:formatted-value/node()"/>
-            <xsl:text> </xsl:text>
-            <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
+            <xsl:if test="opentopic-index:index.entry[1]">
+              <xsl:text> </xsl:text>
+              <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
+            </xsl:if>
         </fo:inline>
     </xsl:template>
 
@@ -318,12 +330,17 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:with-param name="id" select="'Index See Also String'"/>
                 </xsl:call-template>
             </fo:inline>
-            <fo:basic-link>
-                <xsl:attribute name="internal-destination">
-                    <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-destination"/>
-                </xsl:attribute>
-                <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
-            </fo:basic-link>
+            <xsl:for-each select="opentopic-index:index.entry">
+                <xsl:if test="not(position() eq 1)">
+                    <xsl:text>, </xsl:text>
+                </xsl:if>
+                <fo:basic-link>
+                    <xsl:attribute name="internal-destination">
+                        <xsl:apply-templates select="." mode="get-see-destination"/>
+                    </xsl:attribute>
+                   <xsl:apply-templates select="." mode="get-see-value"/>
+                </fo:basic-link>
+            </xsl:for-each>
         </fo:block>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -59,6 +59,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="warn-enabled" select="true()"/>
 
   <xsl:key name="index-key" match="opentopic-index:index.entry" use="@value"/>
+  <xsl:key name="index-leaves"
+    match="opentopic-index:index.entry
+              [empty(opentopic-index:index.entry|opentopic-index:see-childs)]
+              [not(ancestor::opentopic-index:index.group)]" 
+    use="@value"/>
 
   <xsl:variable name="index-entries">
             <xsl:apply-templates select="/" mode="index-entries"/>
@@ -180,9 +185,11 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates/>
   </xsl:template>
   <xsl:template match="opentopic-index:index.entry">
-      <xsl:for-each select="opentopic-index:refID[last()]">
-          <fo:inline index-key="{@indexid}"/>
-      </xsl:for-each>
+      <xsl:if test="empty(opentopic-index:index.entry|opentopic-index:see-childs)">
+          <xsl:for-each select="opentopic-index:refID[last()]">
+              <fo:inline index-key="{@indexid}"/>
+          </xsl:for-each>
+      </xsl:if>
       <xsl:apply-templates/>
   </xsl:template>
 
@@ -372,7 +379,7 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:variable>
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
-                            <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm) 
+                            <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm and exists(key('index-leaves',@value))) 
                               then (opentopic-index:refID)
                               else ()"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -62,7 +62,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:key name="index-leaves"
     match="opentopic-index:index.entry
               [empty(opentopic-index:index.entry|opentopic-index:see-childs)]
-              [not(ancestor::opentopic-index:index.group)]" 
+              [empty(ancestor::opentopic-index:index.group)]" 
     use="@value"/>
 
   <xsl:variable name="index-entries">
@@ -250,7 +250,7 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:call-template>
                 </fo:inline>
                 <xsl:for-each select="opentopic-index:index.entry">
-                    <xsl:if test="not(position() eq 1)">
+                    <xsl:if test="position() ne 1">
                         <xsl:text>, </xsl:text>
                     </xsl:if>
                     <fo:basic-link>
@@ -277,7 +277,7 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:call-template>
                     </fo:inline>
                     <xsl:for-each select="opentopic-index:index.entry">
-                        <xsl:if test="not(position() eq 1)">
+                        <xsl:if test="position() ne 1">
                             <xsl:text>, </xsl:text>
                         </xsl:if>
                         <fo:basic-link>
@@ -316,7 +316,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="opentopic-index:index.entry" mode="get-see-value">
         <fo:inline>
             <xsl:apply-templates select="opentopic-index:formatted-value/node()"/>
-            <xsl:if test="opentopic-index:index.entry[1]">
+            <xsl:if test="exists(opentopic-index:index.entry)">
               <xsl:text> </xsl:text>
               <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
             </xsl:if>
@@ -331,7 +331,7 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:call-template>
             </fo:inline>
             <xsl:for-each select="opentopic-index:index.entry">
-                <xsl:if test="not(position() eq 1)">
+                <xsl:if test="position() ne 1">
                     <xsl:text>, </xsl:text>
                 </xsl:if>
                 <fo:basic-link>
@@ -397,7 +397,7 @@ See the accompanying LICENSE file for applicable license.
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
                             <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm and exists(key('index-leaves',@value))) 
-                              then (opentopic-index:refID)
+                              then opentopic-index:refID
                               else ()"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
                             <xsl:with-param name="no-page" select="$isNoPage"/>
@@ -446,8 +446,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:if>
           <xsl:variable name="following-idx" select="following-sibling::opentopic-index:index.entry[@value = $value and opentopic-index:refID]"/>
           <xsl:if test="count(preceding-sibling::opentopic-index:index.entry[@value = $value]) = 0">
-            <xsl:variable name="page-setting" select=" (ancestor-or-self::opentopic-index:index.entry/@no-page | ancestor-or-self::opentopic-index:index.entry/@start-page)[last()]"/>
-            <xsl:variable name="isNoPage" select=" $page-setting = 'true' and name($page-setting) = 'no-page' "/>
+            <xsl:variable name="page-setting" select="(ancestor-or-self::opentopic-index:index.entry/@no-page | ancestor-or-self::opentopic-index:index.entry/@start-page)[last()]"/>
+            <xsl:variable name="isNoPage" select="$page-setting = 'true' and name($page-setting) = 'no-page' "/>
             <xsl:apply-templates select="." mode="make-index-ref">
               <xsl:with-param name="idxs" select="opentopic-index:refID"/>
               <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -62,6 +62,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:key name="index-leaves"
     match="opentopic-index:index.entry
               [empty(opentopic-index:index.entry|opentopic-index:see-childs)]
+              [empty(ancestor::opentopic-index:see-also-childs|ancestor::opentopic-index:see-childs)]
               [empty(ancestor::opentopic-index:index.group)]" 
     use="@value"/>
 
@@ -185,7 +186,13 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates/>
   </xsl:template>
   <xsl:template match="opentopic-index:index.entry">
-      <xsl:if test="empty(opentopic-index:index.entry|opentopic-index:see-childs)">
+      <!-- Do not create page link anchor for the index if:
+        * there is a subterm
+        * there is a child <index-see> redirect
+        * this entry is itself the "see" or "see also" reference -->
+      <xsl:if test="empty(opentopic-index:index.entry|
+        opentopic-index:see-childs|
+        ancestor::opentopic-index:see-also-childs|ancestor::opentopic-index:see-childs)">
           <xsl:for-each select="opentopic-index:refID[last()]">
               <fo:inline index-key="{@indexid}"/>
           </xsl:for-each>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -40,7 +40,8 @@ See the accompanying LICENSE file for applicable license.
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="xs opentopic-index comparer opentopic-func ot-placeholder">
 
-  <xsl:variable name="index.continued-enabled" select="true()"/>
+  <xsl:variable name="index.continued-enabled" select="true()" as="xs:boolean"/>
+  <xsl:variable name="index.allow-link-with-subterm" select="true()" as="xs:boolean"/>
 
     <!-- *************************************************************** -->
     <!-- Create index templates                                          -->
@@ -220,16 +221,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="opentopic-index:index.entry[not(opentopic-index:index.entry)]" mode="index-postprocess" priority="1">
         <xsl:variable name="page-setting" select=" (ancestor-or-self::opentopic-index:index.entry/@no-page | ancestor-or-self::opentopic-index:index.entry/@start-page)[last()]"/>
-    <xsl:variable name="isNoPage" select=" $page-setting = 'true' and name($page-setting) = 'no-page' "/>
+        <xsl:variable name="isNoPage" select=" $page-setting = 'true' and name($page-setting) = 'no-page' "/>
         <xsl:variable name="value" select="@value"/>
         <xsl:variable name="refID" select="opentopic-index:refID/@value"/>
 
         <xsl:if test="opentopic-func:getIndexEntry($value,$refID)">
             <xsl:apply-templates select="." mode="make-index-ref">
-        <xsl:with-param name="idxs" select="opentopic-index:refID"/>
-        <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
-        <xsl:with-param name="no-page" select="$isNoPage"/>
-      </xsl:apply-templates>
+                <xsl:with-param name="idxs" select="opentopic-index:refID"/>
+                <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
+                <xsl:with-param name="no-page" select="$isNoPage"/>
+            </xsl:apply-templates>
         </xsl:if>
     </xsl:template>
 
@@ -371,6 +372,9 @@ See the accompanying LICENSE file for applicable license.
                         </xsl:variable>
                         <xsl:if test="contains($isNormalChilds,'true ')">
                           <xsl:apply-templates select="." mode="make-index-ref">
+                            <xsl:with-param name="idxs" select="if ($index.allow-link-with-subterm) 
+                              then (opentopic-index:refID)
+                              else ()"/>
                             <xsl:with-param name="inner-text" select="opentopic-index:formatted-value"/>
                             <xsl:with-param name="no-page" select="$isNoPage"/>
                           </xsl:apply-templates>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Current PDF output will drop all instances of an index term from the index, if even one instance of the term has a sub-term. This is done silently, so adding one secondary or tertiary term can erase any number of page links for the primary term.

Doing this ignores what the actual markup says, and might not even be the original intent (some of the code design is unclear). 

Some indexing tools follow a practice that when there are child terms, the author should not index the primary; however, our code should respect the markup and leave that restriction to local rules.

The update here adds a variable `$index.allow-link-with-subterm` which defaults to `true()`; if set to `false()` it will ignore the links on the parent term as we do today. However, that should not be the default.

## Motivation and Context

Fixes #3320 
Fixes #3314

## How Has This Been Tested?

Tested with the content in 3320; using the default `true()` setting keeps the expected links, while setting to `false()` removes them.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_