### PR TITLE
Use block for index to work around FOP issue #2455

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -38,9 +38,42 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:apply-templates/>
   </xsl:template>
+  
+  <!-- At start of a section, fo:wrapper will add extra line breaks, but fo:block does not.
+          Workaround for FOP issue: https://issues.apache.org/jira/browse/FOP-2016
+  Use fo:block instead of fo:wrapper when:
+  * In a section or example
+  * No preceeding elements in the section other than title, other index terms, or DITAVAL flags
+  * No preceding text nodes with text -->
+  <xsl:function name="opentopic-index:use-block-in-section" as="xs:boolean">
+    <xsl:param name="ctx" as="element()"/>
+    <xsl:choose>
+      <xsl:when test="empty($ctx/ancestor::opentopic-index:index.entry[last()]/
+        parent::*[contains(@class,' topic/section ') or contains(@class,' topic/example ')])">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:when test="exists($ctx/ancestor::opentopic-index:index.entry[last()]/
+        preceding-sibling::*[not(self::opentopic-index:index.entry or contains(@class,' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop '))])">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:when test="exists($ctx/ancestor::opentopic-index:index.entry[last()]/preceding-sibling::text()[normalize-space(.)!=''])">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="true()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 
   <xsl:template match="opentopic-index:refID" mode="make-wrapper">
-    <fo:wrapper id="{opentopic-func:get-unique-refid-value(.)}"/>
+    <xsl:choose>
+      <xsl:when test="opentopic-index:use-block-in-section(.)">
+        <fo:block id="{opentopic-func:get-unique-refid-value(.)}" margin-bottom="0pt" margin-top="0pt" margin-left="0pt" margin-right="0pt" />
+      </xsl:when>
+      <xsl:otherwise>
+        <fo:wrapper id="{opentopic-func:get-unique-refid-value(.)}" />
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="opentopic-index:index.entry" mode="make-index-ref">

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -47,16 +47,19 @@ See the accompanying LICENSE file for applicable license.
   * No preceding text nodes with text -->
   <xsl:function name="opentopic-index:use-block-in-section" as="xs:boolean">
     <xsl:param name="ctx" as="element()"/>
+    <xsl:variable name="primaryTerm" select="$ctx/ancestor::opentopic-index:index.entry[last()]" as="element()"/>
     <xsl:choose>
-      <xsl:when test="empty($ctx/ancestor::opentopic-index:index.entry[last()]/
+      <xsl:when test="empty($primaryTerm/
         parent::*[contains(@class,' topic/section ') or contains(@class,' topic/example ')])">
         <xsl:sequence select="false()"/>
       </xsl:when>
-      <xsl:when test="exists($ctx/ancestor::opentopic-index:index.entry[last()]/
-        preceding-sibling::*[not(self::opentopic-index:index.entry or contains(@class,' topic/title ') or contains(@class,' ditaot-d/ditaval-startprop '))])">
+      <xsl:when test="exists($primaryTerm/
+        preceding-sibling::*[not(self::opentopic-index:index.entry or 
+                                 contains(@class,' topic/title ') or 
+                                 contains(@class,' ditaot-d/ditaval-startprop '))])">
         <xsl:sequence select="false()"/>
       </xsl:when>
-      <xsl:when test="exists($ctx/ancestor::opentopic-index:index.entry[last()]/preceding-sibling::text()[normalize-space(.)!=''])">
+      <xsl:when test="exists($primaryTerm/preceding-sibling::text()[normalize-space(.)!=''])">
         <xsl:sequence select="false()"/>
       </xsl:when>
       <xsl:otherwise>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Similar to #3379 but with focus on FOP, and more limited in scope.

Index terms use `fo:wrapper` to create points the index can link to.

In FOP, this causes extra space in a lot of contexts, as mentioned in both #3042 and #2455, due to a known bug in FOP. That bug can be worked around _in certain contexts_ by using `fo:block`, which does not add space. However, in other contexts, it will not remove the extra space, and may even cause new line breaks.

This fix focuses on index terms at the start of `<section>` or `<example>` elements, which I think is quite a common practice, and the specific place reported in both of those issues. I can also verify that the fix works in this location. If we want to extend this to other locations, we need to do so selectively, because it's easy to cause problems by adding new `fo:block` elements (for example, when one appears between two sentences in a paragraph).

Specifically, it will use `fo:block` for index anchors when:

- Parent of the primary index entry is section or example
- Only elements before the primary entry are title, other index terms, or the DITAVAL flagging content
- All text nodes before the primary entry are empty

I made this into a function to make all of that testing easier to follow. I also anticipate that we may want to add other conditions in the future that use `fo:block`, and having that long test in a function will make it easier to understand when we add more.

## Motivation and Context

Fixes #2455

## How Has This Been Tested?

Sample attached.
[3042.zip](https://github.com/dita-ot/dita-ot/files/3719623/3042.zip)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
