### PR TITLE
Remove filtered and renamed topics from publish-set after branch filtering #2980

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -74,6 +74,11 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
     /** Absolute URI to map being processed. */
     protected URI currentFile;
     private final Set<URI> filtered = new HashSet<>();
+    
+    /* Sets to track what topics are renamed in map, still in map, filtered from map */ 
+    private final Set<URI> renamedTopics = new HashSet<>();
+    private final Set<URI> sameNameTopics = new HashSet<>();
+    private final Set<URI> filteredTopics = new HashSet<>();
 
     public BranchFilterModule() {
         builder = XMLUtils.getDocumentBuilder();
@@ -140,6 +145,8 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         rewriteDuplicates(doc.getDocumentElement());
         logger.debug("Filter topics and generate copies");
         generateCopies(doc.getDocumentElement(), Collections.emptyList());
+        logger.debug("Remove obsolete references");
+        removeObsoleteReferences();
         logger.debug("Filter existing topics");
         filterTopics(doc.getDocumentElement(), Collections.emptyList());
 
@@ -300,6 +307,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         }
 
         if (exclude) {
+            addToFilteredSet(elem);
             elem.getParentNode().removeChild(elem);
         } else {
             final List<Element> childElements = getChildElements(elem);
@@ -321,6 +329,23 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
             for (final Element child : childElements) {
                 filterBranches(child, fs, props);
             }
+        }
+    }
+    
+    /** When a branch is filtered, add references in branch to filtered set **/
+    private void addToFilteredSet(final Element elem) {
+        final String copyTo = elem.getAttribute(BRANCH_COPY_TO);
+        final String href = elem.getAttribute(ATTRIBUTE_NAME_HREF);
+        if (!copyTo.isEmpty()) {
+            final URI dstUri = map.resolve(copyTo);
+            filteredTopics.add(dstUri);
+        }
+        if (!href.isEmpty()) {
+            final URI srcUri = map.resolve(href);
+            filteredTopics.add(srcUri);
+        }
+        for (final Element child : getChildElements(elem)) {
+            addToFilteredSet(child);
         }
     }
 
@@ -345,10 +370,10 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         final List<FilterUtils> fs = combineFilterUtils(topicref, filters);
 
         final String copyTo = topicref.getAttribute(BRANCH_COPY_TO);
+        final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
         if (!copyTo.isEmpty()) {
             final URI dstUri = map.resolve(copyTo);
             final URI dstAbsUri = job.tempDirURI.resolve(dstUri);
-            final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
             final URI srcUri = map.resolve(href);
             final URI srcAbsUri = job.tempDirURI.resolve(srcUri);
             final FileInfo srcFileInfo = job.getFileInfo(srcUri);
@@ -356,6 +381,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 //                final FileInfo fi = new FileInfo.Builder(srcFileInfo).uri(dstUri).build();
 //                 TODO: Maybe Job should be updated earlier?
 //                job.add(fi);
+                renamedTopics.add(srcUri);
                 logger.info("Filtering " + srcAbsUri + " to " + dstAbsUri);
                 final ProfilingFilter writer = new ProfilingFilter();
                 writer.setLogger(logger);
@@ -380,12 +406,31 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
                 // disable filtering again
                 topicref.setAttribute(SKIP_FILTER, Boolean.TRUE.toString());
             }
+        } else if (!href.isEmpty()) {
+            final URI srcUri = map.resolve(href);
+            sameNameTopics.add(srcUri);
         }
         for (final Element child: getChildElements(topicref, MAP_TOPICREF)) {
             if (DITAVAREF_D_DITAVALREF.matches(child)) {
                 continue;
             }
             generateCopies(child, fs);
+        }
+    }
+    
+    /** Remove files from job if they were renamed and no longer exist with original name **/
+    private void removeObsoleteReferences() {
+        /** If a file was renamed and no longer exists with original name, remove from job **/
+        for (final URI file: renamedTopics) {
+            if (!sameNameTopics.contains(file) && job.getFileInfo(file) != null) {
+                job.remove(job.getFileInfo(file));
+            }
+        }
+        /** If a file reference was filtered from map and no longer exists, remove from job **/
+        for (final URI file: filteredTopics) {
+            if (!sameNameTopics.contains(file) && job.getFileInfo(file) != null) {
+                job.remove(job.getFileInfo(file));
+            }
         }
     }
 

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -57,7 +57,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita")) {
+        for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita", "exclude.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -144,7 +144,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         final List<String> exp = Arrays.asList(
                 "installation-procedure.dita", "getting-started.dita",
                 //"http://example.com/install.dita",
-                "configure.dita",
+                //"configure.dita",
                 "input.ditamap", "install.dita", "linux.ditaval", "perform-install.dita",
                 "configure-novice.dita", "novice.ditaval", "configure-admin.dita",
                 "advanced.ditaval", "install-mac.dita", "mac.ditaval",
@@ -165,7 +165,8 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 "configure-admin.dita", "install-mac.dita", "perform-install-mac.dita",
                 "installation-procedure-mac.dita", "configure-novice-mac.dita", "configure-admin-mac.dita",
                 "install-win.dita", "perform-install-win.dita", "installation-procedure-win.dita",
-                "configure-novice-win.dita", "configure-admin-win.dita", "install-linux.dita", "install.dita"
+                "configure-novice-win.dita", "configure-admin-win.dita", "install-linux.dita", "install.dita",
+                "exclude.dita"
 
         );
         Collections.sort(filesExp);
