### PR TITLE
Implement configurable label/title/description separator strings

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/strings-common.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-common.xml
@@ -8,6 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <strings xml:lang="">
   <str name="figure-number-separator"> </str>
+  <str name="label-separator">. </str>
   <str name="OpenQuote">“</str>
   <str name="CloseQuote">”</str>
   <str name="ColonSymbol">:</str>

--- a/src/main/plugins/org.dita.base/xsl/common/strings-common.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/strings-common.xml
@@ -7,12 +7,22 @@ Copyright 2017 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <strings xml:lang="">
+
+  <!-- "Figure 1. Figure Title. Description here"
+              ^ ^^            ^^
+              | ||            ||
+              | ||            desc-separator
+              | label-separator
+              figure-number-separator -->
   <str name="figure-number-separator"> </str>
   <str name="label-separator">. </str>
+  <str name="desc-separator">. </str>
+
   <str name="OpenQuote">“</str>
   <str name="CloseQuote">”</str>
   <str name="ColonSymbol">:</str>
   <str name="#menucascade-separator"> &gt; </str>
+
   <!-- Text that goes before a link to a topic -->
   <str name="intro-to-topic-link"></str>
 </strings>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -579,7 +579,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]" mode="title-number">
     <xsl:param name="number" as="xs:integer"/>
-    <xsl:sequence select="concat(dita-ot:get-variable(., 'Table'), ' ', $number, '. ')"/>
+    <xsl:sequence select="concat(dita-ot:get-variable(., 'Table'), ' ', $number, dita-ot:get-variable(., 'label-separator'))"/>
   </xsl:template>
 
   <xsl:template mode="title-number" priority="1" match="
