### PR TITLE
add new html5 and xhtml transformation parameters (args.html5.domaina…

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -185,6 +185,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl"/>
         <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl"/>
         <param name="PRESERVE-DITA-CLASS" expression="${args.html5.classattr}" if:set="args.html5.classattr"/>
+        <param name="PRESERVE-DITA-DOMAIN" expression="${args.html5.domainattr}" if:set="args.html5.domainattr"/>
         <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
         <param name="include.rellinks" expression="${include.rellinks}"/>
         <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow"/>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -28,7 +28,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:param name="PRESERVE-DITA-CLASS" select="'yes'"/>
   
   <!-- Preserve DITA domain/class ancestry in XHTML output; values are 'yes' or 'no' -->
-  <xsl:param name="PRESERVE-DITA-DOMAIN" select="'yes'"/>
+  <xsl:param name="PRESERVE-DITA-DOMAIN" select="'no'"/>
   
   <!-- the file name containing XHTML to be placed in the HEAD area
        (file name and extension only - no path). -->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -27,6 +27,9 @@ See the accompanying LICENSE file for applicable license.
   <!-- Preserve DITA class ancestry in XHTML output; values are 'yes' or 'no' -->
   <xsl:param name="PRESERVE-DITA-CLASS" select="'yes'"/>
   
+  <!-- Preserve DITA domain/class ancestry in XHTML output; values are 'yes' or 'no' -->
+  <xsl:param name="PRESERVE-DITA-DOMAIN" select="'yes'"/>
+  
   <!-- the file name containing XHTML to be placed in the HEAD area
        (file name and extension only - no path). -->
   <xsl:param name="HDF"/>
@@ -1780,6 +1783,15 @@ See the accompanying LICENSE file for applicable license.
         </xsl:value-of>
       </xsl:if>
     </xsl:variable>
+    <xsl:variable name="domainancestry" as="xs:string?">
+      <xsl:if test="$PRESERVE-DITA-DOMAIN= 'yes'">
+        <xsl:value-of>
+          <xsl:apply-templates select="." mode="get-element-ancestry">
+            <xsl:with-param name="includedomain" select="'yes'"/>
+          </xsl:apply-templates>
+        </xsl:value-of>
+      </xsl:if>
+    </xsl:variable>
     <xsl:variable name="outputclass-attribute" as="xs:string">
       <xsl:value-of>
         <xsl:apply-templates select="@outputclass" mode="get-value-for-class"/>
@@ -1789,6 +1801,7 @@ See the accompanying LICENSE file for applicable license.
          combine user output class with element default, giving priority to the user value. -->
     <xsl:variable name="classes" as="xs:string*"
                   select="tokenize($ancestry, '\s+'),
+                          tokenize($domainancestry, '/s+'),
                           $using-output-class,
                           $draft-revs, 
                           tokenize($outputclass-attribute, '\s+')"/>
@@ -1813,6 +1826,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Get the ancestry of the current element (name only, not module) -->
   <xsl:template match="*" mode="get-element-ancestry">
     <xsl:param name="checkclass" select="@class"/>
+    <xsl:param name="includedomain" select="'no'"/>
     <xsl:if test="contains($checkclass, '/')">
       <xsl:variable name="lastpair">
         <xsl:call-template name="get-last-class-pair">
@@ -1823,10 +1837,18 @@ See the accompanying LICENSE file for applicable license.
       <xsl:if test="contains(substring-before($checkclass, $lastpair), '/')">
         <xsl:apply-templates select="." mode="get-element-ancestry">
           <xsl:with-param name="checkclass" select="substring-before($checkclass, $lastpair)"/>
+          <xsl:with-param name="includedomain" select="$includedomain"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
       </xsl:if>
-      <xsl:value-of select="substring-after($lastpair, '/')"/>
+      <xsl:choose>
+        <xsl:when test="$includedomain='no'">
+          <xsl:value-of select="substring-after($lastpair, '/')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$lastpair"/>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -140,6 +140,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
         <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
         <param name="PRESERVE-DITA-CLASS" expression="${args.xhtml.classattr}" if:set="args.xhtml.classattr"/>
+        <param name="PRESERVE-DITA-DOMAIN" expression="${args.xhtml.domainattr}" if:set="args.xhtml.domainattr"/>
         <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
         <param name="include.rellinks" expression="${include.rellinks}"/>
         <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -49,6 +49,9 @@ See the accompanying LICENSE file for applicable license.
 <!-- Preserve DITA class ancestry in XHTML output; values are 'yes' or 'no' -->
 <xsl:param name="PRESERVE-DITA-CLASS" select="'yes'"/>
 
+<!-- Preserve DITA domain/class ancestry in XHTML output; values are 'yes' or 'no' -->
+<xsl:param name="PRESERVE-DITA-DOMAIN" select="'yes'"/>
+
 <!-- the file name containing XHTML to be placed in the HEAD area
      (file name and extension only - no path). -->
 <xsl:param name="HDF"/>
@@ -1953,21 +1956,25 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="get-element-ancestry"/>
     </xsl:if>
   </xsl:variable>
+  <xsl:variable name="domainancestry">
+    <xsl:if test="$PRESERVE-DITA-DOMAIN = 'yes'">
+      <xsl:apply-templates select="." mode="get-element-ancestry">
+        <xsl:with-param name="includedomain" select="'yes'"/>
+      </xsl:apply-templates>
+    </xsl:if>
+  </xsl:variable>
   <xsl:variable name="outputclass-attribute">
     <xsl:apply-templates select="@outputclass" mode="get-value-for-class"/>
   </xsl:variable>
   <!-- Revised design with DITA-OT 1.5: include class ancestry if requested; 
        combine user output class with element default, giving priority to the user value. -->
-  <xsl:if test="string-length(normalize-space(concat($outputclass-attribute, $using-output-class, $ancestry))) > 0">
-    <xsl:attribute name="class">
-      <xsl:value-of select="$ancestry"/>
-      <xsl:if test="string-length(normalize-space($ancestry)) > 0 and 
-                    string-length(normalize-space($using-output-class)) > 0"><xsl:text> </xsl:text></xsl:if>
-      <xsl:value-of select="normalize-space($using-output-class)"/>
-      <xsl:if test="string-length(normalize-space(concat($ancestry, $using-output-class))) > 0 and
-                    string-length(normalize-space($outputclass-attribute)) > 0"><xsl:text> </xsl:text></xsl:if>
-      <xsl:value-of select="$outputclass-attribute"/>
-    </xsl:attribute>
+  <xsl:variable name="classes" as="xs:string*"
+                select="tokenize($ancestry, '\s+'),
+                        tokenize($domainancestry, '/s+'),
+                        $using-output-class,
+                        tokenize($outputclass-attribute, '\s+')"/>
+  <xsl:if test="exists($classes)">
+    <xsl:attribute name="class" select="string-join(distinct-values($classes), ' ')"/>
   </xsl:if>
 </xsl:template>
   
@@ -1987,6 +1994,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- Get the ancestry of the current element (name only, not module) -->
 <xsl:template match="*" mode="get-element-ancestry">
   <xsl:param name="checkclass" select="@class"/>
+  <xsl:param name="includedomain" select="'no'"/>
   <xsl:if test="contains($checkclass, '/')">
     <xsl:variable name="lastpair">
       <xsl:call-template name="get-last-class-pair">
@@ -1997,10 +2005,18 @@ See the accompanying LICENSE file for applicable license.
     <xsl:if test="contains(substring-before($checkclass, $lastpair), '/')">
       <xsl:apply-templates select="." mode="get-element-ancestry">
         <xsl:with-param name="checkclass" select="substring-before($checkclass, $lastpair)"/>
+        <xsl:with-param name="includedomain" select="$includedomain"/>
       </xsl:apply-templates>
       <xsl:text> </xsl:text>
     </xsl:if>
-    <xsl:value-of select="substring-after($lastpair, '/')"/>
+    <xsl:choose>
+      <xsl:when test="$includedomain='no'">
+        <xsl:value-of select="substring-after($lastpair, '/')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$lastpair"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
add new html5 and xhtml transformation parameters (args.html5.domainattr, args.xhtml.domainattr) to preserve DITA domain/class information in `@class` attributes

Signed-off-by: Chris Papademetrious <chrispy@synopsys.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description
This feature adds a new parameter for the html5 transformation (`args.html5.domainattr`) and the xhtml transformation (`args.xhtml.domainattr`). When set to `yes`, the domain/class is included in the `@class` attribute in the published output:

`<div class="fig ex topic/fig snps-d/ex fignone" id="ex34">`

## Motivation and Context
The Oxygen XML Author tool uses CSS to configure the look and feel of its editor. However, the CSS must be written to match the full "domain/class" values present in the `@class` attributes of DITA elements.

With this new feature, the "domain/class" values can be preserved in the HTML5/XHTML output so that CSS files can be shared between the editor and published output without duplicating all the selectors for the "class" and "domain/class" variants.

## How Has This Been Tested?
I created a testcase file with specializations, then ran both transformations with the parameters set to true and false, then diffed the output.

## Type of Changes
It introduces a new parameter in each transform. The default behavior is left unchanged.

## Checklist
This is my first pull request and my first time contributing to a public project. Please let me know how to add a unit test for this, if one is needed. Thanks!