### PR TITLE
Add in-memory Store implementation

### DIFF
--- a/src/main/java/org/dita/dost/ant/DITAOTCopy.java
+++ b/src/main/java/org/dita/dost/ant/DITAOTCopy.java
@@ -17,10 +17,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.util.FileUtils;
+import org.dita.dost.util.Job;
 
 /**
  * Class description goes here.
@@ -124,7 +126,12 @@ public final class DITAOTCopy extends Task {
 
     private List<String> getIncludes() throws IOException {
         if (includes == null && includesFile == null) {
-            return Collections.emptyList();
+            final Job job = getProject().getReference(ANT_REFERENCE_JOB);
+            return job
+                    .getFileInfo(fi -> fi.isFlagImage)
+                    .stream()
+                    .map(fi -> fi.file.toString())
+                    .collect(Collectors.toList());
         }
         if (includesFile != null) {
             final List<String> res = new ArrayList<>();

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -186,17 +186,17 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         initXmlReader();
 
         // Output subject schemas
-        outputSubjectScheme();
         subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
         subjectSchemeReader.setJob(job);
+        outputSubjectScheme();
         dic = subjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
 
         if (profilingEnabled) {
             final DitaValReader filterReader = new DitaValReader();
             filterReader.setLogger(logger);
             filterReader.setJob(job);
-            if (ditavalFile != null && ditavalFile.exists()) {
+            if (job.getStore().exists(ditavalFile.toURI())) {
                 filterReader.read(ditavalFile.getAbsoluteFile());
                 baseFilterUtils = new FilterUtils(printTranstype.contains(transtype), filterReader.getFilterMap(),
                         filterReader.getForegroundConflictColor(), filterReader.getBackgroundConflictColor());

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -190,7 +190,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
         subjectSchemeReader.setJob(job);
-        dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
+        dic = subjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
 
         if (profilingEnabled) {
             final DitaValReader filterReader = new DitaValReader();
@@ -315,7 +315,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
      */
     private void outputSubjectScheme() throws DITAOTException {
         try {
-            final Map<URI, Set<URI>> graph = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
+            final Map<URI, Set<URI>> graph = subjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
 
             final Queue<URI> queue = new LinkedList<>(graph.keySet());
             final Set<URI> visitedSet = new HashSet<>();

--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -66,7 +66,7 @@ final class FilterModule extends AbstractPipelineModuleImpl {
         subjectSchemeReader.setJob(job);
         Map<URI, Set<URI>> dic;
         try {
-            dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
+            dic = subjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
         } catch (final IOException e) {
             throw new DITAOTException(e);
         }

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -34,7 +34,6 @@ import java.io.*;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,7 +42,8 @@ import static org.dita.dost.reader.GenListModuleReader.*;
 import static org.dita.dost.util.Configuration.Mode;
 import static org.dita.dost.util.Configuration.printTranstype;
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.Job.*;
+import static org.dita.dost.util.Job.FileInfo;
+import static org.dita.dost.util.Job.USER_INPUT_FILE_LIST_FILE;
 import static org.dita.dost.util.URLUtils.*;
 
 /**
@@ -894,8 +894,11 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         }
 
         try {
-            SubjectSchemeReader.writeMapToXML(addMapFilePrefix(listFilter.getRelationshipGrap()), new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
-            SubjectSchemeReader.writeMapToXML(addMapFilePrefix(schemeDictionary), new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
+            final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
+            subjectSchemeReader.setLogger(logger);
+            subjectSchemeReader.setJob(job);
+            subjectSchemeReader.writeMapToXML(addMapFilePrefix(listFilter.getRelationshipGrap()), new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
+            subjectSchemeReader.writeMapToXML(addMapFilePrefix(schemeDictionary), new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
         } catch (final IOException e) {
             throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -929,7 +929,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
      * @param relativeRootFile list value
      */
     private void writeListFile(final File inputfile, final String relativeRootFile) {
-        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(inputfile)))) {
+        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(inputfile.toURI())))) {
             bufferedWriter.write(relativeRootFile);
             bufferedWriter.flush();
         } catch (final IOException e) {
@@ -1033,10 +1033,10 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         }
 
         // write list attribute to file
