### PR TITLE
Move from JAXP to S9API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile group: 'xerces', name: 'xercesImpl', version:'2.12.0'
     compile group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     compile group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
-    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.9.1-4'
+    compile group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.9.1-7'
     compile group: 'com.ibm.icu', name: 'icu4j', version:'61.1'
     compile group: 'org.apache.ant', name: 'ant', version:'1.10.6'
     compile group: 'org.apache.ant', name: 'ant-launcher', version:'1.10.6'

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -29,9 +29,6 @@ import org.xml.sax.XMLFilter;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -42,7 +39,8 @@ import static java.util.Collections.singletonList;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.StringUtils.getExtProps;
 import static org.dita.dost.util.StringUtils.getExtPropsFromSpecializations;
-import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.toURI;
 import static org.dita.dost.util.XMLUtils.*;
 
 /**
@@ -147,23 +145,11 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         filterTopics(doc.getDocumentElement(), Collections.emptyList());
 
         logger.debug("Writing " + currentFile);
-        Result result = null;
+
         try {
-            Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            result = new StreamResult(currentFile.toString());
-            serializer.transform(new DOMSource(doc), result);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final TransformerConfigurationException | TransformerFactoryConfigurationError e) {
-            throw new RuntimeException(e);
-        } catch (final TransformerException e) {
-            logger.error("Failed to serialize " + map.toString() + ": " + e.getMessageAndLocation(), e);
-        } finally {
-            try {
-                close(result);
-            } catch (final IOException e) {
-                logger.error("Failed to close result stream for " + map.toString() + ": " + e.getMessage(), e);
-            }
+            xmlUtils.writeDocument(doc, currentFile);
+        } catch (final IOException e) {
+            logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -9,6 +9,7 @@
 package org.dita.dost.module;
 
 import com.google.common.annotations.VisibleForTesting;
+import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.commons.io.FileUtils;
 import org.apache.xml.resolver.tools.CatalogResolver;
@@ -31,12 +32,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -47,6 +46,7 @@ import java.util.stream.IntStream;
 import static java.util.Collections.emptyMap;
 import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
 import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITAMAP;
+import static org.dita.dost.util.XMLUtils.toErrorListener;
 
 /**
  * Move temporary files not based on output URI to match output URI structure.
@@ -62,7 +62,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     private final XMLUtils xmlUtils = new XMLUtils();
 
     private boolean useResultFilename;
-    private Transformer rewriteTransformer;
+    private XsltTransformer rewriteTransformer;
     private RewriteRule rewriteClass;
 
     @Override
@@ -75,17 +75,27 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
         useResultFilename = Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME))
                 .map(Boolean::parseBoolean)
                 .orElse(false);
+        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
         rewriteTransformer = Optional.ofNullable(input.get("result.rewrite-rule.xsl"))
-                .map(file -> URLUtils.toURI(file).toString())
+                .map(file -> {
+                    try {
+                        return catalogResolver.resolve(URLUtils.toURI(file).toString(), null);
+                    } catch (TransformerException e) {
+                        throw new RuntimeException(e.getMessage(), e);
+                    }
+                })
                 .map(f -> {
                     try {
-                        final TransformerFactory factory = TransformerFactory.newInstance();
-                        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
-                        factory.setURIResolver(catalogResolver);
-                        return factory.newTransformer(catalogResolver.resolve(f, null));
+                        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
+                        config.setURIResolver(catalogResolver);
+                        final Processor processor = new Processor(config);
+                        final XsltCompiler xsltCompiler = processor.newXsltCompiler();
+                        xsltCompiler.setErrorListener(toErrorListener(logger));
+                        final XsltExecutable xsltExecutable = xsltCompiler.compile(new StreamSource(f.toString()));
+                        return xsltExecutable.load();
                     } catch (UncheckedXPathException e) {
                         throw new RuntimeException("Failed to compile XSLT: " + e.getXPathException().getMessageAndLocation(), e);
-                    } catch (TransformerException e) {
+                    } catch (SaxonApiException e) {
                         throw new RuntimeException("Failed to compile XSLT: " + e.getMessage(), e);
                     }
                 })
@@ -183,10 +193,12 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
             try {
                 final DOMSource source = new DOMSource(serialize(fis));
                 final Map<URI, FileInfo> files = new HashMap<>();
-                final SAXResult result = new SAXResult(new Job.JobHandler(new HashMap<>(), files));
-                rewriteTransformer.transform(source, result);
+                final Destination result = new SAXDestination(new Job.JobHandler(new HashMap<>(), files));
+                rewriteTransformer.setSource(source);
+                rewriteTransformer.setDestination(result);
+                rewriteTransformer.transform();
                 return files.values();
-            } catch (IOException | TransformerException e) {
+            } catch (IOException | SaxonApiException e) {
                 throw new DITAOTException(e);
             }
         }

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -86,9 +86,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
                 })
                 .map(f -> {
                     try {
-                        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
-                        config.setURIResolver(catalogResolver);
-                        final Processor processor = new Processor(config);
+                        final Processor processor = xmlUtils.getProcessor();
                         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
                         xsltCompiler.setErrorListener(toErrorListener(logger));
                         final XsltExecutable xsltExecutable = xsltCompiler.compile(new StreamSource(f.toString()));

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -8,9 +8,7 @@
  */
 package org.dita.dost.module;
 
