### PR TITLE
Adjust flag path during conref

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -476,7 +476,7 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:if test="@id and contains(@class, ' topic/topic ')">
                       <xsl:attribute name="id" select="generate-id(.)"/>
                     </xsl:if>
-                    <xsl:apply-templates select="@href|@dita-ot:imagerefuri|@dita-ot:original-imageref|@imageref">
+                    <xsl:apply-templates select="@href | @dita-ot:imagerefuri | @dita-ot:original-imageref | @imageref">
                       <xsl:with-param name="current-relative-path" select="$current-relative-path"/>
                       <xsl:with-param name="topicid" select="$topicid"/>
                       <xsl:with-param name="elemid" select="$elemid"/>
@@ -529,7 +529,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- topichead is specialized from topicref, and requires @navtitle -->
   <xsl:template match="*[contains(@class, ' mapgroup-d/topichead ')]/@navtitle" mode="original-attributes" priority="10"/>
 
-  <xsl:template match="@dita-ot:imagerefuri|@dita-ot:original-imageref|@imageref">
+  <xsl:template match="@dita-ot:imagerefuri | @dita-ot:original-imageref | @imageref">
     <xsl:param name="current-relative-path" tunnel="yes" as="xs:string"/>
     <xsl:param name="conref-filename" tunnel="yes" as="xs:string?"/>
     <xsl:param name="conref-ids" tunnel="yes" as="xs:string*"/>
@@ -538,7 +538,6 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="contains(., '://') or starts-with(., '/')">
           <xsl:value-of select="."/>
         </xsl:when>
-        
         <xsl:otherwise>
           <xsl:value-of select="concat($current-relative-path, .)"/>
         </xsl:otherwise>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -476,12 +476,12 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:if test="@id and contains(@class, ' topic/topic ')">
                       <xsl:attribute name="id" select="generate-id(.)"/>
                     </xsl:if>
-                    <xsl:apply-templates select="@href">
+                    <xsl:apply-templates select="@href|@dita-ot:imagerefuri|@dita-ot:original-imageref|@imageref">
                       <xsl:with-param name="current-relative-path" select="$current-relative-path"/>
                       <xsl:with-param name="topicid" select="$topicid"/>
                       <xsl:with-param name="elemid" select="$elemid"/>
                     </xsl:apply-templates>
-                    <xsl:copy-of select="@* except (@id, @href)"/>
+                    <xsl:copy-of select="@* except (@id, @href, @dita-ot:imagerefuri, @dita-ot:original-imageref, @imageref)"/>
                     <xsl:apply-templates select="* | comment() | processing-instruction() | text()">
                       <xsl:with-param name="current-relative-path" select="$current-relative-path"/>
                       <xsl:with-param name="topicid" select="$topicid"/>
@@ -528,6 +528,23 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/state ')]/@value" mode="original-attributes" priority="10"/>
   <!-- topichead is specialized from topicref, and requires @navtitle -->
   <xsl:template match="*[contains(@class, ' mapgroup-d/topichead ')]/@navtitle" mode="original-attributes" priority="10"/>
+
+  <xsl:template match="@dita-ot:imagerefuri|@dita-ot:original-imageref|@imageref">
+    <xsl:param name="current-relative-path" tunnel="yes" as="xs:string"/>
+    <xsl:param name="conref-filename" tunnel="yes" as="xs:string?"/>
+    <xsl:param name="conref-ids" tunnel="yes" as="xs:string*"/>
+    <xsl:attribute name="{name()}">
+      <xsl:choose>
+        <xsl:when test="contains(., '://') or starts-with(., '/')">
+          <xsl:value-of select="."/>
+        </xsl:when>
+        
+        <xsl:otherwise>
+          <xsl:value-of select="concat($current-relative-path, .)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:attribute>
+  </xsl:template>
 
   <xsl:template match="@href">
     <xsl:param name="current-relative-path" tunnel="yes" as="xs:string"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Today, if 1) you have a local `@href` value in a topic (such as a cross reference or an image), and 2) you reuse that as part of a content-reference _in another directory_, we will adjust the path on `@href` while resolving the content reference so that it is still valid.

For example, if you have a topic in `plugin1/` that uses `<image href="pluginOne.jpg"/>`, _and_ you pull that image as part of a block into `plugin2/`, the `conref` code adjusts that image so that it becomes `<image href="../plugin1/pluginOne.jpg"/>`

When our DITAVAL flagging process moved to the start of `preprocess` / `preprocess2`, it introduced an error when those flag images go through the same process. The images added early in the process use `@imageref` (the DITAVAL attribute) (along with a couple of `dita-ot:` namespaced ones that we make use of in our process). Because content reference only updates `@href`, flags in the example above will refer to `pluginOne.jpg` instead of `../plugin1/pluginOne.jpg`.

This update just processes the `imageref` attributes the same way as `href`, skipping conditions that don't make sense. It looks for absolute paths by checking for `://` in the reference, and by checking for a leading `/`. If those are not present, it assumes relative path and adjusts.

## Motivation and Context

Fixes the issue where HTML output used flags correctly when content in the source topic is flagged, but was broken when those same flags came in from reused content in another directory.

## How Has This Been Tested?

Tested with the attached samples for html5 and pdf. 
[jira550.zip](https://github.com/dita-ot/dita-ot/files/3736191/jira550.zip)

Out of the box `html5` output is still broken for this due to errors in `copy-flag`. I've got some local hacks I'm not proud of to get around that for our html; this fix just ensures the path is valid when we get to that point.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
