### PR TITLE
preserve dita domains via option

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -185,6 +185,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl"/>
         <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl"/>
         <param name="PRESERVE-DITA-CLASS" expression="${args.html5.classattr}" if:set="args.html5.classattr"/>
+        <param name="PRESERVE-DITA-DOMAIN" expression="${args.html5.domainattr}" if:set="args.html5.domainattr"/>
         <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
         <param name="include.rellinks" expression="${include.rellinks}"/>
         <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow"/>

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -42,6 +42,10 @@ See the accompanying LICENSE file for applicable license.
       <val default="true">yes</val>
       <val>no</val>
     </param>
+    <param name="args.html5.domainattr" desc="Specifies whether to include the DITA domain/class ancestry inside the HTML5 elements." type="enum">
+      <val>yes</val>
+      <val default="true">no</val>
+    </param>
     <param name="args.html5.contenttarget" desc="Specifies the value of the @target attribute on the &lt;base&gt; element in the TOC file." type="string">
       <val default="true">contentwin</val>
     </param>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -27,6 +27,9 @@ See the accompanying LICENSE file for applicable license.
   <!-- Preserve DITA class ancestry in XHTML output; values are 'yes' or 'no' -->
   <xsl:param name="PRESERVE-DITA-CLASS" select="'yes'"/>
   
+  <!-- Preserve DITA domain/class ancestry in XHTML output; values are 'yes' or 'no' -->
+  <xsl:param name="PRESERVE-DITA-DOMAIN" select="'no'"/>
+ 
   <!-- the file name containing XHTML to be placed in the HEAD area
        (file name and extension only - no path). -->
   <xsl:param name="HDF"/>
@@ -1780,6 +1783,15 @@ See the accompanying LICENSE file for applicable license.
         </xsl:value-of>
       </xsl:if>
     </xsl:variable>
+    <xsl:variable name="domainancestry" as="xs:string?">
+      <xsl:if test="$PRESERVE-DITA-DOMAIN = 'yes'">
+        <xsl:value-of>
+          <xsl:apply-templates select="." mode="get-element-ancestry">
+            <xsl:with-param name="includedomain" select="'yes'"/>
+          </xsl:apply-templates>
+        </xsl:value-of>
+      </xsl:if>
+    </xsl:variable>
     <xsl:variable name="outputclass-attribute" as="xs:string">
       <xsl:value-of>
         <xsl:apply-templates select="@outputclass" mode="get-value-for-class"/>
@@ -1789,6 +1801,7 @@ See the accompanying LICENSE file for applicable license.
          combine user output class with element default, giving priority to the user value. -->
     <xsl:variable name="classes" as="xs:string*"
                   select="tokenize($ancestry, '\s+'),
+                          tokenize($domainancestry, '/s+'),
                           $using-output-class,
                           $draft-revs, 
                           tokenize($outputclass-attribute, '\s+')"/>
@@ -1813,6 +1826,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Get the ancestry of the current element (name only, not module) -->
   <xsl:template match="*" mode="get-element-ancestry">
     <xsl:param name="checkclass" select="@class"/>
+    <xsl:param name="includedomain" select="'no'"/>
     <xsl:if test="contains($checkclass, '/')">
       <xsl:variable name="lastpair">
         <xsl:call-template name="get-last-class-pair">
@@ -1823,10 +1837,18 @@ See the accompanying LICENSE file for applicable license.
       <xsl:if test="contains(substring-before($checkclass, $lastpair), '/')">
         <xsl:apply-templates select="." mode="get-element-ancestry">
           <xsl:with-param name="checkclass" select="substring-before($checkclass, $lastpair)"/>
+          <xsl:with-param name="includedomain" select="$includedomain"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
       </xsl:if>
-      <xsl:value-of select="substring-after($lastpair, '/')"/>
+      <xsl:choose>
+        <xsl:when test="$includedomain='no'">
+          <xsl:value-of select="substring-after($lastpair, '/')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$lastpair"/>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -140,6 +140,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
         <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
         <param name="PRESERVE-DITA-CLASS" expression="${args.xhtml.classattr}" if:set="args.xhtml.classattr"/>
+        <param name="PRESERVE-DITA-DOMAIN" expression="${args.xhtml.domainattr}" if:set="args.xhtml.domainattr"/>
         <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
         <param name="include.rellinks" expression="${include.rellinks}"/>
         <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />


### PR DESCRIPTION
## Description
This pull request adds new arguments to the HTML5 and XHTML transformations that preserve the full domain-qualified class values ($domain/$element) in the output \@class attribute values.

- existing arguments (on by default)
    - args.html5.classattr
    - args.xhtml.classattr
- new arguments (OFF by default)
    - args.html5.domainattr
    - args.xhtml.domainattr

For example,

```
<strong class="ph b topic/ph hi-d/b">This is bold.</strong>
```

The controls are independent and can be enabled/disabled in any combination.

## Motivation and Context
Oxygen XML Author uses domain-qualified CSS selectors. Preserving domain-qualified @class values in the output allows better CSS reuse between the editing and output environments.

## How Has This Been Tested?
I ran the following commands:

```
./gradlew
./gradlew test
./gradlew integrationTest
```

then ran manual tests to confirm the functionality.

## Type of Changes
A new Boolean $includedomain parameter is added to the get-element-ancestry templates that allow it to return results that are/are not domain-qualified. This is then called conditionally based on the value of both the "classattr" and "domainattr" arguments.

## Documentation and Compatibility
When creating this change, I converted the XHTML string-appending @class attribute construction to the newer tokenization-based approach used by HTML5. However, this causes some integrationTest failures due to duplicate class values being uniquified:

```
Caused by: java.lang.AssertionError: Expected attribute value 'ph cmd ph' but was 'ph cmd'
```

I think the tokenized behavior is better, but I don't know enough to update the tests accordingly.