### PR TITLE
Add spanning and title to simpletable in HTML5 #3464

### DIFF
--- a/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2013 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.writer;
+
+import org.dita.dost.util.XMLUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.util.*;
+
+import static org.dita.dost.util.Constants.*;
+
+/**
+ * Normalize simpletable content.
+ *
+ * <ul>
+ *   <li>Rewrite table column names to {@code "col" num}, where {@code num} is the column number, and add column name to every entry.</li>
+ * </ul>
+ */
+public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {
+
+    private static final String ATTRIBUTE_NAME_COLSPAN = "colspan";
+    private static final String ATTRIBUTE_NAME_ROWSPAN = "rowspan";
+    private static final String ATTR_X = "x";
+    private static final String ATTR_Y = "y";
+
+    private final Deque<String> classStack = new LinkedList<>();
+    private int depth;
+    private final Map<String, String> ns = new HashMap<>();
+
+    private int rowNumber;
+    private ArrayList<Span> previousRow;
+    private ArrayList<Span> currentRow;
+    private int currentColumn;
+
+    public NormalizeSimpleTableFilter() {
+        super();
+        depth = 0;
+    }
+
+    @Override
+    public void startPrefixMapping(final String prefix, final String uri) throws SAXException {
+        ns.put(prefix, uri);
+        getContentHandler().startPrefixMapping(prefix, uri);
+    }
+
+    @Override
+    public void endPrefixMapping(final String prefix) throws SAXException {
+        getContentHandler().endPrefixMapping(prefix);
+        ns.remove(prefix);
+    }
+
+    @Override
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
+        depth++;
+        if (depth == 1 && !ns.containsKey(DITA_OT_NS_PREFIX)) {
+            super.startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
+        }
+
+        final AttributesImpl res = new AttributesImpl(atts);
+        final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
+        classStack.addFirst(cls);
+
+        if (TOPIC_SIMPLETABLE.matches(cls)) {
+            rowNumber = 0;
+            previousRow = null;
+            currentRow = null;
+        } else if (TOPIC_STROW.matches(cls) || TOPIC_STHEAD.matches(cls)) {
+            rowNumber++;
+            currentRow = previousRow != null ? new ArrayList<>(Arrays.asList(new Span[previousRow.size()])) : new ArrayList<>();
+            currentColumn = 0;
+        } else if (TOPIC_STENTRY.matches(cls)) {
+            final int colspan = getSpan(atts, ATTRIBUTE_NAME_COLSPAN);
+            final int rowspan = getSpan(atts, ATTRIBUTE_NAME_ROWSPAN);
+            final Span prev;
+            if (previousRow != null) {
+                prev = previousRow.get(currentColumn);
+                if (prev != null && prev.y > 1) {
+                    for (int i = 0; i < prev.x; i++) {
+                        currentColumn = currentColumn + 1; //prev.x - 1;
+                        grow(currentRow, currentColumn + 1);
+                        currentRow.set(currentColumn, null);
+                    }
+                }
+            } else {
+                prev = new Span(1, 1);
+            }
+            grow(currentRow, currentColumn + colspan);
+            final Span span = new Span(colspan, rowspan);
+
+            currentRow.set(currentColumn, span);
+
+            XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_X, DITA_OT_NS_PREFIX + ":" + ATTR_X, "CDATA", Integer.toString(currentColumn + 1));
+            XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_Y, DITA_OT_NS_PREFIX + ":" + ATTR_Y, "CDATA", Integer.toString(rowNumber));
+
+            currentColumn = currentColumn + colspan;
+        }
+
+        getContentHandler().startElement(uri, localName, qName, res);
+    }
+
+    private void grow(final ArrayList<?> array, final int size) {
+        while (array.size() < size) {
+            array.add(null);
+        }
+    }
+
+    private int getSpan(final Attributes atts, final String name) {
+        final String span = atts.getValue(name);
+        if (span != null) {
+            return Integer.parseInt(span);
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+        getContentHandler().endElement(uri, localName, qName);
+        final String cls = classStack.removeFirst();
+        if (TOPIC_STROW.matches(cls) || TOPIC_STHEAD.matches(cls)) {
+            previousRow = currentRow;
+            currentRow = null;
+            currentColumn = -1;
+        }
+
+        if (depth == 1) {
+            super.endPrefixMapping(DITA_OT_NS_PREFIX);
+        }
+        depth--;
+    }
+
+    private static class Span {
+        public final int x;
+        public final int y;
+
+        private Span(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+}

--- a/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
@@ -20,7 +20,7 @@ import static org.dita.dost.util.Constants.*;
  * Normalize simpletable content.
  *
  * <ul>
- *   <li>Rewrite table column names to {@code "col" num}, where {@code num} is the column number, and add column name to every entry.</li>
+ *   <li>Add column coordinates to entries</li>
  * </ul>
  */
 public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {

--- a/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
@@ -26,7 +26,7 @@ import static org.dita.dost.util.Constants.*;
  *   <li>Rewrite table column names to {@code "col" num}, where {@code num} is the column number, and add column name to every entry.</li>
  * </ul>
  */
-public final class NormalizeTableFilter extends AbstractXMLFilter {
+public class NormalizeTableFilter extends AbstractXMLFilter {
 
     private static final String ATTRIBUTE_NAME_COLNAME = "colname";
     private static final String ATTRIBUTE_NAME_COLNUM = "colnum";

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -362,6 +362,7 @@ See the accompanying LICENSE file for applicable license.
         <filter class="org.dita.dost.writer.NormalizeTableFilter">
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
+        <filter class="org.dita.dost.writer.NormalizeSimpleTableFilter"/>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
         <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -316,6 +316,7 @@ See the accompanying LICENSE file for applicable license.
         <filter class="org.dita.dost.writer.NormalizeTableFilter">
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
+        <filter class="org.dita.dost.writer.NormalizeSimpleTableFilter"/>
         <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
         <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>

--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -249,12 +249,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:function name="simpletable:is-keycol-entry" as="xs:boolean">
     <xsl:param name="entry" as="element()"/>
 
-    <xsl:variable name="table" as="element()"
-      select="simpletable:get-current-table($entry)"/>
+    <xsl:variable name="keycol" as="xs:integer?"
+      select="simpletable:get-current-table($entry)/@keycol/xs:integer(.)"/>
 
-    <xsl:sequence select="
-      $table/@keycol and xs:integer($table/@keycol) eq count($entry/preceding-sibling::*) + 1
-    "/>
+    <xsl:sequence select="$keycol = $entry/@dita-ot:x/xs:integer(.)"/>
   </xsl:function>
   
   <xsl:function name="dita-ot:normalize-href" as="xs:string?">

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -224,28 +224,24 @@ See the accompanying LICENSE file for applicable license.
     </thead>
   </xsl:template>
 
-  <xsl:template match="*[simpletable:is-head-entry(.)]">
-    <th>
-      <xsl:apply-templates select="." mode="simpletable:entry"/>
-    </th>
-  </xsl:template>
-
-  <xsl:template match="*[simpletable:is-body-entry(.)][simpletable:is-keycol-entry(.)]">
-    <th scope="row">
-      <xsl:apply-templates select="." mode="simpletable:entry"/>
-    </th>
-  </xsl:template>
-
-  <xsl:template match="*[simpletable:is-body-entry(.)][not(simpletable:is-keycol-entry(.))]" name="topic.stentry">
+  <xsl:template match="*[simpletable:is-body-entry(.)]" name="topic.stentry">
     <td>
       <xsl:apply-templates select="." mode="simpletable:entry"/>
     </td>
   </xsl:template>
 
+  <xsl:template match="*[simpletable:is-head-entry(.)]
+                     | *[simpletable:is-body-entry(.)][simpletable:is-keycol-entry(.) or @scope]"
+                priority="2">
+    <th>
+      <xsl:apply-templates select="." mode="simpletable:entry"/>
+    </th>
+  </xsl:template>
+
   <xsl:template match="*[contains(@class, ' topic/stentry ')]" mode="simpletable:entry">
     <xsl:apply-templates select="." mode="table:common"/>
     <xsl:apply-templates select="." mode="simpletable:headers"/>
-    <xsl:apply-templates select="@colspan | @rowspan"/>
+    <xsl:apply-templates select="@colspan | @rowspan | @scope"/>
     <xsl:choose>
       <xsl:when test="*|text()|processing-instruction()">
         <xsl:apply-templates/>
@@ -256,18 +252,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
 
-<!--  <xsl:template match="*[table:is-thead-entry(.)]" mode="simpletable:headers">-->
-<!--    <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>-->
-<!--  </xsl:template>-->
-
-<!--  <xsl:template match="*[table:is-tbody-entry(.)]" mode="simpletable:headers">-->
-<!--    &lt;!&ndash;    <xsl:if test="table:is-row-header(.)">&ndash;&gt;-->
-<!--    &lt;!&ndash;      <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>&ndash;&gt;-->
-<!--    &lt;!&ndash;    </xsl:if>&ndash;&gt;-->
-<!--    <xsl:call-template name="simpletable:add-headers-attribute"/>-->
-<!--  </xsl:template>-->
-
-  <xsl:template match="@colspan | @rowspan">
+  <xsl:template match="@colspan | @rowspan | @scope">
     <xsl:copy/>
   </xsl:template>
   
@@ -284,44 +269,14 @@ See the accompanying LICENSE file for applicable license.
                   select="if (@colspan)
                           then xs:integer(@dita-ot:x) to (xs:integer(@dita-ot:x) + xs:integer(@colspan) - 1)
                           else xs:integer(@dita-ot:x)"/>
-<!--    <xsl:attribute name="xs">-->
-<!--      <xsl:for-each select="$xs">-->
-<!--        <xsl:text> </xsl:text>-->
-<!--        <xsl:value-of select="."/>-->
-<!--      </xsl:for-each>-->
-<!--    </xsl:attribute>-->
     <xsl:variable name="stentry" as="element()*"
                   select="../../*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')]
                                                                        [xs:integer(@dita-ot:x) = $xs]"/>
     <xsl:if test="exists($stentry)">
       <xsl:variable name="ids" as="xs:string*" select="$stentry/dita-ot:generate-html-id(.)" />
       <xsl:attribute name="headers" select="$ids" separator=" "/>
-      <xsl:choose>
-        <xsl:when test="@headers">
-
-        </xsl:when>
-        <xsl:otherwise>
-
-        </xsl:otherwise>
-
-      </xsl:choose>
-      <xsl:call-template name="simpletable:add-headers-attribute"/>
     </xsl:if>
   </xsl:template>
-
-
-  <xsl:template name="simpletable:add-headers-attribute">
-    <!--    &lt;!&ndash; Find the IDs of all headers that are aligned above this cell. May contain duplicates due to spanning cells. &ndash;&gt;-->
-    <!--    <xsl:variable name="all-thead-headers" select="table:get-matching-thead-headers(.)" as="xs:string*"/>-->
-    <!--    &lt;!&ndash; Row header should be 0 or 1 today, but future updates may allow multiple &ndash;&gt;-->
-    <!--    <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>-->
-    <!--    <xsl:if test="exists($all-row-headers) or exists($all-thead-headers)">-->
-    <!--      <xsl:attribute name="headers"-->
-    <!--                     select="distinct-values($all-row-headers), distinct-values($all-thead-headers)"-->
-    <!--                     separator=" "/>-->
-    <!--    </xsl:if>-->
-  </xsl:template>
-
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-header" priority="10">
     <xsl:variable name="gen" as="element(gen)">

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -223,6 +223,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/stentry ')]" mode="simpletable:entry">
     <xsl:apply-templates select="." mode="table:common"/>
     <xsl:apply-templates select="." mode="headers"/>
+    <xsl:apply-templates select="@colspan | @rowspan"/>
     <xsl:choose>
       <xsl:when test="*|text()|processing-instruction()">
         <xsl:apply-templates/>
@@ -232,7 +233,11 @@ See the accompanying LICENSE file for applicable license.
       </xsl:when>
     </xsl:choose>
   </xsl:template>
-
+  
+  <xsl:template match="@colspan | @rowspan">
+    <xsl:copy/>
+  </xsl:template>
+  
   <xsl:template match="*[simpletable:is-head-entry(.)]" mode="headers">
     <xsl:attribute name="scope" select="'col'"/>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -244,7 +244,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' topic/stentry ')]" mode="simpletable:entry">
     <xsl:apply-templates select="." mode="table:common"/>
-    <xsl:apply-templates select="." mode="headers"/>
+    <xsl:apply-templates select="." mode="simpletable:headers"/>
     <xsl:apply-templates select="@colspan | @rowspan"/>
     <xsl:choose>
       <xsl:when test="*|text()|processing-instruction()">
@@ -255,20 +255,73 @@ See the accompanying LICENSE file for applicable license.
       </xsl:when>
     </xsl:choose>
   </xsl:template>
-  
+
+<!--  <xsl:template match="*[table:is-thead-entry(.)]" mode="simpletable:headers">-->
+<!--    <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>-->
+<!--  </xsl:template>-->
+
+<!--  <xsl:template match="*[table:is-tbody-entry(.)]" mode="simpletable:headers">-->
+<!--    &lt;!&ndash;    <xsl:if test="table:is-row-header(.)">&ndash;&gt;-->
+<!--    &lt;!&ndash;      <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>&ndash;&gt;-->
+<!--    &lt;!&ndash;    </xsl:if>&ndash;&gt;-->
+<!--    <xsl:call-template name="simpletable:add-headers-attribute"/>-->
+<!--  </xsl:template>-->
+
   <xsl:template match="@colspan | @rowspan">
     <xsl:copy/>
   </xsl:template>
   
-  <xsl:template match="*[simpletable:is-head-entry(.)]" mode="headers">
+  <xsl:template match="*[simpletable:is-head-entry(.)]" mode="simpletable:headers">
     <xsl:attribute name="scope" select="'col'"/>
+    <xsl:attribute name="id" select="dita-ot:generate-html-id(.)"/>
   </xsl:template>
 
-  <xsl:template match="*[simpletable:is-body-entry(.)]" mode="headers">
+  <xsl:template match="*[simpletable:is-body-entry(.)]" mode="simpletable:headers">
     <xsl:if test="simpletable:is-keycol-entry(.)">
       <xsl:attribute name="scope" select="'row'"/>
     </xsl:if>
+    <xsl:variable name="xs" as="xs:integer+"
+                  select="if (@colspan)
+                          then xs:integer(@dita-ot:x) to (xs:integer(@dita-ot:x) + xs:integer(@colspan) - 1)
+                          else xs:integer(@dita-ot:x)"/>
+<!--    <xsl:attribute name="xs">-->
+<!--      <xsl:for-each select="$xs">-->
+<!--        <xsl:text> </xsl:text>-->
+<!--        <xsl:value-of select="."/>-->
+<!--      </xsl:for-each>-->
+<!--    </xsl:attribute>-->
+    <xsl:variable name="stentry" as="element()*"
+                  select="../../*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')]
+                                                                       [xs:integer(@dita-ot:x) = $xs]"/>
+    <xsl:if test="exists($stentry)">
+      <xsl:variable name="ids" as="xs:string*" select="$stentry/dita-ot:generate-html-id(.)" />
+      <xsl:attribute name="headers" select="$ids" separator=" "/>
+      <xsl:choose>
+        <xsl:when test="@headers">
+
+        </xsl:when>
+        <xsl:otherwise>
+
+        </xsl:otherwise>
+
+      </xsl:choose>
+      <xsl:call-template name="simpletable:add-headers-attribute"/>
+    </xsl:if>
   </xsl:template>
+
+
+  <xsl:template name="simpletable:add-headers-attribute">
+    <!--    &lt;!&ndash; Find the IDs of all headers that are aligned above this cell. May contain duplicates due to spanning cells. &ndash;&gt;-->
+    <!--    <xsl:variable name="all-thead-headers" select="table:get-matching-thead-headers(.)" as="xs:string*"/>-->
+    <!--    &lt;!&ndash; Row header should be 0 or 1 today, but future updates may allow multiple &ndash;&gt;-->
+    <!--    <xsl:variable name="all-row-headers" select="table:get-matching-row-headers(.)" as="xs:string*"/>-->
+    <!--    <xsl:if test="exists($all-row-headers) or exists($all-thead-headers)">-->
+    <!--      <xsl:attribute name="headers"-->
+    <!--                     select="distinct-values($all-row-headers), distinct-values($all-thead-headers)"-->
+    <!--                     separator=" "/>-->
+    <!--    </xsl:if>-->
+  </xsl:template>
+
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-header" priority="10">
     <xsl:variable name="gen" as="element(gen)">

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -169,8 +169,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="spec-title"/>
     <table>
       <xsl:apply-templates select="." mode="table:common"/>
+      <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
       <xsl:call-template name="dita2html:simpletable-cols"/>
-
       <xsl:apply-templates select="*[contains(@class, ' topic/sthead ')]"/>
       <xsl:apply-templates select="." mode="generate-table-header"/>
 
@@ -184,6 +184,28 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="css-class">
     <xsl:apply-templates select="@frame, @expanse, @scale" mode="#current"/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]">
+    <caption>
+      <xsl:apply-templates select="." mode="label"/>
+      <xsl:apply-templates/>
+    </caption>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]" mode="label">
+    <span class="table--title-label">
+      <xsl:apply-templates select="." mode="title-number">
+        <xsl:with-param name="number" as="xs:integer"
+          select="count((key('enumerableByClass', 'topic/table') | key('enumerableByClass', 'topic/simpletable'))            
+                        [. &lt;&lt; current()])"/>
+      </xsl:apply-templates>
+    </span>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]" mode="title-number">
+    <xsl:param name="number" as="xs:integer"/>
+    <xsl:sequence select="concat(dita-ot:get-variable(., 'Table'), ' ', $number, '. ')"/>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' topic/strow ')]" name="topic.strow">

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -566,7 +566,8 @@ See the accompanying LICENSE file for applicable license.
     <span class="table--title-label">
       <xsl:apply-templates select="." mode="title-number">
         <xsl:with-param name="number" as="xs:integer"
