### PR TITLE
Use fo:wrapper for index point #3042

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -194,7 +194,7 @@ See the accompanying LICENSE file for applicable license.
         opentopic-index:see-childs|
         ancestor::opentopic-index:see-also-childs|ancestor::opentopic-index:see-childs)">
           <xsl:for-each select="opentopic-index:refID[last()]">
-              <fo:inline index-key="{@indexid}"/>
+              <fo:wrapper index-key="{@indexid}"/>
           </xsl:for-each>
       </xsl:if>
       <xsl:apply-templates/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Uses `<fo:wrapper>` instead of `<fo:inline>` for index anchors for Antenna House and XEP output, as suggested by #3042 

## Motivation and Context

Fixes #3042 for Antenna House and (I believe) XEP. When index terms exist between blocks (or as the first thing inside of a block container), generating `fo:inline` will result in extra space, while `fo:wrapper` keeps the working index but does not add space.

## How Has This Been Tested?

Tested with the attached samples, which include index terms inside of sections in `container.dita`, between `title` and `p`, as well as between paragraphs. Before the fix those locations both got extra space, with the fix they do not. 
[3042.zip](https://github.com/dita-ot/dita-ot/files/3715543/3042.zip)

Unfortunately @infotexture and @lief-erickson I was not able to get this fixed with FOP. 

- The current code does not add any blocks due to the index terms; it only adds the `fo:wrapper`.
- That's the correct markup, but as @raducoravu noted, FOP has a bug -- open since 2012 -- about that causing extra space. (Note the comment from FOP devs in 2012, rating it low priority because of the significant design impact.)
- There's a suggestion in #2455 to use `fo:block` instead, which pretty clearly seems like the wrong markup, but works around the issue in some cases. I tested with that, and it does fix the issue of index terms at the start of a block, but not between two blocks, and it breaks with terms inside of running text.
- Sections generate the title, followed by an `fo:block` for all of the content. If an index uses an empty block **first** inside that container - no space appears, so the problem is fixed. But if it appears between two paragraphs in the section, I still have extra space. If I have it in the middle of a paragraph, it creates a line break, so it makes the output worse.
- This means if we want to use the `fo:block` workaround, it would have to be selective. Even sections would get tricky because you don't need to have blocks; you can have one 500-sentence paragraph with index terms scattered around.
- Basically the only place I'm confident that switching to `fo:block` actually fixes a problem is in a section, after the title, where there is nothing but title + white space before the term. We could catch this, but I'm not sure if we could go further without risking trouble.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

