### PR TITLE
Add project validation schema to distribution build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,7 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         exclude "temp"
         include "config/**"
         include "resources/plugin.rnc"
+        include "resources/project.rnc"
         // legacy build scripts
         include "startcmd.*"
         include "bin/ant"


### PR DESCRIPTION
Restore the missing RELAX NG schema for project validation to distribution build packages as referenced in the documentation under https://www.dita-ot.org/dev/topics/using-project-files.html.

Fixes #3409.

Signed-off-by: Roger Sheen <roger@infotexture.net>
