### PR TITLE
Add extension point for PDF2 index processing

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -172,7 +172,9 @@ with those set forth herein.
   </target>
 
   <target name="transform.topic2fo"
-          depends="transform.topic2fo.init,
+          dita:extension="depends org.dita.dost.platform.InsertDependsAction"
+          dita:depends="transform.topic2fo.init,
+                   {depend.org.dita.pdf2.index},
                    transform.topic2fo.index,
                    transform.topic2fo.main,
                    transform.topic2fo.i18n"/>
@@ -242,7 +244,7 @@ with those set forth herein.
     <property name="args.tablelink.style" value="NUMTITLE"/>
   </target>
 
-  <target name="transform.topic2fo.index">
+  <target name="transform.topic2fo.index" unless="pdf2.index.skip">
     <taskdef classname="com.idiominc.ws.opentopic.fo.index2.IndexPreprocessorTask"
              name="index-preprocess" classpathref="project.class.path"/>
     
@@ -272,11 +274,12 @@ with those set forth herein.
     </condition>
     <property name="index.config.file" value="${cfg.dir}/common/index/${default.language}.xml"/>
 
+    <echo level="info">Processing ${inputFile} to ${dita.temp.dir}/stage1.xml</echo>
     <index-preprocess input="${inputFile.url}" output="${dita.temp.dir}/stage1.xml"
                       indexConfig="${index.config.file}" locale="${document.locale}"
                       draft="${args.draft}">
       <xmlcatalog refid="xml.catalog"/>
-    </index-preprocess> 
+    </index-preprocess>
   </target>
   
   <target name="transform.topic2fo.main">

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -175,7 +175,6 @@ with those set forth herein.
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
           dita:depends="transform.topic2fo.init,
                    {depend.org.dita.pdf2.index},
-                   transform.topic2fo.index,
                    transform.topic2fo.main,
                    transform.topic2fo.i18n"/>
     

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -244,7 +244,15 @@ with those set forth herein.
     <property name="args.tablelink.style" value="NUMTITLE"/>
   </target>
 
-  <target name="transform.topic2fo.index" unless="pdf2.index.skip">
+  <target name="transform.topic2fo.index.init">
+    <condition property="_pdf2.index.skip" value="true">
+      <istrue value="${pdf2.index.skip}"/>
+    </condition>
+  </target>
+
+  <target name="transform.topic2fo.index"
+          depends="transform.topic2fo.index.init"
+          unless="_pdf2.index.skip">
     <taskdef classname="com.idiominc.ws.opentopic.fo.index2.IndexPreprocessorTask"
              name="index-preprocess" classpathref="project.class.path"/>
     

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -15,6 +15,7 @@ See the accompanying LICENSE file for applicable license.
   <extension-point id="depend.org.dita.pdf2.format.pre" name="Formatting pre-target"/>
   <extension-point id="depend.org.dita.pdf2.format" name="Formatting target"/>
   <extension-point id="depend.org.dita.pdf2.format.post" name="Formatting post-target"/>
+  <extension-point id="depend.org.dita.pdf2.index" name="Indexing target"/>
   <extension-point id="org.dita.pdf2.catalog.relative" name="Configuration XML catalog"/>
   <extension-point id="dita.conductor.pdf2.param" name="PDF XSLT parameters"/>
   <extension-point id="dita.conductor.pdf2.formatter.check" name="Formatter check"/>

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -54,6 +54,10 @@ See the accompanying LICENSE file for applicable license.
       <val desc="Enables chunk processing">true</val>
       <val desc="Disables chunk processing" default="true">false</val>
     </param>
+    <param name="pdf2.index.skip" desc="Disable built-in index processing." type="enum">
+      <val>yes</val>
+      <val default="true">no</val>
+    </param>
   </transtype>
   <transtype name="pdf2" extends="pdf" desc="PDF2"/>
   <feature extension="dita.transtype.print" value="pdf"/>

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -67,6 +67,7 @@ See the accompanying LICENSE file for applicable license.
   <feature extension="dita.conductor.pdf2.formatter.check" value="ah"/>
   <feature extension="dita.xsl.strings" file="cfg/common/vars/strings.xml"/>
   <feature extension="dita.specialization.catalog.relative" file="cfg/catalog.xml"/>
+  <feature extension="depend.org.dita.pdf2.index" value="transform.topic2fo.index"/>
   <template file="build_template.xml"/>
   <template file="cfg/catalog_template.xml"/>
   <template file="xsl/fo/i18n-postprocess_template.xsl"/>


### PR DESCRIPTION
Add extension point `depend.org.dita.pdf2.index` to PDF2. This allows adding custom index processing targets to PDF2. In order to disable to default index processing, a new property `pdf2.index.skip` is added. When a custom index target is used, the contract for the extension point requires that the output is written into `stage1.xml` in the temporary directory for backwards compatibility.
