### PR TITLE
Allow extending eclipsehelp

### DIFF
--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -64,7 +64,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
         final ChunkMapReader mapReader = new ChunkMapReader();
         mapReader.setLogger(logger);
         mapReader.setJob(job);
-        mapReader.supportToNavigation(INDEX_TYPE_ECLIPSEHELP.equals(transtype));
+        mapReader.supportToNavigation(transtype.contains(INDEX_TYPE_ECLIPSEHELP));
         if (input.getAttribute(ROOT_CHUNK_OVERRIDE) != null) {
             mapReader.setRootChunkOverride(input.getAttribute(ROOT_CHUNK_OVERRIDE));
         }
@@ -72,7 +72,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
         try {
             final Job.FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
             final File mapFile = new File(job.tempDirURI.resolve(in.uri));
-            if (transtype.equals(INDEX_TYPE_ECLIPSEHELP) && isEclipseMap(mapFile.toURI())) {
+            if (transtype.contains(INDEX_TYPE_ECLIPSEHELP) && isEclipseMap(mapFile.toURI())) {
                 for (final FileInfo f : job.getFileInfo()) {
                     if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
                         mapReader.read(new File(job.tempDir, f.file.getPath()).getAbsoluteFile());

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -250,7 +250,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             filterUtils = parseFilterFile();
         }
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             exportAnchorsFilter = new ExportAnchorsFilter();
             exportAnchorsFilter.setInputFile(rootFile);
         }
@@ -379,7 +379,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             pipe.add(profilingFilter);
         }
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             exportAnchorsFilter.setCurrentFile(fileToParse);
             exportAnchorsFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
             pipe.add(exportAnchorsFilter);
@@ -904,7 +904,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
         }
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -180,7 +180,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             filterUtils = parseFilterFile();
         }
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             exportAnchorsFilter = new ExportAnchorsFilter();
             exportAnchorsFilter.setInputFile(rootFile);
         }
@@ -791,7 +791,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
         }
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             final DelayConrefUtils delayConrefUtils = new DelayConrefUtils();
             delayConrefUtils.setLogger(logger);
             delayConrefUtils.setJob(job);

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -101,7 +101,7 @@ public final class MapReaderModule extends AbstractReaderModule {
         normalizeFilter.setLogger(logger);
         pipe.add(normalizeFilter);
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             exportAnchorsFilter.setCurrentFile(fileToParse);
             exportAnchorsFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
             pipe.add(exportAnchorsFilter);

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -270,7 +270,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
 
         pipe.add(topicFragmentFilter);
 
-        if (INDEX_TYPE_ECLIPSEHELP.equals(transtype)) {
+        if (transtype.contains(INDEX_TYPE_ECLIPSEHELP)) {
             exportAnchorsFilter.setCurrentFile(fileToParse);
             exportAnchorsFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
             pipe.add(exportAnchorsFilter);


### PR DESCRIPTION
Signed-off-by: thendarion <16006640+thendarion@users.noreply.github.com>

---
name: #3468 Allow extending eclipsehelp
about: allow eclipsehelp trastypes to use standard eclipsehelp features

---

## Description
instead of equals, use contains, so transtype="my-eclipsehelp" is picked up too

## Motivation and Context
resolves #3468 Allow extending eclipsehelp

## How Has This Been Tested?
currently DOST doesn't seem to have related tests

## Type of Changes
- New feature 

## Documentation and Compatibility
- What documentation changes are needed for this feature?
nothing
- Will this change affect backwards compatibility or other users' overrides?
nope