### PR TITLE
Add spanning and title to simpletable in PDF2 #3464 

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -74,6 +74,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:key name="enumerableByClass"
              match="*[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |
                     *[contains(@class, ' topic/table ')][*[contains(@class, ' topic/title ')]] |
+                    *[contains(@class, ' topic/simpletable ')][*[contains(@class, ' topic/title ')]] |
                     *[contains(@class,' topic/fn ') and empty(@callout)]"
               use="tokenize(@class, ' ')"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -312,7 +312,9 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
   
   <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]" mode="table.title-number">
-    <xsl:value-of select="count(key('enumerableByClass', 'topic/table')[. &lt;&lt; current()][dita-ot:notExcludedByDraftElement(.)])"/>
+    <xsl:value-of select="count((key('enumerableByClass', 'topic/table') | key('enumerableByClass', 'topic/simpletable'))
+                                [. &lt;&lt; current()]
+                                [dita-ot:notExcludedByDraftElement(.)])"/>
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tgroup ')]" name="tgroup">
@@ -867,6 +869,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="*[1]" mode="count-max-simpletable-cells"/>
         </xsl:variable>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
+        <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <fo:table xsl:use-attribute-sets="simpletable">
             <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="globalAtts"/>
@@ -910,6 +913,31 @@ See the accompanying LICENSE file for applicable license.
         </fo:table>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
     </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]">