-          select="count(key('enumerableByClass', 'topic/table')[. &lt;&lt; current()])"/>
+          select="count((key('enumerableByClass', 'topic/table') | key('enumerableByClass', 'topic/simpletable'))
+                        [. &lt;&lt; current()])"/>
       </xsl:apply-templates>
     </span>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2653,6 +2653,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:key name="enumerableByClass"
     match="*[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |
     *[contains(@class, ' topic/table ')][*[contains(@class, ' topic/title ')]] |
+    *[contains(@class, ' topic/simpletable ')][*[contains(@class, ' topic/title ')]] |
     *[contains(@class,' topic/fn ') and empty(@callout)]"
     use="tokenize(@class, '\s+')"/>
   

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 
 import static org.dita.dost.TestUtils.assertXMLEqual;
 
-public class NormalizeTableFilterTest {
+public class NormalizeSimpleTableFilterTest {
 
     @Test
     public void testNoFilter() throws Exception {
@@ -38,13 +38,14 @@ public class NormalizeTableFilterTest {
 
         final Transformer t = TransformerFactory.newInstance().newTransformer();
         final InputStream src = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
-        final NormalizeTableFilter f = new NormalizeTableFilter();
+        final NormalizeSimpleTableFilter f = new NormalizeSimpleTableFilter();
         f.setParent(XMLUtils.getXMLReader());
         f.setLogger(new TestUtils.TestLogger());
         final SAXSource s = new SAXSource(f, new InputSource(src));
 
         final Document act = db.newDocument();
         t.transform(s, new DOMResult(act));
+
         assertXMLEqual(db.parse(expStream), act);
     }
 

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable " id="tab_foo1">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">foo1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">foo2</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+      </strow>
+    </simpletable>
+    <simpletable class="- topic/simpletable " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
+      </strow>
+    </simpletable>
+    <simpletable class="- topic/simpletable ">
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">3 1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="1">4 1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="1">5 1</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " colspan="2" dita-ot:x="1" dita-ot:y="2">1 2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">3 2</stentry>
+        <stentry class="- topic/stentry " colspan="2" dita-ot:x="4" dita-ot:y="2">4 2</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+        <stentry class="- topic/stentry " colspan="2" rowspan="2" dita-ot:x="3" dita-ot:y="3">3 3</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="3">5 3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="4">1 4</stentry>
+        <stentry class="- topic/stentry " rowspan="2" dita-ot:x="2" dita-ot:y="4">2 4</stentry>
+        <stentry class="- topic/stentry " rowspan="3" dita-ot:x="5" dita-ot:y="4">5 4</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="5" rowspan="2">1 5</stentry>
+        <stentry class="- topic/stentry " colspan="2" dita-ot:x="3" dita-ot:y="5">3 5</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="6">2 6</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="6">3 6</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="6">4 6</stentry>
+      </strow>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="7">1 7</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="7">2 7</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="7">3 7</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="7">4 7</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="7">5 7</stentry>
+      </sthead>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable " id="tab_foo1">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">foo1</stentry>
+        <stentry class="- topic/stentry ">foo2</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e1</stentry>
+        <stentry class="- topic/stentry ">e2</stentry>
+      </strow>
+    </simpletable>
+    <simpletable class="- topic/simpletable " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">s1</stentry>
+        <stentry class="- topic/stentry ">s2</stentry>
+        <stentry class="- topic/stentry ">s3</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e1</stentry>
+        <stentry class="- topic/stentry ">e2</stentry>
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+    </simpletable>
+    <simpletable class="- topic/simpletable ">
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">1 1</stentry>
+        <stentry class="- topic/stentry ">2 1</stentry>
+        <stentry class="- topic/stentry ">3 1</stentry>
+        <stentry class="- topic/stentry ">4 1</stentry>
+        <stentry class="- topic/stentry ">5 1</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " colspan="2">1 2</stentry>
+        <stentry class="- topic/stentry ">3 2</stentry>
+        <stentry class="- topic/stentry " colspan="2">4 2</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">1 3</stentry>
+        <stentry class="- topic/stentry ">2 3</stentry>
+        <stentry class="- topic/stentry " colspan="2" rowspan="2">3 3</stentry>
+        <stentry class="- topic/stentry ">5 3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">1 4</stentry>
+        <stentry class="- topic/stentry " rowspan="2">2 4</stentry>
+        <stentry class="- topic/stentry " rowspan="3">5 4</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " rowspan="2">1 5</stentry>
+        <stentry class="- topic/stentry " colspan="2">3 5</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">2 6</stentry>
+        <stentry class="- topic/stentry ">3 6</stentry>
+        <stentry class="- topic/stentry ">4 6</stentry>
+      </strow>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">1 7</stentry>
+        <stentry class="- topic/stentry ">2 7</stentry>
+        <stentry class="- topic/stentry ">3 7</stentry>
+        <stentry class="- topic/stentry ">4 7</stentry>
+        <stentry class="- topic/stentry ">5 7</stentry>
+      </sthead>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/conref/exp/preprocess/lang-common0.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common0.dita
@@ -130,8 +130,8 @@
           <cmd class="- topic/ph task/cmd ">step 4</cmd>
           <choicetable class="- topic/simpletable task/choicetable " keycol="1">
             <chrow class="- topic/strow task/chrow ">
-              <choption class="- topic/stentry task/choption ">option</choption>
-              <chdesc class="- topic/stentry task/chdesc ">description</chdesc>
+              <choption class="- topic/stentry task/choption " dita-ot:x="1" dita-ot:y="1">option</choption>
+              <chdesc class="- topic/stentry task/chdesc " dita-ot:x="2" dita-ot:y="1">description</chdesc>
             </chrow>
           </choicetable>
         </step>
@@ -149,9 +149,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>

--- a/src/test/resources/conref/exp/preprocess/lang-common1.dita
+++ b/src/test/resources/conref/exp/preprocess/lang-common1.dita
@@ -198,8 +198,8 @@
           <cmd class="- topic/ph task/cmd ">step 4</cmd>
           <choicetable class="- topic/simpletable task/choicetable " keycol="1">
             <chrow class="- topic/strow task/chrow ">
-              <choption class="- topic/stentry task/choption ">option</choption>
-              <chdesc class="- topic/stentry task/chdesc ">description</chdesc>
+              <choption class="- topic/stentry task/choption " dita-ot:x="1" dita-ot:y="1">option</choption>
+              <chdesc class="- topic/stentry task/chdesc " dita-ot:x="2" dita-ot:y="1">description</chdesc>
             </chrow>
           </choicetable>
         </step>
@@ -227,9 +227,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>
@@ -241,9 +241,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>

--- a/src/test/resources/conref/exp/preprocess2/lang-common0.dita
+++ b/src/test/resources/conref/exp/preprocess2/lang-common0.dita
@@ -130,8 +130,8 @@
           <cmd class="- topic/ph task/cmd ">step 4</cmd>
           <choicetable class="- topic/simpletable task/choicetable " keycol="1">
             <chrow class="- topic/strow task/chrow ">
-              <choption class="- topic/stentry task/choption ">option</choption>
-              <chdesc class="- topic/stentry task/chdesc ">description</chdesc>
+              <choption class="- topic/stentry task/choption " dita-ot:x="1" dita-ot:y="1">option</choption>
+              <chdesc class="- topic/stentry task/chdesc " dita-ot:x="2" dita-ot:y="1">description</chdesc>
             </chrow>
           </choicetable>
         </step>
@@ -149,9 +149,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>

--- a/src/test/resources/conref/exp/preprocess2/lang-common1.dita
+++ b/src/test/resources/conref/exp/preprocess2/lang-common1.dita
@@ -124,8 +124,8 @@
           <cmd class="- topic/ph task/cmd ">step 4</cmd>
           <choicetable class="- topic/simpletable task/choicetable " keycol="1">
             <chrow class="- topic/strow task/chrow ">
-              <choption class="- topic/stentry task/choption ">option</choption>
-              <chdesc class="- topic/stentry task/chdesc ">description</chdesc>
+              <choption class="- topic/stentry task/choption " dita-ot:x="1" dita-ot:y="1">option</choption>
+              <chdesc class="- topic/stentry task/chdesc " dita-ot:x="2" dita-ot:y="1">description</chdesc>
             </chrow>
           </choicetable>
         </step>
@@ -149,9 +149,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>
@@ -161,9 +161,9 @@
     <refbody class="- topic/body        reference/refbody ">
       <properties class="- topic/simpletable reference/properties ">
         <property class="- topic/strow       reference/property ">
-          <proptype class="- topic/stentry     reference/proptype ">Type</proptype>
-          <propvalue class="- topic/stentry     reference/propvalue ">Value</propvalue>
-          <propdesc class="- topic/stentry     reference/propdesc ">Description</propdesc>
+          <proptype class="- topic/stentry     reference/proptype " dita-ot:x="1" dita-ot:y="1">Type</proptype>
+          <propvalue class="- topic/stentry     reference/propvalue " dita-ot:x="2" dita-ot:y="1">Value</propvalue>
+          <propdesc class="- topic/stentry     reference/propdesc " dita-ot:x="3" dita-ot:y="1">Description</propdesc>
         </property>
       </properties>
     </refbody>

--- a/src/test/resources/mappull-topicid/exp/preprocess/tables.dita
+++ b/src/test/resources/mappull-topicid/exp/preprocess/tables.dita
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<topic id="table" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" domains="(topic)" class="- topic/topic ">
+<topic id="table" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" domains="(topic)" class="- topic/topic ">
  <title class="- topic/title ">Use the topic ID in the topic</title>
  <body class="- topic/body ">
   <simpletable  class="- topic/simpletable " id="table">
-   <strow  class="- topic/strow "><stentry class="- topic/stentry ">table entry</stentry></strow>
+   <strow  class="- topic/strow "><stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">table entry</stentry></strow>
   </simpletable>
  </body>
 </topic>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
   xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl">
 
@@ -360,8 +359,8 @@
         <x:param name="entry" select="//strow/stentry[1]">
           <simpletable class="- topic/simpletable " keycol="1">
             <strow class="- topic/strow ">
-              <stentry class="- topic/stentry "/>
-              <stentry class="- topic/stentry "/>
+              <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1"/>
+              <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1"/>
             </strow>
           </simpletable>
         </x:param>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -43,4 +43,25 @@
     <xsl:copy-of select="@id"/>
   </xsl:template>
   
+  <xsl:function name="dita-ot:generate-stable-id" as="xs:string">
+    <xsl:param name="element" as="element()"/>
+    
+    <xsl:value-of>
+      <xsl:for-each select="$element/ancestor-or-self::*">
+        <xsl:if test="position() ne 1">_</xsl:if>
+        <xsl:value-of select="name()"/>
+        <xsl:text>-</xsl:text>
+        <xsl:number/>
+      </xsl:for-each>
+    </xsl:value-of>
+    <!--
+    <xsl:variable name="topic" select="$element/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]" as="element()"/>
+    <xsl:variable name="parent-element" select="$element/ancestor-or-self::*[@id][1][not(. is $topic)]" as="element()?"/>
+    <xsl:variable name="closest" select="($parent-element, $topic)[1]" as="element()"/>
+    <xsl:variable name="index" select="count($closest/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
+    
+    <xsl:sequence select="dita-ot:generate-id($topic/@id, string-join(($parent-element/@id, local-name($element), string($index)), $HTML_ID_SEPARATOR))"/>
+    -->
+  </xsl:function>
+  
 </xsl:stylesheet>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+                xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
+                version="2.0"
+                exclude-result-prefixes="xs dita-ot table simpletable">
+  
+  <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/simpletable.xsl"/>
+
+  <xsl:key name="enumerableByClass"
+    match="
+      *[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |
+      *[contains(@class, ' topic/table ')][*[contains(@class, ' topic/title ')]] |
+      *[contains(@class, ' topic/simpletable ')][*[contains(@class, ' topic/title ')]] |
+      *[contains(@class, ' topic/fn ') and empty(@callout)]"
+    use="tokenize(@class, '\s+')"/>
+  
+  <xsl:template name="bidi-area" as="xs:boolean">
+    <xsl:sequence select="false()"/>
+  </xsl:template>
+  
+  <xsl:template name="spec-title">
+    <xsl:if test="@spectitle">
+      <div style="margin-top: 1em;">
+        <strong>
+          <xsl:value-of select="@spectitle"/>
+        </strong>
+      </div>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:function name="dita-ot:get-variable" as="node()*">
+    <xsl:param name="ctx" as="node()"/>
+    <xsl:param name="id" as="xs:string"/>
+    <!--xsl:param name="params" as="node()*"/-->
+    <xsl:value-of select="$id"/>
+  </xsl:function>
+  
+  <xsl:template match="*" mode="table:common">
+    <xsl:copy-of select="@id"/>
+  </xsl:template>
+  
+</xsl:stylesheet>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="simpletable.xsl">
+
+  <x:scenario label="title">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <title class="- topic/title ">foo</title>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has caption">
+      <table>
+        <caption>
+          <span class="table--title-label">Table 1. </span>foo</caption>
+        <colgroup>
+          <col style="width:33.33333333333333%"/>
+          <col style="width:33.33333333333333%"/>
+          <col style="width:33.33333333333333%"/>
+        </colgroup>
+        <tbody>
+          <tr>
+            <td>e1</td>
+            <td>e2</td>
+            <td>e3</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="header">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <table>
+        <colgroup>
+          <col style="width:33.33333333333333%"/>
+          <col style="width:33.33333333333333%"/>
+          <col style="width:33.33333333333333%"/>
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col">s1</th>
+            <th scope="col">s2</th>
+            <th scope="col">s3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>e1</td>
+            <td>e2</td>
+            <td>e3</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="span">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">3 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="1">4 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="1">5 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="1" dita-ot:y="2">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">3 2</stentry>
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="4" dita-ot:y="2">4 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+          <stentry class="- topic/stentry " colspan="2" rowspan="2" dita-ot:x="3" dita-ot:y="3">3 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="3">5 3</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="4">1 4</stentry>
+          <stentry class="- topic/stentry " rowspan="2" dita-ot:x="2" dita-ot:y="4">2 4</stentry>
+          <stentry class="- topic/stentry " rowspan="3" dita-ot:x="5" dita-ot:y="4">5 4</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="5" rowspan="2">1 5</stentry>
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="3" dita-ot:y="5">3 5</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="6">2 6</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="6">3 6</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="6">4 6</stentry>
+        </strow>
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="7">1 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="7">2 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="7">3 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="7">4 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="7">5 7</stentry>
+        </sthead>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <table>
+        <colgroup>
+          <col style="width:20%"/>
+          <col style="width:20%"/>
+          <col style="width:20%"/>
+          <col style="width:20%"/>
+          <col style="width:20%"/>
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col">1 1</th>
+            <th scope="col">2 1</th>
+            <th scope="col">3 1</th>
+            <th scope="col">4 1</th>
+            <th scope="col">5 1</th>
+          </tr>
+        </thead>
+        <thead>
+          <tr>
+            <th scope="col">1 7</th>
+            <th scope="col">2 7</th>
+            <th scope="col">3 7</th>
+            <th scope="col">4 7</th>
+            <th scope="col">5 7</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="2">1 2</td>
+            <td>3 2</td>
+            <td colspan="2">4 2</td>
+          </tr>
+          <tr>
+            <td>1 3</td>
+            <td>2 3</td>
+            <td colspan="2" rowspan="2">3 3</td>
+            <td>5 3</td>
+          </tr>
+          <tr>
+            <td>1 4</td>
+            <td rowspan="2">2 4</td>
+            <td rowspan="3">5 4</td>
+          </tr>
+          <tr>
+            <td rowspan="2">1 5</td>
+            <td colspan="2">3 5</td>
+          </tr>
+          <tr>
+            <td>2 6</td>
+            <td>3 6</td>
+            <td>4 6</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+
+</x:description>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
@@ -59,16 +59,16 @@
         </colgroup>
         <thead>
           <tr>
-            <th scope="col">s1</th>
-            <th scope="col">s2</th>
-            <th scope="col">s3</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-1">s1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-2">s2</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-3">s3</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>e1</td>
-            <td>e2</td>
-            <td>e3</td>
+            <td headers="simpletable-1_sthead-1_stentry-1">e1</td>
+            <td headers="simpletable-1_sthead-1_stentry-2">e2</td>
+            <td headers="simpletable-1_sthead-1_stentry-3">e3</td>
           </tr>
         </tbody>
       </table>
@@ -110,13 +110,13 @@
           <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="6">3 6</stentry>
           <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="6">4 6</stentry>
         </strow>
-        <sthead class="- topic/sthead ">
+        <strow class="- topic/strow ">
           <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="7">1 7</stentry>
           <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="7">2 7</stentry>
           <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="7">3 7</stentry>
           <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="7">4 7</stentry>
           <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="7">5 7</stentry>
-        </sthead>
+        </strow>
       </simpletable>
     </x:context>
     <x:expect label="has thead">
@@ -130,47 +130,98 @@
         </colgroup>
         <thead>
           <tr>
-            <th scope="col">1 1</th>
-            <th scope="col">2 1</th>
-            <th scope="col">3 1</th>
-            <th scope="col">4 1</th>
-            <th scope="col">5 1</th>
-          </tr>
-        </thead>
-        <thead>
-          <tr>
-            <th scope="col">1 7</th>
-            <th scope="col">2 7</th>
-            <th scope="col">3 7</th>
-            <th scope="col">4 7</th>
-            <th scope="col">5 7</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-1">1 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-2">2 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-3">3 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-4">4 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-5">5 1</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td colspan="2">1 2</td>
-            <td>3 2</td>
-            <td colspan="2">4 2</td>
+            <td headers="simpletable-1_sthead-1_stentry-1 simpletable-1_sthead-1_stentry-2" colspan="2">1 2</td>
+            <td headers="simpletable-1_sthead-1_stentry-3">3 2</td>
+            <td headers="simpletable-1_sthead-1_stentry-4 simpletable-1_sthead-1_stentry-5" colspan="2">4 2</td>
           </tr>
           <tr>
-            <td>1 3</td>
-            <td>2 3</td>
-            <td colspan="2" rowspan="2">3 3</td>
-            <td>5 3</td>
+            <td headers="simpletable-1_sthead-1_stentry-1">1 3</td>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 3</td>
+            <td headers="simpletable-1_sthead-1_stentry-3 simpletable-1_sthead-1_stentry-4" colspan="2" rowspan="2">3 3</td>
+            <td headers="simpletable-1_sthead-1_stentry-5">5 3</td>
           </tr>
           <tr>
-            <td>1 4</td>
-            <td rowspan="2">2 4</td>
-            <td rowspan="3">5 4</td>
+            <td headers="simpletable-1_sthead-1_stentry-1">1 4</td>
+            <td headers="simpletable-1_sthead-1_stentry-2" rowspan="2">2 4</td>
+            <td headers="simpletable-1_sthead-1_stentry-5" rowspan="3">5 4</td>
           </tr>
           <tr>
-            <td rowspan="2">1 5</td>
-            <td colspan="2">3 5</td>
+            <td headers="simpletable-1_sthead-1_stentry-1" rowspan="2">1 5</td>
+            <td headers="simpletable-1_sthead-1_stentry-3 simpletable-1_sthead-1_stentry-4" colspan="2">3 5</td>
           </tr>
           <tr>
-            <td>2 6</td>
-            <td>3 6</td>
-            <td>4 6</td>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 6</td>
+            <td headers="simpletable-1_sthead-1_stentry-3">3 6</td>
+            <td headers="simpletable-1_sthead-1_stentry-4">4 6</td>
+          </tr>
+          <tr>
+            <td headers="simpletable-1_sthead-1_stentry-1">1 7</td>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 7</td>
+            <td headers="simpletable-1_sthead-1_stentry-3">3 7</td>
+            <td headers="simpletable-1_sthead-1_stentry-4">4 7</td>
+            <td headers="simpletable-1_sthead-1_stentry-5">5 7</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
+  
+  <x:scenario label="headers">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1" id="id1">s1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1" id="id2">s2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="1">s4</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2" headers="id1">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2" headers="id2">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2" headers="id3">e3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="2" headers="id3">e4</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3" colspan="2" headers="id1 id2">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="3" colspan="2">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <table>
+        <colgroup>
+          <col style="width:25%"/>
+          <col style="width:25%"/>
+          <col style="width:25%"/>
+          <col style="width:25%"/>
+        </colgroup>
+        <thead>
+          <tr>
+            <th id="id1" scope="col">s1</th>
+            <th id="id2" scope="col">s2</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-3">s3</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-4">s4</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td headers="id1">e1</td>
+            <td headers="id2">e2</td>
+            <td headers="simpletable-1_sthead-1_stentry-3">e3</td>
+            <td headers="simpletable-1_sthead-1_stentry-4">e4</td>
+          </tr>
+          <tr>
+            <td colspan="2" headers="id1 id2">e1</td>
+            <td colspan="2" headers="simpletable-1_sthead-1_stentry-3 simpletable-1_sthead-1_stentry-4">e3</td>
           </tr>
         </tbody>
       </table>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec
@@ -174,7 +174,7 @@
       </table>
     </x:expect>
   </x:scenario>
-  
+
   <x:scenario label="headers">
     <x:context select="/simpletable">
       <simpletable class="- topic/simpletable ">
@@ -228,5 +228,90 @@
     </x:expect>
   </x:scenario>
 
+  <x:scenario label="keycol">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable " keycol="1">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">2 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has th column">
+      <table>
+        <colgroup>
+          <col style="width:50%"/>
+          <col style="width:50%"/>
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-1">1 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-2">2 1</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row" headers="simpletable-1_sthead-1_stentry-1">1 2</th>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 2</td>
+          </tr>
+          <tr>
+            <th scope="row" headers="simpletable-1_sthead-1_stentry-1">1 3</th>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 3</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="scope">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2" scope="row">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">2 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has th column">
+      <table>
+        <colgroup>
+          <col style="width:50%"/>
+          <col style="width:50%"/>
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-1">1 1</th>
+            <th scope="col" id="simpletable-1_sthead-1_stentry-2">2 1</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row" headers="simpletable-1_sthead-1_stentry-1">1 2</th>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 2</td>
+          </tr>
+          <tr>
+            <td headers="simpletable-1_sthead-1_stentry-1">1 3</td>
+            <td headers="simpletable-1_sthead-1_stentry-2">2 3</td>
+          </tr>
+        </tbody>
+      </table>
+    </x:expect>
+  </x:scenario>
 
 </x:description>


### PR DESCRIPTION
Per https://github.com/oasis-tcs/dita/issues/292 add support to HTML5:

- [x] add `<title>` as the first element of `<simpletable>`
- [x] add `@colspan` and `@rowspan` attributes to `<stentry>`
- [x] add `@headers` and `@scope` to `<stentry>`