### PR TITLE
Restore library references required for SVG in PDF

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/build.gradle
+++ b/src/main/plugins/org.dita.pdf2.fop/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     runtimeOnly(group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.12') {
         exclude group: 'xalan'
     }
+    runtimeOnly group: 'xml-apis', name: 'xml-apis-ext', version: '1.3.04'
     runtimeOnly group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
     runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop-pdf-images', version: '2.4') {
     }
@@ -39,6 +40,7 @@ task copyInstall(type: Copy) {
         include 'pdfbox-*.jar'
         include 'slf4j-api-*.jar'
         include 'xmlgraphics-commons-*.jar'
+        include 'xml-apis-ext-*.jar'
     }
     destinationDir = file("lib")
 }
@@ -55,6 +57,7 @@ task copyDistTemp(type: Copy) {
         include 'pdfbox-*.jar'
         include 'slf4j-api-*.jar'
         include 'xmlgraphics-commons-*.jar'
+        include 'xml-apis-ext-*.jar'
         into "plugins/org.dita.pdf2.fop/lib"
     }
     destinationDir = file("${rootProject.buildDir}/tmp/dist")

--- a/src/main/plugins/org.dita.pdf2.fop/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/plugin.xml
@@ -17,6 +17,7 @@ See the accompanying LICENSE file for applicable license.
   <feature extension="dita.conductor.lib.import" file="lib/fop-2.4.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/fop-pdf-images-2.4.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/jcl-over-slf4j-1.7.25.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/xml-apis-ext-1.3.04.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/pdfbox-2.0.17.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/slf4j-api-1.7.25.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xmlgraphics-commons-2.4.jar"/>


### PR DESCRIPTION
Amends 3bdb1bf, which removed these references while upgrading to FOP 2.4.

Partial solution for #3414.

🚧 **Work in progress**

@jelovirt 58ae15b ensures SVG images are rendered in PDF if the JAR file is present in `org.dita.pdf2.fop/lib`, but does not yet package the library or licensing information in the distribution build.

_Additional changes required:_

- [x] Include JAR file in distribution package