+    <fo:block xsl:use-attribute-sets="table.title">
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="." mode="customTitleAnchor"/>
+      <xsl:call-template name="getVariable">
+        <xsl:with-param name="id" select="'Table.title'"/>
+        <xsl:with-param name="params">
+          <number>
+            <xsl:apply-templates select="." mode="table.title-number"/>
+          </number>
+          <title>
+            <xsl:apply-templates/>
+          </title>
+        </xsl:with-param>
+      </xsl:call-template>
+    </fo:block>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]" mode="table.title-number">
+    <xsl:value-of select="count((key('enumerableByClass', 'topic/table') | key('enumerableByClass', 'topic/simpletable'))
+                                [. &lt;&lt; current()]
+                                [dita-ot:notExcludedByDraftElement(.)])"/>
+  </xsl:template>
+  
   
     <xsl:template match="*[contains(@class,' topic/simpletable ')]
         [empty(*[contains(@class,' topic/strow ')]/*[contains(@class,' topic/stentry ')])]" priority="10"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -978,7 +978,11 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="commonattributes"/>
             <fo:table-row xsl:use-attribute-sets="sthead__row">
                 <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
-                <xsl:variable name="row-cell-count" select="count(*[contains(@class, ' topic/stentry ')])" as="xs:integer"/>
+                <xsl:variable name="row-cell-count" as="xs:integer">
+                  <xsl:variable name="last" select="*[contains(@class, ' topic/stentry ')][last()]"/>
+                  <xsl:variable name="span" select="if (exists($last/@colspan)) then (xs:integer($last/@colspan) - 1) else 0"/>
+                  <xsl:sequence select="xs:integer($last/@dita-ot:x) + $span"/>
+                </xsl:variable>
                 <xsl:if test="$row-cell-count &lt; $number-cells">
                     <xsl:apply-templates select="." mode="fillInMissingSimpletableCells">
                         <xsl:with-param name="fill-in-count" select="$number-cells - $row-cell-count"/>
@@ -995,7 +999,11 @@ See the accompanying LICENSE file for applicable license.
         <fo:table-row xsl:use-attribute-sets="strow">
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
-            <xsl:variable name="row-cell-count" select="count(*[contains(@class, ' topic/stentry ')])" as="xs:integer"/>
+            <xsl:variable name="row-cell-count" as="xs:integer">
+              <xsl:variable name="last" select="*[contains(@class, ' topic/stentry ')][last()]"/>
+              <xsl:variable name="span" select="if (exists($last/@colspan)) then (xs:integer($last/@colspan) - 1) else 0"/>
+              <xsl:sequence select="xs:integer($last/@dita-ot:x) + $span"/>
+            </xsl:variable>
             <xsl:if test="$row-cell-count &lt; $number-cells">
                 <xsl:apply-templates select="." mode="fillInMissingSimpletableCells">
                     <xsl:with-param name="fill-in-count" select="$number-cells - $row-cell-count"/>
@@ -1007,6 +1015,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/sthead ')]/*[contains(@class, ' topic/stentry ')]">
         <fo:table-cell xsl:use-attribute-sets="sthead.stentry">
             <xsl:call-template name="commonattributes"/>
+            <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -171,11 +171,11 @@ See the accompanying LICENSE file for applicable license.
          skip to next row. Currently known to match ditaval-startprop when flagging used on simpletable
          as well as suitesol:changebar-start when revision bar used on sthead or stentry. -->
     <xsl:template match="*" mode="count-max-simpletable-cells" as="xs:integer">
-      <xsl:param name="maxcount" select="0" as="xs:integer"/>
-      <xsl:apply-templates select="following-sibling::*[1]" mode="count-max-simpletable-cells">
-        <xsl:with-param name="maxcount" select="$maxcount"/>
-      </xsl:apply-templates>
+      <xsl:variable name="simpletable" select="ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]"/>
+      <xsl:variable name="xs" as="xs:integer+" select="$simpletable//@dita-ot:x/xs:integer(.)"/>
+      <xsl:sequence select="max($xs)"/>
     </xsl:template>
+  
     <!-- Count the max number of cells in any row of a simpletable -->
     <xsl:template match="*[contains(@class, ' topic/sthead ')] | *[contains(@class, ' topic/strow ')]" mode="count-max-simpletable-cells" as="xs:integer">
       <xsl:param name="maxcount" select="0" as="xs:integer"/>
@@ -1044,6 +1044,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/strow ')]/*[contains(@class, ' topic/stentry ')]">
         <fo:table-cell xsl:use-attribute-sets="strow.stentry">
             <xsl:call-template name="commonattributes"/>
+            <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="count(preceding-sibling::*[contains(@class, ' topic/stentry ')]) + 1"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
 
@@ -1076,6 +1077,15 @@ See the accompanying LICENSE file for applicable license.
             </xsl:choose>
         </fo:table-cell>
     </xsl:template>
+  
+  <xsl:template name="simpletableApplySpansAttrs">
+    <xsl:if test="exists(@rowspan) and xs:integer(@rowspan) gt 1">
+      <xsl:attribute name="number-rows-spanned" select="xs:integer(@rowspan)"/>
+    </xsl:if>
+    <xsl:if test="exists(@colspan) and xs:integer(@colspan) gt 1">
+      <xsl:attribute name="number-columns-spanned" select="xs:integer(@colspan)"/>
+    </xsl:if>
+  </xsl:template>
 
     <xsl:template match="*" mode="simpletableHorizontalBorders">
         <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"

--- a/src/test/java/org/dita/dost/util/XSpecTest.java
+++ b/src/test/java/org/dita/dost/util/XSpecTest.java
@@ -7,7 +7,6 @@
  */
 package org.dita.dost.util;
 
-import org.apache.xml.resolver.Catalog;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -10,6 +10,8 @@
   <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl"/>
   <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/simpletable.xsl"/>
 
+  <!-- Mocks -->
+
   <xsl:key name="enumerableByClass"
     match="
       *[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  exclude-result-prefixes="xs"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  exclude-result-prefixes="xs dita-ot"
   version="2.0">
   
   <!--xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/basic-settings.xsl"/>
@@ -9,20 +10,81 @@
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl"/-->
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/xsl/fo/tables.xsl"/>
   
+  <!-- Mocks -->
   
-  <!--xsl:variable name="writing-mode" select="'lr'"/-->
-  <xsl:attribute-set name="table.tgroup"/>
-  <xsl:attribute-set name="simpletable"/>
+  <xsl:variable name="locale" select="'en'"/>
+
+  <xsl:attribute-set name="dl__body"/>
+  <xsl:attribute-set name="dl.dlhead__row"/>
+  <xsl:attribute-set name="dl.dlhead"/>
+  <xsl:attribute-set name="dl"/>
+  <xsl:attribute-set name="dlentry.dd__content"/>
+  <xsl:attribute-set name="dlentry.dd"/>
+  <xsl:attribute-set name="dlentry.dt__content"/>
+  <xsl:attribute-set name="dlentry.dt"/>
+  <xsl:attribute-set name="dlentry"/>
+  <xsl:attribute-set name="dlhead.ddhd__cell"/>
+  <xsl:attribute-set name="dlhead.ddhd__content"/>
+  <xsl:attribute-set name="dlhead.dthd__cell"/>
+  <xsl:attribute-set name="dlhead.dthd__content"/>
+  <xsl:attribute-set name="relcell"/>
+  <xsl:attribute-set name="relcolspec"/>
+  <xsl:attribute-set name="relheader"/>
+  <xsl:attribute-set name="relrow"/>
+  <xsl:attribute-set name="reltable__title"/>
+  <xsl:attribute-set name="reltable"/>
   <xsl:attribute-set name="simpletable__body"/>
-  <xsl:attribute-set name="strow"/>
-  <xsl:attribute-set name="strow.stentry__keycol-content"/>
-  <xsl:attribute-set name="strow.stentry__content"/>
-  <xsl:attribute-set name="strow.stentry"/>
+  <xsl:attribute-set name="simpletable"/>
   <xsl:attribute-set name="sthead__row"/>
-  <xsl:attribute-set name="sthead"/>
-  <xsl:attribute-set name="sthead.stentry__keycol-content"/>
   <xsl:attribute-set name="sthead.stentry__content"/>
+  <xsl:attribute-set name="sthead.stentry__keycol-content"/>
   <xsl:attribute-set name="sthead.stentry"/>
+  <xsl:attribute-set name="sthead"/>
+  <xsl:attribute-set name="strow.stentry__content"/>
+  <xsl:attribute-set name="strow.stentry__keycol-content"/>
+  <xsl:attribute-set name="strow.stentry"/>
+  <xsl:attribute-set name="strow"/>
+  <xsl:attribute-set name="table__container"/>
+  <xsl:attribute-set name="table.tgroup"/>
+  <xsl:attribute-set name="table.title"/>
+  <xsl:attribute-set name="table"/>
+  <xsl:attribute-set name="tbody.row.entry__content"/>
+  <xsl:attribute-set name="tbody.row.entry__content"/>
+  <xsl:attribute-set name="tbody.row.entry__firstcol"/>
+  <xsl:attribute-set name="tbody.row.entry"/>
+  <xsl:attribute-set name="tbody.row"/>
+  <xsl:attribute-set name="tgroup.tbody"/>
+  <xsl:attribute-set name="tgroup.thead"/>
+  <xsl:attribute-set name="thead.row.entry__content"/>
+  <xsl:attribute-set name="thead.row.entry__content"/>
+  <xsl:attribute-set name="thead.row.entry"/>
+  <xsl:attribute-set name="thead.row"/>
+  
+  <xsl:template name="get-id"/>
+  
+  <xsl:key name="enumerableByClass"
+    match="*[contains(@class, ' topic/fig ')][*[contains(@class, ' topic/title ')]] |
+           *[contains(@class, ' topic/table ')][*[contains(@class, ' topic/title ')]] |
+           *[contains(@class, ' topic/simpletable ')][*[contains(@class, ' topic/title ')]] |
+           *[contains(@class,' topic/fn ') and empty(@callout)]"
+    use="tokenize(@class, ' ')"/>
+  
+  <xsl:template match="*[contains(@class,' topic/title ')]" mode="customTitleAnchor"/>
+  
+  <xsl:function name="dita-ot:notExcludedByDraftElement">
+    <xsl:param name="ctx" as="element()"/>
+    <xsl:sequence select="true()"/>
+  </xsl:function>
+  
+  <xsl:template name="getVariable">
+    <xsl:param name="id"/>
+    <xsl:param name="params"/>
+    <xsl:value-of select="$id"/>
+    <xsl:for-each select="$params/*">
+      <xsl:text> </xsl:text>
+      <xsl:copy-of select="node()"/>      
+    </xsl:for-each>
+  </xsl:template>
   
   <xsl:template name="output-message">
     <xsl:param name="id"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  exclude-result-prefixes="xs"
+  version="2.0">
+  
+  <!--xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/basic-settings.xsl"/>
+  <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl"/>
+  <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl"/-->
+  <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/xsl/fo/tables.xsl"/>
+  
+  
+  <!--xsl:variable name="writing-mode" select="'lr'"/-->
+  <xsl:attribute-set name="table.tgroup"/>
+  <xsl:attribute-set name="simpletable"/>
+  <xsl:attribute-set name="simpletable__body"/>
+  <xsl:attribute-set name="strow"/>
+  <xsl:attribute-set name="strow.stentry__keycol-content"/>
+  <xsl:attribute-set name="strow.stentry__content"/>
+  <xsl:attribute-set name="strow.stentry"/>
+  <xsl:attribute-set name="sthead__row"/>
+  <xsl:attribute-set name="sthead"/>
+  <xsl:attribute-set name="sthead.stentry__keycol-content"/>
+  <xsl:attribute-set name="sthead.stentry__content"/>
+  <xsl:attribute-set name="sthead.stentry"/>
+  
+  <xsl:template name="output-message">
+    <xsl:param name="id"/>
+  </xsl:template>
+  
+  <xsl:template name="commonattributes"/>
+  
+  <xsl:template name="processAttrSetReflection">
+    <xsl:param name="attrSet"/>
+    <xsl:param name="path"/>
+  </xsl:template>
+  
+  <xsl:template name="setExpanse"/>
+  
+  <xsl:template match="*" mode="ancestor-start-flag"/>
+  <xsl:template match="*" mode="ancestor-end-flag"/>
+  
+</xsl:stylesheet>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
@@ -16,6 +16,7 @@
       </simpletable>
     </x:context>
     <x:expect label="has caption">
+      <fo:block>Table.title 1 foo</fo:block>
       <fo:table>
         <fo:table-body>
           <fo:table-row>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="simpletable.xsl">
+
+  <x:scenario label="title">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <title class="- topic/title ">foo</title>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has caption">
+      <fo:table>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>e1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e3</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="header">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <fo:table>
+        <fo:table-header>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>s1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>s2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>s3</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-header>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>e1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e3</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="span">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">3 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="1">4 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="1">5 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="1" dita-ot:y="2">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">3 2</stentry>
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="4" dita-ot:y="2">4 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+          <stentry class="- topic/stentry " colspan="2" rowspan="2" dita-ot:x="3" dita-ot:y="3">3 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="3">5 3</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="4">1 4</stentry>
+          <stentry class="- topic/stentry " rowspan="2" dita-ot:x="2" dita-ot:y="4">2 4</stentry>
+          <stentry class="- topic/stentry " rowspan="3" dita-ot:x="5" dita-ot:y="4">5 4</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="5" rowspan="2">1 5</stentry>
+          <stentry class="- topic/stentry " colspan="2" dita-ot:x="3" dita-ot:y="5">3 5</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="6">2 6</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="6">3 6</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="6">4 6</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="7">1 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="7">2 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="7">3 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="7">4 7</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="5" dita-ot:y="7">5 7</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <fo:table>
+        <fo:table-header>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>4 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>5 1</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-header>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>4 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>5 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 4</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 4</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>5 4</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 5</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 5</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>2 6</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 6</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>4 6</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 7</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 7</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>3 7</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>4 7</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>5 7</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="headers">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1" id="id1">s1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1" id="id2">s2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="1">s4</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2" headers="id1">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2" headers="id2">e2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2" headers="id3">e3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="4" dita-ot:y="2" headers="id3">e4</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3" colspan="2" headers="id1 id2">e1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="3" colspan="2">e3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has thead">
+      <fo:table>
+        <fo:table-header>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>s1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>s2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>s3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>s4</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-header>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>e1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e4</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>e1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>e3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>
+                <fo:inline>&#xA0;</fo:inline>
+              </fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="keycol">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable " keycol="1">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">2 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has th column">
+      <fo:table>
+        <fo:table-header>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 1</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-header>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 2</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 3</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="scope">
+    <x:context select="/simpletable">
+      <simpletable class="- topic/simpletable ">
+        <sthead class="- topic/sthead ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">2 1</stentry>
+        </sthead>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2" scope="row">1 2</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">2 2</stentry>
+        </strow>
+        <strow class="- topic/strow ">
+          <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="3">1 3</stentry>
+          <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="3">2 3</stentry>
+        </strow>
+      </simpletable>
+    </x:context>
+    <x:expect label="has th column">
+      <fo:table>
+        <fo:table-header>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 1</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-header>
+        <fo:table-body>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 2</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+          <fo:table-row>
+            <fo:table-cell>
+              <fo:block>1 3</fo:block>
+            </fo:table-cell>
+            <fo:table-cell>
+              <fo:block>2 3</fo:block>
+            </fo:table-cell>
+          </fo:table-row>
+        </fo:table-body>
+      </fo:table>
+    </x:expect>
+  </x:scenario>
+
+</x:description>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
@@ -190,11 +190,6 @@
             <fo:table-cell number-columns-spanned="2">
               <fo:block>3 5</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
             <fo:table-cell>
@@ -205,11 +200,6 @@
             </fo:table-cell>
             <fo:table-cell>
               <fo:block>4 6</fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
             </fo:table-cell>
           </fo:table-row>
           <fo:table-row>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
@@ -148,13 +148,13 @@
         </fo:table-header>
         <fo:table-body>
           <fo:table-row>
-            <fo:table-cell>
+            <fo:table-cell number-columns-spanned="2">
               <fo:block>1 2</fo:block>
             </fo:table-cell>
             <fo:table-cell>
               <fo:block>3 2</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-columns-spanned="2">
               <fo:block>4 2</fo:block>
             </fo:table-cell>
             <fo:table-cell>
@@ -175,7 +175,7 @@
             <fo:table-cell>
               <fo:block>2 3</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-rows-spanned="2" number-columns-spanned="2">
               <fo:block>3 3</fo:block>
             </fo:table-cell>
             <fo:table-cell>
@@ -191,10 +191,10 @@
             <fo:table-cell>
               <fo:block>1 4</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-rows-spanned="2">
               <fo:block>2 4</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-rows-spanned="3">
               <fo:block>5 4</fo:block>
             </fo:table-cell>
             <fo:table-cell>
@@ -209,10 +209,10 @@
             </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
-            <fo:table-cell>
+            <fo:table-cell number-rows-spanned="2">
               <fo:block>1 5</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-columns-spanned="2">
               <fo:block>3 5</fo:block>
             </fo:table-cell>
             <fo:table-cell>
@@ -329,10 +329,10 @@
             </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
-            <fo:table-cell>
+            <fo:table-cell number-columns-spanned="2">
               <fo:block>e1</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
+            <fo:table-cell number-columns-spanned="2">
               <fo:block>e3</fo:block>
             </fo:table-cell>
             <fo:table-cell>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec
@@ -157,16 +157,6 @@
             <fo:table-cell number-columns-spanned="2">
               <fo:block>4 2</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
             <fo:table-cell>
@@ -181,11 +171,6 @@
             <fo:table-cell>
               <fo:block>5 3</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
             <fo:table-cell>
@@ -197,16 +182,6 @@
             <fo:table-cell number-rows-spanned="3">
               <fo:block>5 4</fo:block>
             </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
           </fo:table-row>
           <fo:table-row>
             <fo:table-cell number-rows-spanned="2">
@@ -214,16 +189,6 @@
             </fo:table-cell>
             <fo:table-cell number-columns-spanned="2">
               <fo:block>3 5</fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
             </fo:table-cell>
             <fo:table-cell>
               <fo:block>
@@ -240,11 +205,6 @@
             </fo:table-cell>
             <fo:table-cell>
               <fo:block>4 6</fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
             </fo:table-cell>
             <fo:table-cell>
               <fo:block>
@@ -334,16 +294,6 @@
             </fo:table-cell>
             <fo:table-cell number-columns-spanned="2">
               <fo:block>e3</fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
-            </fo:table-cell>
-            <fo:table-cell>
-              <fo:block>
-                <fo:inline>&#xA0;</fo:inline>
-              </fo:block>
             </fo:table-cell>
           </fo:table-row>
         </fo:table-body>


### PR DESCRIPTION
Per https://github.com/oasis-tcs/dita/issues/292 add support to PDF2:

- [x] add `<title>` as the first element of `<simpletable>`
- [x] add `@colspan` and `@rowspan` attributes to `<stentry>`
- [x] add `@headers` and `@scope` to `<stentry>`