### PR TITLE
Add external-link mode for target=blank

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/map2html5-coverImpl_template.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5-coverImpl_template.xsl
@@ -84,7 +84,7 @@ See the accompanying LICENSE file for applicable license.
                   </xsl:choose>
                 </xsl:attribute>
                 <xsl:if test="@scope = 'external' or not(not(@format) or @format = 'dita' or @format = 'ditamap')">
-                  <xsl:attribute name="target">_blank</xsl:attribute>
+                  <xsl:apply-templates select="." mode="external-link"/>
                 </xsl:if>
                 <xsl:value-of select="$title"/>
               </a>

--- a/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
@@ -81,7 +81,7 @@ See the accompanying LICENSE file for applicable license.
                   </xsl:choose>
                 </xsl:attribute>
                 <xsl:if test="@scope = 'external' or not(not(@format) or @format = 'dita' or @format = 'ditamap')">
-                  <xsl:attribute name="target">_blank</xsl:attribute>
+                  <xsl:apply-templates select="." mode="external-link"/>
                 </xsl:if>
                 <xsl:value-of select="$title"/>
               </a>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -736,7 +736,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <xsl:template match="*" mode="add-link-target-attribute">
     <xsl:if test="@scope = 'external' or @type = 'external' or ((lower-case(@format) = 'pdf') and not(@scope = 'local'))">
-      <xsl:attribute name="target">_blank</xsl:attribute>
+      <xsl:apply-templates select="." mode="external-link"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -592,6 +592,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="node()" mode="external-link" as="attribute()*">
     <xsl:attribute name="target">_blank</xsl:attribute>
+    <xsl:attribute name="rel">external noopener</xsl:attribute>
   </xsl:template>
   
   <!-- =========== SINGLE PART LISTS =========== -->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -572,7 +572,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:attribute>
             <xsl:choose>
               <xsl:when test="@type = 'external'">
-                <xsl:attribute name="target">_blank</xsl:attribute>
+                <xsl:apply-templates select="." mode="external-link"/>
               </xsl:when>
               <xsl:otherwise><!--nop - no target needed for internal or biblio types (OR-should internal force DITA xref-like processing? What is intent? @type is only internal/external/bibliographic) --></xsl:otherwise>
             </xsl:choose>
@@ -590,6 +590,9 @@ See the accompanying LICENSE file for applicable license.
     </blockquote>
   </xsl:template>
   
+  <xsl:template match="node()" mode="external-link" as="attribute()*">
+    <xsl:attribute name="target">_blank</xsl:attribute>
+  </xsl:template>
   
   <!-- =========== SINGLE PART LISTS =========== -->
   

--- a/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
@@ -120,7 +120,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="imagemap-xref">
    <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute>
    <xsl:if test="@scope='external' or @type='external' or ((@format='PDF' or @format='pdf') and not(@scope='local'))">
-    <xsl:attribute name="target">_blank</xsl:attribute>
+     <xsl:apply-templates select="." mode="external-link"/>
    </xsl:if>
   </xsl:template>
   


### PR DESCRIPTION
Add `external-link` mode to generate `target="blank"` attribute in HTML5. This allows easy extension to include e.g. `rel="noopener"` attribute to external links.

Fixes #3480