-import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -489,15 +487,8 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             throw new DITAOTException("Failed to make directory " + p.getAbsolutePath());
         }
         try {
-            final Serializer serializer = processor.newSerializer(filename);
-            final XdmNode source = processor.newDocumentBuilder().wrap(root);
-            serializer.serializeNode(source);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final SaxonApiException e) {
-            logger.error(e.getMessage(), e) ;
-            throw new DITAOTException(e);
-        } catch (final Exception e) {
+            xmlUtils.writeDocument(root, filename.toURI());
+        } catch (final IOException e) {
             logger.error(e.getMessage(), e) ;
             throw new DITAOTException(e);
         }

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -487,7 +487,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             throw new DITAOTException("Failed to make directory " + p.getAbsolutePath());
         }
         try {
-            xmlUtils.writeDocument(root, filename.toURI());
+            xmlUtils.writeDocument(root, filename);
         } catch (final IOException e) {
             logger.error(e.getMessage(), e) ;
             throw new DITAOTException(e);

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -8,34 +8,9 @@
  */
 package org.dita.dost.module;
 
-import static org.dita.dost.reader.GenListModuleReader.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.getRelativePath;
-import static org.dita.dost.util.FileUtils.resolve;
-import static org.dita.dost.util.Job.*;
-import static org.dita.dost.util.Configuration.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.FilterUtils.*;
-import static org.dita.dost.util.XMLUtils.*;
-
-import java.io.*;
-import java.net.URI;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.Result;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
-import javax.xml.transform.stream.StreamResult;
-
-import net.sf.saxon.trans.UncheckedXPathException;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -51,6 +26,28 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.*;
 import org.xml.sax.ext.LexicalHandler;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.dita.dost.reader.GenListModuleReader.ROOT_URI;
+import static org.dita.dost.reader.GenListModuleReader.isFormatDita;
+import static org.dita.dost.util.Configuration.Mode;
+import static org.dita.dost.util.Configuration.printTranstype;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.getRelativePath;
+import static org.dita.dost.util.FileUtils.resolve;
+import static org.dita.dost.util.FilterUtils.SUBJECT_SCHEME_EXTENSION;
+import static org.dita.dost.util.Job.FileInfo;
+import static org.dita.dost.util.URLUtils.exists;
+import static org.dita.dost.util.URLUtils.toFile;
+import static org.dita.dost.util.XMLUtils.close;
 
 
 /**
@@ -152,13 +149,8 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         }
 
         InputSource in = null;
-        Result out = null;
         try {
             reader.setErrorHandler(new DITAOTXMLErrorHandler(currentFile.toString(), logger));
-
-            final TransformerFactory tf = TransformerFactory.newInstance();
-            final SAXTransformerFactory stf = (SAXTransformerFactory) tf;
-            final TransformerHandler serializer = stf.newTransformerHandler();
 
             XMLReader parser = getXmlReader(f.format);
             XMLReader xmlSource = parser;
@@ -177,20 +169,16 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             } catch (final SAXNotRecognizedException e) {}
 
             in = new InputSource(f.src.toString());
-            out = new StreamResult(new FileOutputStream(outputFile));
-            serializer.setResult(out);
-            xmlSource.setContentHandler(serializer);
-            xmlSource.parse(new InputSource(f.src.toString()));
+
+            final Serializer result = processor.newSerializer(outputFile);
+
+            xmlSource.setContentHandler(result.getContentHandler());
+            xmlSource.parse(in);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
             logger.error(e.getMessage(), e) ;
         } finally {
-            try {
-                close(out);
-            } catch (final Exception e) {
-                logger.error(e.getMessage(), e) ;
-            }
             try {
                 close(in);
             } catch (final IOException e) {
@@ -204,6 +192,8 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     }
 
     private void init() throws IOException, DITAOTException, SAXException {
+        initXmlReader();
+
         // Output subject schemas
         outputSubjectScheme();
         subjectSchemeReader = new SubjectSchemeReader();
@@ -224,8 +214,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             }
             baseFilterUtils.setLogger(logger);
         }
-
-        initXmlReader();
 
         initFilters();
     }
@@ -500,29 +488,18 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         if (!p.exists() && !p.mkdirs()) {
             throw new DITAOTException("Failed to make directory " + p.getAbsolutePath());
         }
-        Result res = null;
         try {
-            res = new StreamResult(new FileOutputStream(filename));
-            final DOMSource ds = new DOMSource(root);
-            final TransformerFactory tff = TransformerFactory.newInstance();
-            final Transformer tf = tff.newTransformer();
-            tf.transform(ds, res);
-        } catch (final UncheckedXPathException e) {
-            logger.error(e.getXPathException().getMessageAndLocation());
+            final Serializer serializer = processor.newSerializer(filename);
+            final XdmNode source = processor.newDocumentBuilder().wrap(root);
+            serializer.serializeNode(source);
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final TransformerException e) {
-            logger.error(e.getMessageAndLocation(), e) ;
+        } catch (final SaxonApiException e) {
+            logger.error(e.getMessage(), e) ;
             throw new DITAOTException(e);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e) ;
             throw new DITAOTException(e);
-        } finally {
-            try {
-                close(res);
-            } catch (IOException e) {
-                throw new DITAOTException(e);
-            }
         }
     }
 

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -157,6 +157,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
      * Create a new instance and do the initialization.
      */
     public GenMapAndTopicListModule() {
+        super();
         fullTopicSet = new HashSet<>(128);
         fullMapSet = new HashSet<>(128);
         hrefTopicSet = new HashSet<>(128);

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -8,7 +8,6 @@
  */
 package org.dita.dost.module;
 
-import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -26,9 +25,6 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLFilter;
 
-import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -447,23 +443,10 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     }
 
     private void writeMap(final FileInfo in, final Document doc) throws DITAOTException {
-        Result out = null;
         try {
-            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            out = new StreamResult(job.tempDirURI.resolve(in.uri).toString());
-            serializer.transform(new DOMSource(doc), out);
-        } catch (final UncheckedXPathException e) {
-            throw new DITAOTException("Failed to write map", e);
-        } catch (final TransformerConfigurationException e) {
-            throw new RuntimeException(e);
-        } catch (final TransformerException e) {
-            throw new DITAOTException("Failed to write map: " + e.getMessageAndLocation(), e);
-        } finally {
-            try {
-                close(out);
-            } catch (IOException e) {
-                logger.error("Failed to close result: " + e.getMessage(), e);
-            }
+            xmlUtils.writeDocument(doc, job.tempDirURI.resolve(in.uri));
+        } catch (final IOException e) {
+            throw new DITAOTException("Failed to write map: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -444,7 +444,8 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
     private void writeMap(final FileInfo in, final Document doc) throws DITAOTException {
         try {
-            xmlUtils.writeDocument(doc, job.tempDirURI.resolve(in.uri));
+            final URI file = job.tempDirURI.resolve(in.uri);
+            xmlUtils.writeDocument(doc, file);
         } catch (final IOException e) {
             throw new DITAOTException("Failed to write map: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -8,9 +8,8 @@
 package org.dita.dost.module;
 
 import com.google.common.io.Files;
-import net.sf.saxon.trans.UncheckedXPathException;
-import net.sf.saxon.lib.StandardErrorListener;
 import net.sf.saxon.s9api.*;
+import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -30,7 +29,6 @@ import java.util.List;
 import static org.dita.dost.reader.GenListModuleReader.KEYREF_ATTRS;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.XMLUtils.toErrorListener;
-import static org.dita.dost.util.XMLUtils.toSaxonLogger;
 
 /**
  * Recursively inline map references in maps.
@@ -43,13 +41,10 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     private XsltExecutable templates;
 
     private void init(final AbstractPipelineInput input) {
-        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
-        config.setURIResolver(CatalogUtils.getCatalogResolver());
-        processor = new Processor(config);
+        final XMLUtils xmlUtils = new XMLUtils();
+        processor = xmlUtils.getProcessor();
         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
-        final StandardErrorListener listener = new StandardErrorListener();
-        listener.setLogger(toSaxonLogger(logger));
-        xsltCompiler.setErrorListener(listener);
+        xsltCompiler.setErrorListener(toErrorListener(logger));
         final File style = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_STYLE));
         try {
             templates = xsltCompiler.compile(new StreamSource(style));

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -22,7 +22,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.util.Collection;
@@ -42,15 +41,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
 
     private Processor processor;
     private XsltExecutable templates;
-//    private XsltExecutable serializer;
 
     private void init(final AbstractPipelineInput input) {
-//        final File styleFile = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_STYLE));
-//        try {
-//            templates = transformerFactory.newTemplates(new StreamSource(styleFile));
-//            serializer = transformerFactory.newTransformer();
-//        } catch (TransformerConfigurationException e) {
-//            throw new RuntimeException("Failed to compile " + styleFile + ": " + e.getMessageAndLocation(), e);
         final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
         config.setURIResolver(CatalogUtils.getCatalogResolver());
         processor = new Processor(config);
@@ -61,7 +53,6 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
         final File style = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_STYLE));
         try {
             templates = xsltCompiler.compile(new StreamSource(style));
-//            serializer = xsltCompiler. transformerFactory.newTransformer();
         } catch (SaxonApiException e) {
             throw new RuntimeException("Failed to compile stylesheet '" + style.getAbsolutePath() + "': " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -8,13 +8,11 @@
  */
 package org.dita.dost.module;
 
-import net.sf.saxon.lib.StandardErrorListener;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.DitaLinksWriter;
@@ -32,7 +30,7 @@ import java.util.Map;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.*;
+import static org.dita.dost.util.XMLUtils.toErrorListener;
 
 /**
  * MoveLinksModule implements move links step in preprocess. It reads the map links

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -8,6 +8,8 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.lib.StandardErrorListener;
+import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -22,19 +24,15 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.*;
+import java.io.File;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.withLogger;
+import static org.dita.dost.util.XMLUtils.*;
 
 /**
  * MoveLinksModule implements move links step in preprocess. It reads the map links
@@ -59,38 +57,33 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
         final File styleFile = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_STYLE));
 
         Document doc;
-        InputStream in = null;
         try {
-            doc = XMLUtils.getDocumentBuilder().newDocument();
-            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setURIResolver(CatalogUtils.getCatalogResolver());
-            final Transformer transformer = withLogger(transformerFactory.newTransformer(new StreamSource(styleFile)), logger);
-            transformer.setURIResolver(CatalogUtils.getCatalogResolver());
+            final XsltCompiler xsltCompiler = new XMLUtils().getProcessor().newXsltCompiler();
+
+            final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
+            transformer.setErrorListener(toErrorListener(logger));
             if (input.getAttribute("include.rellinks") != null) {
-                transformer.setParameter("include.rellinks", input.getAttribute("include.rellinks"));
+                transformer.setParameter(new QName("include.rellinks"),
+                        XdmItem.makeValue(input.getAttribute("include.rellinks")));
             }
-            transformer.setParameter("INPUTMAP", job.getInputMap());
-            in = new BufferedInputStream(new FileInputStream(inputFile));
-            final Source source = new StreamSource(in);
-            source.setSystemId(inputFile.toURI().toString());
-            final DOMResult result = new DOMResult(doc);
-            transformer.transform(source, result);
+            transformer.setParameter(new QName("INPUTMAP"), XdmItem.makeValue(job.getInputMap()));
+
+            final Source source = new StreamSource(inputFile);
+            doc = XMLUtils.getDocumentBuilder().newDocument();
+            final DOMDestination result = new DOMDestination(doc);
+
+            transformer.setSource(source);
+            transformer.setDestination(result);
+
+            transformer.transform();
         } catch (final UncheckedXPathException e) {
             throw new DITAOTException("Failed to read links from " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final TransformerException e) {
-            throw new DITAOTException("Failed to read links from " + inputFile + ": " + e.getMessageAndLocation(), e);
+        } catch (final SaxonApiException e) {
+            throw new DITAOTException("Failed to read links from " + inputFile + ": " + e.getMessage(), e);
         } catch (final Exception e) {
             throw new DITAOTException("Failed to read links from " + inputFile + ": " + e.getMessage(), e);
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (final IOException e) {
-                    logger.error("Failed to close input stream: " + e.getMessage(), e);
-                }
-            }
         }
 
         final Map<File, Map<String, Element>> mapSet = getMapping(doc);

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -10,6 +10,7 @@ package org.dita.dost.module;
 import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xml.resolver.tools.CatalogResolver;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
@@ -36,6 +37,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
 
     private static final String FEATURE_GRAMMAR_POOL = "http://apache.org/xml/properties/internal/grammar-pool";
 
+    final XMLUtils xmlUtils;
     /**
      * XMLReader instance for parsing dita file
      */
@@ -53,6 +55,16 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
      */
     File ditaDir;
     Processor processor;
+
+    public SourceReaderModule() {
+        xmlUtils = new XMLUtils();
+    }
+
+    @Override
+    public void setLogger(final DITAOTLogger logger) {
+        super.setLogger(logger);
+        xmlUtils.setLogger(logger);
+    }
 
     /**
      * Get reader for input format

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -7,7 +7,9 @@
  */
 package org.dita.dost.module;
 
+import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
+import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
@@ -50,6 +52,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
      * Absolute DITA-OT base path.
      */
     File ditaDir;
+    Processor processor;
 
     /**
      * Get reader for input format
@@ -125,7 +128,12 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
         }
 
         CatalogUtils.setDitaDir(ditaDir);
-        reader.setEntityResolver(CatalogUtils.getCatalogResolver());
+        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+        reader.setEntityResolver(catalogResolver);
+
+        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
+        config.setURIResolver(catalogResolver);
+        processor = new Processor(config);
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -143,9 +143,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
         final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
         reader.setEntityResolver(catalogResolver);
 
-        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
-        config.setURIResolver(catalogResolver);
-        processor = new Processor(config);
+        processor = xmlUtils.getProcessor();
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -23,17 +23,17 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.XMLUtils.*;
+import static org.dita.dost.util.XMLUtils.getChildElements;
 
 /**
  * Branch filter module for topics.
@@ -109,21 +109,10 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
         filterTopics(doc.getDocumentElement(), Collections.emptyList(), subjectSchemeMap);
 
         logger.debug("Writing " + currentFile);
-        Result result = null;
         try {
-            Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            result = new StreamResult(currentFile.toString());
-            serializer.transform(new DOMSource(doc), result);
-        } catch (final TransformerConfigurationException | TransformerFactoryConfigurationError e) {
-            throw new RuntimeException(e);
-        } catch (final TransformerException e) {
-            logger.error("Failed to serialize " + map.toString() + ": " + e.getMessageAndLocation(), e);
-        } finally {
-            try {
-                close(result);
-            } catch (final IOException e) {
-                logger.error("Failed to close result stream for " + map.toString() + ": " + e.getMessage(), e);
-            }
+            xmlUtils.writeDocument(doc, currentFile);
+        } catch (final IOException e) {
+            logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -9,7 +9,6 @@
 package org.dita.dost.platform;
 
 import net.sf.saxon.trans.UncheckedXPathException;
-import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.Attributes;

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -30,17 +30,11 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
 import java.util.Map.Entry;
@@ -815,9 +809,8 @@ public final class Integrator {
         final File plugins = new File(ditaDir, CONFIG_DIR + File.separator + "plugins.xml");
         logger.debug("Writing " + plugins);
         try {
-            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            serializer.transform(new DOMSource(pluginsDoc), new StreamResult(plugins));
-        } catch (final TransformerConfigurationException e) {
+            new XMLUtils().writeDocument(pluginsDoc, plugins);
+        } catch (final IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -8,7 +8,6 @@
  */
 package org.dita.dost.reader;
 
-import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.ChunkModule.ChunkFilenameGenerator;
@@ -26,12 +25,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.Result;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -287,25 +287,10 @@ public final class ChunkMapReader extends AbstractDomFilter {
     }
 
     private void outputMapFile(final URI file, final Document doc) {
-        Result result = null;
         try {
-            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            result = new StreamResult(new FileOutputStream(new File(file)));
-            serializer.transform(new DOMSource(doc), result);
-        } catch (final UncheckedXPathException e) {
-            logger.error(e.getXPathException().getMessageAndLocation(), e);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final TransformerException e) {
-            logger.error(e.getMessageAndLocation(), e);
-        } catch (final Exception e) {
+            xmlUtils.writeDocument(doc, file);
+        } catch (final IOException e) {
             logger.error(e.getMessage(), e);
-        } finally {
-            try {
-                close(result);
-            } catch (final IOException e) {
-                logger.error(e.getMessage(), e);
-            }
         }
     }
 

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -8,25 +8,21 @@
  */
 package org.dita.dost.reader;
 
-import static java.util.Arrays.asList;
-import static org.dita.dost.module.GenMapAndTopicListModule.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.URLUtils;
+import org.dita.dost.util.XMLUtils;
+import org.dita.dost.writer.AbstractDomFilter;
+import org.w3c.dom.*;
 
 import java.io.File;
 import java.net.URI;
 import java.util.*;
 import java.util.Map.Entry;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLUtils;
-import org.dita.dost.writer.AbstractDomFilter;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+import static java.util.Arrays.asList;
+import static org.dita.dost.module.GenMapAndTopicListModule.ELEMENT_STUB;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.stripFragment;
 
 /**
  * Cascade map metadata to child topic references and collect metadata for topics.

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -29,6 +29,7 @@ import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.event.ProxyReceiver;
 import net.sf.saxon.jaxp.TransformerImpl;
 import net.sf.saxon.serialize.Emitter;
+import net.sf.saxon.lib.Logger;
 import net.sf.saxon.serialize.MessageWarner;
 import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
@@ -107,6 +108,33 @@ public final class XMLUtils {
             });
         }
         return transformer;
+    }
+
+    public static Logger toSaxonLogger(final DITAOTLogger logger) {
+        return new Logger() {
+            @Override
+            public void println(String message, int severity) {
+                switch(severity) {
+                    case Logger.INFO:
+                        logger.info(message);
+                        break;
+                    case Logger.WARNING:
+                        logger.warn(message);
+                        break;
+                    case Logger.ERROR:
+                        logger.error(message);
+                        break;
+                    case Logger.DISASTER:
+                        throw new RuntimeException(message);
+                    default:
+                        throw new IllegalArgumentException();
+                }
+            }
+            @Override
+            public StreamResult asStreamResult() {
+                return null;
+            }
+        };
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -28,6 +28,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import net.sf.saxon.event.ProxyReceiver;
 import net.sf.saxon.jaxp.TransformerImpl;
+import net.sf.saxon.lib.StandardErrorListener;
 import net.sf.saxon.serialize.Emitter;
 import net.sf.saxon.lib.Logger;
 import net.sf.saxon.serialize.MessageWarner;
@@ -108,6 +109,12 @@ public final class XMLUtils {
             });
         }
         return transformer;
+    }
+
+    public static ErrorListener toErrorListener(final DITAOTLogger logger) {
+        final StandardErrorListener listener = new StandardErrorListener();
+        listener.setLogger(toSaxonLogger(logger));
+        return listener;
     }
 
     public static Logger toSaxonLogger(final DITAOTLogger logger) {

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -774,17 +774,28 @@ public final class XMLUtils {
      * Write DOM document to file.
      *
      * @param doc document to store
-     * @param dst absolute destination file URI
+     * @param dst absolute destination file
      * @throws IOException if serializing file fails
      */
-    public void writeDocument(final Document doc, final URI dst) throws IOException {
+    public void writeDocument(final Document doc, final File dst) throws IOException {
         try {
-            final Serializer serializer = processor.newSerializer(new File(dst));
+            final Serializer serializer = processor.newSerializer(dst);
             final XdmNode source = processor.newDocumentBuilder().wrap(doc);
             serializer.serializeNode(source);
         } catch (SaxonApiException e) {
             throw new IOException(e);
         }
+    }
+
+    /**
+     * Write DOM document to file.
+     *
+     * @param doc document to store
+     * @param dst absolute destination file URI
+     * @throws IOException if serializing file fails
+     */
+    public void writeDocument(final Document doc, final URI dst) throws IOException {
+        writeDocument(doc, new File(dst));
     }
 
     /**
@@ -802,6 +813,13 @@ public final class XMLUtils {
         } catch (SaxonApiException e) {
             throw new IOException(e);
         }
+    }
+
+    /**
+     * Get common S9API processor.
+     */
+    public Processor getProcessor() {
+        return processor;
     }
 
     /**

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -53,7 +53,7 @@ public abstract class AbstractDomFilter implements AbstractReader {
         if (resDoc != null) {
             try {
                 logger.debug("Writing " + filename.toURI());
-                xmlUtils.writeDocument(resDoc, filename.toURI());
+                xmlUtils.writeDocument(resDoc, filename);
             } catch (final IOException e) {
                 throw new DITAOTException("Failed to serialize " + filename.getAbsolutePath() + ": " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
@@ -9,37 +9,17 @@
 package org.dita.dost.writer.include;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.exception.DITAOTXMLErrorHandler;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.Configuration;
-import org.dita.dost.util.Job;
 import org.dita.dost.writer.AbstractXMLFilter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.sax.SAXResult;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.dita.dost.util.CatalogUtils.getCatalogResolver;
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.getDocumentBuilder;
+import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Include element resolver filter.

--- a/src/main/java/org/dita/dost/writer/include/IncludeXml.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeXml.java
@@ -11,6 +11,7 @@ package org.dita.dost.writer.include;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
@@ -18,11 +19,6 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.sax.SAXResult;
 import java.io.IOException;
 import java.net.URI;
 
@@ -37,12 +33,15 @@ final class IncludeXml {
     private final URI currentFile;
     private final ContentHandler contentHandler;
     private final DITAOTLogger logger;
+    private final XMLUtils xmlUtils;
 
     IncludeXml(Job job, URI currentFile, ContentHandler contentHandler, DITAOTLogger logger) {
         this.job = job;
         this.currentFile = currentFile;
         this.contentHandler = contentHandler;
         this.logger = logger;
+        this.xmlUtils = new XMLUtils();
+        xmlUtils.setLogger(logger);
     }
 
     boolean include(final Attributes atts) {
@@ -61,11 +60,8 @@ final class IncludeXml {
                 src = doc;
             }
 
-            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            final DOMSource source = new DOMSource(src);
-            final SAXResult result = new SAXResult(new IncludeFilter(contentHandler));
-            serializer.transform(source, result);
-        } catch (SAXException | IOException | TransformerException e) {
+            xmlUtils.writeDocument(src, new IncludeFilter(contentHandler));
+        } catch (SAXException | IOException e) {
             logger.error("Failed to process include {}", fileInfo.src, e);
             return false;
         }

--- a/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
@@ -7,20 +7,6 @@
  */
 package org.dita.dost.pdf2;
 
-import static javax.xml.XMLConstants.*;
-
-import java.io.*;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.parsers.*;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -32,6 +18,16 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.xml.XMLConstants.XML_NS_URI;
 
 /**
  * Generate list of variable files.
@@ -91,13 +87,10 @@ public final class VariableFileTask extends Task {
                 root.appendChild(lang);
             }
 
-            final Transformer serializer = TransformerFactory.newInstance().newTransformer();
-            serializer.transform(new DOMSource(d), new StreamResult(file));
+            new XMLUtils().writeDocument(d, file.toURI());
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final TransformerException e) {
-            throw new BuildException("Failed to write output file: " + e.getMessageAndLocation(), e);
-        } catch (final Exception e) {
+        } catch (final SAXException | IOException e) {
             throw new BuildException("Failed to write output file: " + e.getMessage(), e);
         } finally {
             if (out != null) {

--- a/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
@@ -87,7 +87,7 @@ public final class VariableFileTask extends Task {
                 root.appendChild(lang);
             }
 
-            new XMLUtils().writeDocument(d, file.toURI());
+            new XMLUtils().writeDocument(d, file);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final SAXException | IOException e) {

--- a/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
@@ -60,8 +60,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("badconref.dita"))
                 .put("validate", "false")
-                .warnCount(2)
-                .errorCount(5)
+                .warnCount(3)
+                .errorCount(4)
                 .test();
     }
 
@@ -71,8 +71,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
-                .errorCount(3)
-                .warnCount(1)
+                .errorCount(2)
+                .warnCount(2)
                 .test();
     }
 
@@ -86,6 +86,7 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
                 .warnCount(0)
                 .test();
     }
+
 
     @Test
     public void testcontrolValueFile4() throws Throwable {

--- a/src/test/java/org/dita/dost/module/XsltModuleTest.java
+++ b/src/test/java/org/dita/dost/module/XsltModuleTest.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.module;
 
+import net.sf.saxon.Configuration;
 import net.sf.saxon.functions.FunctionLibraryList;
 import net.sf.saxon.jaxp.SaxonTransformerFactory;
 import net.sf.saxon.lib.CollationURIResolver;
@@ -23,25 +24,25 @@ import static org.junit.Assert.*;
 public class XsltModuleTest {
 
     private XsltModule xsltModule;
-    private SaxonTransformerFactory tf;
+    private Configuration configuration;
 
     @Before
     public void setUp() {
         xsltModule = new XsltModule();
-        tf = (SaxonTransformerFactory) TransformerFactory.newInstance("net.sf.saxon.jaxp.SaxonTransformerFactory", getClass().getClassLoader());
+        configuration = new Configuration();
     }
 
     @Test
     public void configureCollationResolvers() {
-        xsltModule.configureCollationResolvers(tf);
-        final CollationURIResolver collationURIResolver = tf.getConfiguration().getCollationURIResolver();
+        xsltModule.configureSaxonCollationResolvers(configuration);
+        final CollationURIResolver collationURIResolver = configuration.getCollationURIResolver();
         assertTrue(collationURIResolver.getClass().isAssignableFrom(DelegatingCollationUriResolverTest.class));
     }
 
     @Test
     public void configureExtensions() {
-        xsltModule.configureExtensions(tf);
+        xsltModule.configureSaxonExtensions(configuration);
         final SymbolicName.F functionName = new SymbolicName.F(new StructuredQName("x", "y", "z"), 0);
-        assertTrue(tf.getConfiguration().getIntegratedFunctionLibrary().isAvailable(functionName));
+        assertTrue(configuration.getIntegratedFunctionLibrary().isAvailable(functionName));
     }
 }

--- a/src/test/java/org/dita/dost/module/XsltModuleTest.java
+++ b/src/test/java/org/dita/dost/module/XsltModuleTest.java
@@ -23,26 +23,5 @@ import static org.junit.Assert.*;
 
 public class XsltModuleTest {
 
-    private XsltModule xsltModule;
-    private Configuration configuration;
 
-    @Before
-    public void setUp() {
-        xsltModule = new XsltModule();
-        configuration = new Configuration();
-    }
-
-    @Test
-    public void configureCollationResolvers() {
-        xsltModule.configureSaxonCollationResolvers(configuration);
-        final CollationURIResolver collationURIResolver = configuration.getCollationURIResolver();
-        assertTrue(collationURIResolver.getClass().isAssignableFrom(DelegatingCollationUriResolverTest.class));
-    }
-
-    @Test
-    public void configureExtensions() {
-        xsltModule.configureSaxonExtensions(configuration);
-        final SymbolicName.F functionName = new SymbolicName.F(new StructuredQName("x", "y", "z"), 0);
-        assertTrue(configuration.getIntegratedFunctionLibrary().isAvailable(functionName));
-    }
 }

--- a/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
@@ -11,6 +11,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,9 +51,7 @@ public class MapMetaReaderTest {
 
     @Test
     public void testRead() throws DITAOTException, SAXException, IOException, ParserConfigurationException{
-        final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-        builderFactory.setNamespaceAware(true);
-        final DocumentBuilder db = builderFactory.newDocumentBuilder();
+        final DocumentBuilder db = XMLUtils.getDocumentBuilder();
         db.setEntityResolver(CatalogUtils.getCatalogResolver());
 
         assertXMLEqual(db.parse(new File(expDir, "test.ditamap")),

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -7,32 +7,55 @@
  */
 package org.dita.dost.util;
 
-import static javax.xml.XMLConstants.*;
-import static org.junit.Assert.*;
+import net.sf.saxon.Configuration;
+import net.sf.saxon.lib.CollationURIResolver;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.SymbolicName;
+import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.TestUtils.CachingLogger.Message;
+import org.dita.dost.module.DelegatingCollationUriResolverTest;
+import org.junit.Test;
+import org.w3c.dom.Attr;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.AttributesImpl;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.List;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.*;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
-import org.dita.dost.TestUtils.CachingLogger;
-import org.dita.dost.TestUtils.CachingLogger.Message;
-import org.w3c.dom.Element;
-import org.w3c.dom.Document;
-import org.w3c.dom.DOMImplementation;
-import org.w3c.dom.Attr;
-import org.xml.sax.Attributes;
-import org.xml.sax.helpers.AttributesImpl;
-import org.junit.Test;
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.junit.Assert.*;
 
 public class XMLUtilsTest {
+
+    @Test
+    public void configureCollationResolvers() {
+        final net.sf.saxon.Configuration configuration = new Configuration();
+        XMLUtils.configureSaxonCollationResolvers(configuration);
+        final CollationURIResolver collationURIResolver = configuration.getCollationURIResolver();
+        assertTrue(collationURIResolver.getClass().isAssignableFrom(DelegatingCollationUriResolverTest.class));
+    }
+
+    @Test
+    public void configureExtensions() {
+        final net.sf.saxon.Configuration configuration = new Configuration();
+        XMLUtils.configureSaxonExtensions(configuration);
+        final SymbolicName.F functionName = new SymbolicName.F(new StructuredQName("x", "y", "z"), 0);
+        assertTrue(configuration.getIntegratedFunctionLibrary().isAvailable(functionName));
+    }
 
     @Test
     public void testGetPrefix() {

--- a/src/test/resources/MapMetaReaderTest/src/test.ditamap
+++ b/src/test/resources/MapMetaReaderTest/src/test.ditamap
@@ -1,4 +1,4 @@
-<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- map/map "
   domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
   title="test" ditaarch:DITAArchVersion="1.3">
   <topicmeta class="- map/topicmeta ">


### PR DESCRIPTION

## Description
Move from JAXP to using S9API for XSLT processing.

## Motivation and Context
JAXP in Saxon is just a wrapper around S9API and we have a hard dependency to Saxon. Thus it makes sense to use S9API directory instead JAXP.

## Documentation and Compatibility
No documentation changes required.
