### PR TITLE
Add support to interleave foreign content to XML project files

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -442,7 +442,9 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             throw new BuildException("");
         }
         try {
-            return ProjectFactory.load(args.projectFile.toURI());
+            final ProjectFactory factory = ProjectFactory.getInstance();
+            factory.setLax(true);
+            return factory.load(args.projectFile.toURI());
         } catch (Exception e) {
             printErrorMessage(e.getMessage());
             throw new BuildException("");

--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.List;
 
 public class ProjectBuilder {

--- a/src/main/resources/project-lax.rnc
+++ b/src/main/resources/project-lax.rnc
@@ -1,0 +1,25 @@
+default namespace project = "https://www.dita-ot.org/project"
+namespace local = ""
+
+anything = ( element * { anything } | attribute * { text } | text )*
+foreign-element = element * - (project:*) { anything }
+foreign-elements = foreign-element*
+foreign-attributes = attribute * - (local:* | project:*) { text }*
+foreign-nodes = ( foreign-attributes | foreign-elements )*
+
+include "project.rnc" {
+  start = foreign-element
+}
+
+project &= foreign-nodes*
+includes &= foreign-nodes*
+deliverable &= foreign-nodes*
+context &= foreign-nodes*
+context-ref &= foreign-nodes*
+input &= foreign-nodes*
+output &= foreign-nodes*
+profile &= foreign-nodes*
+ditaval &= foreign-nodes*
+publication &= foreign-nodes*
+publication-ref &= foreign-nodes*
+param &= foreign-nodes*

--- a/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
@@ -15,16 +15,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class ProjectBuilderTest {

--- a/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
@@ -11,6 +11,7 @@ package org.dita.dost.project;
 import org.dita.dost.project.Project.Context;
 import org.dita.dost.project.Project.Deliverable;
 import org.dita.dost.project.Project.Publication;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,6 +24,13 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class ProjectFactoryTest {
+
+    private ProjectFactory factory;
+
+    @Before
+    public void setUp() {
+        factory = ProjectFactory.getInstance();
+    }
 
     @Test
     public void resolveReferences_deliverable() {
@@ -115,7 +123,7 @@ public class ProjectFactoryTest {
     @Test
     public void read() throws IOException, URISyntaxException {
         final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/simple.json").toURI();
-        final Project project = ProjectFactory.load(file);
+        final Project project = factory.load(file);
         assertEquals(1, project.deliverables.size());
         assertTrue(project.deliverables.get(0).context.inputs.inputs.get(0).href.isAbsolute());
         assertTrue(project.includes.isEmpty());
@@ -124,7 +132,7 @@ public class ProjectFactoryTest {
     @Test
     public void readMultiple() throws IOException, URISyntaxException {
         final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/multiple.json").toURI();
-        final Project project = ProjectFactory.load(file);
+        final Project project = factory.load(file);
         assertEquals(1, project.deliverables.size());
         assertTrue(project.deliverables.get(0).context.inputs.inputs.get(0).href.isAbsolute());
         assertTrue(project.includes.isEmpty());
@@ -134,7 +142,7 @@ public class ProjectFactoryTest {
     @Test
     public void deserializeJsonRoot() throws IOException, URISyntaxException {
         final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/root.json").toURI();
-        final Project project = ProjectFactory.load(input);
+        final Project project = factory.load(input);
         assertEquals(1, project.deliverables.size());
         assertEquals(2, project.includes.size());
     }
@@ -142,7 +150,7 @@ public class ProjectFactoryTest {
     @Test
     public void deserializeJsonProduct() throws IOException, URISyntaxException {
         final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/product.json").toURI();
-        final Project project = ProjectFactory.load(input);
+        final Project project = factory.load(input);
         assertEquals(1, project.deliverables.size());
         assertEquals(1, project.publications.size());
         assertEquals("common-sitePub2", project.deliverables.get(0).publication.id);
@@ -151,7 +159,7 @@ public class ProjectFactoryTest {
     @Test(expected = RuntimeException.class)
     public void deserializeJsonRecursive() throws IOException, URISyntaxException {
         final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/recursive.json").toURI();
-        ProjectFactory.load(input);
+        factory.load(input);
     }
 
 }

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.project;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -19,7 +20,12 @@ import static org.junit.Assert.*;
 
 public class XmlReaderTest {
 
-    private final XmlReader xmlReader = new XmlReader();
+    private XmlReader xmlReader;
+
+    @Before
+    public void setUp() {
+        xmlReader = new XmlReader();
+    }
 
     @Test
     public void deserializeXmlSimple() throws IOException {
@@ -75,6 +81,22 @@ public class XmlReaderTest {
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/minimal.xml")) {
             final ProjectBuilder project = xmlReader.read(input, null);
             assertEquals(1, project.deliverables.size());
+        }
+    }
+
+    @Test
+    public void deserializeXmlForeign() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/foreign.xml")) {
+            xmlReader.setLax(true);
+            final ProjectBuilder project = xmlReader.read(input, null);
+            assertEquals(1, project.deliverables.size());
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void deserializeXmlForeignStrict() throws IOException {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/foreign.xml")) {
+            xmlReader.read(input, null);
         }
     }
 }

--- a/src/test/resources/org/dita/dost/project/foreign.xml
+++ b/src/test/resources/org/dita/dost/project/foreign.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../../../main/resources/project-lax.rnc" type="application/relax-ng-compact-syntax"?>
+<example:export xmlns:example="https://example.com">
+  <project xmlns="https://www.dita-ot.org/project" example:id="GUID1234">
+    <example:authorization user="usr1234"/>
+    <deliverable>
+      <context>
+        <example:filter>attr('audience').includes('devops')</example:filter>
+        <input href="site.ditamap" resource="example:site/1/en"/>
+      </context>
+      <output href="./site"/>
+      <publication transtype="html5"/>
+    </deliverable>
+  </project>
+</example:export>


### PR DESCRIPTION
## Description
Add support to interleave elements and attributes from foreign namespaces in project XML files.

## Motivation and Context
This allows custom elements and attributes in project files for e.g. when a single CMS export files contains both DITA-OT project configuration and CMS metadata.

## How Has This Been Tested?
Reader tests have been extended to include foreign content.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