-        final String fileKey = org.dita.dost.util.Constants.REL_FLAGIMAGE_LIST.substring(0, org.dita.dost.util.Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
-        prop.setProperty(fileKey, org.dita.dost.util.Constants.REL_FLAGIMAGE_LIST.substring(0, org.dita.dost.util.Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
+        final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
+        prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
         final File list = new File(job.tempDir, prop.getProperty(fileKey));
-        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(list)))) {
+        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             final Iterator<URI> it = newSet.iterator();
             while (it.hasNext()) {
                 bufferedWriter.write(it.next().getPath());
@@ -1049,7 +1049,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             logger.error(e.getMessage(), e) ;
         }
 
-        prop.setProperty(org.dita.dost.util.Constants.REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
+        prop.setProperty(REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
     }
 
 }

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -105,7 +105,7 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
         final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
         ditavalbuilder.setEntityResolver(CatalogUtils.getCatalogResolver());
         XMLStreamWriter export = null;
-        try (OutputStream exportStream = new FileOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL))) {
+        try (OutputStream exportStream = job.getStore().getOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL).toURI())) {
             export = XMLOutputFactory.newInstance().createXMLStreamWriter(exportStream, "UTF-8");
             export.writeStartDocument();
             export.writeStartElement("val");

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -88,7 +88,7 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
         if (!outputDir.exists() && !outputDir.mkdirs()) {
             logger.error("Failed to create directory " + outputDir.getAbsolutePath());
         }
-        try (final OutputStream output = new BufferedOutputStream(new FileOutputStream(out))) {
+        try (final OutputStream output = new BufferedOutputStream(job.getStore().getOutputStream(out.toURI()))) {
             if (style != null) {
                 final Processor processor = xmlUtils.getProcessor();
                 final XsltCompiler xsltCompiler = processor.newXsltCompiler();

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -152,10 +152,10 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
         }
 
         // write list attribute to file
-        final String fileKey = Constants.REL_FLAGIMAGE_LIST.substring(0, Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
-        prop.setProperty(fileKey, Constants.REL_FLAGIMAGE_LIST.substring(0, Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
+        final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
+        prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
         final File list = new File(job.tempDir, prop.getProperty(fileKey));
-        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(list, true)))) {
+        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());
                 bufferedWriter.write('\n');
@@ -165,7 +165,7 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
             logger.error(e.getMessage(), e) ;
         }
 
-        prop.setProperty(Constants.REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
+        prop.setProperty(REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
     }
 
     private FileInfo getOrCreateFileInfo(final URI file) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -758,9 +758,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
 
         try {
             logger.info("Serializing job specification");
-            if (!job.tempDir.exists() && !job.tempDir.mkdirs()) {
-                throw new DITAOTException("Failed to create " + job.tempDir + " directory");
-            }
             job.write();
         } catch (final IOException e) {
             throw new DITAOTException("Failed to serialize job configuration files: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -803,7 +803,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
      * @param relativeRootFile list value
      */
     private void writeListFile(final File inputfile, final String relativeRootFile) {
-        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(inputfile)))) {
+        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(inputfile.toURI())))) {
             bufferedWriter.write(relativeRootFile);
             bufferedWriter.flush();
         } catch (final IOException e) {
@@ -908,10 +908,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
 
         // write list attribute to file
-        final String fileKey = Constants.REL_FLAGIMAGE_LIST.substring(0, Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
-        prop.setProperty(fileKey, Constants.REL_FLAGIMAGE_LIST.substring(0, Constants.REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
+        final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
+        prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
         final File list = new File(job.tempDir, prop.getProperty(fileKey));
-        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(list)))) {
+        try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());
                 bufferedWriter.write('\n');
@@ -921,7 +921,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             logger.error(e.getMessage(), e) ;
         }
 
-        prop.setProperty(Constants.REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
+        prop.setProperty(REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
     }
 
     private XMLReader getXmlReader(final String format) throws SAXException {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -767,8 +767,11 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
 
         try {
-            SubjectSchemeReader.writeMapToXML(addMapFilePrefix(listFilter.getRelationshipGrap()), new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
-            SubjectSchemeReader.writeMapToXML(addMapFilePrefix(schemeDictionary), new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
+            final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
+            subjectSchemeReader.setLogger(logger);
+            subjectSchemeReader.setJob(job);
+            subjectSchemeReader.writeMapToXML(addMapFilePrefix(listFilter.getRelationshipGrap()), new File(job.tempDir, FILE_NAME_SUBJECT_RELATION));
+            subjectSchemeReader.writeMapToXML(addMapFilePrefix(schemeDictionary), new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
         } catch (final IOException e) {
             throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -10,7 +10,6 @@ package org.dita.dost.reader;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -25,12 +24,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -64,7 +59,6 @@ public final class DitaValReader implements AbstractReader {
     private String backgroundConflictColor;
 
     private TempFileNameScheme tempFileNameScheme;
-    private final DocumentBuilder builder;
     /** List of absolute flagging image paths. */
     private final List<URI> imageList;
 
@@ -83,13 +77,6 @@ public final class DitaValReader implements AbstractReader {
         imageList = new ArrayList<>(256);
         relFlagImageList = new ArrayList<>(256);
 
-        try {
-            final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-            builderFactory.setNamespaceAware(true);
-            builder = builderFactory.newDocumentBuilder();
-        } catch (final ParserConfigurationException e) {
-            throw new RuntimeException(e);
-        }
         filterAttributes = Stream.of(Configuration.configuration.getOrDefault("filter-attributes", "")
                 .trim().split("\\s*,\\s*"))
                 .map(QName::valueOf)
@@ -142,10 +129,9 @@ public final class DitaValReader implements AbstractReader {
         ditaVal = input;
 
         final Document doc;
-        builder.setErrorHandler(new DITAOTXMLErrorHandler(ditaVal.toString(), logger));
         try {
-            doc = builder.parse(input.toString());
-        } catch (SAXException | IOException e) {
+            doc = job.getStore().getDocument(input);
+        } catch (IOException e) {
             logger.error("Failed to read DITAVAL file: " + e.getMessage(), e);
             return;
         }

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -103,7 +103,7 @@ public class SubjectSchemeReader {
      *
      * @param inputFile XML properties file absolute path
      */
-    public static Map<URI, Set<URI>> readMapFromXML(final File inputFile) throws IOException {
+    public Map<URI, Set<URI>> readMapFromXML(final File inputFile) throws IOException {
         final Map<URI, Set<URI>> graph = new HashMap<>();
         if (!inputFile.exists()) {
             return Collections.emptyMap();
@@ -137,7 +137,7 @@ public class SubjectSchemeReader {
      * @param m map to serialize
      * @param outputFile output filename, relative to temporary directory
      */
-    public static void writeMapToXML(final Map<URI, Set<URI>> m, final File outputFile) throws IOException {
+    public void writeMapToXML(final Map<URI, Set<URI>> m, final File outputFile) throws IOException {
         if (m == null) {
             return;
         }
@@ -147,7 +147,7 @@ public class SubjectSchemeReader {
             final String value = StringUtils.join(entry.getValue(), COMMA);
             prop.setProperty(key.getPath(), value);
         }
-        try (OutputStream os = new FileOutputStream(outputFile)) {
+        try (OutputStream os = job.getStore().getOutputStream(outputFile.toURI())) {
             prop.storeToXML(os, null);
         } catch (final IOException e) {
             throw new IOException("Failed to write subject scheme graph: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -109,7 +109,7 @@ public class SubjectSchemeReader {
             return Collections.emptyMap();
         }
         final Properties prop = new Properties();
-        try (FileInputStream in = new FileInputStream(inputFile)) {
+        try (InputStream in = new BufferedInputStream(job.getStore().getInputStream(inputFile.toURI()))) {
             prop.loadFromXML(in);
         } catch (final IOException e) {
             throw new IOException("Failed to read subject scheme graph: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/store/AbstractStore.java
+++ b/src/main/java/org/dita/dost/store/AbstractStore.java
@@ -26,9 +26,13 @@ import static org.dita.dost.util.URLUtils.toURI;
  */
 public abstract class AbstractStore implements Store {
 
+    static final boolean LOG = false;
+
     protected final XMLUtils xmlUtils;
     public final File tempDir;
     public final URI tempDirUri;
+
+//    final TransformerFactory tf;
 
     public AbstractStore(final File tempDir, final XMLUtils xmlUtils) {
         if (!tempDir.isAbsolute()) {
@@ -37,16 +41,46 @@ public abstract class AbstractStore implements Store {
         this.tempDirUri = tempDir.toURI();
         this.tempDir = tempDir;
         this.xmlUtils = xmlUtils;
+//        tf = TransformerFactory.newInstance();
     }
 
     @Override
     public URI getUri(final URI path) {
+//        if (path.isAbsolute()) {
+//            if (path.normalize().toString().startsWith(tempDirUri.toString())) {
+//                return URI.create(path.normalize().toString() + ".xxx");
+//            } else {
+//                return path.normalize();
+//            }
+//        } else {
+//            return URI.create(tempDirUri.resolve(path).normalize().toString() + ".xxx");
+//        }
         return tempDirUri.resolve(path).normalize();
     }
 
     protected boolean isTempFile(final URI f) {
         return f.toString().startsWith(tempDirUri.toString());
     }
+
+//    @Override
+//    public void transform(final URI src, final ContentHandler dst) throws DITAOTException {
+//        try {
+////            final Transformer serializer = tf.newTransformer();
+////            serializer.setURIResolver(this);
+//
+//            final Source source = getSource(src);
+//            final SAXDestination destination = new SAXDestination(dst);
+////            final Result result = new SAXResult(dst);
+//
+////            xmlUtils.getProcessor().se
+////            serializer.transform(source, result);
+//            xmlUtils.getProcessor().writeXdmValue(source, destination);
+//        } catch (final RuntimeException e) {
+//            throw e;
+//        } catch (final Exception e) {
+//            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+//        }
+//    }
 
     @Override
     public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
@@ -61,6 +95,10 @@ public abstract class AbstractStore implements Store {
 
     @Override
     public void transform(final URI src, final List<XMLFilter> filters) throws DITAOTException {
+//        assert input.isAbsolute();
+//        if (!input.getScheme().equals("file")) {
+//            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+//        }
         final URI dst = toURI(src.toString() + FILE_EXTENSION_TEMP).normalize();
         transformURI(src, dst, filters);
         try {
@@ -76,4 +114,37 @@ public abstract class AbstractStore implements Store {
 
     abstract void transformUri(final URI input, final URI output, final XsltTransformer transformer) throws DITAOTException;
 
+//    @Override
+//    public void transform(final URI src, final URI outputFile, final List<XMLFilter> filters) throws DITAOTException {
+//        try {
+//            final IdentityTransformer serializer = (IdentityTransformer) tf.newTransformer();
+//            serializer.getConfiguration().setErrorListener(new ErrorGatherer(new ArrayList<>()));
+//            final URIResolver resolver = new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), this);
+//            serializer.setURIResolver(resolver);
+//
+//            final Source source = getSource(src);
+//            final Result result = getResult(outputFile);
+//
+//            ContentHandler handler;
+//            final TransformerHandler th = ((SAXTransformerFactory) tf).newTransformerHandler();
+//            th.getTransformer().setURIResolver(this);
+//            th.setResult(result);
+//            handler = th;
+//
+//            final ArrayList<XMLFilter> fs = new ArrayList<>(filters);
+//            Collections.reverse(fs);
+//            for (final XMLFilter filter : fs) {
+//                filter.setContentHandler(handler);
+//                handler = (ContentHandler) filter;
+//            }
+//
+//            final Result intermediate = new SAXResult(handler);
+//
+//            serializer.transform(source, intermediate);
+//        } catch (final RuntimeException e) {
+//            throw e;
+//        } catch (final Exception e) {
+//            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+//        }
+//    }
 }

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -8,8 +8,6 @@
 
 package org.dita.dost.store;
 
-import net.sf.saxon.dom.DOMNodeWrapper;
-import net.sf.saxon.dom.DocumentWrapper;
 import net.sf.saxon.dom.NodeOverNodeInfo;
 import net.sf.saxon.event.PipelineConfiguration;
 import net.sf.saxon.event.Receiver;
@@ -107,6 +105,15 @@ public class CacheStore extends AbstractStore implements Store {
             return true;
         }
         return fallback.exists(f);
+    }
+
+    @Override
+    public long getLastModified(final URI path) {
+        final URI f = stripFragment(toAbsolute(path)).normalize();
+        if (cache.containsKey(f)) {
+            return cache.get(f).lastModified;
+        }
+        return fallback.getLastModified(f);
     }
 
     @Override
@@ -609,11 +616,17 @@ public class CacheStore extends AbstractStore implements Store {
         private final Document doc;
         private final XdmNode node;
         private final byte[] bytes;
+        private long lastModified;
 
-        private Entry(final Document doc, final XdmNode node, byte[] bytes) {
+        private Entry(final Document doc, final XdmNode node, final byte[] bytes) {
+            this(doc, node, bytes, System.currentTimeMillis());
+        }
+
+        private Entry(final Document doc, final XdmNode node, final byte[] bytes, final long lastModified) {
             this.doc = doc;
             this.node = node;
             this.bytes = bytes;
+            this.lastModified = lastModified;
         }
     }
 }

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -1,0 +1,619 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import net.sf.saxon.dom.DOMNodeWrapper;
+import net.sf.saxon.dom.DocumentWrapper;
+import net.sf.saxon.dom.NodeOverNodeInfo;
+import net.sf.saxon.event.PipelineConfiguration;
+import net.sf.saxon.event.Receiver;
+import net.sf.saxon.event.ReceivingContentHandler;
+import net.sf.saxon.event.Sender;
+import net.sf.saxon.lib.ParseOptions;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.TreeInfo;
+import net.sf.saxon.s9api.*;
+import net.sf.saxon.serialize.SerializationProperties;
+import net.sf.saxon.trans.UncheckedXPathException;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.tree.wrapper.RebasedDocument;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.XMLUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLFilter;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
+import java.net.URI;
+import java.util.*;
+
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.toURI;
+
+/**
+ * DOM and memory based store, backed up by a disk store.
+ */
+public class CacheStore extends AbstractStore implements Store {
+
+    private final StreamStore fallback;
+    private final Map<URI, Entry> cache;
+
+    public CacheStore(final File tempDir, final XMLUtils xmlUtils) {
+        super(tempDir, xmlUtils);
+        fallback = new StreamStore(tempDir, xmlUtils);
+        this.cache = new HashMap<>();
+    }
+
+    @Override
+    public void delete(final URI file) throws IOException {
+        final URI f = file.normalize();
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                remove(f);
+                return;
+            }
+        }
+        cacheMiss(f);
+        fallback.delete(file);
+    }
+
+    @Override
+    public void copy(final URI src, final URI dst) throws IOException {
+        if (cache.containsKey(src)) {
+            final URI s = toAbsolute(src);
+            final Entry entry = get(s);
+            final URI d = toAbsolute(dst);
+            put(d, entry);
+            return;
+        }
+        cacheMiss(src);
+        fallback.copy(src, dst);
+    }
+
+    @Override
+    public void move(final URI src, final URI dst) throws IOException {
+        if (LOG) System.err.println("Cache move: " + src + " -> " + dst);
+        if (cache.containsKey(src)) {
+            final URI s = toAbsolute(src);
+            final URI d = toAbsolute(dst);
+            final Entry remove = remove(s);
+            final Entry wrap = rebase(remove, d);
+            put(d, wrap);
+            return;
+        }
+        cacheMiss(src);
+        fallback.move(src, dst);
+    }
+
+    @Override
+    public boolean exists(final URI path) {
+        final URI f = stripFragment(toAbsolute(path)).normalize();
+        if (cache.containsKey(f)) {
+            return true;
+        }
+        return fallback.exists(f);
+    }
+
+    @Override
+    public Source resolve(final String href, final String base) throws TransformerException {
+        final URI b = toAbsolute(toURI(base));
+        final URI h = toURI(href);
+        assert b.isAbsolute();
+        assert h.isAbsolute();
+        final URI f = b.resolve(h).normalize();
+        if (LOG) System.err.println("Cache resolve: " + f);
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = get(f);
+                return toSource(entry, f);
+            }
+        }
+        return fallback.resolve(href, base);
+    }
+
+    @Override
+    public Source getSource(final URI path) {
+        assert path.isAbsolute();
+        final URI f = getUri(path).normalize();
+        if (LOG) System.err.println("Cache getSource: " + f);
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = get(f);
+                return toSource(entry, f);
+            }
+            cacheMiss(f);
+        }
+        return fallback.getSource(f);
+    }
+
+    @Override
+    public Document getImmutableDocument(URI path) throws IOException {
+        final URI f = toAbsolute(path);
+        if (LOG) System.err.println("getImmutableDocument:" + f);
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = cache.get(f);
+                if (entry.doc != null) {
+                    return entry.doc;
+                } else if (entry.node != null) {
+                    final NodeInfo nodeInfo = entry.node.getUnderlyingNode();
+                    final Document doc = (Document) NodeOverNodeInfo.wrap(nodeInfo);
+                    put(f, new Entry(doc, entry.node, null));
+                    return doc;
+                } else if (entry.bytes != null) {
+                    try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
+                        final Document doc = XMLUtils.getDocumentBuilder().parse(in, f.toString());
+                        put(f, new Entry(doc, null, entry.bytes));
+                        return doc;
+                    } catch (SAXException e) {
+                        throw new IOException(e);
+                    }
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+            cacheMiss(f);
+        }
+        return fallback.getDocument(path);
+    }
+
+    @Override
+    public XdmNode getImmutableNode(URI path) throws IOException {
+        final URI f = toAbsolute(path);
+        if (LOG) System.err.println("getImmutableNode:" + f);
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = cache.get(f);
+                if (entry.node != null) {
+                    return entry.node;
+                } else if (entry.doc != null) {
+                    final XdmNode node = xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
+                    put(f, new Entry(entry.doc, node, entry.bytes));
+                    return node;
+                } else if (entry.bytes != null) {
+                    try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
+                        final StreamSource source = new StreamSource(in);
+                        source.setSystemId(f.toString());
+                        final XdmNode node = xmlUtils.getProcessor().newDocumentBuilder().build(source);
+                        put(f, new Entry(entry.doc, node, entry.bytes));
+                    } catch (SaxonApiException e) {
+                        throw new IOException(e);
+                    }
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+            cacheMiss(f);
+        }
+        return fallback.getImmutableNode(path);
+    }
+
+    @Override
+    public Document getDocument(final URI path) throws IOException {
+        final URI f = toAbsolute(path);
+        if (LOG) System.err.println("getDocument:" + f);
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = get(f);
+                if (entry.doc != null) {
+                    return (Document) entry.doc.cloneNode(true);
+                } else if (entry.node != null) {
+                    return cloneDocument(entry.node);
+                } else if (entry.bytes != null) {
+                    try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
+                        final InputSource inputSource = new InputSource(in);
+                        inputSource.setSystemId(f.toString());
+                        final Document doc = XMLUtils.getDocumentBuilder().parse(inputSource);
+                        put(f, new Entry(doc, entry.node, entry.bytes));
+                        return doc;
+                    } catch (SAXException e) {
+                        throw new IOException(e);
+                    }
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+            cacheMiss(f);
+        }
+        return fallback.getDocument(path);
+    }
+
+    @Override
+    public void writeDocument(final Document doc, final URI path) throws IOException {
+        if (isTempFile(path)) {
+            if (LOG) System.err.println("writeDocument: " + path);
+            doc.setDocumentURI(path.toString());
+            final XdmNode node = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
+            final NodeInfo nodeInfo = node.getUnderlyingNode();
+            if (nodeInfo.getBaseURI() == null || nodeInfo.getBaseURI().isEmpty()) {
+                nodeInfo.setSystemId(doc.getBaseURI());
+            }
+            put(path, new Entry(null, node, null));
+        } else {
+            fallback.writeDocument(doc, path);
+        }
+    }
+
+    @Override
+    public void writeDocument(final XdmNode node, final URI path) throws IOException {
+        if (isTempFile(path)) {
+            if (LOG) System.err.println("writeDocument: " + path);
+//            final NodeInfo nodeInfo = node.getUnderlyingNode();
+//            if (nodeInfo.getBaseURI() == null || nodeInfo.getBaseURI().isEmpty()) {
+//                nodeInfo.setSystemId(doc.getBaseURI());
+//            }
+            put(path, new Entry(null, node, null));
+        } else {
+            fallback.writeDocument(node, path);
+        }
+    }
+
+    @Override
+    public void writeDocument(final Node doc, final ContentHandler dst) throws IOException {
+        fallback.writeDocument(doc, dst);
+    }
+
+    @Override
+    public void writeDocument(final XdmNode node, final ContentHandler dst) throws IOException {
+        fallback.writeDocument(node, dst);
+    }
+
+    @Override
+    public Destination getDestination(final URI path) throws IOException {
+        if (isTempFile(path)) {
+            final XdmDestination dst = new XdmDestination();
+            dst.setBaseURI(path);
+            dst.onClose(() -> {
+                final XdmNode node = dst.getXdmNode();
+                put(path, new Entry(null, node, null));
+            });
+            return dst;
+        }
+        return fallback.getDestination(path);
+    }
+
+    @Override
+    public ContentHandler getContentHandler(final URI outputFile) throws SaxonApiException, IOException {
+        final net.sf.saxon.Configuration configuration = xmlUtils.getProcessor().getUnderlyingConfiguration();
+        final PipelineConfiguration pipelineConfiguration = configuration.makePipelineConfiguration();
+
+        final Destination dst = getDestination(outputFile);
+        final Receiver receiver = dst.getReceiver(pipelineConfiguration, new SerializationProperties());
+
+        final ReceivingContentHandler receivingContentHandler = new ReceivingContentHandler();
+        receivingContentHandler.setPipelineConfiguration(pipelineConfiguration);
+        receivingContentHandler.setReceiver(receiver);
+
+        return receivingContentHandler;
+    }
+
+    @Override
+    public void transform(final URI src, final ContentHandler dst) throws DITAOTException {
+        final URI f = src.normalize();
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                try {
+                    final Source source = getSource(src);
+                    final Receiver receiver = getReceiver(dst);
+                    Sender.send(source, receiver, new ParseOptions());
+                } catch (final RuntimeException e) {
+                    throw e;
+                } catch (final Exception e) {
+                    throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+                }
+                return;
+            }
+        }
+        fallback.transform(src, dst);
+    }
+
+    @Override
+    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
+        final URI src = input.normalize();
+        if (isTempFile(src)) {
+            try {
+                final Source source = getSource(src);
+                final ContentHandler serializer = getContentHandler(src);
+                final ContentHandler pipe = getPipe(filters, serializer);
+                final Receiver receiver = getReceiver(pipe);
+                Sender.send(source, receiver, new ParseOptions());
+                // getDestination will handle save to cache
+            } catch (IOException | XPathException | SaxonApiException e) {
+                throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+            }
+        } else {
+            fallback.transform(src, filters);
+        }
+    }
+
+    @Override
+    void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        if (isTempFile(input)) {
+            try {
+                ContentHandler dst = getContentHandler(output);
+                ContentHandler pipe = getPipe(filters, dst);
+                transform(input, pipe);
+            } catch (IOException | SaxonApiException e) {
+                throw new DITAOTException("Failed to transform " + input + ": " + e.getMessage(), e);
+            }
+            return;
+        }
+        fallback.transformURI(input, output, filters);
+    }
+
+    @Override
+    public void transform(final URI input, final URI output, final XsltTransformer transformer) throws DITAOTException {
+        final URI src = input.normalize();
+        final URI dst = output.normalize();
+        if (src.equals(dst)) {
+            transform(src, transformer);
+        } else {
+            transformUri(src, dst, transformer);
+        }
+    }
+
+    @Override
+    public void transform(final URI src, final XsltTransformer transformer) throws DITAOTException {
+        final boolean useTmpBuf = !isTempFile(src.normalize());
+        final URI dst = useTmpBuf
+                ? toURI(src + FILE_EXTENSION_TEMP).normalize()
+                : src;
+        try {
+            final Source source = getSource(src);
+            transformer.setSource(source);
+            final Destination result = getDestination(dst);
+            result.setDestinationBaseURI(src);
+            transformer.setDestination(result);
+            transformer.transform();
+            if (useTmpBuf) {
+                move(dst, src);
+            }
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to transform document", e);
+        } catch (final SaxonApiException e) {
+            throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
+        } catch (final IOException e) {
+            throw new DITAOTException("Failed to replace " + src + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    void transformUri(final URI src, final URI dst, final XsltTransformer transformer) throws DITAOTException {
+        try {
+            final Source source = getSource(src);
+            transformer.setSource(source);
+            final Destination result = getDestination(dst);
+            transformer.setDestination(result);
+            transformer.transform();
+        } catch (final UncheckedXPathException e) {
+            throw new DITAOTException("Failed to transform document", e);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final SaxonApiException e) {
+            throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public InputStream getInputStream(final URI path) throws IOException {
+        final URI f = path.normalize();
+        if (isTempFile(f)) {
+            if (cache.containsKey(f)) {
+                final Entry entry = cache.get(f);
+                if (entry.bytes != null) {
+                    return new ByteArrayInputStream(entry.bytes);
+                } else if (entry.node != null) {
+                    try (ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
+                        final XdmNode source = entry.node;
+                        final Serializer serializer = xmlUtils.getProcessor().newSerializer(buf);
+                        serializer.serializeNode(source);
+                        final byte[] bytes = buf.toByteArray();
+                        cache.put(f, new Entry(entry.doc, entry.node, bytes));
+                        return new ByteArrayInputStream(bytes);
+                    } catch (SaxonApiException e) {
+                        throw new IOException(e);
+                    }
+                } else if (entry.doc != null) {
+                    try (ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
+                        final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
+                        final Serializer serializer = xmlUtils.getProcessor().newSerializer(buf);
+                        serializer.serializeNode(source);
+                        final byte[] bytes = buf.toByteArray();
+                        cache.put(f, new Entry(entry.doc, entry.node, bytes));
+                        return new ByteArrayInputStream(bytes);
+                    } catch (SaxonApiException e) {
+                        throw new IOException(e);
+                    }
+                }
+            }
+        }
+        return fallback.getInputStream(path);
+    }
+
+    @Override
+    public OutputStream getOutputStream(final URI path) throws IOException {
+        final URI f = getUri(path);
+        if (LOG) System.err.println("  getOutputStream:" + f);
+        if (isTempFile(f)) {
+            return new OutputStreamBuffer(f);
+        }
+        return fallback.getOutputStream(f);
+    }
+
+    private class OutputStreamBuffer extends ByteArrayOutputStream {
+        private final URI path;
+
+        private OutputStreamBuffer(final URI path) {
+            this.path = path;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            put(path, new Entry(null, null, toByteArray()));
+        }
+    }
+
+    private ContentHandler getPipe(List<XMLFilter> filters, ContentHandler dst1) {
+        final List<XMLFilter> rev = new ArrayList<>(filters);
+        Collections.reverse(rev);
+        for (final XMLFilter filter : rev) {
+            final XMLFilterImpl filterImpl = (XMLFilterImpl) filter;
+            filterImpl.setContentHandler(dst1);
+            dst1 = filterImpl;
+        }
+        return dst1;
+    }
+
+    private Receiver getReceiver(final ContentHandler dst) {
+        final SAXDestination result = new SAXDestination(dst);
+        final PipelineConfiguration pipe = xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration();
+        return result.getReceiver(pipe, new SerializationProperties());
+    }
+
+    private URI toAbsolute(final URI path) {
+        return (path.isAbsolute() ? path : tempDirUri.resolve(path)).normalize();
+    }
+
+    private void cacheMiss(final URI f) {
+//        System.err.println("Cache miss: " + f);
+//        throw new IllegalStateException("Cache miss: " + f);
+    }
+
+    private Entry put(URI path, Entry entry) {
+        if (entry.node != null) {
+            final XdmNode node = entry.node;
+            assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+        }
+        if (entry.doc != null) {
+            final Document doc = entry.doc;
+            assert doc.getBaseURI() != null && !doc.getBaseURI().isEmpty();
+        }
+        return cache.put(path, entry);
+    }
+
+    private Entry get(URI s) {
+        final Entry entry = cache.get(s);
+        if (entry.node != null) {
+            final XdmNode node = entry.node;
+            assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+        } else if (entry.doc != null) {
+            final Document node = entry.doc;
+            assert node.getBaseURI() != null && !node.getBaseURI().isEmpty();
+        }
+        return entry;
+    }
+
+    private Entry remove(URI f) {
+        final Entry entry = cache.remove(f);
+        if (entry.node != null) {
+            final XdmNode node = entry.node;
+            assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+        } else if (entry.doc != null) {
+            final Document node = entry.doc;
+            assert node.getBaseURI() != null && !node.getBaseURI().isEmpty();
+        }
+        return entry;
+    }
+
+    private Entry rebase(final Entry remove, final URI d) {
+        XdmNode node = null;
+        Document doc = null;
+        if (remove.node != null) {
+            final TreeInfo treeInfo = remove.node.getUnderlyingNode().getTreeInfo();
+//            if (treeInfo instanceof DOMNodeWrapper) {
+//                Node n = ((DOMNodeWrapper) treeInfo).getUnderlyingNode();
+//                n.getOwnerDocument().setDocumentURI(d.toString());
+//                doc = (Document) n;
+//            } else if (treeInfo instanceof DocumentWrapper) {
+//                doc = (Document) ((DocumentWrapper) treeInfo).docNode;
+//                doc.setDocumentURI(d.toString());
+//            } else {
+                final TreeInfo rebasedDocument = new RebasedDocument(treeInfo,
+                        nodeInfo -> d.toString(),
+                        nodeInfo -> d.toString());
+                rebasedDocument.setSystemId(d.toString());
+                final DocumentBuilder builder = xmlUtils.getProcessor().newDocumentBuilder();
+                builder.setBaseURI(d);
+                node = builder.wrap(rebasedDocument.getRootNode());
+//            }
+        }
+        if (remove.doc != null) {
+            remove.doc.setDocumentURI(d.toString());
+            doc = remove.doc;
+        }
+        return new Entry(doc, node, remove.bytes);
+    }
+
+    private Source toSource(final Entry entry, final URI path) {
+        if (entry.doc != null) {
+            return new DOMSource(entry.doc);
+        } else if (entry.node != null) {
+            final NodeInfo underlyingNode = entry.node.getUnderlyingNode();
+            if (underlyingNode.getSystemId().equals(path)) {
+                return underlyingNode;
+            } else {
+                final Entry rebase = rebase(entry, path);
+                return rebase.node.asSource();
+//                final TreeInfo rebasedDocument = new RebasedDocument(underlyingNode.getTreeInfo(),
+//                        nodeInfo -> path.toString(),
+//                        nodeInfo -> path.toString());
+//                rebasedDocument.setSystemId(path.toString());
+//                return rebasedDocument;
+            }
+        } else if (entry.bytes != null) {
+            final StreamSource source = new StreamSource(new ByteArrayInputStream(entry.bytes));
+            source.setSystemId(path.toString());
+            return source;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private Document cloneDocument(final XdmNode node) throws IOException {
+        try {
+            final Document doc = XMLUtils.getDocumentBuilder().newDocument();
+            final DOMDestination destination = new DOMDestination(doc);
+            final Receiver receiver = destination.getReceiver(
+                    xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
+                    new SerializationProperties());
+            Sender.send(node.asSource(), receiver, new ParseOptions());
+            // Don't save mutable doc into cache
+            return doc;
+        } catch (XPathException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static class Entry {
+        private final Document doc;
+        private final XdmNode node;
+        private final byte[] bytes;
+
+        private Entry(final Document doc, final XdmNode node, byte[] bytes) {
+            this.doc = doc;
+            this.node = node;
+            this.bytes = bytes;
+        }
+    }
+}

--- a/src/main/java/org/dita/dost/store/CacheStoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/CacheStoreBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import org.dita.dost.util.XMLUtils;
+
+import java.io.File;
+
+/**
+ * Memory store builder
+ *
+ * @since 3.5
+ */
+public class CacheStoreBuilder implements StoreBuilder {
+
+    private File tempDir;
+    private XMLUtils xmlUtils;
+
+    @Override
+    public String getType() {
+        return "memory";
+    }
+
+    @Override
+    public StoreBuilder setTempDir(File tempDir) {
+        this.tempDir = tempDir;
+        return this;
+    }
+
+    @Override
+    public StoreBuilder setXmlUtils(XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
+        return this;
+    }
+
+    @Override
+    public Store build() {
+        return new CacheStore(tempDir, xmlUtils);
+    }
+}

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -211,6 +211,13 @@ public interface Store extends URIResolver {
     boolean exists(URI path);
 
     /**
+     * Returns the time that the resouce was last modified.
+     * @param path file to test, absolute or relative
+     * @return epoch timestamp or zero
+     */
+    long getLastModified(URI path);
+
+    /**
      * Move temporary file
      *
      * @param src source file, absolute or relative

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -64,6 +64,7 @@ public class StreamStore extends AbstractStore implements Store {
 
     @Override
     public Document getDocument(final URI path) throws IOException {
+        if (LOG) System.err.println("  getDocument:" + path);
         try {
             return XMLUtils.getDocumentBuilder().parse(path.toString());
         } catch (final Exception e) {
@@ -131,6 +132,33 @@ public class StreamStore extends AbstractStore implements Store {
             throw new DITAOTException(e);
         }
     }
+
+//    @Override
+//    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
+//        assert input.isAbsolute();
+//        if (!input.getScheme().equals("file")) {
+//            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+//        }
+//
+//        final File inputFile = new File(input);
+//        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
+//        transformURI(inputFile.toURI(), outputFile.toURI(), filters);
+//        try {
+//            deleteQuietly(inputFile);
+//            moveFile(outputFile, inputFile);
+//        } catch (final IOException e) {
+//            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
+//        }
+//    }
+//
+//    @Override
+//    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+//        if (input.equals(output)) {
+//            transform(input, filters);
+//        } else {
+//            transformURI(input, output, filters);
+//        }
+//    }
 
     @Override
     void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
@@ -218,10 +246,12 @@ public class StreamStore extends AbstractStore implements Store {
     public Source getSource(final URI path) {
         final URI f = getUri(path);
         if (isTempFile(f)) {
+            if (LOG) System.err.println("  getSource:" + f);
             final Source s = new StreamSource(f.toString());
             s.setSystemId(f.toString());
             return s;
         } else {
+            if (LOG) System.err.println("  getSource:" + path);
             return new StreamSource(path.toString());
         }
     }
@@ -275,6 +305,7 @@ public class StreamStore extends AbstractStore implements Store {
     public Source resolve(final String href, final String base) throws TransformerException {
         final URI h = toURI(href);
         final URI f = h.isAbsolute() ? h : toURI(base).resolve(h);
+        if (LOG) System.err.println("  resolve: " + f);
         if (isTempFile(f)) {
             return new StreamSource(f.toString());
         }
@@ -285,10 +316,13 @@ public class StreamStore extends AbstractStore implements Store {
     public InputStream getInputStream(final URI path) throws IOException {
         final URI f = getUri(path);
         if (isTempFile(f)) {
+            if (LOG) System.err.println("  getInputStream:" + f);
             return new FileInputStream(toFile(f));
         } else if ("file".equals(path.getScheme())) {
+            if (LOG) System.err.println("  getInputStream:" + path);
             return new FileInputStream(toFile(path));
         } else {
+            if (LOG) System.err.println("  getInputStream:" + f);
             return f.toURL().openStream();
         }
     }
@@ -297,11 +331,15 @@ public class StreamStore extends AbstractStore implements Store {
     public OutputStream getOutputStream(final URI path) throws IOException {
         final URI f = getUri(path);
         if (isTempFile(f)) {
+            if (LOG) System.err.println("  getOutputStream:" + f);
             return Files.newOutputStream(Paths.get(f));
         } else if ("file".equals(path.getScheme())) {
+            if (LOG) System.err.println("  getOutputStream:" + path);
             return Files.newOutputStream(Paths.get(path));
         } else {
+            if (LOG) System.err.println("  getOutputStream:" + f);
             throw new UnsupportedOperationException("Unable to write to " + f);
+//            return f.toURL().openStream();
         }
     }
 }

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -302,6 +302,12 @@ public class StreamStore extends AbstractStore implements Store {
     }
 
     @Override
+    public long getLastModified(final URI path) {
+        final File d = new File(getUri(URLUtils.setFragment(path, null)));
+        return d.lastModified();
+    }
+
+    @Override
     public Source resolve(final String href, final String base) throws TransformerException {
         final URI h = toURI(href);
         final URI f = h.isAbsolute() ? h : toURI(base).resolve(h);

--- a/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
+++ b/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
@@ -8,15 +8,25 @@
 package org.dita.dost.store.ant.types;
 
 import org.apache.tools.ant.types.Resource;
-import org.dita.dost.util.Job;
+import org.apache.tools.ant.util.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Objects;
+import org.dita.dost.util.Job;
 
-public class StoreResource extends Resource {
+public class StoreResource extends Resource
+//        implements
+        //Touchable,
+        //FileProvider,
+        //Appendable,
+//        ResourceFactory
+{
+
+    private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
+    private static final int NULL_FILE = Resource.getMagicNumber("null file".getBytes());
 
     private URI file;
     private Job job;
@@ -26,6 +36,105 @@ public class StoreResource extends Resource {
         this.file = file;
     }
 
+//    /**
+//     * Construct a new StoreResource from a File.
+//     * @param f the File represented.
+//     */
+//    public StoreResource(URI f) {
+//        setFile(f);
+//    }
+
+//    /**
+//     * Create a new StoreResource.
+//     * @param p Project
+//     * @param f File represented
+//     * @since Ant 1.8
+//     */
+//    public StoreResource(Project p, File f) {
+//        this(f);
+//        setProject(p);
+//    }
+
+//    /**
+//     * Constructor for Ant attribute introspection.
+//     * @param p the Project against which to resolve <code>s</code>.
+//     * @param s the absolute or Project-relative filename as a String.
+//     * @see org.apache.tools.ant.IntrospectionHelper
+//     */
+//    public StoreResource(Project p, String s) {
+//        this(p, p.resolveFile(s));
+//    }
+
+//    /**
+//     * Set the File for this StoreResource.
+//     * @param f the File to be represented.
+//     */
+//    public void setFile(File f) {
+//        checkAttributesAllowed();
+//        file = f;
+//        if (f != null && (getBaseDir() == null || !FILE_UTILS.isLeadingPath(getBaseDir(), f))) {
+//            setBaseDir(f.getParentFile());
+//        }
+//    }
+
+    // FileProvider
+
+//    /**
+//     * Get the file represented by this StoreResource.
+//     * @return the File.
+//     */
+//    @Override
+//    public File getFile() {
+//        if (isReference()) {
+//            return getRef().getFile();
+//        }
+//        dieOnCircularReference();
+//        synchronized (this) {
+//            if (file == null) {
+//                //try to resolve file set via basedir/name property setters:
+//                File d = getBaseDir();
+//                String n = super.getName();
+//                if (n != null) {
+//                    setFile(FILE_UTILS.resolveFile(d, n));
+//                }
+//            }
+//        }
+//        return file;
+//    }
+
+//    /**
+//     * Set the basedir for this StoreResource.
+//     * @param b the basedir as File.
+//     */
+//    public void setBaseDir(File b) {
+//        checkAttributesAllowed();
+//        baseDir = b;
+//    }
+
+//    /**
+//     * Return the basedir to which the name is relative.
+//     * @return the basedir as File.
+//     */
+//    public File getBaseDir() {
+//        if (isReference()) {
+//            return getRef().getBaseDir();
+//        }
+//        dieOnCircularReference();
+//        return baseDir;
+//    }
+
+//    /**
+//     * Overrides the super version.
+//     * @param r the Reference to set.
+//     */
+//    @Override
+//    public void setRefid(Reference r) {
+//        if (file != null || baseDir != null) {
+//            throw tooManyAttributes();
+//        }
+//        super.setRefid(r);
+//    }
+
     /**
      * Get the name of this StoreResource.  If the basedir is set,
      * the name will be relative to that.  Otherwise the basename
@@ -34,6 +143,12 @@ public class StoreResource extends Resource {
      */
     @Override
     public String getName() {
+//        if (isReference()) {
+//            return getRef().getName();
+//        }
+//        File b = getBaseDir();
+//        return b == null ? getNotNullFile().getName()
+//            : FILE_UTILS.removeLeadingPath(b, getNotNullFile());
         return file.getPath();
     }
 
@@ -43,6 +158,8 @@ public class StoreResource extends Resource {
      */
     @Override
     public boolean isExists() {
+//        return isReference() ? getRef().isExists()
+//            : getNotNullFile().exists();
         return job.getStore().exists(job.tempDirURI.resolve(file));
     }
 
@@ -52,6 +169,9 @@ public class StoreResource extends Resource {
      */
     @Override
     public long getLastModified() {
+//        return isReference()
+//            ? getRef().getLastModified()
+//            : getNotNullFile().lastModified();
         // TODO: Add long lastModified entry to cache Store
         return -1;
     }
@@ -62,6 +182,8 @@ public class StoreResource extends Resource {
      */
     @Override
     public boolean isDirectory() {
+//        return isReference() ? getRef().isDirectory()
+//            : getNotNullFile().isDirectory();
         return false;
     }
 
@@ -71,6 +193,8 @@ public class StoreResource extends Resource {
      */
     @Override
     public long getSize() {
+//        return isReference() ? getRef().getSize()
+//            : getNotNullFile().length();
         return -1;
     }
 
@@ -81,6 +205,8 @@ public class StoreResource extends Resource {
      */
     @Override
     public InputStream getInputStream() throws IOException {
+//        return isReference() ? getRef().getInputStream()
+//            : Files.newInputStream(getNotNullFile().toPath());
         return job.getStore().getInputStream(job.tempDirURI.resolve(file));
     }
 
@@ -94,8 +220,38 @@ public class StoreResource extends Resource {
      */
     @Override
     public OutputStream getOutputStream() throws IOException {
+//        if (isReference()) {
+//            return getRef().getOutputStream();
+//        }
+//        return getOutputStream(false);
         return job.getStore().getOutputStream(job.tempDirURI.resolve(file));
     }
+
+//    /**
+//     * {@inheritDoc}
+//     */
+//    @Override
+//    public OutputStream getAppendOutputStream() throws IOException {
+//        if (isReference()) {
+//            return getRef().getAppendOutputStream();
+//        }
+//        return getOutputStream(true);
+//    }
+
+//    private OutputStream getOutputStream(boolean append) throws IOException {
+//        File f = getNotNullFile();
+//        if (f.exists()) {
+//            if (f.isFile() && !append) {
+//                f.delete();
+//            }
+//        } else {
+//            File p = f.getParentFile();
+//            if (p != null && !(p.exists())) {
+//                p.mkdirs();
+//            }
+//        }
+//        return FileUtils.newOutputStream(f.toPath(), append);
+//    }
 
     /**
      * Compare this StoreResource to another Resource.
@@ -105,6 +261,27 @@ public class StoreResource extends Resource {
      */
     @Override
     public int compareTo(Resource another) {
+//        if (isReference()) {
+//            return getRef().compareTo(another);
+//        }
+//        if (this.equals(another)) {
+//            return 0;
+//        }
+//        FileProvider otherFP = another.as(FileProvider.class);
+//        if (otherFP != null) {
+//            File f = getFile();
+//            if (f == null) {
+//                return -1;
+//            }
+//            File of = otherFP.getFile();
+//            if (of == null) {
+//                return 1;
+//            }
+//            int compareFiles = f.compareTo(of);
+//            return compareFiles != 0 ? compareFiles
+//                : getName().compareTo(another.getName());
+//        }
+//        return super.compareTo(another);
         // TODO add a way to compare resources
         return -1;
     }
@@ -119,11 +296,17 @@ public class StoreResource extends Resource {
         if (this == another) {
             return true;
         }
+//        if (isReference()) {
+//            return getRef().equals(another);
+//        }
         if (another == null || !(another.getClass().equals(getClass()))) {
             return false;
         }
         StoreResource otherfr = (StoreResource) another;
         return Objects.equals(file, otherfr.file);
+//                getFile() == null
+//            ? otherfr.getFile() == null
+//            : getFile().equals(otherfr.getFile()) && getName().equals(otherfr.getName());
     }
 
     /**
@@ -132,6 +315,10 @@ public class StoreResource extends Resource {
      */
     @Override
     public int hashCode() {
+//        if (isReference()) {
+//            return getRef().hashCode();
+//        }
+//        return MAGIC * (getFile() == null ? NULL_FILE : getFile().hashCode());
         return file.hashCode();
     }
 
@@ -141,6 +328,14 @@ public class StoreResource extends Resource {
      */
     @Override
     public String toString() {
+//        if (isReference()) {
+//            return getRef().toString();
+//        }
+//        if (file == null) {
+//            return "(unbound file resource)";
+//        }
+//        String absolutePath = file.getAbsolutePath();
+//        return FILE_UTILS.normalize(absolutePath).getAbsolutePath();
         return job.tempDirURI.resolve(file).toString();
     }
 
@@ -150,8 +345,58 @@ public class StoreResource extends Resource {
      */
     @Override
     public boolean isFilesystemOnly() {
+//        if (isReference()) {
+//            return getRef().isFilesystemOnly();
+//        }
+//        dieOnCircularReference();
         return true;
     }
+
+//    /**
+//     * Implement the Touchable interface.
+//     * @param modTime new last modification time.
+//     */
+//    @Override
+//    public void touch(long modTime) {
+//        if (isReference()) {
+//            getRef().touch(modTime);
+//            return;
+//        }
+//        if (!getNotNullFile().setLastModified(modTime)) {
+//            log("Failed to change file modification time", Project.MSG_WARN);
+//        }
+//    }
+
+//    /**
+//     * Get the file represented by this StoreResource, ensuring it is not null.
+//     * @return the not-null File.
+//     * @throws BuildException if file is null.
+//     */
+//    protected File getNotNullFile() {
+//        if (getFile() == null) {
+//            throw new BuildException("file attribute is null!");
+//        }
+//        dieOnCircularReference();
+//        return getFile();
+//    }
+
+//    /**
+//     * Create a new resource that matches a relative or absolute path.
+//     * If the current instance has a compatible baseDir attribute, it is copied.
+//     * @param path relative/absolute path to a resource
+//     * @return a new resource of type StoreResource
+//     * @throws BuildException if desired
+//     * @since Ant1.8
+//     */
+//    @Override
+//    public Resource getResource(String path) {
+//        File newfile = FILE_UTILS.resolveFile(getFile(), path);
+//        StoreResource fileResource = new StoreResource(newfile);
+//        if (FILE_UTILS.isLeadingPath(getBaseDir(), newfile)) {
+//            fileResource.setBaseDir(getBaseDir());
+//        }
+//        return fileResource;
+//    }
 
     @Override
     protected StoreResource getRef() {

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -20,10 +20,7 @@ import org.w3c.dom.NodeList;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.*;
 
 import static org.dita.dost.util.Constants.*;
@@ -246,7 +243,7 @@ public final class DelayConrefUtils {
                                    final TempFileNameScheme tempFileNameScheme)
             throws DITAOTException {
         XMLStreamWriter export = null;
-        try (OutputStream exportStream = new FileOutputStream(new File(job.tempDir, FILE_NAME_EXPORT_XML))) {
+        try (OutputStream exportStream = new BufferedOutputStream(job.getStore().getOutputStream(new File(job.tempDir, FILE_NAME_EXPORT_XML).toURI()))) {
             export = XMLOutputFactory.newInstance().createXMLStreamWriter(exportStream, "UTF-8");
             export.writeStartDocument();
             export.writeStartElement("stub");

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -140,7 +140,8 @@ public final class Job {
         }
         this.tempDir = tempDir;
         this.store = store;
-        tempDirURI = tempDir.toURI();
+        final URI tmpDirUri = tempDir.toURI();
+        tempDirURI = tmpDirUri.toString().endsWith("/") ? tmpDirUri : URI.create(tmpDirUri + "/");
         jobFile = new File(tempDir, JOB_FILE);
         prop = new HashMap<>();
         read();
@@ -309,9 +310,6 @@ public final class Job {
      * @throws IOException if writing configuration files failed
      */
     public void write() throws IOException {
-        if (!tempDir.exists() && !tempDir.mkdirs()) {
-            throw new IOException("Failed to create " + tempDir + " directory");
-        }
         try (Writer outStream = new BufferedWriter(new OutputStreamWriter(getStore().getOutputStream(jobFile.toURI())))) {
             XMLStreamWriter out = null;
             try {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -7,6 +7,7 @@
  */
 package org.dita.dost.util;
 
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.store.Store;
 import org.w3c.dom.Document;
@@ -21,6 +22,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.Result;
 import javax.xml.transform.dom.DOMResult;
 import java.io.*;
 import java.lang.reflect.Field;
@@ -167,7 +169,7 @@ public final class Job {
      * @return {@code true} if configuration file has been update after this object has been created or serialized
      */
     public boolean isStale() {
-        return jobFile.lastModified() > lastModified;
+        return getStore().getLastModified(jobFile.toURI()) > lastModified;
     }
 
     /**
@@ -178,14 +180,11 @@ public final class Job {
      * @throws IllegalStateException if configuration files are missing
      */
     private void read() throws IOException {
-        lastModified = jobFile.lastModified();
-        if (jobFile.exists()) {
+        lastModified = getStore().getLastModified(jobFile.toURI());
+        if (getStore().exists(jobFile.toURI())) {
             try (final InputStream in = new FileInputStream(jobFile)) {
-                final XMLReader parser = XMLUtils.getXMLReader();
-                parser.setContentHandler(new JobHandler(prop, files));
-
-                parser.parse(new InputSource(in));
-            } catch (final SAXException e) {
+                getStore().transform(jobFile.toURI(), new JobHandler(prop, files));
+            } catch (final DITAOTException e) {
                 throw new IOException("Failed to read job file: " + e.getMessage());
             }
         } else {
@@ -313,7 +312,7 @@ public final class Job {
         if (!tempDir.exists() && !tempDir.mkdirs()) {
             throw new IOException("Failed to create " + tempDir + " directory");
         }
-        try (Writer outStream = Files.newBufferedWriter(jobFile.toPath())) {
+        try (Writer outStream = new BufferedWriter(new OutputStreamWriter(getStore().getOutputStream(jobFile.toURI())))) {
             XMLStreamWriter out = null;
             try {
                 out = XMLOutputFactory.newInstance().createXMLStreamWriter(outStream);
@@ -332,7 +331,7 @@ public final class Job {
         } catch (final IOException e) {
             throw new IOException("Failed to write file: " + e.getMessage());
         }
-        lastModified = jobFile.lastModified();
+        lastModified = getStore().getLastModified(jobFile.toURI());
     }
 
     public Document serialize() throws IOException {

--- a/src/main/java/org/dita/dost/util/KeyDef.java
+++ b/src/main/java/org/dita/dost/util/KeyDef.java
@@ -11,13 +11,6 @@ import net.sf.saxon.s9api.XdmNode;
 
 import java.net.URI;
 
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
-import net.sf.saxon.s9api.XdmNode;
-import org.dita.dost.exception.DITAOTException;
-import org.w3c.dom.Element;
 import static org.dita.dost.util.Constants.*;
 
 /**

--- a/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
@@ -306,7 +306,7 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
             hasWritten = false;
             inputFile = new File(file);
             outputFile = new File(file + FILE_EXTENSION_TEMP);
-            output = new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8);
+            output = new OutputStreamWriter(job.getStore().getOutputStream(outputFile.toURI()), StandardCharsets.UTF_8);
 
             topicIdList.clear();
             reader.setErrorHandler(new DITAOTXMLErrorHandler(file, logger));

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -6,7 +6,8 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<project name="ditaot-init">
+<project name="ditaot-init"
+         xmlns:if="ant:if">
     
   <!-- Read configuration properties -->
   <loadproperties>
@@ -120,8 +121,12 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- create required directories -->
     <mkdir dir="${output.dir}" />
-    <delete dir="${dita.temp.dir}" quiet="false"/>
-    <mkdir dir="${dita.temp.dir}" />
+    <local name="createTempDir"/>
+    <condition property="createTempDir" value="true">
+      <equals arg1="${store-type}" arg2="file"/>
+    </condition>
+    <delete dir="${dita.temp.dir}" quiet="false" if:true="${createTempDir}"/>
+    <mkdir dir="${dita.temp.dir}" if:true="${createTempDir}" />
 
     <!-- Validate the xml file or not,default is validation(true)-->
     <property name="validate" value="true"/>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -492,9 +492,7 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.copy-flag.skip"
     description="Copy flag files">
-    <property name="flagimagefile" value="flagimage.list"/>
-    <job-helper file="flagimage.list" property="flagimagelist"/>
-    <dita-ot-copy todir="${dita.output.dir}" includesfile="${dita.temp.dir}/${flagimagefile}" relativepaths="${relflagimagelist}" />
+    <dita-ot-copy todir="${dita.output.dir}" relativepaths="${relflagimagelist}" />
   </target>
   
   <target name="copy-flag-check">

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -110,13 +110,12 @@ See the accompanying LICENSE file for applicable license.
                    html5.topics.common.inner"/>
 
   <target name="html5.topic.init">
-    <local name="html5.map"/>
-    <loadfile property="html5.map" srcfile="${dita.temp.dir}/${user.input.file.listfile}" unless:set="noMap">
-      <filterchain>
-        <headfilter lines="1"/>
-      </filterchain>
-    </loadfile>
-    <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}" validate="no" unless:set="noMap"/>
+    <pathconvert property="html5.map">
+      <first>
+        <ditafileset format="ditamap" input="true"/>
+      </first>
+    </pathconvert>
+    <makeurl property="html5.map.url" file="${html5.map}" validate="no" unless:set="noMap"/>
     <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no" if:set="dita.input.valfile"/>
   </target>
 

--- a/src/main/resources/META-INF/services/org.dita.dost.store.StoreBuilder
+++ b/src/main/resources/META-INF/services/org.dita.dost.store.StoreBuilder
@@ -1,1 +1,2 @@
 org.dita.dost.store.StreamStoreBuilder
+org.dita.dost.store.CacheStoreBuilder

--- a/src/test/java/org/dita/dost/index/IndexTermCollectionTest.java
+++ b/src/test/java/org/dita/dost/index/IndexTermCollectionTest.java
@@ -155,8 +155,7 @@ public class IndexTermCollectionTest {
 
     @After
     public void tearDown() throws IOException {
-        System.err.println(tempDir);
-//        TestUtils.forceDelete(tempDir);
+        TestUtils.forceDelete(tempDir);
     }
 
 }

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -35,10 +35,6 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
@@ -189,12 +185,6 @@ public class KeyrefModuleTest {
         assertEquals(subMapTask.scope, childScope);
 
         final Document act = toDocument(destination.getXdmNode());
-        try {
-            TransformerFactory.newInstance().newTransformer().transform(new DOMSource(exp), new StreamResult(System.out));
-            TransformerFactory.newInstance().newTransformer().transform(new DOMSource(act), new StreamResult(System.out));
-        } catch (TransformerException e) {
-            e.printStackTrace();
-        }
         assertXMLEqual(exp, act);
     }
 

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -161,8 +161,6 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "d.ditamap").toURI());
         parser.write(new File(tempDir, "d.ditamap"));
 
-        System.err.println(new File(expDir, "d.ditamap"));
-        System.err.println(new File(tempDir, "d.ditamap"));
         assertXMLEqual(new InputSource(new File(expDir, "d.ditamap").toURI().toString()),
                 new InputSource(new File(tempDir, "d.ditamap").toURI().toString()));
     }


### PR DESCRIPTION
## Description
Add in-memory `Store` implementation that keeps XML files as s9api's `XdmNode` instances.

## Motivation and Context
Possible performance improvement in some cases.

## How Has This Been Tested?
Currents tests pass.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

