### PR TITLE
Keep the param name required.

### DIFF
--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -75,7 +75,7 @@ publication-ref =
 param =
   ## Publication parameter
   element param {
-    attribute name { text }?,
+    attribute name { text },
     (attribute href { xsd:anyURI }
      | attribute path { xsd:anyURI }
      | attribute value { text })


### PR DESCRIPTION
---
name: The param name should be required
about: Propose changes to fix an issue

---

## Description
Remove the optional on the param name.

## Motivation and Context
Parameters need a name.

Signed-off-by: George Bina <george@oxygenxml.com>
