### PR TITLE
Move hard-coded indexshow styles to Sass partial

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_indexterms.scss
+++ b/src/main/plugins/org.dita.html5/sass/_indexterms.scss
@@ -1,0 +1,13 @@
+// This file is part of the DITA Open Toolkit project.
+//
+// Copyright 2019 Roger Sheen
+//
+// See the accompanying LICENSE file for applicable license.
+
+// Sass partial for index term styles (hardcoded in `topic.xsl` prior to DITA-OT 3.4)
+
+.indexterm {
+  background-color: $indexterm-background;
+  border: 1pt $indexterm-border solid;
+  margin: 1pt;
+}

--- a/src/main/plugins/org.dita.html5/sass/_variables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_variables.scss
@@ -41,6 +41,10 @@ $hazard-iso-blue:       #005387;
 // Text color for hazard statements with dark backgrounds: danger (red), note (blue)
 $hazard-heading-light:  #fff;
 
+// Index term colors (when args.indexshow=yes)
+$indexterm-background: #fdf !default;
+$indexterm-border: #000 !default;
+
 //== Scaffolding
 //
 //## Settings for some of the most global styles.

--- a/src/main/plugins/org.dita.html5/sass/commonltr.scss
+++ b/src/main/plugins/org.dita.html5/sass/commonltr.scss
@@ -13,6 +13,7 @@
 @import 'display-attr';
 @import 'figures';
 @import 'headings';
+@import 'indexterms';
 @import 'links';
 @import 'lists';
 @import 'notes';

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1631,14 +1631,14 @@ See the accompanying LICENSE file for applicable license.
        <xsl:when test="@keyref and @href">
          <a>
            <xsl:apply-templates select="." mode="add-linking-attributes"/>
-           <span style="margin: 1pt; background-color: #ffddff; border: 1pt black solid;">
+           <span>
              <xsl:call-template name="commonattributes"/>
              <xsl:apply-templates/>
            </span>
          </a>
        </xsl:when>
        <xsl:otherwise>
-         <span style="margin: 1pt; background-color: #ffddff; border: 1pt black solid;">
+         <span>
            <xsl:call-template name="commonattributes"/>
            <xsl:apply-templates/>
          </span>


### PR DESCRIPTION
The inline style attributes prevent users from customizing the presentation of index terms when these are emitted to HTML5 output with `args.indexshow=yes`.

These changes move the default presentation rules to CSS to allow users to override presentation in custom stylesheets.

The output is visually equivalent to the results generated by previous toolkit versions.

Signed-off-by: Roger Sheen <roger@infotexture.net>
