### PR TITLE
Bundle org.dita.index and disable PDF2 indexing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,8 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
 def bundled = [
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/2.3.1/org.lwdita-2.3.1.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
-        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip"
+        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
+        "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip"
 ]
 
 apply from: 'gradle/dist.gradle'

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -25,6 +25,7 @@ def licenses = [
         [name: 'isorelax', title: 'Isorelax', license: ['isorelax.txt']],
         [name: 'gradle-wrapper'],
         [name: 'org.lwdita'],
+        [name: 'index'],
         [name: 'fo'],
         [name: 'eclipsehelp'],
         [name: 'eclipsehelp'],

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -290,6 +290,10 @@ with those set forth herein.
   </target>
   
   <target name="transform.topic2fo.main">
+    <local name="_stage1.exists"/>
+    <available property="_stage1.exists" file="${dita.temp.dir}/stage1.xml"/>
+    <copy file="${inputFile}" tofile="${dita.temp.dir}/stage1.xml" unless:set="_stage1.exists"/>
+
     <!--makeurl seems to output file:/C: style instead of file:///C:, but xep, fop, and ah all accept it.-->
     <makeurl property="artworkPrefixUrl" file="${artworkPrefix}"/>
     <makeurl property="dita.map.output.dir.url" file="${pdf2.temp.dir}" validate="no"/>

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -67,7 +67,8 @@ See the accompanying LICENSE file for applicable license.
   <feature extension="dita.conductor.pdf2.formatter.check" value="ah"/>
   <feature extension="dita.xsl.strings" file="cfg/common/vars/strings.xml"/>
   <feature extension="dita.specialization.catalog.relative" file="cfg/catalog.xml"/>
-  <feature extension="depend.org.dita.pdf2.index" value="transform.topic2fo.index"/>
+  <!-- Disable deprecated built-in indexing -->
+  <!--<feature extension="depend.org.dita.pdf2.index" value="transform.topic2fo.index"/>-->
   <template file="build_template.xml"/>
   <template file="cfg/catalog_template.xml"/>
   <template file="xsl/fo/i18n-postprocess_template.xsl"/>


### PR DESCRIPTION
Disable PDF2 index processing and bundle org.dita.index plug-in to be used instead.