@@ -588,7 +588,7 @@ See the accompanying LICENSE file for applicable license.
    /*[contains(@class, ' topic/title ')]
   ">
     <xsl:param name="number" as="xs:integer"/>
-    <xsl:sequence select="concat($number, '. ', dita-ot:get-variable(., 'Table'), ' ')"/>
+    <xsl:sequence select="concat($number, dita-ot:get-variable(., 'label-separator'), dita-ot:get-variable(., 'Table'), ' ')"/>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]" name="topic.table_title">

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -383,7 +383,9 @@ See the accompanying LICENSE file for applicable license.
               <xsl:choose>     <!-- Hungarian: "1. Table " -->
                 <xsl:when test="$ancestorlang = ('hu', 'hu-hu')">
                   <xsl:value-of select="$tbl-count-actual"/>
-                  <xsl:text>. </xsl:text>
+                  <xsl:call-template name="getVariable">
+                    <xsl:with-param name="id" select="'label-separator'"/>
+                  </xsl:call-template>
                   <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Table'"/>
                   </xsl:call-template>
@@ -395,13 +397,17 @@ See the accompanying LICENSE file for applicable license.
                   </xsl:call-template>
                   <xsl:text> </xsl:text>
                   <xsl:value-of select="$tbl-count-actual"/>
-                  <xsl:text>. </xsl:text>
+                  <xsl:call-template name="getVariable">
+                    <xsl:with-param name="id" select="'label-separator'"/>
+                  </xsl:call-template>
                 </xsl:otherwise>
               </xsl:choose>
             </span>
             <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="tabletitle"/>
             <xsl:if test="*[contains(@class, ' topic/desc ')]">
-              <xsl:text>. </xsl:text>
+              <xsl:call-template name="getVariable">
+                <xsl:with-param name="id" select="'label-separator'"/>
+              </xsl:call-template>
             </xsl:if>
           </span>
           <xsl:for-each select="*[contains(@class, ' topic/desc ')]">

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -406,7 +406,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="tabletitle"/>
             <xsl:if test="*[contains(@class, ' topic/desc ')]">
               <xsl:call-template name="getVariable">
-                <xsl:with-param name="id" select="'label-separator'"/>
+                <xsl:with-param name="id" select="'desc-separator'"/>
               </xsl:call-template>
             </xsl:if>
           </span>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2751,7 +2751,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="figtitle"/>
           <xsl:if test="*[contains(@class, ' topic/desc ')]">
             <xsl:call-template name="getVariable">
-              <xsl:with-param name="id" select="'label-separator'"/>
+              <xsl:with-param name="id" select="'desc-separator'"/>
             </xsl:call-template>
           </xsl:if>
           <xsl:for-each select="*[contains(@class, ' topic/desc ')]">

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2728,7 +2728,9 @@ See the accompanying LICENSE file for applicable license.
             <xsl:choose>      <!-- Hungarian: "1. Figure " -->
               <xsl:when test="$ancestorlang = ('hu', 'hu-hu')">
                 <xsl:value-of select="$fig-count-actual"/>
-                <xsl:text>. </xsl:text>
+                <xsl:call-template name="getVariable">
+                  <xsl:with-param name="id" select="'label-separator'"/>
+                </xsl:call-template>
                 <xsl:call-template name="getVariable">
                   <xsl:with-param name="id" select="'Figure'"/>
                 </xsl:call-template>
@@ -2740,13 +2742,17 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:call-template>
                 <xsl:text> </xsl:text>
                 <xsl:value-of select="$fig-count-actual"/>
-                <xsl:text>. </xsl:text>
+                <xsl:call-template name="getVariable">
+                  <xsl:with-param name="id" select="'label-separator'"/>
+                </xsl:call-template>
               </xsl:otherwise>
             </xsl:choose>
           </span>
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="figtitle"/>
           <xsl:if test="*[contains(@class, ' topic/desc ')]">
-            <xsl:text>. </xsl:text>
+            <xsl:call-template name="getVariable">
+              <xsl:with-param name="id" select="'label-separator'"/>
+            </xsl:call-template>
           </xsl:if>
           <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
             <span class="figdesc">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -2404,7 +2404,7 @@ See the accompanying LICENSE file for applicable license.
        <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="figtitle"/>
        <xsl:if test="*[contains(@class, ' topic/desc ')]">
          <xsl:call-template name="getVariable">
-           <xsl:with-param name="id" select="'label-separator'"/>
+           <xsl:with-param name="id" select="'desc-separator'"/>
          </xsl:call-template>
        </xsl:if>
       </span>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -2381,7 +2381,9 @@ See the accompanying LICENSE file for applicable license.
          <xsl:choose>      <!-- Hungarian: "1. Figure " -->
           <xsl:when test="$ancestorlang = ('hu', 'hu-hu')">
            <xsl:value-of select="$fig-count-actual"/>
-           <xsl:text>. </xsl:text>
+           <xsl:call-template name="getVariable">
+             <xsl:with-param name="id" select="'label-separator'"/>
+           </xsl:call-template>
            <xsl:call-template name="getVariable">
             <xsl:with-param name="id" select="'Figure'"/>
            </xsl:call-template>
@@ -2393,13 +2395,17 @@ See the accompanying LICENSE file for applicable license.
            </xsl:call-template>
            <xsl:text> </xsl:text>
            <xsl:value-of select="$fig-count-actual"/>
-           <xsl:text>. </xsl:text>
+           <xsl:call-template name="getVariable">
+             <xsl:with-param name="id" select="'label-separator'"/>
+           </xsl:call-template>
           </xsl:otherwise>
          </xsl:choose>
         </span>
        <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="figtitle"/>
        <xsl:if test="*[contains(@class, ' topic/desc ')]">
-         <xsl:text>. </xsl:text>
+         <xsl:call-template name="getVariable">
+           <xsl:with-param name="id" select="'label-separator'"/>
+         </xsl:call-template>
        </xsl:if>
       </span>
       <xsl:for-each select="*[contains(@class, ' topic/desc ')]">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -1000,7 +1000,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="tabletitle"/>
           <xsl:if test="*[contains(@class, ' topic/desc ')]">
             <xsl:call-template name="getVariable">
-              <xsl:with-param name="id" select="'label-separator'"/>
+              <xsl:with-param name="id" select="'desc-separator'"/>
             </xsl:call-template>
           </xsl:if>
         </span>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -977,7 +977,9 @@ See the accompanying LICENSE file for applicable license.
             <xsl:choose>     <!-- Hungarian: "1. Table " -->
               <xsl:when test="$ancestorlang = ('hu', 'hu-hu')">
                 <xsl:value-of select="$tbl-count-actual"/>
-                <xsl:text>. </xsl:text>
+                <xsl:call-template name="getVariable">
+                  <xsl:with-param name="id" select="'label-separator'"/>
+                </xsl:call-template>
                 <xsl:call-template name="getVariable">
                   <xsl:with-param name="id" select="'Table'"/>
                 </xsl:call-template>
@@ -989,13 +991,17 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:call-template>
                 <xsl:text> </xsl:text>
                 <xsl:value-of select="$tbl-count-actual"/>
-                <xsl:text>. </xsl:text>
+                <xsl:call-template name="getVariable">
+                  <xsl:with-param name="id" select="'label-separator'"/>
+                </xsl:call-template>
               </xsl:otherwise>
             </xsl:choose>
           </span>
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="tabletitle"/>
           <xsl:if test="*[contains(@class, ' topic/desc ')]">
-            <xsl:text>. </xsl:text>
+            <xsl:call-template name="getVariable">
+              <xsl:with-param name="id" select="'label-separator'"/>
+            </xsl:call-template>
           </xsl:if>
         </span>
         <xsl:for-each select="*[contains(@class, ' topic/desc ')]">


### PR DESCRIPTION
Signed-off-by: Chris Papademetrious <chrispy@synopsys.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description
This is a proposed change to make the ". " separator between figure/table title labels, <title> text, and <desc> elements configurable via a string.

## Motivation and Context
Our content uses a colon to separate figure and table titles:

Figure 1: Some Figure
Table 1: Some Table

After creating a plugin to implement this single-character change, I realized it would be more user-friendly to configure this via a single configurable string (in org.dita.base/xsl/common/strings-common.xml). For example,

  <str name="label-separator">: </str>
  <str name="desc-separator"> -- </str>

## How Has This Been Tested?
I created a testcase to confirm that the default HTML5 and XHTML output remains unchanged, then I reran it with a different string values to confirm that the output was adjusted as desired.

## Type of Changes
This new feature was implemented by identifying the places where the title content was generated, then changing the hardcoded text strings to equivalent variables.

## Checklist
Please let me know if unit tests are needed for this type of enhancement. (I would need to learn how to add and run them.) Thanks!