@@ -193,16 +194,14 @@ public class BranchFilterModuleTest extends BranchFilterModule {
 
         final List<String> exp = Arrays.asList(
                 "main/novice.ditaval", "main/advanced.ditaval",
-                "main/kiddo.dita", "main/kiddodefault.dita", "main/parent.dita", "main/parentdefault.dita",
-                "main/parentdefault-1.dita", "main/parent-novice.dita", "main/PREFIX-parent-advanced.dita",
-                "main/PREFIX-weechild-advanced.dita", "main/subdirkiddo.dita", "main/subdirkiddodefault.dita",
-                "main/testuplevels.ditamap", "main/weechilddefault-1.dita", "main/weechild-novice.dita",
-                "main/subdir/PREFIX-weechild-advanced.dita", "main/subdir/weechilddefault-1.dita", "main/subdir/weechild-novice.dita",
-                "peer/peerkiddo.dita", "peer/peerkiddodefault.dita", "peer/peerkiddodefault-1.dita",
-                "peer/peerkiddo-novice.dita", "peer/PREFIX-peerkiddo-advanced.dita",
-                "main/weechild.dita", "main/subdir/weechilddefault.dita",
-                "main/subdir/weechild.dita", "main/weechilddefault.dita");
-        
+                "main/kiddodefault.dita", "main/parentdefault.dita", "main/parentdefault-1.dita", 
+                "main/parent-novice.dita",  "main/PREFIX-parent-advanced.dita", "main/PREFIX-weechild-advanced.dita", 
+                "main/subdirkiddodefault.dita", "main/testuplevels.ditamap", "main/weechilddefault-1.dita", 
+                "main/weechild-novice.dita", "main/subdir/PREFIX-weechild-advanced.dita", 
+                "main/subdir/weechilddefault-1.dita",  "main/subdir/weechild-novice.dita",
+                "peer/peerkiddodefault.dita",  "peer/peerkiddodefault-1.dita",
+                "peer/peerkiddo-novice.dita", "peer/PREFIX-peerkiddo-advanced.dita", "main/weechild.dita", 
+                "main/subdir/weechilddefault.dita", "main/subdir/weechild.dita", "main/weechilddefault.dita");
         assertEquals(exp.size(), job.getFileInfo().size());
         for (final String f : exp) {
             assertNotNull(job.getFileInfo(URI.create(f)));

--- a/src/test/resources/BranchFilterModuleTest/src/exclude.dita
+++ b/src/test/resources/BranchFilterModuleTest/src/exclude.dita
@@ -1,0 +1,8 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+id="testexclude" ditaarch:DITAArchVersion="1.3">
+<title class="- topic/title ">Topic is excluded entirely</title>
+<body class="- topic/body ">
+<p class="- topic/p ">Linux topic in a branch filtered for mac</p>
+</body>
+</topic>

--- a/src/test/resources/BranchFilterModuleTest/src/input.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/input.ditamap
@@ -41,6 +41,7 @@
         <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">linux-</dvrKeyscopePrefix>
       </ditavalmeta>
     </ditavalref>
+    <topicref class="- map/topicref " href="exclude.dita" platform="linux"/>
   </topicref>
   <topicref class="- map/topicref " href="install.dita" copy-to="getting-started.dita"/>
 </map>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <robander@us.ibm.com>

## Description

Modifies the branch filtering module to:

1. Track all topic references that are filtered out due to branch filtering (set `filteredTopics`)
1. Track all topics that are renamed due to branch filtering (set `renamedTopics`)
1. Track all topics that are still exist after filtering, and are not renamed (set `sameNameTopics`)
1. After renaming and filtering of the map, remove any topics from job if they were filtered or renamed, and also do not appear in the third list (that last check will catch a topic that is renamed within a filtered branch, but also appear with the original name, either in another copy of the branch or somewhere outside of the branch).

~Once the approach is validated and tests corrected, I hope to also update to fix #2865, which I think I've diagnosed but not yet fixed.~

## Motivation and Context

Fixes #2980 

## How Has This Been Tested?

Attaching test cases, which include:

1. A branch filtered twice (each copy renames topics), including one topic that is filtered out of one copy
2. A branch that is filtered twice (once with original name, once with rename), including a different topic filtered out of each copy
3. A topic that appears in the renamed branches but also appears outside the branch with original name
4. A topic outside of any renamed branch
[2980.zip](https://github.com/dita-ot/dita-ot/files/3853142/2980.zip)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist

Still need to update tests for changes (fix broken tests and add new for this condition)