### PR TITLE
Use singleton XML utils

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -23,6 +23,7 @@ import org.dita.dost.module.XmlFilterModule;
 import org.dita.dost.module.XmlFilterModule.FilterPair;
 import org.dita.dost.module.XsltModule;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.store.Store;
 import org.dita.dost.util.Constants;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
@@ -294,6 +295,7 @@ public final class ExtensibleAntInvoker extends Task {
      * @return job configuration
      */
     public static Job getJob(final File tempDir, final Project project) {
+        final Store store = project.getReference(ANT_REFERENCE_STORE);
         Job job = project.getReference(ANT_REFERENCE_JOB);
         if (job != null && job.isStale()) {
             project.log("Reload stale job configuration reference", Project.MSG_VERBOSE);
@@ -301,7 +303,7 @@ public final class ExtensibleAntInvoker extends Task {
         }
         if (job == null) {
             try {
-                job = new Job(tempDir);
+                job = new Job(tempDir, store);
             } catch (final IOException ioe) {
                 throw new BuildException(ioe);
             }

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -27,6 +27,7 @@ import org.dita.dost.store.Store;
 import org.dita.dost.util.Constants;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.asList;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FileUtils.supportedImageExtensions;
+import static org.dita.dost.util.URLUtils.toFile;
 
 /**
  * Ant task for executing pipeline modules.
@@ -168,7 +170,7 @@ public final class ExtensibleAntInvoker extends Task {
     public void execute() throws BuildException {
         initialize();
 
-        final Job job = getJob(tempDir, getProject());
+        final Job job = getJob(getProject());
         final XMLUtils xmlUtils = getXmlUtils();
 
         try {
@@ -290,11 +292,17 @@ public final class ExtensibleAntInvoker extends Task {
     /**
      * Get job configuration from Ant project reference or create new.
      *
-     * @param tempDir configuration directory
      * @param project Ant project
      * @return job configuration
      */
-    public static Job getJob(final File tempDir, final Project project) {
+    public static Job getJob(final Project project) {
+        File tempDir = toFile(project.getUserProperty(ANT_TEMP_DIR));
+        if (tempDir == null) {
+            tempDir = toFile(project.getProperty(ANT_TEMP_DIR));
+        }
+        if (tempDir == null) {
+            throw new IllegalStateException(String.format("Ant property %s not set", ANT_TEMP_DIR));
+        }
         final Store store = project.getReference(ANT_REFERENCE_STORE);
         Job job = project.getReference(ANT_REFERENCE_JOB);
         if (job != null && job.isStale()) {

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -26,6 +26,7 @@ import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Constants;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 
 import java.io.BufferedReader;
@@ -167,6 +168,8 @@ public final class ExtensibleAntInvoker extends Task {
         initialize();
 
         final Job job = getJob(tempDir, getProject());
+        final XMLUtils xmlUtils = getXmlUtils();
+
         try {
             for (final ModuleElem m : modules) {
                 m.setProject(getProject());
@@ -179,6 +182,7 @@ public final class ExtensibleAntInvoker extends Task {
                 long start = System.currentTimeMillis();
                 mod.setLogger(logger);
                 mod.setJob(job);
+                mod.setXmlUtils(xmlUtils);
                 mod.execute(pipelineInput);
                 long end = System.currentTimeMillis();
                 logger.debug("{0} processing took {1} ms", mod.getClass().getSimpleName(), end - start);
@@ -304,6 +308,21 @@ public final class ExtensibleAntInvoker extends Task {
             project.addReference(ANT_REFERENCE_JOB, job);
         }
         return job;
+    }
+
+    /**
+     * Get XML utils from Ant project reference or create new.
+     *
+     * @return XML utils
+     */
+    public XMLUtils getXmlUtils() {
+        XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
+        if (xmlUtils == null) {
+            xmlUtils = new XMLUtils();
+            xmlUtils.setLogger(logger);
+            getProject().addReference(ANT_REFERENCE_XML_UTILS, xmlUtils);
+        }
+        return xmlUtils;
     }
 
     private Set<File> readListFile(final List<IncludesFileElem> includes, final DITAOTAntLogger logger) {

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -17,12 +17,16 @@ import org.dita.dost.util.XMLUtils;
 import java.io.File;
 
 import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
+import static org.dita.dost.util.URLUtils.toFile;
 
 public final class InitializeProjectTask extends Task {
     @Override
     public void execute() throws BuildException {
         log("Initializing project", Project.MSG_INFO);
-        final File ditaDir = new File(getProject().getUserProperty("dita.dir"));
+        final File ditaDir = toFile(getProject().getUserProperty("dita.dir"));
+        if (!ditaDir.isAbsolute()) {
+            throw new IllegalArgumentException("DITA-OT installation directory " + ditaDir + " must be absolute");
+        }
         CatalogUtils.setDitaDir(ditaDir);
         XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
         if (xmlUtils == null) {

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2013 Jarno Elovirta
+ * Copyright 2020 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
@@ -22,6 +22,11 @@ import static org.dita.dost.util.Constants.ANT_REFERENCE_STORE;
 import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
 import static org.dita.dost.util.URLUtils.toFile;
 
+/**
+ * Initialize Ant references.
+ *
+ * @since 3.5
+ */
 public final class InitializeProjectTask extends Task {
     @Override
     public void execute() throws BuildException {

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2013 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.ant;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.dita.dost.log.DITAOTAntLogger;
+import org.dita.dost.util.CatalogUtils;
+import org.dita.dost.util.XMLUtils;
+
+import java.io.File;
+
+import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
+
+public final class InitializeProjectTask extends Task {
+    @Override
+    public void execute() throws BuildException {
+        log("Initializing project", Project.MSG_INFO);
+        final File ditaDir = new File(getProject().getUserProperty("dita.dir"));
+        CatalogUtils.setDitaDir(ditaDir);
+        XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
+        if (xmlUtils == null) {
+            xmlUtils = new XMLUtils();
+            xmlUtils.setLogger(new DITAOTAntLogger(getProject()));
+            getProject().addReference(ANT_REFERENCE_XML_UTILS, xmlUtils);
+        }
+    }
+}

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -26,7 +26,7 @@ public final class InitializeProjectTask extends Task {
     @Override
     public void execute() throws BuildException {
         log("Initializing project", Project.MSG_INFO);
-        final File ditaDir = toFile(getProject().getUserProperty("dita.dir"));
+        final File ditaDir = toFile(getProject().getProperty("dita.dir"));
         if (!ditaDir.isAbsolute()) {
             throw new IllegalArgumentException("DITA-OT installation directory " + ditaDir + " must be absolute");
         }

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -11,11 +11,14 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.dita.dost.log.DITAOTAntLogger;
+import org.dita.dost.store.Store;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
 
 import java.io.File;
 
+import static org.dita.dost.util.Constants.ANT_REFERENCE_STORE;
 import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
 import static org.dita.dost.util.URLUtils.toFile;
 
@@ -33,6 +36,11 @@ public final class InitializeProjectTask extends Task {
             xmlUtils = new XMLUtils();
             xmlUtils.setLogger(new DITAOTAntLogger(getProject()));
             getProject().addReference(ANT_REFERENCE_XML_UTILS, xmlUtils);
+        }
+        Store store = getProject().getReference(ANT_REFERENCE_STORE);
+        if (store == null) {
+            store = new StreamStore(xmlUtils);
+            getProject().addReference(ANT_REFERENCE_STORE, store);
         }
     }
 }

--- a/src/main/java/org/dita/dost/ant/JobPropertyTask.java
+++ b/src/main/java/org/dita/dost/ant/JobPropertyTask.java
@@ -21,11 +21,9 @@ import org.dita.dost.util.Job;
  */
 public final class JobPropertyTask extends Task {
 
-    private File dir;
-
     @Override
     public void execute() throws BuildException {
-        final Job job = getJob(dir, getProject());
+        final Job job = getJob(getProject());
         for (final Map.Entry<String, String> e: job.getProperties().entrySet()) {
             getProject().setProperty(e.getKey(), e.getValue());
         }
@@ -34,8 +32,9 @@ public final class JobPropertyTask extends Task {
     /**
      * Set directory where to read job configuration
      */
+    @Deprecated
     public void setDir(final File dir) {
-        this.dir = dir;
+        // NOOP
     }
 
 }

--- a/src/main/java/org/dita/dost/ant/types/JobMapper.java
+++ b/src/main/java/org/dita/dost/ant/types/JobMapper.java
@@ -41,11 +41,7 @@ public class JobMapper implements FileNameMapper {
     private String extension;
 
     public void setProject(Project project) {
-        File tempDir = new File(project.getProperty(ANT_TEMP_DIR));
-        if (!tempDir.isAbsolute()) {
-            tempDir = new File(project.getBaseDir(), tempDir.getPath());
-        }
-        job = ExtensibleAntInvoker.getJob(tempDir, project);
+        job = ExtensibleAntInvoker.getJob(project);
     }
 
     @Override

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -89,14 +89,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     @VisibleForTesting
     Job getJob() {
-        String tempDir = getProject().getUserProperty(ANT_TEMP_DIR);
-        if (tempDir == null) {
-            tempDir = getProject().getProperty(ANT_TEMP_DIR);
-        }
-        if (tempDir == null) {
-            throw new IllegalStateException();
-        }
-        final Job job = ExtensibleAntInvoker.getJob(new File(tempDir), getProject());
+        final Job job = ExtensibleAntInvoker.getJob(getProject());
         if (job == null) {
             throw new IllegalStateException();
         }

--- a/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
@@ -120,17 +120,32 @@ public final class DITAOTAntLogger extends MarkerIgnoringBase implements DITAOTL
 
     @Override
     public void error(String format, Object arg) {
-        log(MessageFormat.format(format, arg), null, Project.MSG_ERR);
+        if (arg instanceof Throwable) {
+            log(format, (Throwable) arg, Project.MSG_ERR);
+        } else {
+            log(MessageFormat.format(format, arg), null, Project.MSG_ERR);
+        }
     }
 
     @Override
     public void error(String format, Object arg1, Object arg2) {
-        log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_ERR);
+        if (arg2 instanceof Throwable) {
+            log(MessageFormat.format(format, arg1), (Throwable) arg2, Project.MSG_ERR);
+        } else {
+            log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_ERR);
+        }
     }
 
     @Override
     public void error(String format, Object... arguments) {
-        log(MessageFormat.format(format, arguments), null, Project.MSG_ERR);
+        final Object last = arguments[arguments.length - 1];
+        if (last instanceof Throwable) {
+            final Object[] init = new Object[arguments.length - 1];
+            System.arraycopy(arguments, 0, init, 0, init.length);
+            log(MessageFormat.format(format, init), (Throwable) last, Project.MSG_ERR);
+        } else {
+            log(MessageFormat.format(format, arguments), null, Project.MSG_ERR);
+        }
     }
 
     @Override

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,8 @@ public interface AbstractPipelineModule {
     void setLogger(DITAOTLogger logger);
 
     void setJob(Job job);
+
+    void setXmlUtils(XMLUtils xmlUtils);
 
     void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter);
 

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -13,6 +13,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -24,6 +25,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
 
     protected DITAOTLogger logger;
     protected Job job;
+    protected XMLUtils xmlUtils;
     Predicate<FileInfo> fileInfoFilter;
     List<XmlFilterModule.FilterPair> filters;
 
@@ -35,6 +37,11 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     @Override
     public void setJob(final Job job) {
         this.job = job;
+    }
+
+    @Override
+    public void setXmlUtils(final XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
     }
 
     @Override

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -123,7 +123,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         final Document doc;
         try {
             logger.debug("Reading " + currentFile);
-            doc = xmlUtils.getDocument(currentFile);
+            doc = job.getStore().getDocument(currentFile);
         } catch (final IOException e) {
             logger.error("Failed to parse " + currentFile, e);
             return;
@@ -145,7 +145,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         logger.debug("Writing " + currentFile);
 
         try {
-            xmlUtils.writeDocument(doc, currentFile);
+            job.getStore().writeDocument(doc, currentFile);
         } catch (final IOException e) {
             logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -20,7 +20,6 @@ import org.dita.dost.util.FilterUtils;
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.ProfilingFilter;
 import org.w3c.dom.*;
 import org.xml.sax.XMLFilter;
@@ -60,7 +59,6 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
     private static final String SKIP_FILTER = "skip-filter";
     private static final String BRANCH_COPY_TO = "filter-copy-to";
 
-    private final XMLUtils xmlUtils;
     private final DitaValReader ditaValReader;
     private TempFileNameScheme tempFileNameScheme;
     private final Map<URI, FilterUtils> filterCache = new HashMap<>();
@@ -77,14 +75,12 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
     public BranchFilterModule() {
         ditaValReader = new DitaValReader();
-        xmlUtils = new XMLUtils();
     }
 
     @Override
     public void setLogger(final DITAOTLogger logger) {
         super.setLogger(logger);
         ditaValReader.setLogger(logger);
-        xmlUtils.setLogger(logger);
     }
 
     @Override

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -379,9 +379,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
                     logger.error("Failed to create directory " + dstDirUri);
                 }
                 try {
-                    xmlUtils.transform(srcAbsUri,
-                                       dstAbsUri,
-                                       pipe);
+                    job.getStore().transform(srcAbsUri, dstAbsUri, pipe);
                 } catch (final DITAOTException e) {
                     logger.error("Failed to filter " + srcAbsUri + " to " + dstAbsUri + ": " + e.getMessage(), e);
                 }
@@ -440,7 +438,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
             logger.info("Filtering " + srcAbsUri);
             try {
-                xmlUtils.transform(srcAbsUri, pipe);
+                job.getStore().transform(srcAbsUri, pipe);
             } catch (final DITAOTException e) {
                 logger.error("Failed to filter " + srcAbsUri + ": " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -16,7 +16,6 @@ import org.dita.dost.util.Configuration;
 import org.dita.dost.util.DitaClass;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.TopicRefWriter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -120,7 +119,6 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
      * @throws DITAOTException if reading ditamap fails
      */
     private boolean isEclipseMap(final URI mapFile) throws DITAOTException {
-        final XMLUtils xmlUtils = new XMLUtils();
         Document doc;
         try {
             doc = xmlUtils.getDocument(mapFile);

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -121,7 +121,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
     private boolean isEclipseMap(final URI mapFile) throws DITAOTException {
         Document doc;
         try {
-            doc = xmlUtils.getDocument(mapFile);
+            doc = job.getStore().getDocument(mapFile);
         } catch (final IOException e) {
             throw new DITAOTException("Failed to parse input map: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -14,13 +14,11 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.commons.io.FileUtils;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.dita.dost.writer.LinkFilter;
 import org.dita.dost.writer.MapCleanFilter;
@@ -59,17 +57,10 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
     private final LinkFilter filter = new LinkFilter();
     private final MapCleanFilter mapFilter = new MapCleanFilter();
-    private final XMLUtils xmlUtils = new XMLUtils();
 
     private boolean useResultFilename;
     private XsltTransformer rewriteTransformer;
     private RewriteRule rewriteClass;
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
-    }
 
     private void init(final Map<String, String> input) {
         useResultFilename = Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME))

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -119,7 +119,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
             // rewrite results
             final Collection<FileInfo> rewritten = rewrite(original);
             // move temp files and update links
-            final Job tempJob = new Job(job.tempDir, emptyMap(), rewritten);
+            final Job tempJob = new Job(job, emptyMap(), rewritten);
             filter.setJob(tempJob);
             mapFilter.setJob(tempJob);
             for (final FileInfo fi : rewritten) {

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -134,7 +134,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
                             final List<XMLFilter> processingPipe = getProcessingPipe(fi, srcFile, destFile);
                             if (!processingPipe.isEmpty()) {
                                 logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
-                                xmlUtils.transform(srcFile.toURI(), destFile.toURI(), processingPipe);
+                                job.getStore().transform(srcFile.toURI(), destFile.toURI(), processingPipe);
                                 if (!srcFile.equals(destFile)) {
                                     logger.debug("Deleting " + srcFile.toURI());
                                     FileUtils.deleteQuietly(srcFile);

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -8,7 +8,6 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -43,7 +42,6 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
     private boolean forceUnique;
     private ForceUniqueFilter forceUniqueFilter;
     private final CopyToReader reader = new CopyToReader();
-    private final XMLUtils xmlUtils = new XMLUtils();
 
     @Override
     public void setJob(final Job job) {
@@ -54,12 +52,6 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             throw new RuntimeException(e);
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
-    }
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
     }
 
     @Override

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -88,7 +88,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
 
         final List<XMLFilter> pipe = getProcessingPipe(in);
 
-        xmlUtils.transform(in, pipe);
+        job.getStore().transform(in, pipe);
     }
 
     /**
@@ -203,7 +203,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
 
         logger.info("Processing " + src + " to " + target);
         try {
-            xmlUtils.transform(src, target, Collections.singletonList(filter));
+            job.getStore().transform(src, target, Collections.singletonList(filter));
         } catch (final DITAOTException e) {
             logger.error("Failed to write copy-to file: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -196,7 +196,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
         subjectSchemeReader.setJob(job);
-        subjectSchemeReader.setXmlUtils(xmlUtils);
         dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
 
         if (profilingEnabled) {

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -342,13 +342,13 @@ public final class DebugAndFilterModule extends SourceReaderModule {
                 final Document parentRoot;
                 if (!tmprel.exists()) {
                     final URI src = job.getFileInfo(parent).src;
-                    parentRoot = xmlUtils.getDocument(src);
+                    parentRoot = job.getStore().getDocument(src);
                 } else {
-                    parentRoot = xmlUtils.getDocument(tmprel.toURI());
+                    parentRoot = job.getStore().getDocument(tmprel.toURI());
                 }
                 if (children != null) {
                     for (final URI childpath: children) {
-                        final Document childRoot = xmlUtils.getDocument(job.getInputFile().resolve(childpath.getPath()));
+                        final Document childRoot = job.getStore().getDocument(job.getInputFile().resolve(childpath.getPath()));
                         mergeScheme(parentRoot, childRoot);
                         generateScheme(new File(job.tempDir, childpath.getPath() + SUBJECT_SCHEME_EXTENSION), childRoot);
                     }
@@ -482,7 +482,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             throw new DITAOTException("Failed to make directory " + p.getAbsolutePath());
         }
         try {
-            xmlUtils.writeDocument(root, filename);
+            job.getStore().writeDocument(root, filename.toURI());
         } catch (final IOException e) {
             logger.error(e.getMessage(), e) ;
             throw new DITAOTException(e);

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -289,8 +289,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     }
 
     private void readArguments(AbstractPipelineInput input) {
-        final File baseDir = toFile(input.getAttribute(ANT_INVOKER_PARAM_BASEDIR));
-        ditaDir = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
         transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
         profilingEnabled = true;
         if (input.getAttribute(ANT_INVOKER_PARAM_PROFILING_ENABLED) != null) {

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -196,6 +196,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
         subjectSchemeReader.setJob(job);
+        subjectSchemeReader.setXmlUtils(xmlUtils);
         dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));
 
         if (profilingEnabled) {

--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -63,6 +63,8 @@ final class FilterModule extends AbstractPipelineModuleImpl {
 
         final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
+        subjectSchemeReader.setJob(job);
+        subjectSchemeReader.setXmlUtils(xmlUtils);
         Map<URI, Set<URI>> dic;
         try {
             dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));

--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -64,7 +64,6 @@ final class FilterModule extends AbstractPipelineModuleImpl {
         final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
         subjectSchemeReader.setLogger(logger);
         subjectSchemeReader.setJob(job);
-        subjectSchemeReader.setXmlUtils(xmlUtils);
         Map<URI, Set<URI>> dic;
         try {
             dic = SubjectSchemeReader.readMapFromXML(new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY));

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -904,7 +904,6 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);
-            delayConrefUtils.setXmlUtils(xmlUtils);
             delayConrefUtils.writeMapToXML(exportAnchorsFilter.getPluginMap());
             delayConrefUtils.writeExportAnchors(exportAnchorsFilter, tempFileNameScheme);
         }

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -904,6 +904,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);
+            delayConrefUtils.setXmlUtils(xmlUtils);
             delayConrefUtils.writeMapToXML(exportAnchorsFilter.getPluginMap());
             delayConrefUtils.writeExportAnchors(exportAnchorsFilter, tempFileNameScheme);
         }

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -264,10 +264,6 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     }
 
     private void parseInputParameters(final AbstractPipelineInput input) {
-        ditaDir = toFile(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
-        if (!ditaDir.isAbsolute()) {
-            throw new IllegalArgumentException("DITA-OT installation directory " + ditaDir + " must be absolute");
-        }
         ditavalFile = new File(job.tempDir, FILE_NAME_MERGED_DITAVAL);
         validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         if (!validate) {

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -127,7 +127,14 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             final List<ResolveTask> jobs = collectProcessingTopics(resourceFis, rootScope, doc);
 
             transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
-            delayConrefUtils = transtype.equals(INDEX_TYPE_ECLIPSEHELP) ? new DelayConrefUtils() : null;
+            if (transtype.equals(INDEX_TYPE_ECLIPSEHELP)) {
+                delayConrefUtils = new DelayConrefUtils();
+                delayConrefUtils.setJob(job);
+                delayConrefUtils.setLogger(logger);
+                delayConrefUtils.setXmlUtils(xmlUtils);
+            } else {
+                delayConrefUtils = null;
+            }
             for (final ResolveTask r: jobs) {
                 if (r.out != null) {
                     processFile(r);

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -9,12 +9,14 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.KeyrefReader;
-import org.dita.dost.util.*;
+import org.dita.dost.util.DelayConrefUtils;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.KeyDef;
+import org.dita.dost.util.KeyScope;
 import org.dita.dost.writer.ConkeyrefFilter;
 import org.dita.dost.writer.KeyrefPaser;
 import org.dita.dost.writer.TopicFragmentFilter;
@@ -52,7 +54,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     final Set<URI> normalProcessingRole = new HashSet<>();
     final Map<URI, Integer> usage = new HashMap<>();
     private TopicFragmentFilter topicFragmentFilter;
-    private final XMLUtils xmlUtils = new XMLUtils();
 
     @Override
     public void setJob(final Job job) {
@@ -63,12 +64,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             throw new RuntimeException(e);
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
-    }
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -399,12 +399,13 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             if (r.out != null) {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri) +
                         " to " + job.tempDirURI.resolve(r.out.uri));
-                xmlUtils.transform(new File(job.tempDir, r.in.file.getPath()),
-                                   new File(job.tempDir, r.out.file.getPath()),
-                                   filters);
+                job.getStore().transform(new File(job.tempDir, r.in.file.getPath()).toURI(),
+                                         new File(job.tempDir, r.out.file.getPath()).toURI(),
+                                         filters);
             } else {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri));
-                xmlUtils.transform(new File(job.tempDir, r.in.file.getPath()), filters);
+                job.getStore().transform(new File(job.tempDir, r.in.file.getPath()).toURI(),
+                                         filters);
             }
             // validate resource-only list
             normalProcessingRole.addAll(parser.getNormalProcessingRoleTargets());

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -429,7 +429,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     private Document readMap(final FileInfo input) throws DITAOTException {
         try {
             final URI in = job.tempDirURI.resolve(input.uri);
-            return xmlUtils.getDocument(in);
+            return job.getStore().getDocument(in);
         } catch (final Exception e) {
             throw new DITAOTException("Failed to parse map: " + e.getMessage(), e);
         }
@@ -438,7 +438,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     private void writeMap(final FileInfo in, final Document doc) throws DITAOTException {
         try {
             final URI file = job.tempDirURI.resolve(in.uri);
-            xmlUtils.writeDocument(doc, file);
+            job.getStore().writeDocument(doc, file);
         } catch (final IOException e) {
             throw new DITAOTException("Failed to write map: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -131,7 +131,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                 delayConrefUtils = new DelayConrefUtils();
                 delayConrefUtils.setJob(job);
                 delayConrefUtils.setLogger(logger);
-                delayConrefUtils.setXmlUtils(xmlUtils);
             } else {
                 delayConrefUtils = null;
             }

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -91,9 +91,9 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
 
         logger.info("Processing " + inputFile.toURI());
         Document doc;
-        try (InputStream in = new BufferedInputStream(new FileInputStream(inputFile))) {
+        try {
             doc = XMLUtils.getDocumentBuilder().newDocument();
-            final Source source = new StreamSource(in, inputFile.toURI().toString());
+            final Source source = job.getStore().getSource(inputFile.toURI());
             final Destination serializer = new DOMDestination(doc);
             final XsltTransformer transformer = templates.load();
             transformer.setErrorListener(toErrorListener(logger));

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -15,7 +15,6 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
-import org.dita.dost.util.DelegatingURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -41,7 +41,6 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     private XsltExecutable templates;
 
     private void init(final AbstractPipelineInput input) {
-        final XMLUtils xmlUtils = new XMLUtils();
         processor = xmlUtils.getProcessor();
         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
         xsltCompiler.setErrorListener(toErrorListener(logger));

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
+import org.dita.dost.util.DelegatingURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
@@ -121,23 +122,9 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
         final FileInfo updated = collectJobInfo(input, doc);
         job.add(updated);
 
-        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-            final Serializer result = processor.newSerializer(out);
-            final XdmNode source = processor.newDocumentBuilder().wrap(doc);
-            result.serializeNode(source);
-        } catch (final UncheckedXPathException e) {
-            throw new DITAOTException("Failed to serialize map " + inputFile, e);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final SaxonApiException e) {
-            try {
-                throw e.getCause();
-            } catch (final XPathException cause) {
-                throw new DITAOTException("Failed to serialize map " + inputFile + ": " + cause.getMessageAndLocation(), e);
-            } catch (Throwable throwable) {
-                throw new DITAOTException("Failed to serialize map " + inputFile + ": " + e.getMessage(), e);
-            }
-        } catch (final Exception e) {
+        try {
+            job.getStore().writeDocument(doc, outputFile.toURI());
+        } catch (final IOException e) {
             throw new DITAOTException("Failed to serialize map " + inputFile + ": " + e.getMessage(), e);
         }
     }

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -48,7 +48,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     /** Absolute paths for filter files. */
     private final List<File> ditavalFiles = new LinkedList<>();
-    private File ditaDir = null;
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
@@ -72,7 +71,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     private void parseInputParameters(final AbstractPipelineInput input) {
         final File basedir = toFile(input.getAttribute(ANT_INVOKER_PARAM_BASEDIR));
-        ditaDir = toFile(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
         if (input.getAttribute(ANT_INVOKER_PARAM_DITAVAL) != null) {
             final String[] allDitavalFiles = input.getAttribute(ANT_INVOKER_PARAM_DITAVAL).split(File.pathSeparator);
             for (final String oneDitavalFile : allDitavalFiles) {
@@ -105,7 +103,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
     private void writeMergedDitaval() throws DITAOTException {
         final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
-        CatalogUtils.setDitaDir(ditaDir);
         ditavalbuilder.setEntityResolver(CatalogUtils.getCatalogResolver());
         XMLStreamWriter export = null;
         try (OutputStream exportStream = new FileOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL))) {

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -56,7 +56,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
 
         Document doc;
         try {
-            final XsltCompiler xsltCompiler = new XMLUtils().getProcessor().newXsltCompiler();
+            final XsltCompiler xsltCompiler = xmlUtils.getProcessor().newXsltCompiler();
 
             final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
             transformer.setErrorListener(toErrorListener(logger));

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -66,7 +66,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             }
             transformer.setParameter(new QName("INPUTMAP"), XdmItem.makeValue(job.getInputMap()));
 
-            final Source source = new StreamSource(inputFile);
+            final Source source = job.getStore().getSource(inputFile.toURI());
             doc = XMLUtils.getDocumentBuilder().newDocument();
             final DOMDestination result = new DOMDestination(doc);
 

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -17,7 +17,6 @@ import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,10 +47,6 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
      * Use grammar pool cache
      */
     boolean gramcache = true;
-    /**
-     * Absolute DITA-OT base path.
-     */
-    File ditaDir;
     Processor processor;
 
     /**
@@ -127,7 +122,6 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
             }
         }
 
-        CatalogUtils.setDitaDir(ditaDir);
         final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
         reader.setEntityResolver(catalogResolver);
 

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -10,11 +10,10 @@ package org.dita.dost.module;
 import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xml.resolver.tools.CatalogResolver;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
-import org.dita.dost.writer.*;
+import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderFactory;
 
@@ -37,7 +36,6 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
 
     private static final String FEATURE_GRAMMAR_POOL = "http://apache.org/xml/properties/internal/grammar-pool";
 
-    final XMLUtils xmlUtils;
     /**
      * XMLReader instance for parsing dita file
      */
@@ -55,16 +53,6 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
      */
     File ditaDir;
     Processor processor;
-
-    public SourceReaderModule() {
-        xmlUtils = new XMLUtils();
-    }
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
-    }
 
     /**
      * Get reader for input format

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -16,7 +16,6 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MergeMapParser;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
@@ -88,7 +87,7 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
         }
         try (final OutputStream output = new BufferedOutputStream(new FileOutputStream(out))) {
             if (style != null) {
-                final Processor processor = new XMLUtils().getProcessor();
+                final Processor processor = xmlUtils.getProcessor();
                 final XsltCompiler xsltCompiler = processor.newXsltCompiler();
                 final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(style)).load();
                 transformer.setErrorListener(toErrorListener(logger));

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -40,7 +40,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
             final URI file = job.tempDirURI.resolve(f.uri);
             logger.info("Processing " + file);
             try {
-                xmlUtils.transform(file, getProcessingPipe(f));
+                job.getStore().transform(file, getProcessingPipe(f));
             } catch (final DITAOTException e) {
                 logger.error("Failed to process XML filter: " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -8,11 +8,9 @@
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.XMLFilter;
 
@@ -27,14 +25,6 @@ import java.util.function.Predicate;
  * {@code startDocument} event.
  */
 public final class XmlFilterModule extends AbstractPipelineModuleImpl {
-
-    private final XMLUtils xmlUtils = new XMLUtils();
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
-    }
 
     /**
      * Filter files through XML filters.

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -97,7 +97,6 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         if (destDir != null) {
             logger.info("Transforming into " + destDir.getAbsolutePath());
         }
-        final XMLUtils xmlUtils = new XMLUtils();
         processor = xmlUtils.getProcessor();
         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
         xsltCompiler.setErrorListener(toErrorListener(logger));

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -88,6 +88,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         }
     }
 
+    @Override
     public AbstractPipelineOutput execute(AbstractPipelineInput input) throws DITAOTException {
         init();
         if ((includes == null || includes.isEmpty()) && (in == null)) {

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -13,11 +13,8 @@ import org.dita.dost.module.AbstractPipelineModuleImpl;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.reader.DitaValReader;
 import org.dita.dost.reader.SubjectSchemeReader;
-import org.dita.dost.util.Constants;
-import org.dita.dost.util.FilterUtils;
-import org.dita.dost.util.Job;
+import org.dita.dost.util.*;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.StringUtils;
 import org.w3c.dom.Element;
 
 import java.io.*;
@@ -68,6 +65,12 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
         super.setLogger(logger);
         ditaValReader.setLogger(logger);
         subjectSchemeReader.setLogger(logger);
+    }
+
+    @Override
+    public void setXmlUtils(final XMLUtils xmlUtils) {
+        super.setXmlUtils(xmlUtils);
+        subjectSchemeReader.setXmlUtils(xmlUtils);
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -67,12 +67,6 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
         subjectSchemeReader.setLogger(logger);
     }
 
-    @Override
-    public void setXmlUtils(final XMLUtils xmlUtils) {
-        super.setXmlUtils(xmlUtils);
-        subjectSchemeReader.setXmlUtils(xmlUtils);
-    }
-
     /**
      * Read subject scheme definitions.
      */

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -88,7 +88,7 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
         final Document doc;
         try {
             logger.debug("Reading " + currentFile);
-            doc = xmlUtils.getDocument(currentFile);
+            doc = job.getStore().getDocument(currentFile);
         } catch (final IOException e) {
             logger.error("Failed to parse " + currentFile, e);
             return;
@@ -103,7 +103,7 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
 
         logger.debug("Writing " + currentFile);
         try {
-            xmlUtils.writeDocument(doc, currentFile);
+            job.getStore().writeDocument(doc, currentFile);
         } catch (final IOException e) {
             logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -51,17 +51,10 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
 
     private static final String BRANCH_COPY_TO = "filter-copy-to";
 
-    private final XMLUtils xmlUtils;
-
     /** Current map being processed, relative to temporary directory */
     private URI map;
     /** Absolute path for filter file. */
     private URI ditavalFile;
-
-    public MapBranchFilterModule() {
-        super();
-        xmlUtils = new XMLUtils();
-    }
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -16,7 +16,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.FilterUtils;
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
 
 import javax.xml.namespace.QName;

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -8,12 +8,10 @@
 package org.dita.dost.module.filter;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.FilterUtils;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.ProfilingFilter;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -48,16 +46,9 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
     private static final String SKIP_FILTER = "skip-filter";
     private static final String BRANCH_COPY_TO = "filter-copy-to";
 
-    private final XMLUtils xmlUtils = new XMLUtils();
     /** Current map being processed, relative to temporary directory */
     private URI map;
     private final Set<URI> filtered = new HashSet<>();
-
-    @Override
-    public void setLogger(final DITAOTLogger logger) {
-        super.setLogger(logger);
-        xmlUtils.setLogger(logger);
-    }
 
     @Override
     public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -78,7 +78,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
         final Document doc;
         try {
             logger.debug("Reading " + currentFile);
-            doc = xmlUtils.getDocument(currentFile);
+            doc = job.getStore().getDocument(currentFile);
         } catch (final IOException e) {
             logger.error("Failed to parse " + currentFile, e);
             return;
@@ -92,7 +92,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
         logger.debug("Writing " + currentFile);
         try {
-            xmlUtils.writeDocument(doc, currentFile);
+            job.getStore().writeDocument(doc, currentFile);
         } catch (final IOException e) {
             logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -132,9 +132,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
                     logger.error("Failed to create directory " + dstDirUri);
                 }
                 try {
-                    xmlUtils.transform(srcAbsUri,
-                                       dstAbsUri,
-                                       pipe);
+                    job.getStore().transform(srcAbsUri, dstAbsUri, pipe);
                 } catch (final DITAOTException e) {
                     logger.error("Failed to filter " + srcAbsUri + " to " + dstAbsUri + ": " + e.getMessage(), e);
                 }
@@ -173,7 +171,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
             logger.info("Filtering " + srcAbsUri);
             try {
-                xmlUtils.transform(srcAbsUri, pipe);
+                job.getStore().transform(srcAbsUri, pipe);
             } catch (final DITAOTException e) {
                 logger.error("Failed to filter " + srcAbsUri + ": " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -381,7 +381,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             } catch (final SAXNotRecognizedException e) {}
 
 //            in = new InputSource(src.toString());
-            out = new StreamResult(new FileOutputStream(outputFile));
+            out = job.getStore().getResult(outputFile.toURI());
             serializer.setResult(out);
             xmlSource.setContentHandler(serializer);
             xmlSource.parse(src.toString());

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -787,6 +787,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);
+            delayConrefUtils.setXmlUtils(xmlUtils);
             delayConrefUtils.writeMapToXML(exportAnchorsFilter.getPluginMap());
             delayConrefUtils.writeExportAnchors(exportAnchorsFilter, tempFileNameScheme);
         }

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -122,8 +122,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     /** Profiling is enabled. */
     private boolean profilingEnabled;
     String transtype;
-    /** Absolute DITA-OT base path. */
-    File ditaDir;
     private File ditavalFile;
     FilterUtils filterUtils;
     /** Absolute path to current destination file. */
@@ -205,11 +203,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     /**
      * Init xml reader used for pipeline parsing.
      *
-     * @param ditaDir absolute path to DITA-OT directory
      * @param validate whether validate input file
      * @throws SAXException parsing exception
      */
-    void initXMLReader(final File ditaDir, final boolean validate) throws SAXException {
+    void initXMLReader(final boolean validate) throws SAXException {
         reader = XMLUtils.getXMLReader();
         reader.setFeature(FEATURE_NAMESPACE, true);
         reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
@@ -234,15 +231,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
                 logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
             }
         }
-        CatalogUtils.setDitaDir(ditaDir);
         reader.setEntityResolver(CatalogUtils.getCatalogResolver());
     }
 
     void parseInputParameters(final AbstractPipelineInput input) {
-        ditaDir = toFile(input.getAttribute(ANT_INVOKER_EXT_PARAM_DITADIR));
-        if (!ditaDir.isAbsolute()) {
-            throw new IllegalArgumentException("DITA-OT installation directory " + ditaDir + " must be absolute");
-        }
         validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
         gramcache = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAM_GRAMCACHE));
@@ -951,7 +943,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
 
-        initXMLReader(ditaDir, validate);
+        initXMLReader(validate);
         initFilters();
     }
 

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -787,7 +787,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);
-            delayConrefUtils.setXmlUtils(xmlUtils);
             delayConrefUtils.writeMapToXML(exportAnchorsFilter.getPluginMap());
             delayConrefUtils.writeExportAnchors(exportAnchorsFilter, tempFileNameScheme);
         }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -17,7 +17,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
 import org.dita.dost.reader.SubjectSchemeReader;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.NormalizeFilter;
 import org.dita.dost.writer.ProfilingFilter;
@@ -152,7 +151,6 @@ public final class TopicReaderModule extends AbstractReaderModule {
         final URI currentFile = job.tempDirURI.resolve(fi.uri);
         try {
             logger.debug("Reading " + currentFile);
-            final XMLUtils xmlUtils = new XMLUtils();
             return xmlUtils.getDocument(currentFile);
         } catch (final IOException e) {
             throw new SAXException("Failed to parse " + currentFile, e);

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -153,7 +153,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
         final URI currentFile = job.tempDirURI.resolve(fi.uri);
         try {
             logger.debug("Reading " + currentFile);
-            return xmlUtils.getDocument(currentFile);
+            return job.getStore().getDocument(currentFile);
         } catch (final IOException e) {
             throw new SAXException("Failed to parse " + currentFile, e);
         }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -90,7 +90,6 @@ public final class TopicReaderModule extends AbstractReaderModule {
                 final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
                 subjectSchemeReader.setLogger(logger);
                 subjectSchemeReader.setJob(job);
-                subjectSchemeReader.setXmlUtils(xmlUtils);
                 logger.debug("Loading subject schemes");
                 final List<Element> subjectSchemes = toList(doc.getDocumentElement().getElementsByTagName("*"));
                 subjectSchemes.stream()

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -89,6 +89,8 @@ public final class TopicReaderModule extends AbstractReaderModule {
             if (doc != null) {
                 final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
                 subjectSchemeReader.setLogger(logger);
+                subjectSchemeReader.setJob(job);
+                subjectSchemeReader.setXmlUtils(xmlUtils);
                 logger.debug("Loading subject schemes");
                 final List<Element> subjectSchemes = toList(doc.getDocumentElement().getElementsByTagName("*"));
                 subjectSchemes.stream()

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -181,7 +181,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
         final List<Reference> res = new ArrayList<>();
         assert startFileInfo.src != null;
         final URI tmp = job.tempDirURI.resolve(startFileInfo.uri);
-        final Source source = new StreamSource(tmp.toString());
+        final Source source = job.getStore().getSource(tmp);
         logger.info("Reading " + tmp);
         try {
             final XMLStreamReader in = XMLInputFactory.newInstance().createXMLStreamReader(source);

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -281,7 +281,7 @@ public final class ChunkMapReader extends AbstractDomFilter {
 
     private void outputMapFile(final URI file, final Document doc) {
         try {
-            xmlUtils.writeDocument(doc, file);
+            job.getStore().writeDocument(doc, file);
         } catch (final IOException e) {
             logger.error(e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -283,7 +283,7 @@ public final class ChunkMapReader extends AbstractDomFilter {
         try {
             job.getStore().writeDocument(doc, file);
         } catch (final IOException e) {
-            logger.error(e.getMessage(), e);
+            logger.error("Failed to serialize map: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -14,7 +14,6 @@ import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLOutputFactory;
@@ -40,7 +39,6 @@ public final class ConrefPushReader extends AbstractXMLReader {
     /** Document used to construct push table DocumentFragments. */
     private final Document pushDocument;
     /** push table.*/
-    private final XMLReader reader;
 
     /**keep the file path of current file under parse
     filePath is useful to get the absolute path of the target file.*/
@@ -91,12 +89,11 @@ public final class ConrefPushReader extends AbstractXMLReader {
         pushcontentWriter = getXMLStreamWriter();
         pushType = null;
         try {
-            reader.parse(filename.toURI().toString());
+            job.getStore().transform(filename.toURI(), this);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
             logger.error(e.getMessage(), e) ;
-            e.printStackTrace();
         }
     }
 
@@ -114,14 +111,6 @@ public final class ConrefPushReader extends AbstractXMLReader {
      */
     public ConrefPushReader() {
         pushtable = new Hashtable<>();
-        try {
-            reader = XMLUtils.getXMLReader();
-            reader.setFeature(FEATURE_NAMESPACE_PREFIX, false);
-            reader.setFeature(FEATURE_NAMESPACE, true);
-            reader.setContentHandler(this);
-        } catch (final Exception e) {
-            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
-        }
 
         pushDocument = XMLUtils.getDocumentBuilder().newDocument();
     }

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -172,7 +172,7 @@ public class SubjectSchemeReader {
         logger.debug("Load subject scheme " + scheme);
 
         try {
-            final Document doc = xmlUtils.getDocument(scheme.toURI());
+            final Document doc = job.getStore().getDocument(scheme.toURI());
             final Element schemeRoot = doc.getDocumentElement();
             if (schemeRoot == null) {
                 return;

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -35,7 +35,6 @@ public class SubjectSchemeReader {
 
     private DITAOTLogger logger;
     private Job job;
-    private XMLUtils xmlUtils;
     private final Map<QName, Map<String, Set<Element>>> bindingMap;
     private final Map<QName, Map<String, Set<String>>> validValuesMap;
     private final Map<QName, Map<String, String>> defaultValueMap;
@@ -97,10 +96,6 @@ public class SubjectSchemeReader {
 
     public void setJob(final Job job) {
         this.job = job;
-    }
-
-    public void setXmlUtils(final XMLUtils xmlUtils) {
-        this.xmlUtils = xmlUtils;
     }
 
     /**

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -35,6 +35,7 @@ public class SubjectSchemeReader {
 
     private DITAOTLogger logger;
     private Job job;
+    private XMLUtils xmlUtils;
     private final Map<QName, Map<String, Set<Element>>> bindingMap;
     private final Map<QName, Map<String, Set<String>>> validValuesMap;
     private final Map<QName, Map<String, String>> defaultValueMap;
@@ -96,6 +97,10 @@ public class SubjectSchemeReader {
 
     public void setJob(final Job job) {
         this.job = job;
+    }
+
+    public void setXmlUtils(final XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
     }
 
     /**
@@ -167,7 +172,6 @@ public class SubjectSchemeReader {
         logger.debug("Load subject scheme " + scheme);
 
         try {
-            final XMLUtils xmlUtils = new XMLUtils();
             final Document doc = xmlUtils.getDocument(scheme.toURI());
             final Element schemeRoot = doc.getDocumentElement();
             if (schemeRoot == null) {

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -8,12 +8,43 @@
 
 package org.dita.dost.store;
 
+import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
+import org.xml.sax.XMLFilter;
 
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 public interface Store {
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param src file to transform and replace
+     * @param filters XML filters to transform file with, may be an empty list
+     */
+    void transform(final URI src, final List<XMLFilter> filters) throws DITAOTException;
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param src input file
+     * @param dst output file
+     * @param filters XML filters to transform file with, may be an empty list
+     */
+    void transform(final URI src, final URI dst, final List<XMLFilter> filters) throws DITAOTException;
+
+    /**
+     * Get temporary file source
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return source for temporary file
+     */
+    Source getSource(URI path);
 
     /**
      * Get DOM document for file. Convenience method.
@@ -32,5 +63,13 @@ public interface Store {
      * @throws IOException if serializing file fails
      */
     void writeDocument(Document doc, URI dst) throws IOException;
+
+    /**
+     * Get temporary file result
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return result for temporary file
+     */
+    Result getResult(URI path);
 
 }

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -9,6 +9,7 @@
 package org.dita.dost.store;
 
 import net.sf.saxon.s9api.Destination;
+import net.sf.saxon.s9api.SaxonApiException;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
@@ -90,4 +91,12 @@ public interface Store {
      */
     Destination getDestination(URI path);
 
+    /**
+     * Get result content handler.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return serializer content handler
+     * @throws SaxonApiException if creating serializer fails
+     */
+    ContentHandler getContentHandler(URI path) throws SaxonApiException;
 }

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -58,7 +58,7 @@ public interface Store {
     Source getSource(URI path);
 
     /**
-     * Get DOM document for file. Convenience method.
+     * Get DOM document for file.
      *
      * @param path temporary file URI, absolute or relative
      * @return document or null if not available
@@ -76,20 +76,12 @@ public interface Store {
     void writeDocument(Document doc, URI dst) throws IOException;
 
     /**
-     * Get temporary file result
-     *
-     * @param path temporary file URI, absolute or relative
-     * @return result for temporary file
-     */
-    Result getResult(URI path);
-
-    /**
      * Get temporary file destination
      *
      * @param path temporary file URI, absolute or relative
      * @return destination for temporary file
      */
-    Destination getDestination(URI path);
+    Destination getDestination(URI path) throws IOException;
 
     /**
      * Get result content handler.
@@ -98,5 +90,5 @@ public interface Store {
      * @return serializer content handler
      * @throws SaxonApiException if creating serializer fails
      */
-    ContentHandler getContentHandler(URI path) throws SaxonApiException;
+    ContentHandler getContentHandler(URI path) throws SaxonApiException, IOException;
 }

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+import java.net.URI;
+
+public interface Store {
+
+    /**
+     * Get DOM document for file. Convenience method.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return document or null if not available
+     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
+     */
+    Document getDocument(URI path) throws IOException;
+
+    /**
+     * Write DOM document to file.
+     *
+     * @param doc document to store
+     * @param dst destination file URI, absolute or relative
+     * @throws IOException if serializing file fails
+     */
+    void writeDocument(Document doc, URI dst) throws IOException;
+
+}

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.store;
 
+import net.sf.saxon.s9api.Destination;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
 import org.xml.sax.XMLFilter;
@@ -71,5 +72,13 @@ public interface Store {
      * @return result for temporary file
      */
     Result getResult(URI path);
+
+    /**
+     * Get temporary file destination
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return destination for temporary file
+     */
+    Destination getDestination(URI path);
 
 }

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -11,6 +11,7 @@ package org.dita.dost.store;
 import net.sf.saxon.s9api.Destination;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.XMLFilter;
 
 import javax.xml.transform.Result;
@@ -21,6 +22,14 @@ import java.net.URI;
 import java.util.List;
 
 public interface Store {
+
+    /**
+     * Read XML into SAX pipe.
+     *
+     * @param src file to read
+     * @param contentHandler SAX pipe to read to
+     */
+    void transform(final URI src, final ContentHandler contentHandler) throws DITAOTException;
 
     /**
      * Transform file with XML filters.

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2019 Jarno Elovirta
+ * Copyright 2020 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
@@ -15,13 +15,16 @@ import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.XMLFilter;
 
-import javax.xml.transform.Result;
 import javax.xml.transform.Source;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
+/**
+ * Abstract XML I/O.
+ *
+ * @since 3.5
+ */
 public interface Store {
 
     /**

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XdmNode;
+import org.dita.dost.util.XMLUtils;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+public class StreamStore implements Store {
+
+    private final XMLUtils xmlUtils;
+
+    public StreamStore(XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
+    }
+
+    /**
+     * Get DOM document for file. Convenience method.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
+     */
+    @Override
+    public Document getDocument(final URI path) throws IOException {
+        try {
+            return XMLUtils.getDocumentBuilder().parse(path.toString());
+        } catch (final IOException | SAXException e) {
+            throw new IOException("Failed to read document: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Write DOM document to file.
+     *
+     * @param doc document to store
+     * @param dst absolute destination file
+     * @throws IOException if serializing file fails
+     */
+    public void writeDocument(final Document doc, final File dst) throws IOException {
+        try {
+            final Serializer serializer = xmlUtils.getProcessor().newSerializer(dst);
+            final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
+            serializer.serializeNode(source);
+        } catch (SaxonApiException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Write DOM document to file.
+     *
+     * @param doc document to store
+     * @param dst absolute destination file URI
+     * @throws IOException if serializing file fails
+     */
+    @Override
+    public void writeDocument(final Document doc, final URI dst) throws IOException {
+        writeDocument(doc, new File(dst));
+    }
+}

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -81,6 +81,21 @@ public class StreamStore implements Store {
         writeDocument(doc, new File(dst));
     }
 
+    @Override
+    public void transform(final URI input, final ContentHandler contentHandler) throws DITAOTException {
+        assert input.isAbsolute();
+        if (!input.getScheme().equals("file")) {
+            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+        }
+        try {
+            final XMLReader xmlReader = XMLUtils.getXMLReader();
+            xmlReader.setContentHandler(contentHandler);
+            xmlReader.parse(input.toString());
+        } catch (SAXException | IOException e) {
+            throw new DITAOTException(e);
+        }
+    }
+
     /**
      * Transform file with XML filters. Only file URIs are supported.
      *

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.store;
 
+import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
 import net.sf.saxon.s9api.XdmNode;
@@ -221,5 +222,10 @@ public class StreamStore implements Store {
     @Override
     public Result getResult(URI path) {
         return new StreamResult(path.toString());
+    }
+
+    @Override
+    public Destination getDestination(URI path) {
+        return xmlUtils.getProcessor().newSerializer(new File(path));
     }
 }

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -11,13 +11,22 @@ package org.dita.dost.store;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
 import net.sf.saxon.s9api.XdmNode;
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
+import org.xml.sax.*;
 
-import java.io.File;
-import java.io.IOException;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
 import java.net.URI;
+import java.util.List;
+
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.io.FileUtils.moveFile;
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
 
 public class StreamStore implements Store {
 
@@ -51,10 +60,10 @@ public class StreamStore implements Store {
      */
     public void writeDocument(final Document doc, final File dst) throws IOException {
         try {
-            final Serializer serializer = xmlUtils.getProcessor().newSerializer(dst);
+            final Serializer serializer = getSerializer(dst.toURI());
             final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
             serializer.serializeNode(source);
-        } catch (SaxonApiException e) {
+        } catch (DITAOTException | SaxonApiException e) {
             throw new IOException(e);
         }
     }
@@ -69,5 +78,148 @@ public class StreamStore implements Store {
     @Override
     public void writeDocument(final Document doc, final URI dst) throws IOException {
         writeDocument(doc, new File(dst));
+    }
+
+    /**
+     * Transform file with XML filters. Only file URIs are supported.
+     *
+     * @param input absolute URI to transform and replace
+     * @param filters XML filters to transform file with, may be an empty list
+     */
+    @Override
+    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
+        assert input.isAbsolute();
+        if (!input.getScheme().equals("file")) {
+            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+        }
+
+        transform(new File(input), filters);
+    }
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param inputFile file to transform and replace
+     * @param filters XML filters to transform file with, may be an empty list
+     */
+    private void transform(final File inputFile, final List<XMLFilter> filters) throws DITAOTException {
+        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
+        transformFile(inputFile, outputFile, filters);
+        try {
+            deleteQuietly(inputFile);
+            moveFile(outputFile, inputFile);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
+        }
+    }
+
+//    /**
+//     * Transform file with XML filters.
+//     *
+//     * @param inputFile input file
+//     * @param outputFile output file
+//     * @param filters XML filters to transform file with, may be an empty list
+//     */
+//    public void transform(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
+//        if (inputFile.equals(outputFile)) {
+//            transform(inputFile, filters);
+//        } else {
+//            transformFile(inputFile, outputFile, filters);
+//        }
+//    }
+
+    private void transformFile(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+
+        try {
+            XMLReader reader = xmlUtils.getXMLReader();
+            for (final XMLFilter filter : filters) {
+                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
+                // when reusing filter with multiple Transformers.
+                filter.setContentHandler(null);
+                filter.setParent(reader);
+                reader = filter;
+            }
+
+            final Serializer result = getSerializer(outputFile.toURI());
+            final ContentHandler serializer = result.getContentHandler();
+            reader.setContentHandler(serializer);
+
+            final InputSource inputSource = new InputSource(inputFile.toURI().toString());
+
+            reader.parse(inputSource);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to transform " + inputFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param input input file
+     * @param output output file
+     * @param filters XML filters to transform file with, may be an empty list
+     */
+    @Override
+    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        if (input.equals(output)) {
+            transform(input, filters);
+        } else {
+            transformURI(input, output, filters);
+        }
+    }
+
+    private void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        final File outputFile = new File(output);
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+
+        try {
+            XMLReader reader = xmlUtils.getXMLReader();
+            for (final XMLFilter filter : filters) {
+                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
+                // when reusing filter with multiple Transformers.
+                filter.setContentHandler(null);
+                filter.setParent(reader);
+                reader = filter;
+            }
+
+            final Serializer result = getSerializer(output);
+            final ContentHandler serializer = result.getContentHandler();
+            reader.setContentHandler(serializer);
+
+            final InputSource inputSource = new InputSource(input.toString());
+
+            reader.parse(inputSource);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to transform " + input + ": " + e.getMessage(), e);
+        }
+    }
+
+    private Serializer getSerializer(final URI dst) throws DITAOTException {
+        final File outputFile = new File(dst);
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+        return xmlUtils.getProcessor().newSerializer(outputFile);
+    }
+
+    @Override
+    public Source getSource(URI path) {
+        return new StreamSource(path.toString());
+    }
+
+    @Override
+    public Result getResult(URI path) {
+        return new StreamResult(path.toString());
     }
 }

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -8,10 +8,14 @@
 
 package org.dita.dost.store;
 
+import net.sf.saxon.event.PipelineConfiguration;
+import net.sf.saxon.event.Receiver;
+import net.sf.saxon.event.ReceivingContentHandler;
 import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
 import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.serialize.SerializationProperties;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
@@ -242,5 +246,23 @@ public class StreamStore implements Store {
     @Override
     public Destination getDestination(URI path) {
         return xmlUtils.getProcessor().newSerializer(new File(path));
+    }
+
+    @Override
+    public ContentHandler getContentHandler(final URI outputFile) throws SaxonApiException {
+        final net.sf.saxon.Configuration configuration = xmlUtils.getProcessor().getUnderlyingConfiguration();
+//        final SerializerFactory sf = configuration.getSerializerFactory();
+        final PipelineConfiguration pipelineConfiguration = configuration.makePipelineConfiguration();
+
+        final Destination dst = getDestination(outputFile);
+        final Receiver receiver = dst.getReceiver(pipelineConfiguration, new SerializationProperties());
+//        final Result out = job.getStore().getResult(outputFile);
+//        final Receiver receiver = sf.getReceiver(out, new SerializationProperties());
+
+        final ReceivingContentHandler receivingContentHandler = new ReceivingContentHandler();
+        receivingContentHandler.setPipelineConfiguration(pipelineConfiguration);
+        receivingContentHandler.setReceiver(receiver);
+
+        return receivingContentHandler;
     }
 }

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -22,9 +22,7 @@ import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.*;
 
-import javax.xml.transform.Result;
 import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +33,11 @@ import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.io.FileUtils.moveFile;
 import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
 
+/**
+ * Stream based XML I/O
+ *
+ * @since 3.5
+ */
 public class StreamStore implements Store {
 
     private final XMLUtils xmlUtils;

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.store;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.sf.saxon.event.PipelineConfiguration;
 import net.sf.saxon.event.Receiver;
 import net.sf.saxon.event.ReceivingContentHandler;
@@ -25,7 +26,8 @@ import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -41,12 +43,6 @@ public class StreamStore implements Store {
         this.xmlUtils = xmlUtils;
     }
 
-    /**
-     * Get DOM document for file. Convenience method.
-     *
-     * @param path temporary file URI, absolute or relative
-     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
-     */
     @Override
     public Document getDocument(final URI path) throws IOException {
         try {
@@ -56,33 +52,15 @@ public class StreamStore implements Store {
         }
     }
 
-    /**
-     * Write DOM document to file.
-     *
-     * @param doc document to store
-     * @param dst absolute destination file
-     * @throws IOException if serializing file fails
-     */
-    public void writeDocument(final Document doc, final File dst) throws IOException {
-        try {
-            final Serializer serializer = getSerializer(dst.toURI());
-            final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
-            serializer.serializeNode(source);
-        } catch (DITAOTException | SaxonApiException e) {
-            throw new IOException(e);
-        }
-    }
-
-    /**
-     * Write DOM document to file.
-     *
-     * @param doc document to store
-     * @param dst absolute destination file URI
-     * @throws IOException if serializing file fails
-     */
     @Override
     public void writeDocument(final Document doc, final URI dst) throws IOException {
-        writeDocument(doc, new File(dst));
+        try {
+            final Serializer serializer = getSerializer(dst);
+            final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
+            serializer.serializeNode(source);
+        } catch (SaxonApiException e) {
+            throw new IOException(e);
+        }
     }
 
     @Override
@@ -91,6 +69,7 @@ public class StreamStore implements Store {
         if (!input.getScheme().equals("file")) {
             throw new IllegalArgumentException("Only file URI scheme supported: " + input);
         }
+
         try {
             final XMLReader xmlReader = XMLUtils.getXMLReader();
             xmlReader.setContentHandler(contentHandler);
@@ -100,12 +79,6 @@ public class StreamStore implements Store {
         }
     }
 
-    /**
-     * Transform file with XML filters. Only file URIs are supported.
-     *
-     * @param input absolute URI to transform and replace
-     * @param filters XML filters to transform file with, may be an empty list
-     */
     @Override
     public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
         assert input.isAbsolute();
@@ -113,79 +86,17 @@ public class StreamStore implements Store {
             throw new IllegalArgumentException("Only file URI scheme supported: " + input);
         }
 
-        transform(new File(input), filters);
-    }
-
-    /**
-     * Transform file with XML filters.
-     *
-     * @param inputFile file to transform and replace
-     * @param filters XML filters to transform file with, may be an empty list
-     */
-    private void transform(final File inputFile, final List<XMLFilter> filters) throws DITAOTException {
+        final File inputFile = new File(input);
         final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
-        transformFile(inputFile, outputFile, filters);
+        transformURI(inputFile.toURI(), outputFile.toURI(), filters);
         try {
             deleteQuietly(inputFile);
             moveFile(outputFile, inputFile);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final Exception e) {
+        } catch (final IOException e) {
             throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
         }
     }
 
-//    /**
-//     * Transform file with XML filters.
-//     *
-//     * @param inputFile input file
-//     * @param outputFile output file
-//     * @param filters XML filters to transform file with, may be an empty list
-//     */
-//    public void transform(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
-//        if (inputFile.equals(outputFile)) {
-//            transform(inputFile, filters);
-//        } else {
-//            transformFile(inputFile, outputFile, filters);
-//        }
-//    }
-
-    private void transformFile(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
-        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
-            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
-        }
-
-        try {
-            XMLReader reader = xmlUtils.getXMLReader();
-            for (final XMLFilter filter : filters) {
-                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
-                // when reusing filter with multiple Transformers.
-                filter.setContentHandler(null);
-                filter.setParent(reader);
-                reader = filter;
-            }
-
-            final Serializer result = getSerializer(outputFile.toURI());
-            final ContentHandler serializer = result.getContentHandler();
-            reader.setContentHandler(serializer);
-
-            final InputSource inputSource = new InputSource(inputFile.toURI().toString());
-
-            reader.parse(inputSource);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new DITAOTException("Failed to transform " + inputFile + ": " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Transform file with XML filters.
-     *
-     * @param input input file
-     * @param output output file
-     * @param filters XML filters to transform file with, may be an empty list
-     */
     @Override
     public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
         if (input.equals(output)) {
@@ -225,11 +136,9 @@ public class StreamStore implements Store {
         }
     }
 
-    private Serializer getSerializer(final URI dst) throws DITAOTException {
+    @VisibleForTesting
+    Serializer getSerializer(final URI dst) {
         final File outputFile = new File(dst);
-        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
-            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
-        }
         return xmlUtils.getProcessor().newSerializer(outputFile);
     }
 
@@ -239,13 +148,8 @@ public class StreamStore implements Store {
     }
 
     @Override
-    public Result getResult(URI path) {
-        return new StreamResult(path.toString());
-    }
-
-    @Override
     public Destination getDestination(URI path) {
-        return xmlUtils.getProcessor().newSerializer(new File(path));
+        return getSerializer(path);
     }
 
     @Override

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1107,6 +1107,8 @@ public final class Constants {
 
     /** Project reference name for job configuration object. */
     public static final String ANT_REFERENCE_JOB = "job";
+    /** Project reference name for XML utils object. */
+    public static final String ANT_REFERENCE_XML_UTILS = "xmlutils";
     /** Temporary directory Ant property name. */
     public static final String ANT_TEMP_DIR = "dita.temp.dir";
 

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1109,6 +1109,7 @@ public final class Constants {
     public static final String ANT_REFERENCE_JOB = "job";
     /** Project reference name for XML utils object. */
     public static final String ANT_REFERENCE_XML_UTILS = "xmlutils";
+    public static final String ANT_REFERENCE_STORE = "store";
     /** Temporary directory Ant property name. */
     public static final String ANT_TEMP_DIR = "dita.temp.dir";
 

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -8,7 +8,6 @@
  */
 package org.dita.dost.util;
 
-import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -21,9 +20,6 @@ import org.w3c.dom.NodeList;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -32,7 +28,6 @@ import java.util.*;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toFile;
-import static org.dita.dost.util.XMLUtils.withLogger;
 
 /**
  *
@@ -47,7 +42,6 @@ public final class DelayConrefUtils {
 
     private DITAOTLogger logger;
     private Job job;
-    private XMLUtils xmlUtils;
 
     /**
      * Constructor.
@@ -64,10 +58,6 @@ public final class DelayConrefUtils {
 
     public void setJob(final Job job) {
         this.job = job;
-    }
-
-    public void setXmlUtils(final XMLUtils xmlUtils) {
-        this.xmlUtils = xmlUtils;
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -245,38 +245,11 @@ public final class DelayConrefUtils {
             entry.setAttribute("key", key);
             entry.appendChild(doc.createTextNode(prop.getProperty(key)));
         }
-        final TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer t;
+
         try {
-            t = withLogger(tf.newTransformer(), logger);
-            t.setOutputProperty(OutputKeys.INDENT, "yes");
-            t.setOutputProperty(OutputKeys.METHOD, "xml");
-            t.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-        } catch (final TransformerConfigurationException tce) {
-            throw new RuntimeException(tce);
-        }
-        final DOMSource doms = new DOMSource(doc);
-        OutputStream out = null;
-        try {
-            out = new FileOutputStream(outputFile);
-            final StreamResult sr = new StreamResult(out);
-            t.transform(doms, sr);
-        } catch (final UncheckedXPathException e) {
-            logger.error("Failed to process map: " + e.getXPathException().getMessageAndLocation(), e);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final TransformerException e) {
-            logger.error("Failed to process map: " + e.getMessageAndLocation(), e);
-        } catch (final Exception e) {
+            job.getStore().writeDocument(doc, outputFile.toURI());
+        } catch (final IOException e) {
             logger.error("Failed to process map: " + e.getMessage(), e);
-        } finally {
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (final IOException e) {
-                    logger.error("Failed to close output stream: " + e.getMessage());
-                }
-            }
         }
     }
 

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -83,7 +83,7 @@ public final class DelayConrefUtils {
         }
         try {
             //load the file
-            final Document root = xmlUtils.getDocument(absolutePathToFile.toURI());
+            final Document root = job.getStore().getDocument(absolutePathToFile.toURI());
 
             //get root element
             final Element doc = root.getDocumentElement();
@@ -132,7 +132,7 @@ public final class DelayConrefUtils {
         try {
             //load export.xml only once
             if (root == null) {
-                root = xmlUtils.getDocument(exportFile.toURI());
+                root = job.getStore().getDocument(exportFile.toURI());
             }
             //get file node which contains the export node
             final Element fileNode = searchForKey(root.getDocumentElement(), href, "file");

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -47,6 +47,7 @@ public final class DelayConrefUtils {
 
     private DITAOTLogger logger;
     private Job job;
+    private XMLUtils xmlUtils;
 
     /**
      * Constructor.
@@ -65,6 +66,9 @@ public final class DelayConrefUtils {
         this.job = job;
     }
 
+    public void setXmlUtils(final XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
+    }
 
     /**
      * Find whether an id is refer to a topic in a dita file.
@@ -79,7 +83,6 @@ public final class DelayConrefUtils {
         }
         try {
             //load the file
-            final XMLUtils xmlUtils = new XMLUtils();
             final Document root = xmlUtils.getDocument(absolutePathToFile.toURI());
 
             //get root element
@@ -129,7 +132,6 @@ public final class DelayConrefUtils {
         try {
             //load export.xml only once
             if (root == null) {
-                final XMLUtils xmlUtils = new XMLUtils();
                 root = xmlUtils.getDocument(exportFile.toURI());
             }
             //get file node which contains the export node

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -20,6 +20,7 @@ import net.sf.saxon.serialize.MessageWarner;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.trans.XsltController;
 import org.apache.xml.resolver.tools.CatalogResolver;
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.LoggingErrorListener;
 import org.dita.dost.module.saxon.DelegatingCollationUriResolver;
@@ -42,6 +43,8 @@ import java.util.stream.Stream;
 
 import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
 import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.io.FileUtils.moveFile;
 import static org.dita.dost.util.Constants.*;
 
 /**
@@ -559,6 +562,147 @@ public final class XMLUtils {
         return buf.toString();
     }
 
+    /**
+     * Transform file with XML filters. Only file URIs are supported.
+     *
+     * @param input absolute URI to transform and replace
+     * @param filters XML filters to transform file with, may be an empty list
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
+        assert input.isAbsolute();
+        if (!input.getScheme().equals("file")) {
+            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+        }
+
+        transform(new File(input), filters);
+    }
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param inputFile file to transform and replace
+     * @param filters XML filters to transform file with, may be an empty list
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    public void transform(final File inputFile, final List<XMLFilter> filters) throws DITAOTException {
+        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
+        transformFile(inputFile, outputFile, filters);
+        try {
+            deleteQuietly(inputFile);
+            moveFile(outputFile, inputFile);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param inputFile input file
+     * @param outputFile output file
+     * @param filters XML filters to transform file with, may be an empty list
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    public void transform(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
+        if (inputFile.equals(outputFile)) {
+            transform(inputFile, filters);
+        } else {
+            transformFile(inputFile, outputFile, filters);
+        }
+    }
+
+    /**
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    private void transformFile(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+
+        try (final InputStream in = new BufferedInputStream(new FileInputStream(inputFile));
+             final OutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+            XMLReader reader = getXMLReader();
+            for (final XMLFilter filter : filters) {
+                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
+                // when reusing filter with multiple Transformers.
+                filter.setContentHandler(null);
+                filter.setParent(reader);
+                reader = filter;
+            }
+
+            final Serializer result = processor.newSerializer(out);
+            final ContentHandler serializer = result.getContentHandler();
+            reader.setContentHandler(serializer);
+
+            final InputSource inputSource = new InputSource(in);
+            inputSource.setSystemId(inputFile.toURI().toString());
+
+            reader.parse(inputSource);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to transform " + inputFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Transform file with XML filters.
+     *
+     * @param input input file
+     * @param output output file
+     * @param filters XML filters to transform file with, may be an empty list
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        if (input.equals(output)) {
+            transform(input, filters);
+        } else {
+            transformURI(input, output, filters);
+        }
+    }
+
+    /**
+     * @deprecated since 3.5
+     */
+    @Deprecated
+    private void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        final File outputFile = new File(output);
+        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+
+        try {
+            XMLReader reader = getXMLReader();
+            for (final XMLFilter filter : filters) {
+                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
+                // when reusing filter with multiple Transformers.
+                filter.setContentHandler(null);
+                filter.setParent(reader);
+                reader = filter;
+            }
+
+            final Serializer result = processor.newSerializer(outputFile);
+            final ContentHandler serializer = result.getContentHandler();
+            reader.setContentHandler(serializer);
+
+            final InputSource inputSource = new InputSource(input.toString());
+
+            reader.parse(inputSource);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final Exception e) {
+            throw new DITAOTException("Failed to transform " + input + ": " + e.getMessage(), e);
+        }
+    }
+
     /** Close input source. */
     public static void close(final InputSource input) throws IOException {
         if (input != null) {
@@ -691,21 +835,6 @@ public final class XMLUtils {
         return builder;
     }
 
-//    /**
-//     * Get DOM document for file. Convenience method.
-//     *
-//     * @param path temporary file URI, absolute or relative
-//     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
-//     */
-//    @Override
-//    public Document getDocument(final URI path) throws IOException {
-//        try {
-//            return getDocumentBuilder().parse(path.toString());
-//        } catch (final IOException | SAXException e) {
-//            throw new IOException("Failed to read document: " + e.getMessage(), e);
-//        }
-//    }
-
     /**
      * Write DOM document to file.
      *
@@ -713,7 +842,6 @@ public final class XMLUtils {
      * @param dst absolute destination file
      * @throws IOException if serializing file fails
      */
-    @Deprecated
     public void writeDocument(final Document doc, final File dst) throws IOException {
         try {
             final Serializer serializer = processor.newSerializer(dst);
@@ -722,18 +850,6 @@ public final class XMLUtils {
         } catch (SaxonApiException e) {
             throw new IOException(e);
         }
-    }
-
-    /**
-     * Write DOM document to file.
-     *
-     * @param doc document to store
-     * @param dst absolute destination file URI
-     * @throws IOException if serializing file fails
-     */
-    @Deprecated
-    public void writeDocument(final Document doc, final URI dst) throws IOException {
-        writeDocument(doc, new File(dst));
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -20,7 +20,6 @@ import net.sf.saxon.serialize.MessageWarner;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.trans.XsltController;
 import org.apache.xml.resolver.tools.CatalogResolver;
-import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.LoggingErrorListener;
 import org.dita.dost.module.saxon.DelegatingCollationUriResolver;
@@ -43,8 +42,6 @@ import java.util.stream.Stream;
 
 import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
 import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.apache.commons.io.FileUtils.deleteQuietly;
-import static org.apache.commons.io.FileUtils.moveFile;
 import static org.dita.dost.util.Constants.*;
 
 /**
@@ -560,131 +557,6 @@ public final class XMLUtils {
             }
         }
         return buf.toString();
-    }
-
-    /**
-     * Transform file with XML filters. Only file URIs are supported.
-     *
-     * @param input absolute URI to transform and replace
-     * @param filters XML filters to transform file with, may be an empty list
-     */
-    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
-        assert input.isAbsolute();
-        if (!input.getScheme().equals("file")) {
-            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
-        }
-
-        transform(new File(input), filters);
-    }
-
-    /**
-     * Transform file with XML filters.
-     *
-     * @param inputFile file to transform and replace
-     * @param filters XML filters to transform file with, may be an empty list
-     */
-    public void transform(final File inputFile, final List<XMLFilter> filters) throws DITAOTException {
-        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
-        transformFile(inputFile, outputFile, filters);
-        try {
-            deleteQuietly(inputFile);
-            moveFile(outputFile, inputFile);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
-        }
-    }
-
-    /**
-     * Transform file with XML filters.
-     *
-     * @param inputFile input file
-     * @param outputFile output file
-     * @param filters XML filters to transform file with, may be an empty list
-     */
-    public void transform(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
-        if (inputFile.equals(outputFile)) {
-            transform(inputFile, filters);
-        } else {
-            transformFile(inputFile, outputFile, filters);
-        }
-    }
-
-    private void transformFile(final File inputFile, final File outputFile, final List<XMLFilter> filters) throws DITAOTException {
-        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
-            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
-        }
-
-        try (final InputStream in = new BufferedInputStream(new FileInputStream(inputFile));
-             final OutputStream out = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-            XMLReader reader = getXMLReader();
-            for (final XMLFilter filter : filters) {
-                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
-                // when reusing filter with multiple Transformers.
-                filter.setContentHandler(null);
-                filter.setParent(reader);
-                reader = filter;
-            }
-
-            final Serializer result = processor.newSerializer(out);
-            final ContentHandler serializer = result.getContentHandler();
-            reader.setContentHandler(serializer);
-
-            final InputSource inputSource = new InputSource(in);
-            inputSource.setSystemId(inputFile.toURI().toString());
-
-            reader.parse(inputSource);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new DITAOTException("Failed to transform " + inputFile + ": " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Transform file with XML filters.
-     *
-     * @param input input file
-     * @param output output file
-     * @param filters XML filters to transform file with, may be an empty list
-     */
-    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
-        if (input.equals(output)) {
-            transform(input, filters);
-        } else {
-            transformURI(input, output, filters);
-        }
-    }
-
-    private void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
-        final File outputFile = new File(output);
-        if (!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
-            throw new DITAOTException("Failed to create output directory " + outputFile.getParentFile().getAbsolutePath());
-        }
-
-        try {
-            XMLReader reader = getXMLReader();
-            for (final XMLFilter filter : filters) {
-                // ContentHandler must be reset so e.g. Saxon 9.1 will reassign ContentHandler
-                // when reusing filter with multiple Transformers.
-                filter.setContentHandler(null);
-                filter.setParent(reader);
-                reader = filter;
-            }
-
-            final Serializer result = processor.newSerializer(outputFile);
-            final ContentHandler serializer = result.getContentHandler();
-            reader.setContentHandler(serializer);
-
-            final InputSource inputSource = new InputSource(input.toString());
-
-            reader.parse(inputSource);
-        } catch (final RuntimeException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new DITAOTException("Failed to transform " + input + ": " + e.getMessage(), e);
-        }
     }
 
     /** Close input source. */

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -819,19 +819,20 @@ public final class XMLUtils {
         return builder;
     }
 
-    /**
-     * Get DOM document for file. Convenience method.
-     *
-     * @param path temporary file URI, absolute or relative
-     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
-     */
-    public Document getDocument(final URI path) throws IOException {
-        try {
-            return getDocumentBuilder().parse(path.toString());
-        } catch (final IOException | SAXException e) {
-            throw new IOException("Failed to read document: " + e.getMessage(), e);
-        }
-    }
+//    /**
+//     * Get DOM document for file. Convenience method.
+//     *
+//     * @param path temporary file URI, absolute or relative
+//     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
+//     */
+//    @Override
+//    public Document getDocument(final URI path) throws IOException {
+//        try {
+//            return getDocumentBuilder().parse(path.toString());
+//        } catch (final IOException | SAXException e) {
+//            throw new IOException("Failed to read document: " + e.getMessage(), e);
+//        }
+//    }
 
     /**
      * Write DOM document to file.
@@ -840,6 +841,7 @@ public final class XMLUtils {
      * @param dst absolute destination file
      * @throws IOException if serializing file fails
      */
+    @Deprecated
     public void writeDocument(final Document doc, final File dst) throws IOException {
         try {
             final Serializer serializer = processor.newSerializer(dst);
@@ -857,6 +859,7 @@ public final class XMLUtils {
      * @param dst absolute destination file URI
      * @throws IOException if serializing file fails
      */
+    @Deprecated
     public void writeDocument(final Document doc, final URI dst) throws IOException {
         writeDocument(doc, new File(dst));
     }

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -21,7 +21,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.*;
@@ -421,9 +420,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final StringBuilder firstTopicId = new StringBuilder();
         final TopicIdParser parser = new TopicIdParser(firstTopicId);
         try {
-            final XMLReader reader = getXMLReader();
-            reader.setContentHandler(parser);
-            reader.parse(ditaTopicFile.toURI().toString());
+            job.getStore().transform(ditaTopicFile.toURI(), parser);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -8,14 +8,12 @@
 package org.dita.dost.writer;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.reader.AbstractReader;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 
-import javax.xml.parsers.DocumentBuilder;
 import java.io.File;
 import java.io.IOException;
 
@@ -38,10 +36,7 @@ public abstract class AbstractDomFilter implements AbstractReader {
         logger.info("Processing " + filename.toURI());
         Document doc;
         try {
-            final DocumentBuilder builder = XMLUtils.getDocumentBuilder();
-            builder.setErrorHandler(new DITAOTXMLErrorHandler(filename.getPath(), logger));
-            logger.debug("Reading " + filename.toURI());
-            doc = builder.parse(filename);
+            doc = job.getStore().getDocument(filename.toURI());
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -38,7 +38,7 @@ public abstract class AbstractDomFilter implements AbstractReader {
         logger.info("Processing " + filename.toURI());
         Document doc;
         try {
-            final DocumentBuilder builder = xmlUtils.getDocumentBuilder();
+            final DocumentBuilder builder = XMLUtils.getDocumentBuilder();
             builder.setErrorHandler(new DITAOTXMLErrorHandler(filename.getPath(), logger));
             logger.debug("Reading " + filename.toURI());
             doc = builder.parse(filename);
@@ -53,7 +53,7 @@ public abstract class AbstractDomFilter implements AbstractReader {
         if (resDoc != null) {
             try {
                 logger.debug("Writing " + filename.toURI());
-                xmlUtils.writeDocument(resDoc, filename);
+                job.getStore().writeDocument(resDoc, filename.toURI());
             } catch (final IOException e) {
                 throw new DITAOTException("Failed to serialize " + filename.getAbsolutePath() + ": " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
@@ -37,7 +37,7 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
     @Override
     public void write(final File filename) throws DITAOTException {
         assert filename.isAbsolute();
-        xmlUtils.transform(filename, Collections.singletonList(this));
+        job.getStore().transform(filename.toURI(), Collections.singletonList(this));
     }
 
     @Override

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -40,20 +40,20 @@ import static org.dita.dost.util.XMLUtils.*;
  */
 public final class ChunkTopicParser extends AbstractChunkTopicParser {
 
-    private final XMLReader reader;
+//    private final XMLReader reader;
 
     /**
      * Constructor.
      */
     public ChunkTopicParser() {
         super();
-        try {
-            reader = getXMLReader();
-            reader.setContentHandler(this);
-            reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
-        } catch (final Exception e) {
-            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
-        }
+//        try {
+//            reader = getXMLReader();
+//            reader.setContentHandler(this);
+//            reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
+//        } catch (final Exception e) {
+//            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
+//        }
     }
 
     @Override
@@ -203,7 +203,8 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                     currentParsingFileTopicIDChangeTable = new HashMap<>();
                     // TODO recursive point
                     logger.info("Processing " + currentParsingFile);
-                    reader.parse(currentParsingFile.toString());
+                    job.getStore().transform(currentParsingFile, this);
+//                    reader.parse(currentParsingFile.toString());
                     if (currentParsingFileTopicIDChangeTable.size() > 0) {
                         final URI href = toURI(topicref.getAttribute(ATTRIBUTE_NAME_HREF));
                         final String pathtoElem = href.getFragment() != null

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -8,16 +8,13 @@
  */
 package org.dita.dost.writer;
 
-import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.*;
@@ -43,7 +40,6 @@ import static org.dita.dost.util.XMLUtils.*;
  */
 public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
 
-    private final XMLReader reader;
     // stub is used as the anchor to mark where to insert generated child
     // topicref inside current topicref
     private Element stub;
@@ -55,20 +51,6 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
     final Deque<Writer> outputStack = new ArrayDeque<>();
     final Deque<Element> stubStack = new ArrayDeque<>();
     final Deque<String> lang = new LinkedList<>();
-
-    /**
-     * Constructor.
-     */
-    public SeparateChunkTopicParser() {
-        super();
-        try {
-            reader = getXMLReader();
-            reader.setContentHandler(this);
-            reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
-        } catch (final Exception e) {
-            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
-        }
-    }
 
     @Override
     public void write(final URI currentFile) {
@@ -188,9 +170,8 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                 rootTopicref.getParentNode().appendChild(siblingStub);
             }
 
-            reader.setErrorHandler(new DITAOTXMLErrorHandler(currentParsingFile.getPath(), logger));
             logger.info("Processing " + currentParsingFile);
-            reader.parse(currentParsingFile.toString());
+            job.getStore().transform(currentParsingFile, this);
             output.flush();
 
             removeStubElements();
@@ -258,7 +239,6 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
      * @return element.
      */
     private Element getTopicDoc(final URI absolutePathToFile) {
-        final XMLUtils xmlUtils = new XMLUtils();
         try {
             final Document doc = job.getStore().getDocument(absolutePathToFile);
             return doc.getDocumentElement();

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -260,7 +260,7 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
     private Element getTopicDoc(final URI absolutePathToFile) {
         final XMLUtils xmlUtils = new XMLUtils();
         try {
-            final Document doc = xmlUtils.getDocument(absolutePathToFile);
+            final Document doc = job.getStore().getDocument(absolutePathToFile);
             return doc.getDocumentElement();
         } catch (final IOException e) {
             logger.error("Failed to parse " + absolutePathToFile + ": " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/writer/include/IncludeText.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeText.java
@@ -49,7 +49,7 @@ final class IncludeText {
             try (BufferedReader codeReader = Files.newBufferedReader(codeFile.toPath(), charset)) {
                 range.copyLines(codeReader);
             } catch (final Exception e) {
-                logger.error("Failed to process include {}", codeFile, e);
+                logger.error("Failed to process include {0}", codeFile, e);
                 return false;
             }
         }

--- a/src/main/java/org/dita/dost/writer/include/IncludeXml.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeXml.java
@@ -43,7 +43,7 @@ final class IncludeXml {
         final URI hrefValue = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
         final Job.FileInfo fileInfo = job.getFileInfo(stripFragment(currentFile.resolve(hrefValue)));
         try {
-            final Document doc = xmlUtils.getDocument(fileInfo.src);
+            final Document doc = job.getStore().getDocument(fileInfo.src);
             Node src = null;
             if (hrefValue.getFragment() != null) {
                 src = doc.getElementById(hrefValue.getFragment());

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -19,6 +19,7 @@ See the accompanying LICENSE file for applicable license.
     <catalogpath path="${dita.plugin.org.dita.base.dir}/catalog-dita.xml"/>
   </xmlcatalog>
 
+  <taskdef name="init-project" classname="org.dita.dost.ant.InitializeProjectTask"/>
   <taskdef name="pipeline" classname="org.dita.dost.ant.ExtensibleAntInvoker"/>
   <taskdef name="dita-ot-echo" classname="org.dita.dost.ant.DITAOTEchoTask"/>
   <taskdef name="dita-ot-fail" classname="org.dita.dost.ant.DITAOTFailTask"/>
@@ -49,6 +50,7 @@ See the accompanying LICENSE file for applicable license.
                    log-arg"/>
 
   <target name="init-properties">
+    <init-project/>
     <property name="default.language" value="en"/>
     <property name="generate-debug-attributes" value="true"/>
     <property name="processing-mode" value="lax"/>

--- a/src/main/plugins/org.dita.base/build_template.xml
+++ b/src/main/plugins/org.dita.base/build_template.xml
@@ -29,7 +29,7 @@ See the accompanying LICENSE file for applicable license.
     <condition property="clean-temp.skip">
       <isfalse value="${clean.temp}"/>
     </condition>
-    <antcall>
+    <antcall inheritRefs="true">
       <target name="dita2${transtype}"/>
       <target name="clean-temp"/>
     </antcall>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -239,7 +239,7 @@ See the accompanying LICENSE file for applicable license.
       <fileset dir="${dita.plugin.org.dita.html5.dir}/css" includes="*.css"/>
     </copy>
     <!-- Copy user specify css file when required -->
-    <antcall target="html5.copy-css-user"/>
+    <antcall target="html5.copy-css-user" inheritRefs="true"/>
   </target>
 
   <target name="html5.copy-css-user" if="user.copycss.yes">

--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -20,7 +20,7 @@ See the accompanying LICENSE file for applicable license.
                    htmlhelp.topics,
                    htmlhelp.copy-image,
                    copy-css">
-    <antcall target="dita.map.htmlhelp"/>
+    <antcall target="dita.map.htmlhelp" inheritRefs="true"/>
   </target>
 
   <target name="dita2htmlhelp.init">

--- a/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
+++ b/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
@@ -22,6 +22,7 @@ import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.StringUtils;
+import org.dita.dost.util.XMLUtils;
 
 /**
  * This class is for get the first xml:lang value set in ditamap/topic files
@@ -66,10 +67,8 @@ public final class CheckLang extends Task {
 
         try {
 
-            final SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
-            final SAXParser saxParser = saxParserFactory.newSAXParser();
             //parse the user input file(usually a map)
-            saxParser.parse(inputmap, parser);
+            job.getStore().transform(new File(inputmap).toURI(), parser);
             String langCode = parser.getLangCode();
             if (!StringUtils.isEmptyString(langCode)) {
                 setActiveProjectProperty("htmlhelp.locale", langCode);
@@ -79,7 +78,7 @@ public final class CheckLang extends Task {
                     if (ATTR_FORMAT_VALUE_DITA.equals(f.format)) {
                         final File topicFile = new File(job.tempDir, f.file.getPath());
                         if (topicFile.exists()) {
-                            saxParser.parse(topicFile, parser);
+                            job.getStore().transform(topicFile.toURI(), parser);
                             langCode = parser.getLangCode();
                             if (!StringUtils.isEmptyString(langCode)) {
                                 setActiveProjectProperty("htmlhelp.locale", langCode);

--- a/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
+++ b/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
@@ -34,8 +34,6 @@ public final class CheckLang extends Task {
 
     private File basedir;
 
-    private File tempdir;
-
     private File outputdir;
 
     private String inputmap;
@@ -52,21 +50,17 @@ public final class CheckLang extends Task {
         logger = new DITAOTAntLogger(getProject());
         logger.info(message);
 
-        new Properties();
-        //ensure tempdir is absolute
-        if (!tempdir.isAbsolute()) {
-            tempdir = new File(basedir, tempdir.getPath()).getAbsoluteFile();
-        }
+        final Job job = getJob(getProject());
+
         //ensure outdir is absolute
         if (!outputdir.isAbsolute()) {
             outputdir = new File(basedir, outputdir.getPath()).getAbsoluteFile();
         }
         //ensure inputmap is absolute
         if (!new File(inputmap).isAbsolute()) {
-            inputmap = new File(tempdir, inputmap).getAbsolutePath();
+            inputmap = new File(job.tempDir, inputmap).getAbsolutePath();
         }
 
-        final Job job = getJob(tempdir, getProject());
 
         final LangParser parser = new LangParser();
 
@@ -83,7 +77,7 @@ public final class CheckLang extends Task {
                 //parse topic files
                 for (final FileInfo f: job.getFileInfo()) {
                     if (ATTR_FORMAT_VALUE_DITA.equals(f.format)) {
-                        final File topicFile = new File(tempdir, f.file.getPath());
+                        final File topicFile = new File(job.tempDir, f.file.getPath());
                         if (topicFile.exists()) {
                             saxParser.parse(topicFile, parser);
                             langCode = parser.getLangCode();
@@ -131,8 +125,9 @@ public final class CheckLang extends Task {
         this.basedir = basedir;
     }
 
+    @Deprecated
     public void setTempdir(final File tempdir) {
-        this.tempdir = tempdir;
+        // NOOP
     }
 
     public void setInputmap(final String inputmap) {

--- a/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
+++ b/src/main/plugins/org.dita.pdf2.axf/build_axf.xml
@@ -190,8 +190,8 @@ See the accompanying LICENSE file for applicable license.
     <property name="outputFile" value="${dita.output.dir}/${outputFile.base}${xsl.formatter.ext}"/>
     <mkdir dir="${dita.output.dir}"/>
     
-    <antcall target="transform.fo2pdf.ah.nooption"/>
-    <antcall target="transform.fo2pdf.ah.hasoption"/>
+    <antcall target="transform.fo2pdf.ah.nooption" inheritRefs="true"/>
+    <antcall target="transform.fo2pdf.ah.hasoption" inheritRefs="true"/>
   </target>
 
   <target name="transform.fo2pdf.ah.nooption" unless="axf.opt">

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -130,7 +130,7 @@ with those set forth herein.
   </target>
 
   <target name="topic2pdf2" if="noMap">
-    <antcall target="preview.topic.pdf"/>
+    <antcall target="preview.topic.pdf" inheritRefs="true"/>
   </target>
 
   <target name="preview.topic.pdf"
@@ -155,7 +155,7 @@ with those set forth herein.
         <param name="style" location="${dita.plugin.org.dita.pdf2.dir}/xsl/common/topicmerge.xsl"/>
       </module>
     </pipeline>
-    <antcall target="publish.map.pdf"/>
+    <antcall target="publish.map.pdf" inheritRefs="true"/>
   </target>
 
   <target name="publish.map.pdf"

--- a/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_dita2xhtml_template.xml
@@ -109,7 +109,7 @@ See the accompanying LICENSE file for applicable license.
       <fileset dir="${dita.plugin.org.dita.xhtml.dir}/resource" includes="*.css"/>
     </copy>
     <!-- Copy user specify css file when required -->
-    <antcall target="copy-css-user"/>
+    <antcall target="copy-css-user" inheritRefs="true"/>
   </target>
 
   <target name="copy-css-user" if="user.copycss.yes">

--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -90,7 +90,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- Set to "true" if you get out-of-memory errors during preprocess
     while processing very large (thousands of files) document sets. -->
     <property name="dita.xhtml.reloadstylesheet" value="false"/>
-    <antcall target="output-css-warn-message"/>
+    <antcall target="output-css-warn-message" inheritRefs="true"/>
   </target>
   
   <target name="output-css-warn-message" if="args.csspath.absolute">

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -10,6 +10,7 @@ package org.dita.dost.module;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,6 +137,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
         
         m.processMap(URI.create("input.ditamap"));
         assertXMLEqual(new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
@@ -187,6 +189,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
         
         m.processMap(URI.create("main/testuplevels.ditamap"));
         assertXMLEqual(new InputSource(new File(uplevelsExpDir, "main/testuplevels.ditamap").toURI().toString()),
@@ -273,6 +276,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
 
         m.processMap(URI.create("test.ditamap"));
 

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -93,6 +94,7 @@ public class DebugAndFilterModuleTest {
         final DebugAndFilterModule module = new DebugAndFilterModule();
         module.setLogger(new TestUtils.TestLogger());
         module.setJob(job);
+        module.setXmlUtils(new XMLUtils());
         module.setProcessingPipe(Collections.emptyList());
         
         module.execute(pipelineInput);

--- a/src/test/java/org/dita/dost/module/DummyPipelineModule.java
+++ b/src/test/java/org/dita/dost/module/DummyPipelineModule.java
@@ -14,6 +14,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -41,6 +42,11 @@ public class DummyPipelineModule implements AbstractPipelineModule {
     @Override
     public void setJob(final Job job) {
         // Noop
+    }
+
+    @Override
+    public void setXmlUtils(final XMLUtils xmlUtils) {
+        // NOOP
     }
 
     @Override

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -11,6 +11,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,6 +63,7 @@ public class TestGenMapAndTopicListModule {
         module.setLogger(new TestUtils.TestLogger());
         final Job job = new Job(tempDir);
         module.setJob(job);
+        module.setXmlUtils(new XMLUtils());
         module.execute(pipelineInput);
 
         return job;

--- a/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
@@ -12,6 +12,7 @@ import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.module.BranchFilterModule.Branch;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,6 +98,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
 
         final FileInfo fi = new FileInfo.Builder()
                 .uri(URI.create("input.ditamap"))
@@ -196,6 +198,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
 
         m.processMap(job.getFileInfo(URI.create("test.ditamap")));
 

--- a/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
+++ b/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
@@ -9,6 +9,7 @@ package org.dita.dost.reader;
 
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
+import org.dita.dost.util.Job;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import java.util.Hashtable;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.apache.commons.io.FileUtils.copyFile;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.TestUtils.buildControlDocument;
 
@@ -41,12 +43,14 @@ public class TestConrefPushReader {
     @Before
     public void setUp() throws IOException {
         tempDir = TestUtils.createTempDir(TestConrefPushReader.class);
+        copyFile(new File(srcDir, "conrefpush_stub.xml"), new File(tempDir, "conrefpush_stub.xml"));
     }
 
     @Test
-    public void testRead() {
+    public void testRead() throws IOException {
         final File filename = new File(srcDir, "conrefpush_stub.xml");
         final ConrefPushReader pushReader = new ConrefPushReader();
+        pushReader.setJob(new Job(tempDir));
         pushReader.read(filename.getAbsoluteFile());
 
         final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = pushReader.getPushMap();

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -11,6 +11,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
 import org.dita.dost.util.XMLUtils;
@@ -47,6 +48,8 @@ public class TestKeyrefReader {
 //        set.add("top");
 //        set.add("nested");
         final KeyrefReader keyrefreader = new KeyrefReader();
+        keyrefreader.setLogger(new TestUtils.TestLogger());
+        keyrefreader.setJob(new Job(srcDir));
 //        keyrefreader.setKeys(set);
         keyrefreader.read(filename.toURI(), readMap(filename));
         final KeyScope act = keyrefreader.getKeyDefinition();

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import com.google.common.io.Files;
+import net.sf.saxon.s9api.Destination;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XdmNode;
+import org.apache.commons.io.FileUtils;
+import org.dita.dost.util.XMLUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import java.io.File;
+import java.io.IOException;
+
+public class StreamStoreTest {
+
+    private XMLUtils xmlUtils;
+    private StreamStore store;
+    private File tmpDir;
+
+    @Before
+    public void setUp() throws Exception {
+        xmlUtils = new XMLUtils();
+        store = new StreamStore(xmlUtils);
+        tmpDir = Files.createTempDir();
+    }
+
+    @Test
+    public void getSerializer_subDirectory() throws IOException, SaxonApiException {
+        final Document doc = XMLUtils.getDocumentBuilder().newDocument();
+        doc.appendChild(doc.createElement("foo"));
+        final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
+
+        final Serializer serializer = store.getSerializer(tmpDir.toURI().resolve("foo/bar"));
+        serializer.serializeNode(source);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+//        FileUtils.deleteDirectory(tmpDir);
+        System.out.println(tmpDir);
+    }
+}


### PR DESCRIPTION
## Description
Use singleton XML utils throughout a single DITA-OT process.

## Motivation and Context
Sharing the XML utils allows using the same Saxon processors. This in turn allows using a shared name pool and other XML related resources.

## Documentation and Compatibility
No documentation changes needed.
