### PR TITLE
Support for addtional input resources

### DIFF
--- a/src/main/java/org/dita/dost/exception/DITAOTException.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTException.java
@@ -8,6 +8,8 @@
  */
 package org.dita.dost.exception;
 
+import net.sf.saxon.trans.UncheckedXPathException;
+import net.sf.saxon.trans.XPathException;
 import org.dita.dost.log.MessageBean;
 
 /**
@@ -29,7 +31,7 @@ public final class DITAOTException extends Exception {
      * as its detail message.
      */
     public DITAOTException() {
-        this(null, null);
+        this(null, (Throwable) null);
     }
 
     /**
@@ -38,7 +40,7 @@ public final class DITAOTException extends Exception {
      * @param message the detail message
      */
     public DITAOTException(final String message) {
-        this(message, null);
+        this(message, (Throwable) null);
     }
 
     /**
@@ -59,6 +61,26 @@ public final class DITAOTException extends Exception {
      */
     public DITAOTException(final String message, final Throwable cause) {
         super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with cause, using location information from a root {@link XPathException}
+     *
+     * @param cause the cause
+     */
+    public DITAOTException(final UncheckedXPathException cause) {
+        super(cause.getXPathException().getMessageAndLocation(), cause.getXPathException());
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause, using location information from a root {@link XPathException}
+     *
+     * @param message the detail message.
+     * @param cause the cause
+     */
+    public DITAOTException(final String message, final UncheckedXPathException cause) {
+        super(message + ": " + cause.getXPathException().getMessageAndLocation(), cause.getXPathException());
     }
 
     /**

--- a/src/main/java/org/dita/dost/invoker/ArgumentParser.java
+++ b/src/main/java/org/dita/dost/invoker/ArgumentParser.java
@@ -60,6 +60,8 @@ final class ArgumentParser {
         ARGUMENTS.put("--deliverable", new StringArgument("project.deliverable"));
         ARGUMENTS.put("-i", new FileOrUriArgument("args.input"));
         ARGUMENTS.put("--input", new FileOrUriArgument("args.input"));
+        ARGUMENTS.put("-r", new FileOrUriArgument("args.resources"));
+        ARGUMENTS.put("--resource", new FileOrUriArgument("args.resources"));
         ARGUMENTS.put("-o", new AbsoluteFileArgument("output.dir"));
         ARGUMENTS.put("--output", new AbsoluteFileArgument("output.dir"));
         ARGUMENTS.put("--filter", new AbsoluteFileListArgument("args.filter"));
@@ -178,6 +180,7 @@ final class ArgumentParser {
     private String uninstallId;
 
     private List<String> inputs = new ArrayList<>();
+    private List<String> resources = new ArrayList<>();
 
     /**
      * The build targets.
@@ -303,6 +306,8 @@ final class ArgumentParser {
                 handleArgNice(args);
             } else if (isLongForm(arg, "-input") || arg.equals("-i")) {
                 handleArgInput(arg, args, ARGUMENTS.get(getArgumentName(arg)));
+            } else if (isLongForm(arg, "-resource") || arg.equals("-r")) {
+                handleArgResource(arg, args, ARGUMENTS.get(getArgumentName(arg)));
             } else if (ARGUMENTS.containsKey(getArgumentName(arg))) {
                 definedProps.putAll(handleParameterArg(arg, args, ARGUMENTS.get(getArgumentName(arg))));
             } else if (getPluginArguments().containsKey(getArgumentName(arg))) {
@@ -329,6 +334,9 @@ final class ArgumentParser {
         if (!inputs.isEmpty()) {
             definedProps.put("args.input", inputs.get(0));
         }
+        if (!resources.isEmpty()) {
+            definedProps.put("args.resources", String.join(File.pathSeparator, resources));
+        }
 
         if (install && msgOutputLevel < Project.MSG_INFO) {
             emacsMode = true;
@@ -340,7 +348,7 @@ final class ArgumentParser {
                 inputs, targets, listeners, propertyFiles, allowInput, keepGoingMode, loggerClassname,
                 inputHandlerClassname, emacsMode, threadPriority, proxy, justPrintUsage, justPrintVersion,
                 justPrintDiagnostics, justPrintPlugins, justPrintTranstypes, justPrintDeliverables, logFile,
-                definedProps);
+                definedProps, resources);
     }
 
     private boolean getUseColor() {
@@ -491,6 +499,14 @@ final class ArgumentParser {
             throw new BuildException("Missing value for input " + entry.getKey());
         }
         inputs.add(argument.getValue((String) entry.getValue()));
+    }
+
+    private void handleArgResource(final String arg, final Deque<String> args, final Argument argument) {
+        final Map.Entry<String, String> entry = parse(arg, args);
+        if (entry.getValue() == null) {
+            throw new BuildException("Missing value for resource " + entry.getKey());
+        }
+        resources.add(argument.getValue(entry.getValue()));
     }
 
     /**

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -49,6 +49,7 @@ final class Arguments {
      */
     final String uninstallId;
     final List<String> inputs;
+    final List<String> resources;
     /**
      * The build targets.
      */
@@ -105,7 +106,7 @@ final class Arguments {
                      String loggerClassname, String inputHandlerClassname, boolean emacsMode, Integer threadPriority,
                      boolean proxy, boolean justPrintUsage, boolean justPrintVersion, boolean justPrintDiagnostics,
                      boolean justPrintPlugins, boolean justPrintTranstypes, boolean justPrintDeliverables,
-                     File logFile, Map<String, Object> definedProps) {
+                     File logFile, Map<String, Object> definedProps, List<String> resources) {
         this.useColor = useColor;
         this.msgOutputLevel = msgOutputLevel;
         this.buildFile = buildFile;
@@ -132,6 +133,7 @@ final class Arguments {
         this.justPrintDeliverables = justPrintDeliverables;
         this.logFile = logFile;
         this.definedProps = definedProps;
+        this.resources = resources;
     }
 
     static abstract class Argument {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -61,6 +61,7 @@ import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
 public class Main extends org.apache.tools.ant.Main implements AntMain {
 
     static final String ANT_ARGS_INPUT = "args.input";
+    static final String ANT_ARGS_RESOURCES = "args.resources";
     static final String ANT_ARGS_INPUTS = "args.inputs";
     static final String ANT_OUTPUT_DIR = "output.dir";
     static final String ANT_BASE_TEMP_DIR = "base.temp.dir";
@@ -758,19 +759,20 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         msg.append("   or: dita --help\n");
         msg.append("   or: dita --version\n");
         msg.append("Arguments: \n");
-        msg.append("  -i <file>, --input=<file>   input file\n");
-        msg.append("  -f <name>, --format=<name>  output format (transformation type)\n");
-        msg.append("  -p <name>, --project=<name> run project file\n");
-        msg.append("  --install [<file>]          install plug-in from a local ZIP file\n");
-        msg.append("  --install [<url>]           install plug-in from a URL\n");
-        msg.append("  --install [<id>]            install plug-in from plugin registry\n");
-        msg.append("  --install                   reload plug-ins\n");
-        msg.append("  --uninstall <id>            uninstall plug-in with the ID\n");
-        msg.append("  --plugins                   print list of installed plug-ins\n");
-        msg.append("  --transtypes                print list of installed transtypes\n");
-        msg.append("  --deliverables              print list of deliverables in project\n");
-        msg.append("  -h, --help                  print this message\n");
-        msg.append("  --version                   print version information and exit\n");
+        msg.append("  -i <file>, --input=<file>    input file\n");
+        msg.append("  -f <name>, --format=<name>   output format (transformation type)\n");
+        msg.append("  -p <name>, --project=<name>  run project file\n");
+        msg.append("  -r <file>, --resource=<file> resource file\n");
+        msg.append("  --install [<file>]           install plug-in from a local ZIP file\n");
+        msg.append("  --install [<url>]            install plug-in from a URL\n");
+        msg.append("  --install [<id>]             install plug-in from plugin registry\n");
+        msg.append("  --install                    reload plug-ins\n");
+        msg.append("  --uninstall <id>             uninstall plug-in with the ID\n");
+        msg.append("  --plugins                    print list of installed plug-ins\n");
+        msg.append("  --transtypes                 print list of installed transtypes\n");
+        msg.append("  --deliverables               print list of deliverables in project\n");
+        msg.append("  -h, --help                   print this message\n");
+        msg.append("  --version                    print version information and exit\n");
         msg.append("Options: \n");
         msg.append("  -o, --output=<dir>          output directory\n");
         // msg.append("  -diagnostics           print information that might be helpful to"
@@ -778,11 +780,11 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // msg.append("                         diagnose or report problems." +
         // lSep);
         // msg.append("  -quiet, -q             be extra quiet" + lSep);
-        msg.append("  --filter=<files>            filter and flagging files\n");
-        msg.append("  --force                     force install plug-in\n");
-        msg.append("  -t, --temp=<dir>            temporary directory\n");
-        msg.append("  -v, --verbose               verbose logging\n");
-        msg.append("  -d, --debug                 print debugging information\n");
+        msg.append("  --filter=<files>             filter and flagging files\n");
+        msg.append("  --force                      force install plug-in\n");
+        msg.append("  -t, --temp=<dir>             temporary directory\n");
+        msg.append("  -v, --verbose                verbose logging\n");
+        msg.append("  -d, --debug                  print debugging information\n");
         // msg.append("  -emacs, -e             produce logging information without adornments"
         // + lSep);
         // msg.append("  -lib <path>            specifies a path to search for jars and classes"
@@ -797,8 +799,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // msg.append("  -buildfile <file>      use given buildfile" + lSep);
         // msg.append("    -file    <file>              ''" + lSep);
         // msg.append("    -f       <file>              ''" + lSep);
-        msg.append("  --<property>=<value>        use value for given property\n");
-        msg.append("  --propertyfile=<name>       load all properties from file\n");
+        msg.append("  --<property>=<value>         use value for given property\n");
+        msg.append("  --propertyfile=<name>        load all properties from file\n");
         // msg.append("  -keep-going, -k        execute all targets that do not depend"
         // + lSep);
         // msg.append("                         on failed target(s)" + lSep);

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -102,8 +102,10 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-        final Job.FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-        processMap(in.uri);
+        final Collection<FileInfo> fis = job.getFileInfo(fi -> fi.isInput || fi.isInputResource);
+        for (FileInfo fi : fis) {
+            processMap(fi.uri);
+        }
 
         try {
             job.write();

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -21,6 +21,8 @@ import static org.dita.dost.util.XMLUtils.*;
 import java.io.*;
 import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -74,6 +76,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     private Map<QName, Map<String, String>> defaultValueMap;
     /** Absolute path to current source file. */
     private URI currentFile;
+    private List<URI> resources;
     private Map<URI, Set<URI>> dic;
     private SubjectSchemeReader subjectSchemeReader;
     private FilterUtils baseFilterUtils;
@@ -256,6 +259,14 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             pipe.add(debugFilter);
         }
 
+//        if (currentFile.equals(rootFile)) {
+//            final ResourceInsertFilter filter = new ResourceInsertFilter();
+//            filter.setLogger(logger);
+//            filter.setResources(resources);
+//            filter.setCurrentFile(currentFile);
+//            pipe.add(filter);
+//        }
+
         if (filterUtils != null) {
             final ProfilingFilter profilingFilter = new ProfilingFilter();
             profilingFilter.setLogger(logger);
@@ -308,6 +319,14 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         genDebugInfo = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
         final String mode = input.getAttribute(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
         processingMode = mode != null ? Mode.valueOf(mode.toUpperCase()) : Mode.LAX;
+
+        if (input.getAttribute(ANT_INVOKER_PARAM_RESOURCES) != null) {
+            resources = Stream.of(input.getAttribute(ANT_INVOKER_PARAM_RESOURCES).split(File.pathSeparator))
+                    .map(resource -> new File(resource).toURI())
+                    .collect(Collectors.toList());
+        } else {
+            resources = Collections.emptyList();
+        }
     }
 
 

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -35,6 +35,7 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.module.GenMapAndTopicListModule.*;
@@ -506,6 +507,8 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             final TransformerFactory tff = TransformerFactory.newInstance();
             final Transformer tf = tff.newTransformer();
             tf.transform(ds, res);
+        } catch (final UncheckedXPathException e) {
+            logger.error(e.getXPathException().getMessageAndLocation());
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -26,7 +26,6 @@ import org.dita.dost.util.*;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.ExportAnchorsFilter;
 import org.dita.dost.writer.ProfilingFilter;
-import org.dita.dost.writer.ResourceInsertFilter;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLFilter;
@@ -494,7 +493,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
      */
     private void processParseResult(final URI currentFile) {
         // Category non-copyto result and update uplevels accordingly
-        for (final Reference file: listFilter.getNonCopytoResult()) {
+        for (final Reference file: listFilter.getNonCopytoResult_Computed()) {
             categorizeReferenceFile(file);
             updateUplevels(file.filename);
         }
@@ -505,7 +504,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             updateUplevels(target);
 
         }
-        for (final URI file: listFilter.getNonTopicrefReferenceSet()) {
+        for (final URI file: listFilter.getNonTopicrefReferenceSet_Computed()) {
             updateUplevels(file);
         }
         schemeSet.addAll(listFilter.getSchemeRefSet());
@@ -522,7 +521,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
         hrefTargetSet.addAll(listFilter.getHrefTargets());
         conrefTargetSet.addAll(listFilter.getConrefTargets());
-        nonConrefCopytoTargetSet.addAll(listFilter.getNonConrefCopytoTargets());
+        nonConrefCopytoTargetSet.addAll(listFilter.getNonConrefCopytoTargets_Computed());
         coderefTargetSet.addAll(listFilter.getCoderefTargets());
         outDitaFilesSet.addAll(listFilter.getOutFilesSet());
 
@@ -753,10 +752,10 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         job.setProperty("uplevels", getLevelsPath(rootTemp));
 
         resourceOnlySet.addAll(resources);
-        resourceOnlySet.addAll(listFilter.getResourceOnlySet());
+        resourceOnlySet.addAll(listFilter.getResourceOnlySet_Computed());
 
         if (job.getOnlyTopicInMap() || !job.crawlTopics()) {
-            resourceOnlySet.addAll(listFilter.getNonTopicrefReferenceSet());
+            resourceOnlySet.addAll(listFilter.getNonTopicrefReferenceSet_Computed());
         }
 
         for (final URI file: outDitaFilesSet) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -199,10 +199,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             initFilters();
             initXmlReader();
 
-            addToWaitList(new Reference(rootFile));
-            for (URI resource : resources) {
-                addToWaitList(new Reference(resource));
-            }
+            readResourceFiles();
+            readStartFile();
             processWaitList();
 
             updateBaseDirectory();
@@ -215,6 +213,30 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         }
 
         return null;
+    }
+
+    private void readResourceFiles() throws DITAOTException {
+        if (!resources.isEmpty()) {
+            for (URI resource : resources) {
+                addToWaitList(new Reference(resource));
+            }
+            processWaitList();
+
+            resourceOnlySet.addAll(hrefTargetSet);
+            resourceOnlySet.addAll(conrefTargetSet);
+            resourceOnlySet.addAll(nonConrefCopytoTargetSet);
+            resourceOnlySet.addAll(outDitaFilesSet);
+            resourceOnlySet.addAll(conrefpushSet);
+            resourceOnlySet.addAll(keyrefSet);
+            resourceOnlySet.addAll(resourceOnlySet);
+            resourceOnlySet.addAll(fullTopicSet);
+            resourceOnlySet.addAll(fullMapSet);
+            resourceOnlySet.addAll(conrefSet);
+        }
+    }
+
+    private void readStartFile() throws DITAOTException {
+        addToWaitList(new Reference(rootFile));
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -449,9 +449,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     private void writeMap(final FileInfo in, final Document doc) throws DITAOTException {
         Result out = null;
         try {
-            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             out = new StreamResult(job.tempDirURI.resolve(in.uri).toString());
-            transformer.transform(new DOMSource(doc), out);
+            serializer.transform(new DOMSource(doc), out);
         } catch (final TransformerConfigurationException e) {
             throw new RuntimeException(e);
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -118,7 +118,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             writeMap(in, doc);
 
             // Read resources maps
-            final Collection<FileInfo> resourceFis = job.getFileInfo(fi -> fi.isInputResource);
+            final Collection<FileInfo> resourceFis = job.getFileInfo(fi -> fi.isInputResource && Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITAMAP));
             final KeyScope rootScope = resourceFis.stream()
                     .map(fi -> {
                         try {

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.GenMapAndTopicListModule.TempFileNameScheme;
@@ -452,6 +453,8 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             out = new StreamResult(job.tempDirURI.resolve(in.uri).toString());
             serializer.transform(new DOMSource(doc), out);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to write map", e);
         } catch (final TransformerConfigurationException e) {
             throw new RuntimeException(e);
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -8,6 +8,7 @@
 package org.dita.dost.module;
 
 import com.google.common.io.Files;
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
@@ -102,6 +103,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
             transformer.setURIResolver(CatalogUtils.getCatalogResolver());
             transformer.setParameter("file-being-processed", inputFile.getName());
             transformer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to merge map " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {
@@ -117,6 +120,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
             final Source source = new DOMSource(doc);
             final Result result = new StreamResult(out);
             serializer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to serialize map " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
@@ -74,6 +75,8 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             source.setSystemId(inputFile.toURI().toString());
             final DOMResult result = new DOMResult(doc);
             transformer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to read links from " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.tools.ant.util.FileUtils;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
@@ -107,6 +108,8 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 }
 
                 t.transform(source, result);
+            } catch (final UncheckedXPathException e) {
+                throw new DITAOTException("Failed to transform document", e);
             } catch (final RuntimeException e) {
                 throw e;
             } catch (final TransformerConfigurationException e) {

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -8,6 +8,8 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.trans.UncheckedXPathException;
+import net.sf.saxon.trans.XPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -101,6 +103,8 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
                 output.write(midBuffer.toByteArray());
                 output.flush();
             }
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to process merged topics", e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -11,6 +11,7 @@ import com.google.common.annotations.VisibleForTesting;
 import net.sf.saxon.jaxp.SaxonTransformerFactory;
 import net.sf.saxon.lib.CollationURIResolver;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.tools.ant.types.XMLCatalog;
 import org.apache.tools.ant.util.FileNameMapper;
 import org.apache.tools.ant.util.FileUtils;
@@ -190,6 +191,10 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                     throw new IOException("Failed to to replace input file " + out.getAbsolutePath());
                 }
             }
+        } catch (final UncheckedXPathException e) {
+            logger.error("Failed to transform document: " + e.getXPathException().getMessageAndLocation(), e);
+            logger.debug("Remove " + tmp.getAbsolutePath());
+            FileUtils.delete(tmp);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -479,7 +479,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
      */
     void processParseResult(final URI currentFile) {
         // Category non-copyto result
-        for (final Reference file: listFilter.getNonCopytoResult()) {
+        for (final Reference file: listFilter.getNonCopytoResult_Computed()) {
             categorizeReferenceFile(file);
         }
         for (final Map.Entry<URI, URI> e : listFilter.getCopytoMap().entrySet()) {
@@ -491,7 +491,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
 
         hrefTargetSet.addAll(listFilter.getHrefTargets());
         conrefTargetSet.addAll(listFilter.getConrefTargets());
-        nonConrefCopytoTargetSet.addAll(listFilter.getNonConrefCopytoTargets());
+        nonConrefCopytoTargetSet.addAll(listFilter.getNonConrefCopytoTargets_Computed());
         coderefTargetSet.addAll(listFilter.getCoderefTargets());
         outDitaFilesSet.addAll(listFilter.getOutFilesSet());
 
@@ -646,7 +646,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
 
         job.setProperty("tempdirToinputmapdir.relative.value", StringUtils.escapeRegExp(getPrefix(relativeRootFile)));
 
-        resourceOnlySet.addAll(listFilter.getResourceOnlySet());
+        resourceOnlySet.addAll(listFilter.getResourceOnlySet_Computed());
 
         for (final URI file: outDitaFilesSet) {
             getOrCreateFileInfo(fileinfos, file).isOutDita = true;

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -47,6 +47,9 @@ public final class MapReaderModule extends AbstractReaderModule {
             init();
 
             readStartFile();
+            for (URI resource : resources) {
+                addToWaitList(new Reference(resource));
+            }
             processWaitList();
 
             handleConref();

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -46,10 +46,8 @@ public final class MapReaderModule extends AbstractReaderModule {
             parseInputParameters(input);
             init();
 
+            readResourceFiles();
             readStartFile();
-            for (URI resource : resources) {
-                addToWaitList(new Reference(resource));
-            }
             processWaitList();
 
             handleConref();

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -67,6 +67,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
             parseInputParameters(input);
             init();
 
+            readResourceFiles();
             readStartFile();
             processWaitList();
 

--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -8,6 +8,8 @@
  */
 package org.dita.dost.platform;
 
+import net.sf.saxon.trans.UncheckedXPathException;
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.Attributes;
@@ -93,6 +95,8 @@ final class FileGenerator extends XMLFilterImpl {
             source.setSystemId(fileName.toURI().toString());
             final Result result = new StreamResult(out);
             serializer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            logger.error(e.getXPathException().getMessageAndLocation());
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -82,7 +82,7 @@ final class FileGenerator extends XMLFilterImpl {
 
         try (final InputStream in = new BufferedInputStream(new FileInputStream(fileName));
              final OutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
             parserFactory.setNamespaceAware(true);
             XMLReader reader = parserFactory.newSAXParser().getXMLReader();
@@ -92,7 +92,7 @@ final class FileGenerator extends XMLFilterImpl {
             final Source source = new SAXSource(reader, new InputSource(in));
             source.setSystemId(fileName.toURI().toString());
             final Result result = new StreamResult(out);
-            transformer.transform(source, result);
+            serializer.transform(source, result);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -8,6 +8,7 @@
  */
 package org.dita.dost.reader;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.ChunkModule.ChunkFilenameGenerator;
@@ -291,6 +292,8 @@ public final class ChunkMapReader extends AbstractDomFilter {
             final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             result = new StreamResult(new FileOutputStream(new File(file)));
             serializer.transform(new DOMSource(doc), result);
+        } catch (final UncheckedXPathException e) {
+            logger.error(e.getXPathException().getMessageAndLocation(), e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -288,9 +288,9 @@ public final class ChunkMapReader extends AbstractDomFilter {
     private void outputMapFile(final URI file, final Document doc) {
         Result result = null;
         try {
-            final Transformer t = TransformerFactory.newInstance().newTransformer();
+            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             result = new StreamResult(new FileOutputStream(new File(file)));
-            t.transform(new DOMSource(doc), result);
+            serializer.transform(new DOMSource(doc), result);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -21,7 +21,6 @@ import org.xml.sax.SAXParseException;
 import java.net.URI;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.dita.dost.util.Configuration.ditaFormat;
 import static org.dita.dost.util.Constants.*;
@@ -155,7 +154,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
      *
      * @return out file set
      */
-    public Set<URI> getOutFilesSet() {
+    public Set<URI> getOutDitaFilesSet() {
         return outDitaFilesSet;
     }
 
@@ -178,29 +177,6 @@ public final class GenListModuleReader extends AbstractXMLFilter {
     }
 
     /**
-     * List of files with "@processing-role=resource-only".
-     *
-     * @return the resource-only set
-     */
-    public Set<URI> getResourceOnlySet_Computed() {
-        final Set<URI> res = new HashSet<>(getResourceOnlySet());
-        res.removeAll(getNormalProcessingRoleSet());
-        return res;
-    }
-
-    /**
-     * List of files referenced by something other than topicref
-     *
-     * @return the resource-only set
-     */
-    public Set<URI> getNonTopicrefReferenceSet_Computed() {
-        final Set<URI> res = new HashSet<>(getNonTopicrefReferenceSet());
-        res.removeAll(getNormalProcessingRoleSet());
-        res.removeAll(getResourceOnlySet());
-        return res;
-    }
-
-    /**
      * Is the processed file a DITA topic.
      *
      * @return {@code true} if DITA topic, otherwise {@code false}
@@ -212,7 +188,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         return rootClass == null || TOPIC_TOPIC.matches(rootClass);
     }
 
-    private String currentFileFormat() {
+    public String currentFileFormat() {
         if (rootClass == null || TOPIC_TOPIC.matches(rootClass)) {
             return ATTR_FORMAT_VALUE_DITA;
         } else if (MAP_MAP.matches(rootClass)) {
@@ -286,31 +262,6 @@ public final class GenListModuleReader extends AbstractXMLFilter {
     }
 
     /**
-     * Get all targets except copy-to.
-     *
-     * @return set of target file path with option format after
-     * {@link org.dita.dost.util.Constants#STICK STICK}
-     */
-    public Set<Reference> getNonCopytoResult_Computed() {
-        final Set<Reference> nonCopytoSet = new LinkedHashSet<>(128);
-
-        nonCopytoSet.addAll(getNonConrefCopytoTargets());
-        for (final URI f : getConrefTargets()) {
-            nonCopytoSet.add(new Reference(stripFragment(f), currentFileFormat()));
-        }
-        for (final URI f : getCopytoMap().values()) {
-            nonCopytoSet.add(new Reference(stripFragment(f)));
-        }
-        for (final URI f : getIgnoredCopytoSourceSet()) {
-            nonCopytoSet.add(new Reference(stripFragment(f)));
-        }
-        for (final URI filename : getCoderefTargetSet()) {
-            nonCopytoSet.add(new Reference(stripFragment(filename)));
-        }
-        return nonCopytoSet;
-    }
-
-    /**
      * Get copy-to map.
      *
      * @return map of copy-to target to souce
@@ -344,26 +295,6 @@ public final class GenListModuleReader extends AbstractXMLFilter {
      */
     public Set<URI> getCoderefTargets() {
         return coderefTargetSet;
-    }
-
-    /**
-     * Get outditafileslist.
-     *
-     * @return Returns the outditafileslist.
-     */
-    public Set<URI> getOutDitaFilesSet() {
-        return outDitaFilesSet;
-    }
-
-    /**
-     * Get non-conref and non-copyto targets.
-     *
-     * @return Returns the nonConrefCopytoTargets.
-     */
-    public Set<URI> getNonConrefCopytoTargets_Computed() {
-        return getNonConrefCopytoTargets().stream()
-                .map(r -> r.filename)
-                .collect(Collectors.toSet());
     }
 
     /**
@@ -418,7 +349,6 @@ public final class GenListModuleReader extends AbstractXMLFilter {
     public Set<URI> getNonTopicrefReferenceSet() {
         return nonTopicrefReferenceSet;
     }
-
 
     /**
      * Reset the internal variables.

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -860,6 +860,7 @@ public final class Constants {
     public static final String ANT_INVOKER_PARAM_BASEDIR = "basedir";
     /**Constants for common params used in ant invoker(inputmap).*/
     public static final String ANT_INVOKER_PARAM_INPUTMAP = "inputmap";
+    public static final String ANT_INVOKER_PARAM_RESOURCES = "resources";
     /**Constants for common params used in ant invoker(ditaval).*/
     public static final String ANT_INVOKER_PARAM_DITAVAL = "ditaval";
     /**Constants for common params used in ant invoker(mergedditaval)*/

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -27,6 +27,7 @@ import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 
@@ -266,6 +267,8 @@ public final class DelayConrefUtils {
             out = new FileOutputStream(outputFile);
             final StreamResult sr = new StreamResult(out);
             t.transform(doms, sr);
+        } catch (final UncheckedXPathException e) {
+            logger.error("Failed to process map: " + e.getXPathException().getMessageAndLocation(), e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -619,6 +619,8 @@ public final class Job {
         public boolean isOutDita;
         /** File is input document that is used as processing root. */
         public boolean isInput;
+        /** Additional input resource. */
+        public boolean isInputResource;
 
         FileInfo(final URI src, final URI uri, final File file) {
             if (uri == null && file == null) throw new IllegalArgumentException(new NullPointerException());
@@ -650,6 +652,7 @@ public final class Job {
                     ", isTarget=" + isTarget +
                     ", isConrefPush=" + isConrefPush +
                     ", isInput=" + isInput +
+                    ", isInputResource=" + isInputResource +
                     ", hasKeyref=" + hasKeyref +
                     ", hasCoderef=" + hasCoderef +
                     ", isSubjectScheme=" + isSubjectScheme +
@@ -677,6 +680,7 @@ public final class Job {
                     isFlagImage == fileInfo.isFlagImage &&
                     isOutDita == fileInfo.isOutDita &&
                     isInput == fileInfo.isInput &&
+                    isInputResource == fileInfo.isInputResource &&
                     Objects.equals(src, fileInfo.src) &&
                     Objects.equals(uri, fileInfo.uri) &&
                     Objects.equals(file, fileInfo.file) &&
@@ -687,7 +691,8 @@ public final class Job {
         @Override
         public int hashCode() {
             return Objects.hash(src, uri, file, result, format, hasConref, isChunked, hasLink, isResourceOnly, isTarget,
-                    isConrefPush, hasKeyref, hasCoderef, isSubjectScheme, isSubtarget, isFlagImage, isOutDita, isInput);
+                    isConrefPush, hasKeyref, hasCoderef, isSubjectScheme, isSubtarget, isFlagImage, isOutDita, isInput,
+                    isInputResource);
         }
 
         public static class Builder {
@@ -710,6 +715,7 @@ public final class Job {
             private boolean isFlagImage;
             private boolean isOutDita;
             private boolean isInput;
+            private boolean isInputResource;
 
             public Builder() {}
             public Builder(final FileInfo orig) {
@@ -731,6 +737,7 @@ public final class Job {
                 isFlagImage = orig.isFlagImage;
                 isOutDita = orig.isOutDita;
                 isInput = orig.isInput;
+                isInputResource = orig.isInputResource;
             }
 
             /**
@@ -755,6 +762,7 @@ public final class Job {
                 if (orig.isFlagImage) isFlagImage = orig.isFlagImage;
                 if (orig.isOutDita) isOutDita = orig.isOutDita;
                 if (orig.isInput) isInput = orig.isInput;
+                if (orig.isInputResource) isInputResource = orig.isInputResource;
                 return this;
             }
 
@@ -797,6 +805,7 @@ public final class Job {
             public Builder isFlagImage(final boolean isFlagImage) { this.isFlagImage = isFlagImage; return this; }
             public Builder isOutDita(final boolean isOutDita) { this.isOutDita = isOutDita; return this; }
             public Builder isInput(final boolean isInput) { this.isInput = isInput; return this; }
+            public Builder isInputResource(final boolean isInputResource) { this.isInputResource = isInputResource; return this; }
 
             public FileInfo build() {
                 if (uri == null && file == null) {
@@ -820,6 +829,7 @@ public final class Job {
                 fi.isFlagImage = isFlagImage;
                 fi.isOutDita = isOutDita;
                 fi.isInput = isInput;   
+                fi.isInputResource = isInputResource;
                 return fi;
             }
 

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -974,8 +974,10 @@ public final class Job {
                 .filter(fi -> fi.isInput)
                 .map(fi -> fi.src)
                 .findAny()
-                .orElse(null);
-
+                .orElseGet(() -> Optional.ofNullable((String) prop.get(PROPERTY_INPUT_MAP_URI))
+                        .map(URLUtils::toURI)
+                        .orElse(null)
+                );
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/KeyScope.java
+++ b/src/main/java/org/dita/dost/util/KeyScope.java
@@ -73,13 +73,13 @@ public class KeyScope {
         if (!Objects.equals(scope1.id, scope2.id)) {
             throw new IllegalArgumentException(String.format("Scopes should have the same ID: %s != %s", scope1.id, scope2.id));
         }
+        final Map<String, KeyDef> keyDefinition = new HashMap<>();
+        scope1.keyDefinition.forEach(keyDefinition::putIfAbsent);
+        scope2.keyDefinition.forEach(keyDefinition::putIfAbsent);
         return new KeyScope(
                 scope1.id,
                 scope1.name,
-                ImmutableMap.<String, KeyDef>builder()
-                        .putAll(scope1.keyDefinition)
-                        .putAll(scope2.keyDefinition)
-                        .build(),
+                unmodifiableMap(keyDefinition),
                 ImmutableList.<KeyScope>builder()
                         .addAll(scope1.childScopes)
                         .addAll(scope2.childScopes)

--- a/src/main/java/org/dita/dost/util/KeyScope.java
+++ b/src/main/java/org/dita/dost/util/KeyScope.java
@@ -7,6 +7,10 @@
  */
 package org.dita.dost.util;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 import java.util.*;
 
 import static java.util.Collections.unmodifiableList;
@@ -18,6 +22,8 @@ import static java.util.Collections.unmodifiableMap;
  * @since 2.2
  */
 public class KeyScope {
+
+    public static final KeyScope EMPTY = new KeyScope(null, null, Collections.emptyMap(), Collections.emptyList());
 
     public final String id;
     public final String name;
@@ -61,5 +67,23 @@ public class KeyScope {
         result = 31 * result + keyDefinition.hashCode();
         result = 31 * result + childScopes.hashCode();
         return result;
+    }
+
+    public static KeyScope merge(final KeyScope scope1, final KeyScope scope2) {
+        if (!Objects.equals(scope1.id, scope2.id)) {
+            throw new IllegalArgumentException(String.format("Scopes should have the same ID: %s != %s", scope1.id, scope2.id));
+        }
+        return new KeyScope(
+                scope1.id,
+                scope1.name,
+                ImmutableMap.<String, KeyDef>builder()
+                        .putAll(scope1.keyDefinition)
+                        .putAll(scope2.keyDefinition)
+                        .build(),
+                ImmutableList.<KeyScope>builder()
+                        .addAll(scope1.childScopes)
+                        .addAll(scope2.childScopes)
+                        .build()
+        );
     }
 }

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -28,6 +28,7 @@ import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.event.Receiver;
 import net.sf.saxon.jaxp.TransformerImpl;
 import net.sf.saxon.serialize.MessageWarner;
+import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.LoggingErrorListener;
@@ -516,6 +517,8 @@ public final class XMLUtils {
             source.setSystemId(inputFile.toURI().toString());
             final Result result = new StreamResult(out);
             transformer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to transform " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {
@@ -565,6 +568,8 @@ public final class XMLUtils {
             final Source source = new SAXSource(reader, src);
             result = new StreamResult(output.toString());
             transformer.transform(source, result);
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to transform " + input, e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -60,9 +60,9 @@ public abstract class AbstractDomFilter implements AbstractReader {
             try {
                 res = new StreamResult(new FileOutputStream(filename));
                 final DOMSource ds = new DOMSource(resDoc);
-                final Transformer tf = TransformerFactory.newInstance().newTransformer();
+                final Transformer serializer = TransformerFactory.newInstance().newTransformer();
                 logger.debug("Writing " + filename.toURI());
-                tf.transform(ds, res);
+                serializer.transform(ds, res);
             } catch (final RuntimeException e) {
                 throw e;
             } catch (final TransformerException e) {

--- a/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
+++ b/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
@@ -12,6 +12,7 @@ import static org.dita.dost.util.URLUtils.*;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.util.*;
@@ -63,7 +64,7 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
                 XMLUtils.removeAttribute(resAtts, ATTRIBUTE_NAME_CONKEYREF);
                 final KeyDef k = keys.get(key);
                 if (k.href != null && (k.scope.equals(ATTR_SCOPE_VALUE_LOCAL))) {
-                    URI target = getRelativePath(k.href);
+                    URI target = getRelativePath(keyDef.source, k.href);
                     final String keyFragment = k.href.getFragment();
                     if (id != null && keyFragment != null) {
                         target = setFragment(target, keyFragment + SLASH + id);
@@ -86,15 +87,15 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
     /**
      * Update href URI.
      *
+     * @param keyMap key definition map URI
      * @param href href URI
      * @return updated href URI
      */
-    private URI getRelativePath(final URI href) {
-        final URI keyValue;
-        final URI inputMap = job.getFileInfo(fi -> fi.isInput).stream()
+    private URI getRelativePath(final URI keyMap, final URI href) {
+        final URI inputMap = Optional.ofNullable(job.getFileInfo(keyMap))
                 .map(fi -> fi.uri)
-                .findFirst()
                 .orElse(null);
+        final URI keyValue;
         if (inputMap != null) {
             final URI tmpMap = job.tempDirURI.resolve(inputMap);
             keyValue = tmpMap.resolve(stripFragment(href));

--- a/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
@@ -42,7 +42,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
     /** Stack of topic IDs. */
     private Deque<String> topicIdStack;
     private final ArrayList<String> topicSpecList;
-    private final Transformer saxToDomTransformer;
+    private final Transformer serializer;
     private static final Attributes relatedLinksAtts = new AttributesBuilder()
             .add(ATTRIBUTE_NAME_CLASS, TOPIC_RELATED_LINKS.toString())
             .build();
@@ -55,7 +55,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
         super();
         topicSpecList = new ArrayList<>();
         try {
-            saxToDomTransformer = TransformerFactory.newInstance().newTransformer();
+            serializer = TransformerFactory.newInstance().newTransformer();
         } catch (final TransformerConfigurationException e) {
             throw new RuntimeException("Failed to configure DOM to SAX transformer: " + e.getMessage(), e);
         }
@@ -165,7 +165,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
             for (int i = 0; i < children.getLength(); i++) {
                 final Node links = rewriteLinks((Element) children.item(i));
                 final Source source = new DOMSource(links);
-                saxToDomTransformer.transform(source, result);
+                serializer.transform(source, result);
             }
         } catch (TransformerException e) {
             throw new SAXException("Failed to serialize DOM node to SAX: " + e.getMessageAndLocation(), e);

--- a/src/main/java/org/dita/dost/writer/ResourceInsertFilter.java
+++ b/src/main/java/org/dita/dost/writer/ResourceInsertFilter.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.writer;
+
+import org.dita.dost.util.XMLUtils.AttributesBuilder;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+import java.net.URI;
+import java.util.List;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+
+public final class ResourceInsertFilter extends AbstractXMLFilter {
+
+    private boolean added = false;
+    private List<URI> resources;
+
+    public void setResources(final List<URI> resources) {
+        this.resources = resources;
+    }
+
+    // SAX methods
+
+    @Override
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
+        super.startElement(uri, localName, qName, atts);
+        if (!added) {
+            for (URI resource : resources) {
+                logger.info("add resource " + resource);
+                super.startElement(NULL_NS_URI, MAP_TOPICREF.localName, MAP_TOPICREF.localName,
+                        getAttributes()
+                                .add(ATTRIBUTE_NAME_HREF, currentFile.resolve(".").relativize(resource).toString())
+                                .add(ATTRIBUTE_NAME_PROCESSING_ROLE, ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY)
+//                                .add(ATTRIBUTE_NAME_FORMAT, FIXME)
+                                .build());
+                super.endElement(NULL_NS_URI, MAP_TOPICREF.localName, MAP_TOPICREF.localName);
+            }
+            added = true;
+        }
+    }
+
+    private AttributesBuilder getAttributes() {
+        return new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, MAP_TOPICREF.toString());
+    }
+
+}

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -121,7 +121,7 @@ See the accompanying LICENSE file for applicable license.
   
   <target name="map-reader"
     description="Generate lists, debug, and filter input map files">
-    <pipeline message="Generate list." taskname="map-reader"
+    <pipeline message="Generate maps" taskname="map-reader"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.reader.MapReaderModule">
         <param name="resources" value="${args.resources}" if:set="args.resources"/>
@@ -244,7 +244,7 @@ See the accompanying LICENSE file for applicable license.
   
   <target name="topic-reader"
     description="Generate file list">
-    <pipeline message="Generate list." taskname="topic-reader"
+    <pipeline message="Generate topics" taskname="topic-reader"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.reader.TopicReaderModule">
         <param name="resources" value="${args.resources}" if:set="args.resources"/>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -90,7 +90,7 @@ See the accompanying LICENSE file for applicable license.
       </condition>
     </dita-ot-fail>
     
-    <basename property="dita.input.filename" file="${args.input}" />    
+    <basename property="dita.input.filename" file="${args.input}" />
     <pathconvert property="dita.map.filename.root">
       <path path="${dita.input.filename}"/>
       <chainedmapper>
@@ -102,6 +102,7 @@ See the accompanying LICENSE file for applicable license.
     
     <echo level="info">*****************************************************************</echo>
     <echo level="info">* input = ${args.input}</echo>
+    <echo level="info">* resources = ${args.resources}</echo>
     <echo level="info">*****************************************************************</echo>
     
     <echoxml file="${dita.temp.dir}/.job.xml">
@@ -123,6 +124,7 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Generate list." taskname="map-reader"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.reader.MapReaderModule">
+        <param name="resources" value="${args.resources}" if:set="args.resources"/>
         <param name="inputdir" location="${args.input.dir}" if:set="args.input.dir"/>
         <param name="ditadir" location="${dita.dir}"/>
         <!--<param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>-->
@@ -241,6 +243,7 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Generate list." taskname="topic-reader"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.reader.TopicReaderModule">
+        <param name="resources" value="${args.resources}" if:set="args.resources"/>
         <param name="inputdir" location="${args.input.dir}" if:set="args.input.dir"/>
         <param name="ditadir" location="${dita.dir}"/>
         <!--<param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>-->

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -146,8 +146,12 @@ See the accompanying LICENSE file for applicable license.
     <!-- TODO replace with direct resource collection availability test -->
     <job-helper file="fullditamap.list" property="fullditamaplist"/>
     <property name="fullditamapfile" value="fullditamap.list"/>
+    <local name="inputMapPath"/>
+    <pathconvert property="inputMapPath">
+      <ditafileset format="dita" input="true"/>
+    </pathconvert>
     <condition property="noMap">
-      <length file="${dita.temp.dir}/${fullditamapfile}" length="0"/>
+      <available file="${inputMapPath}"/>
     </condition>
     <delete file="${dita.temp.dir}/${fullditamapfile}"/>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -148,10 +148,10 @@ See the accompanying LICENSE file for applicable license.
     <property name="fullditamapfile" value="fullditamap.list"/>
     <local name="inputMapPath"/>
     <pathconvert property="inputMapPath">
-      <ditafileset format="dita" input="true"/>
+      <ditafileset format="ditamap" input="true"/>
     </pathconvert>
     <condition property="noMap">
-      <available file="${inputMapPath}"/>
+      <equals arg1="${inputMapPath}" arg2=""/>
     </condition>
     <delete file="${dita.temp.dir}/${fullditamapfile}"/>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -185,10 +185,12 @@ See the accompanying LICENSE file for applicable license.
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
     <local name="inputMapPath"/>
     <pathconvert property="inputMapPath">
-      <ditafileset format="dita" input="true"/>
+      <ditafileset format="ditamap" input="true"/>
     </pathconvert>
     <condition property="noMap">
-      <available file="${inputMapPath}"/>
+      <not>
+        <available file="${inputMapPath}"/>
+      </not>
     </condition>
   </target>
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -188,9 +188,7 @@ See the accompanying LICENSE file for applicable license.
       <ditafileset format="ditamap" input="true"/>
     </pathconvert>
     <condition property="noMap">
-      <not>
-        <available file="${inputMapPath}"/>
-      </not>
+      <equals arg1="${inputMapPath}" arg2=""/>
     </condition>
   </target>
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -183,8 +183,12 @@ See the accompanying LICENSE file for applicable license.
     <dirname property="_dita.map.output.dir" file="${dita.output.dir}/${user.input.file}" />
     <dirname property="_dita.map.temp.dir" file="${dita.temp.dir}/${user.input.file}" />
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
+    <local name="inputMapPath"/>
+    <pathconvert property="inputMapPath">
+      <ditafileset format="dita" input="true"/>
+    </pathconvert>
     <condition property="noMap">
-      <length file="${dita.temp.dir}/${fullditamapfile}" length="0"/>
+      <available file="${inputMapPath}"/>
     </condition>
   </target>
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -63,6 +63,7 @@ See the accompanying LICENSE file for applicable license.
     
     <echo level="info">*****************************************************************</echo>
     <echo level="info">* input = ${args.input}</echo>
+    <echo level="info">* resources = ${args.resources}</echo>
     <echo level="info">*****************************************************************</echo>
   </target>
   
@@ -99,6 +100,7 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Generate list." taskname="gen-list"
       inputmap="${args.input}">
       <module class="org.dita.dost.module.GenMapAndTopicListModule">
+        <param name="resources" value="${args.resources}" if:set="args.resources"/>
         <param name="inputdir" location="${args.input.dir}" if:set="args.input.dir"/>
         <param name="ditadir" location="${dita.dir}"/>
         <param name="validate" value="${validate}"/>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -98,6 +98,7 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="args.input" desc="Specifies the master file for your documentation project." type="file" required="true"/>
     <param name="args.input.dir" desc="Specifies the base directory for your documentation project." type="dir"/>
+    <param name="args.resources" desc="Specifies resource files." type="file"/>
     <param name="args.output.base" desc="Specifies the name of the output file without file extension." type="string"/>
     <param name="args.tablelink.style" desc="Specifies how cross references to tables are styled." type="enum">
       <val>NUMBER</val>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -210,7 +210,7 @@ See the accompanying LICENSE file for applicable license.
       <pipeline message="Convert DITA map to HTML5" taskname="xslt">
       <xslt destdir="${html5.toc.output.dir}"
             style="${args.html5.toc.xsl}">
-        <ditafileset input="true"/>
+        <ditafileset input="true" format="ditamap"/>
         <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile"/>
         <param name="OUTEXT" expression="${out.ext}" if:set="out.ext"/>
         <param name="contenttarget" expression="${args.html5.contenttarget}" if:set="args.html5.contenttarget"/>

--- a/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.*;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -90,7 +91,8 @@ public final class VariableFileTask extends Task {
                 root.appendChild(lang);
             }
 
-            TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(file));
+            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
+            serializer.transform(new DOMSource(d), new StreamResult(file));
         } catch (final RuntimeException e) {
             throw e;
         } catch (final TransformerException e) {

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -52,7 +52,7 @@ See the accompanying LICENSE file for applicable license.
       <pipeline>
       <xslt destdir="${xhtml.toc.output.dir}"
             style="${args.xhtml.toc.xsl}">
-        <ditafileset input="true"/>
+        <ditafileset input="true" format="ditamap"/>
         <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
         <param name="contenttarget" expression="${args.xhtml.contenttarget}" if:set="args.xhtml.contenttarget"/>
         <param name="CSS" expression="${args.css.file}" if:set="args.css.file" />

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.dita.dost.AbstractIntegrationTest.Transtype.*;
+import static org.junit.Assert.fail;
 
 public abstract class IntegrationTest extends AbstractIntegrationTest {
 
@@ -530,6 +531,26 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
         builder().name("rng")
                 .transtype(PREPROCESS)
                 .input(Paths.get("root.ditamap"))
+                .test();
+    }
+
+    @Test
+    public void resource_map() throws Throwable {
+        final Path testDir = Paths.get("src", "test", "resources", "resource", "src");
+        builder().name("resource_map")
+                .transtype(PREPROCESS)
+                .input(Paths.get("map.ditamap"))
+                .put("args.resources", Paths.get("keys.ditamap"))
+                .test();
+    }
+
+    @Test
+    public void resource_topic() throws Throwable {
+        final Path testDir = Paths.get("src", "test", "resources", "resource", "src");
+        builder().name("resource_topic")
+                .transtype(PREPROCESS)
+                .input(Paths.get("topic.dita"))
+                .put("args.resources", Paths.get("keys.ditamap"))
                 .test();
     }
 }

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -536,7 +536,6 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void resource_map() throws Throwable {
-        final Path testDir = Paths.get("src", "test", "resources", "resource", "src");
         builder().name("resource_map")
                 .transtype(PREPROCESS)
                 .input(Paths.get("map.ditamap"))
@@ -546,7 +545,6 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void resource_topic() throws Throwable {
-        final Path testDir = Paths.get("src", "test", "resources", "resource", "src");
         builder().name("resource_topic")
                 .transtype(PREPROCESS)
                 .input(Paths.get("topic.dita"))

--- a/src/test/java/org/dita/dost/TestUtils.java
+++ b/src/test/java/org/dita/dost/TestUtils.java
@@ -155,17 +155,17 @@ public class TestUtils {
         InputStream in = null;
         try {
             in = new BufferedInputStream(new FileInputStream(file));
-            final Transformer t = TransformerFactory.newInstance().newTransformer();
+            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
             XMLReader p = XMLReaderFactory.createXMLReader();
             p.setEntityResolver(CatalogUtils.getCatalogResolver());
             if (normalize) {
-                t.setOutputProperty(OutputKeys.INDENT, "yes");
+                serializer.setOutputProperty(OutputKeys.INDENT, "yes");
                 p = new NormalizingXMLFilterImpl(p);
             }
             if (clean) {
                 p = new CleaningXMLFilterImpl(p);
             }
-            t.transform(new SAXSource(p, new InputSource(in)),
+            serializer.transform(new SAXSource(p, new InputSource(in)),
                     new StreamResult(std));
         } finally {
             if (in != null) {

--- a/src/test/java/org/dita/dost/exception/DITAOTExceptionTest.java
+++ b/src/test/java/org/dita/dost/exception/DITAOTExceptionTest.java
@@ -31,7 +31,7 @@ public class DITAOTExceptionTest {
 
     @Test
     public void testDITAOTExceptionStringThrowable() {
-        new DITAOTException(null, null);
+        new DITAOTException(null, (Throwable) null);
         new DITAOTException("test", new RuntimeException());
     }
 

--- a/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
+++ b/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
@@ -14,7 +14,9 @@ import org.dita.dost.reader.GenListModuleReader.Reference;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
+import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.SAXException;
@@ -26,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,9 +53,34 @@ public class TestGenListModuleReader {
         tempDir = TestUtils.createTempDir(TestGenListModuleReader.class);
     }
 
+    @Before
+    public void setUp() throws IOException {
+        reader = new GenListModuleReader();
+        reader.setLogger(new TestUtils.TestLogger());
+        reader.setJob(new Job(tempDir));
+        reader.setContentHandler(new DefaultHandler());
+        final URI currentFile = new File(inputDir, "root-map-01.ditamap").toURI();
+        reader.setCurrentFile(currentFile);
+        reader.setPrimaryDitamap(currentFile);
+    }
+
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         FileUtils.deleteQuietly(tempDir);
+    }
+
+    @Test
+    public void startDocument() throws SAXException {
+        reader.startDocument();
+    }
+
+    @Test
+    public void startElement() throws SAXException {
+        reader.startDocument();
+        reader.startElement("", "topic", "topic", new AttributesBuilder()
+                .add("class", "- topic/topic ")
+                .add("id", "abc")
+                .build());
     }
 
     @Test
@@ -225,13 +251,8 @@ public class TestGenListModuleReader {
         final File ditaDir = new File("src" + File.separator + "main").getAbsoluteFile();
 
         final boolean validate = false;
-        reader = new GenListModuleReader();
-        reader.setLogger(new TestUtils.TestLogger());
         reader.setCurrentFile(rootFile.toURI());
         reader.setPrimaryDitamap(rootFile.toURI());
-        reader.setJob(new Job(tempDir));
-
-        reader.setContentHandler(new DefaultHandler());
 
         final XMLReader parser = initXMLReader(ditaDir, validate, new File(rootFile.getPath()).getCanonicalFile());
         parser.setContentHandler(reader);

--- a/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
+++ b/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
@@ -100,13 +100,13 @@ public class TestGenListModuleReader {
                 srcDirUri.resolve("topics/xreffin-topic-1.xml"),
                 srcDirUri.resolve("topics/target-topic-c.xml"),
                 srcDirUri.resolve("topics/target-topic-a.xml"))),
-                reader.getNonConrefCopytoTargets());
+                reader.getNonConrefCopytoTargets_Computed());
 
         assertEquals(new HashSet(Arrays.asList(
                 new Reference(srcDirUri.resolve("topics/xreffin-topic-1.xml")),
                 new Reference(srcDirUri.resolve("topics/target-topic-c.xml")),
                 new Reference(srcDirUri.resolve("topics/target-topic-a.xml")))),
-                reader.getNonCopytoResult());
+                reader.getNonCopytoResult_Computed());
 
         assertEquals(new HashSet(Arrays.asList(
                 srcDirUri.resolve("topics/xreffin-topic-1.xml"),
@@ -121,9 +121,9 @@ public class TestGenListModuleReader {
                 reader.getOutFilesSet());
 
         assertEquals(emptySet(),
-                reader.getNonTopicrefReferenceSet());
+                reader.getNonTopicrefReferenceSet_Computed());
 
-        assertTrue(reader.getResourceOnlySet().isEmpty());
+        assertTrue(reader.getResourceOnlySet_Computed().isEmpty());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
 
@@ -149,22 +149,22 @@ public class TestGenListModuleReader {
 
         assertEquals(new HashSet(Arrays.asList(
                 srcDirUri.resolve("maps/toolbars.dita"))),
-                reader.getNonConrefCopytoTargets());
+                reader.getNonConrefCopytoTargets_Computed());
 
         assertEquals(new HashSet(Arrays.asList(
                 new Reference(srcDirUri.resolve("maps/toolbars.dita")))),
-                reader.getNonCopytoResult());
+                reader.getNonCopytoResult_Computed());
 
         assertTrue(reader.getOutDitaFilesSet().isEmpty());
 
         assertTrue(reader.getOutFilesSet().isEmpty());
 
-        assertTrue(reader.getResourceOnlySet().isEmpty());
+        assertTrue(reader.getResourceOnlySet_Computed().isEmpty());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
 
         assertEquals(emptySet(),
-                reader.getNonTopicrefReferenceSet());
+                reader.getNonTopicrefReferenceSet_Computed());
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());
@@ -204,7 +204,7 @@ public class TestGenListModuleReader {
                 "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(conrefDirUri::resolve)
                         .collect(Collectors.toSet()),
-                reader.getNonConrefCopytoTargets());
+                reader.getNonConrefCopytoTargets_Computed());
 
         assertEquals(Stream.of(
                 "resourceonly.dita",
@@ -215,7 +215,7 @@ public class TestGenListModuleReader {
                 "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(f -> new Reference(conrefDirUri.resolve(f)))
                         .collect(Collectors.toSet()),
-                reader.getNonCopytoResult());
+                reader.getNonCopytoResult_Computed());
 
         assertEquals(emptySet(),
                 reader.getOutDitaFilesSet());
@@ -231,12 +231,12 @@ public class TestGenListModuleReader {
                 "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(conrefDirUri::resolve)
                         .collect(Collectors.toSet()),
-                reader.getResourceOnlySet());
+                reader.getResourceOnlySet_Computed());
 
         assertTrue(reader.getCoderefTargets().isEmpty());
 
         assertEquals(emptySet(),
-                reader.getNonTopicrefReferenceSet());
+                reader.getNonTopicrefReferenceSet_Computed());
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());

--- a/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
@@ -142,7 +142,7 @@ public class ConkeyrefFilterTest {
 
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setCurrentFile(job.tempDirURI.resolve("product/topic.dita"));
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", URI.create("../common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, URI.create("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", URI.create("../common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, job.tempDirURI.resolve("maps/root.map"), null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
             public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {

--- a/src/test/resources/resource_map/exp/preprocess/keys.ditamap
+++ b/src/test/resources/resource_map/exp/preprocess/keys.ditamap
@@ -32,4 +32,5 @@
       </topicmeta>
     </keydef>
   </topicgroup>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
 </map>

--- a/src/test/resources/resource_map/exp/preprocess/keys.ditamap
+++ b/src/test/resources/resource_map/exp/preprocess/keys.ditamap
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">value</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">override</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope">
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">scope value</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">override</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+  </topicgroup>
+</map>

--- a/src/test/resources/resource_map/exp/preprocess/map.ditamap
+++ b/src/test/resources/resource_map/exp/preprocess/map.ditamap
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">base</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" keyscope="scope" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">base</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref class="- map/topicref " href="topic.dita" type="topic">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Topic</navtitle>
+      <?ditaot gentext?>
+      <linktext class="- map/linktext ">Topic</linktext>
+    </topicmeta>
+  </topicref>
+</map>

--- a/src/test/resources/resource_map/exp/preprocess/resourceOnly.dita
+++ b/src/test/resources/resource_map/exp/preprocess/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_map/exp/preprocess/topic.dita
+++ b/src/test/resources/resource_map/exp/preprocess/topic.dita
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)"
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">key: <keyword class="- topic/keyword " keyref="key">value</keyword>
+    </p>
+    <p class="- topic/p ">common: <keyword class="- topic/keyword " keyref="common">base</keyword>
+    </p>
+    <p class="- topic/p ">scope key: <keyword class="- topic/keyword " keyref="scope.key">scope value</keyword>
+    </p>
+    <p class="- topic/p ">scope common: <keyword class="- topic/keyword " keyref="scope.common" keyscope="scope"
+        >base</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/resource_map/exp/preprocess2/keys.ditamap
+++ b/src/test/resources/resource_map/exp/preprocess2/keys.ditamap
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of the DITA Open Toolkit project.
+  ~
+  ~ Copyright 2019 Jarno Elovirta
+  ~
+  ~ See the accompanying LICENSE file for applicable license.
+  -->
+
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope"/>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
+</map>

--- a/src/test/resources/resource_map/exp/preprocess2/map.ditamap
+++ b/src/test/resources/resource_map/exp/preprocess2/map.ditamap
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of the DITA Open Toolkit project.
+  ~
+  ~ Copyright 2019 Jarno Elovirta
+  ~
+  ~ See the accompanying LICENSE file for applicable license.
+  -->
+
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <topicref class="- map/topicref " href="topic.dita" type="topic">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">Topic</navtitle>
+      <?ditaot gentext?>
+      <linktext class="- map/linktext ">Topic</linktext>
+    </topicmeta>
+  </topicref>
+</map>

--- a/src/test/resources/resource_map/exp/preprocess2/resourceOnly.dita
+++ b/src/test/resources/resource_map/exp/preprocess2/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_map/exp/preprocess2/topic.dita
+++ b/src/test/resources/resource_map/exp/preprocess2/topic.dita
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)"
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">key: <keyword class="- topic/keyword " keyref="key">value</keyword>
+    </p>
+    <p class="- topic/p ">common: <keyword class="- topic/keyword " keyref="common">base</keyword>
+    </p>
+    <p class="- topic/p ">scope key: <keyword class="- topic/keyword " keyref="scope.key">scope value</keyword>
+    </p>
+    <p class="- topic/p ">scope common: <keyword class="- topic/keyword " keyref="scope.common" keyscope="scope"
+        >base</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/resource_map/src/keys.ditamap
+++ b/src/test/resources/resource_map/src/keys.ditamap
@@ -1,0 +1,34 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">value</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">override</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope">
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">scope value</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">override</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+  </topicgroup>
+</map>

--- a/src/test/resources/resource_map/src/keys.ditamap
+++ b/src/test/resources/resource_map/src/keys.ditamap
@@ -31,4 +31,5 @@
       </topicmeta>
     </keydef>
   </topicgroup>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
 </map>

--- a/src/test/resources/resource_map/src/map.ditamap
+++ b/src/test/resources/resource_map/src/map.ditamap
@@ -1,0 +1,19 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">base</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" keyscope="scope" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">base</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref class="- map/topicref " href="topic.dita"/>
+</map>

--- a/src/test/resources/resource_map/src/resourceOnly.dita
+++ b/src/test/resources/resource_map/src/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_map/src/topic.dita
+++ b/src/test/resources/resource_map/src/topic.dita
@@ -1,0 +1,11 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">key: <keyword class="- topic/keyword " keyref="key"/></p>
+    <p class="- topic/p ">common: <keyword class="- topic/keyword " keyref="common"/></p>
+    <p class="- topic/p ">scope key: <keyword class="- topic/keyword " keyref="scope.key"/></p>
+    <p class="- topic/p ">scope common: <keyword class="- topic/keyword " keyref="scope.common"/></p>
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/exp/preprocess/keys.ditamap
+++ b/src/test/resources/resource_topic/exp/preprocess/keys.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">value</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+</map>

--- a/src/test/resources/resource_topic/exp/preprocess/keys.ditamap
+++ b/src/test/resources/resource_topic/exp/preprocess/keys.ditamap
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-  cascade="nomerge" class="- map/map "
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
   ditaarch:DITAArchVersion="1.3"
   domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
   <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
@@ -10,4 +9,28 @@
       </keywords>
     </topicmeta>
   </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">override</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope">
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">scope value</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">override</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+  </topicgroup>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
 </map>

--- a/src/test/resources/resource_topic/exp/preprocess/resourceOnly.dita
+++ b/src/test/resources/resource_topic/exp/preprocess/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/exp/preprocess/topic.dita
+++ b/src/test/resources/resource_topic/exp/preprocess/topic.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic "
+  domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)"
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">keyword: <keyword class="- topic/keyword " keyref="key">value</keyword></p>
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/exp/preprocess2/keys.ditamap
+++ b/src/test/resources/resource_topic/exp/preprocess2/keys.ditamap
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of the DITA Open Toolkit project.
+  ~
+  ~ Copyright 2019 Jarno Elovirta
+  ~
+  ~ See the accompanying LICENSE file for applicable license.
+  -->
+
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="nomerge" class="- map/map "
+  ditaarch:DITAArchVersion="1.3"
+  domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope"/>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
+</map>

--- a/src/test/resources/resource_topic/exp/preprocess2/resourceOnly.dita
+++ b/src/test/resources/resource_topic/exp/preprocess2/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/exp/preprocess2/topic.dita
+++ b/src/test/resources/resource_topic/exp/preprocess2/topic.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  class="- topic/topic "
+  domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)"
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">keyword: <keyword class="- topic/keyword " keyref="key">value</keyword></p>
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/src/keys.ditamap
+++ b/src/test/resources/resource_topic/src/keys.ditamap
@@ -8,4 +8,28 @@
       </keywords>
     </topicmeta>
   </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">override</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="scope">
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">scope value</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+    <keydef class="+ map/topicref mapgroup-d/keydef " keys="common" processing-role="resource-only">
+      <topicmeta class="- map/topicmeta ">
+        <keywords class="- topic/keywords ">
+          <keyword class="- topic/keyword ">override</keyword>
+        </keywords>
+      </topicmeta>
+    </keydef>
+  </topicgroup>
+  <topicref class="+ map/topicref " href="resourceOnly.dita"/>
 </map>

--- a/src/test/resources/resource_topic/src/keys.ditamap
+++ b/src/test/resources/resource_topic/src/keys.ditamap
@@ -1,0 +1,11 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="key" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">value</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+</map>

--- a/src/test/resources/resource_topic/src/resourceOnly.dita
+++ b/src/test/resources/resource_topic/src/resourceOnly.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Resource only</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/resource_topic/src/topic.dita
+++ b/src/test/resources/resource_topic/src/topic.dita
@@ -1,0 +1,8 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="topic_rdr_hgq_sjb" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Topic</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">keyword: <keyword class="- topic/keyword " keyref="key"/></p>
+  </body>
+</topic>


### PR DESCRIPTION
## Description
Add support for additional input resources that are referenced as resource-only.

## Motivation and Context
This allows processing e.g. individual topics with key references without needing to create a wrapper map that defines the keys.

## Example

`topic.dita`
```xml
<topic id="topic">
  <title>Installing <keyword key="product"/></title>
  …
</topic>
```

`keys.ditamap`
```xml
<map>
  <keydef keys="product">
    <topicmeta>
      <keywords>
        <keyword>Product</keyword>
      </keywords>
    </topicmeta>
  </keydef>  
</topic>
```

When processed with

```bash
dita -i topic.dita -r keys.ditamap -f html5
```

Will result 

> **Installing Product**
> …