### PR TITLE
Remove reference to deprecated args.logdir parameter

### DIFF
--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -120,8 +120,6 @@ See the accompanying LICENSE file for applicable license.
     <delete dir="${dita.temp.dir}" quiet="false"/>
     <mkdir dir="${dita.temp.dir}" />
 
-    <property name="args.logdir" value="${output.dir}"/>
-
     <!-- Validate the xml file or not,default is validation(true)-->
     <property name="validate" value="true"/>
     

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -98,8 +98,6 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="args.input" desc="Specifies the master file for your documentation project." type="file" required="true"/>
     <param name="args.input.dir" desc="Specifies the base directory for your documentation project." type="dir"/>
-    <!-- Deprecated since 2.5 -->
-    <param name="args.logdir" desc="Specifies the location where DITA-OT places log files for your project." type="dir" deprecated="true"/>
     <param name="args.output.base" desc="Specifies the name of the output file without file extension." type="string"/>
     <param name="args.tablelink.style" desc="Specifies how cross references to tables are styled." type="enum">
       <val>NUMBER</val>


### PR DESCRIPTION
## Description
Removed reference to parameter which is deprecated and no longer works.

## Motivation and Context
Fixes #3398.

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>