### PR TITLE
added attribute-sets for linklists

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/concept.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/concept.xsl
@@ -26,12 +26,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:sequence select="3"/>
   </xsl:template>
   
+  <xsl:attribute-set name="linklist-concept">
+    <xsl:attribute name="outputclass">relconcepts</xsl:attribute>
+  </xsl:attribute-set>
+  
   <!-- Wrapper for concept group: "Related concepts" in a <div>. -->
   <xsl:template match="*[contains(@class, ' topic/link ')][@type='concept']" mode="related-links:result-group"
           name="related-links:result.concept" as="element()">
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
-      <linklist class="- topic/linklist " outputclass="relinfo relconcepts">
+      <linklist class="- topic/linklist " xsl:use-attribute-sets="linklist linklist-concept ">
         <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -302,12 +302,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:sequence select="1"/>
   </xsl:template>
   
+  <xsl:attribute-set name="linklist-reference">
+    <xsl:attribute name="outputclass">relref</xsl:attribute>
+  </xsl:attribute-set>
+  
   <!-- Reference wrapper for HTML: "Related reference" in <div>. -->
   <xsl:template match="*[contains(@class, ' topic/link ')][@type='reference']" mode="related-links:result-group"
                 name="related-links:result.reference" as="element()">
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
-      <linklist class="- topic/linklist " outputclass="relinfo relref">
+      <linklist class="- topic/linklist " xsl:use-attribute-sets="linklist linklist-reference">
         <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -273,12 +273,16 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     </xsl:for-each>
   </xsl:template>
 
+  
+  <xsl:attribute-set name="linklist">
+    <xsl:attribute name="outputclass">relinfo</xsl:attribute>
+  </xsl:attribute-set>
   <!-- Override no-name group wrapper template for HTML: output "Related Information" in a <linklist>. -->
   <xsl:template match="*[contains(@class, ' topic/link ')]" mode="related-links:result-group" name="related-links:group-result."
                 as="element()">
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="exists($links)">
-      <linklist class="- topic/linklist " outputclass="relinfo">
+      <linklist class="- topic/linklist " xsl:use-attribute-sets="linklist">
         <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -673,12 +673,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:sequence select="2"/>
   </xsl:template>
   
+  <xsl:attribute-set name="linklist-task">
+    <xsl:attribute name="outputclass">reltasks</xsl:attribute>
+  </xsl:attribute-set>
+  
   <!-- Task wrapper for HTML: "Related tasks" in <div>. -->
   <xsl:template match="*[contains(@class, ' topic/link ')][@type='task']" mode="related-links:result-group"
                 name="related-links:result.task" as="element()">
     <xsl:param name="links" as="node()*"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
-      <linklist class="- topic/linklist " outputclass="relinfo reltasks">
+      <linklist class="- topic/linklist " xsl:use-attribute-sets="linklist linklist-task">
         <xsl:copy-of select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
         <title class="- topic/title ">
           <xsl:call-template name="getVariable">


### PR DESCRIPTION
Signed-off-by: Lionel Moizeau <lionel.moizeau@lumapps.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description
I added attribute sets for linklist,

## Motivation and Context
I did it in order to be able to add a class without overriding the whole template.

## How Has This Been Tested?
I built a map with a reltable that linked a concept, a reference, a task, and a topic.
I built the OT from the tip of the `develop` branch.

## Type of Changes


- New feature _(non-breaking change which adds functionality)_


## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    - I have updated the unit tests to reflect the changes in my code. **I do not know how**
