### PR TITLE
Add outputclass support to DITAVAL

### DIFF
--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -238,7 +238,8 @@ public final class DitaValReader implements AbstractReader {
                 style != null ? style.trim().split("\\s+") : null,
                 getValue(elem, ATTRIBUTE_NAME_CHANGEBAR),
                 readFlagImage(elem, "startflag"),
-                readFlagImage(elem, "endflag"));
+                readFlagImage(elem, "endflag"),
+                getValue(elem, ATTRIBUTE_NAME_OUTPUTCLASS));
     }
 
     private FlagImage readFlagImage(final Element elem, final String name) {

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -223,7 +223,7 @@ public final class FilterUtils {
             return res.stream()
                     .map(f -> new Flag(ELEMENT_NAME_PROP, conflictColor ? foregroundConflictColor : f.color,
                             conflictBackcolor ? backgroundConflictColor : f.backcolor,
-                            f.style, f.changebar, f.startflag, f.endflag))
+                            f.style, f.changebar, f.startflag, f.endflag, f.outputClass))
                     .collect(Collectors.toSet());
         } else {
             return res;
@@ -707,9 +707,10 @@ public final class FilterUtils {
         public final String changebar;
         public final FlagImage startflag;
         public final FlagImage endflag;
+        public final String outputClass;
 
         public Flag(String proptype, String color, String backcolor, String[] style, String changebar,
-                FlagImage startflag, FlagImage endflag) {
+                FlagImage startflag, FlagImage endflag, String outputClass) {
             this.proptype = proptype;
             this.color = color;
             this.backcolor = backcolor;
@@ -717,12 +718,14 @@ public final class FilterUtils {
             this.changebar = changebar;
             this.startflag = startflag;
             this.endflag = endflag;
+            this.outputClass = outputClass;
         }
 
         public Flag adjustPath(final URI currentFile, final Job job) {
             return new Flag(proptype, color, backcolor, style, changebar,
                     adjustPath(startflag, currentFile, job),
-                    adjustPath(endflag, currentFile, job));
+                    adjustPath(endflag, currentFile, job),
+                    outputClass);
         }
 
         private FlagImage adjustPath(final FlagImage img, final URI currentFile, final Job job) {
@@ -743,37 +746,30 @@ public final class FilterUtils {
         }
 
         public void writeStartFlag(final ContentHandler contentHandler) throws SAXException {
-            final StringBuilder outputclass = new StringBuilder();
+            final StringBuilder outputClassAttr = new StringBuilder();
+            final StringBuilder styleAttr = new StringBuilder();
             if (color != null) {
-                outputclass.append("color:").append(color).append(";");
+                styleAttr.append("color:").append(color).append(";");
             }
             if (backcolor != null) {
-                outputclass.append("background-color:").append(backcolor).append(";");
+                styleAttr.append("background-color:").append(backcolor).append(";");
+            }
+            if (outputClass != null) {
+                outputClassAttr.append(outputClass).append(" ");
             }
             if (style != null) {
                 for (final String style : style) {
-                    switch (style) {
-                        case "italics":
-                            outputclass.append("font-style:italic;");
-                            break;
-                        case "bold":
-                            outputclass.append("font-weight:bold;");
-                            break;
-                        case "underline":
-                        case "double-underline":
-                            outputclass.append("text-decoration:").append(style).append(";");
-                            break;
-                        case "overline":
-                            outputclass.append("text-decoration:overline;");
-                            break;
-                    }
+                    outputClassAttr.append(style).append(" ");
                 }
             }
 
             final XMLUtils.AttributesBuilder atts = new XMLUtils.AttributesBuilder()
                     .add(ATTRIBUTE_NAME_CLASS, "+ topic/foreign ditaot-d/ditaval-startprop ");
-            if (outputclass.length() != 0) {
-                atts.add(ATTRIBUTE_NAME_OUTPUTCLASS, outputclass.toString());
+            if (outputClassAttr.length() != 0) {
+                atts.add(ATTRIBUTE_NAME_OUTPUTCLASS, outputClassAttr.toString().trim());
+            }
+            if (styleAttr.length() != 0) {
+                atts.add(ATTRIBUTE_NAME_STYLE, styleAttr.toString().trim());
             }
             contentHandler.startElement(NULL_NS_URI, "ditaval-startprop", "ditaval-startprop",
                     atts.build());
@@ -800,6 +796,9 @@ public final class FilterUtils {
             }
             if (style != null) {
                 propAtts.add("style", Stream.of(style).collect(Collectors.joining(" ")));
+            }
+            if (outputClass != null) {
+                propAtts.add("outputclass", outputClass);
             }
             if (changebar != null) {
                 propAtts.add("changebar", changebar);
@@ -913,6 +912,7 @@ public final class FilterUtils {
                     "color='" + color + '\'' +
                     ", backcolor='" + backcolor + '\'' +
                     ", style=" + Arrays.toString(style) +
+                    ", outputclass=" + outputClass +
                     ", changebar='" + changebar + '\'' +
                     ", startflag=" + startflag +
                     ", endflag=" + endflag +
@@ -930,6 +930,7 @@ public final class FilterUtils {
             if (!Objects.equals(backcolor, flag.backcolor)) return false;
             // Probably incorrect - comparing Object[] arrays with Arrays.equals
             if (!Arrays.equals(style, flag.style)) return false;
+            if (!Objects.equals(outputClass, flag.outputClass)) return false;
             if (!Objects.equals(changebar, flag.changebar)) return false;
             if (!Objects.equals(startflag, flag.startflag)) return false;
             return Objects.equals(endflag, flag.endflag);
@@ -941,6 +942,7 @@ public final class FilterUtils {
             result = 31 * result + (backcolor != null ? backcolor.hashCode() : 0);
             result = 31 * result + Arrays.hashCode(style);
             result = 31 * result + (changebar != null ? changebar.hashCode() : 0);
+            result = 31 * result + (outputClass != null ? outputClass.hashCode() : 0);
             result = 31 * result + (startflag != null ? startflag.hashCode() : 0);
             result = 31 * result + (endflag != null ? endflag.hashCode() : 0);
             return result;

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -109,14 +109,15 @@ See the accompanying LICENSE file for applicable license.
                    html5.topics.common,
                    html5.topics.common.inner"/>
 
-  <target name="html5.topic.init" unless="noMap">
-    <loadfile property="html5.map" srcfile="${dita.temp.dir}/${user.input.file.listfile}">
+  <target name="html5.topic.init">
+    <local name="html5.map"/>
+    <loadfile property="html5.map" srcfile="${dita.temp.dir}/${user.input.file.listfile}" unless:set="noMap">
       <filterchain>
         <headfilter lines="1"/>
       </filterchain>
     </loadfile>
-    <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}"/>
-    <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no"/>
+    <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}" unless:set="noMap"/>
+    <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no" if:set="dita.input.valfile"/>
   </target>
 
   <target name="html5.image-metadata"

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -34,15 +34,15 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
     <xsl:template match="*[contains(@class,' hi-d/tt ')]" name="topic.hi-d.tt">
-      <span style="font-family: monospace">
-        <xsl:call-template name="commonattributes"/>
-        <xsl:if test="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass">
+      <span>
+        <xsl:call-template name="commonattributes">
+          <xsl:with-param name="default-output-class" select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass"/>
+        </xsl:call-template>
           <!-- Combine TT style with style from ditaval, if present -->
           <xsl:attribute name="style">
             <xsl:text>font-family: monospace; </xsl:text>
             <xsl:value-of select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass"/>
           </xsl:attribute>
-        </xsl:if>
         <xsl:call-template name="setidaname"/>
         <xsl:apply-templates/>
       </span>

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
           <!-- Combine TT style with style from ditaval, if present -->
           <xsl:attribute name="style">
             <xsl:text>font-family: monospace; </xsl:text>
-            <xsl:value-of select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass"/>
+            <xsl:value-of select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style"/>
           </xsl:attribute>
         <xsl:call-template name="setidaname"/>
         <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
@@ -18,7 +18,9 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->
+    <!--
     <xsl:attribute name="style"><xsl:value-of select="."/></xsl:attribute>
+    -->
   </xsl:template>
 
   <!-- By default, process flags where encountered: at the start and end of the element content. -->

--- a/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
@@ -16,11 +16,9 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
                 version="2.0">
 
-  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style">
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->
-    <!--
-    <xsl:attribute name="style"><xsl:value-of select="."/></xsl:attribute>
-    -->
+    <xsl:attribute name="style" select="."/>
   </xsl:template>
 
   <!-- By default, process flags where encountered: at the start and end of the element content. -->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -755,6 +755,7 @@ See the accompanying LICENSE file for applicable license.
     <dt>
       <!-- Get xml:lang and ditaval styling from DLENTRY, then override with local -->
       <xsl:apply-templates select="../@xml:lang"/>
+      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
       <xsl:for-each select="..">
         <xsl:call-template name="commonattributes"/>
       </xsl:for-each>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -703,8 +703,7 @@ See the accompanying LICENSE file for applicable license.
          Maintain that for now, though may want to update in the future to keep a wrapper in all cases.
          Considering using div instead of span, with a default inline CSS style. -->
     <xsl:choose>
-      <xsl:when test="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop |
-                      *[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass">
+      <xsl:when test="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop">
         <span>
           <xsl:call-template name="commonattributes"/>
           <xsl:apply-templates/>
@@ -755,8 +754,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
     <dt>
       <!-- Get xml:lang and ditaval styling from DLENTRY, then override with local -->
-      <xsl:apply-templates select="../@xml:lang"/> 
-      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+      <xsl:apply-templates select="../@xml:lang"/>
       <xsl:for-each select="..">
         <xsl:call-template name="commonattributes"/>
       </xsl:for-each>
@@ -1715,10 +1713,9 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Process standard attributes that may appear anywhere. Previously this was "setclass" -->
   <xsl:template name="commonattributes">
-    <xsl:param name="default-output-class"/>
+    <xsl:param name="default-output-class" select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass"/>
     <xsl:apply-templates select="@xml:lang"/>
     <xsl:apply-templates select="@dir"/>
-    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
     <xsl:apply-templates select="." mode="set-output-class">
       <xsl:with-param name="default" select="$default-output-class"/>
     </xsl:apply-templates>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -242,7 +242,7 @@ See the accompanying LICENSE file for applicable license.
        <!-- Do not reset xml:lang if it is already set on <html> -->
        <!-- Moved outputclass to the body tag -->
        <!-- Keep ditaval based styling at this point (replace DITA-OT 1.6 and earlier call to gen-style) -->
-       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
      </xsl:when>
      <xsl:otherwise>
        <xsl:call-template name="commonattributes">
@@ -828,7 +828,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/dthd ')]" name="topic.dthd">
     <dt>
       <!-- Get ditaval style and xml:lang from DLHEAD, then override with local -->
-      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
       <xsl:apply-templates select="../@xml:lang"/>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setidaname"/>
@@ -844,7 +844,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/ddhd ')]" name="topic.ddhd">
     <dd>
       <!-- Get ditaval style and xml:lang from DLHEAD, then override with local -->
-      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+      <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
       <xsl:apply-templates select="../@xml:lang"/>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setidaname"/>
@@ -1716,6 +1716,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="default-output-class" select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass"/>
     <xsl:apply-templates select="@xml:lang"/>
     <xsl:apply-templates select="@dir"/>
+    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:apply-templates select="." mode="set-output-class">
       <xsl:with-param name="default" select="$default-output-class"/>
     </xsl:apply-templates>
@@ -2401,7 +2402,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Add all attributes. To add your own additional attributes, use mode="addAttributesToBody". -->
   <xsl:template match="*" mode="addAttributesToHtmlBodyElement">
     <!-- Already put xml:lang on <html>; do not copy to body with commonattributes -->
-    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <!--output parent or first "topic" tag's outputclass as class -->
     <xsl:if test="@outputclass">
       <xsl:attribute name="class" select="@outputclass"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -18,7 +18,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="chapterBody">
     <body>
-      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
       <xsl:if test="@outputclass">
         <xsl:attribute name="class" select="@outputclass"/>
       </xsl:if>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -310,7 +310,7 @@ See the accompanying LICENSE file for applicable license.
      <!-- Do not reset xml:lang if it is already set on <html> -->
      <!-- Moved outputclass to the body tag -->
      <!-- Keep ditaval based styling at this point (replace DITA-OT 1.6 and earlier call to gen-style) -->
-     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
    </xsl:when>
    <xsl:otherwise>
      <xsl:call-template name="commonattributes">
@@ -857,8 +857,7 @@ See the accompanying LICENSE file for applicable license.
        Maintain that for now, though may want to update in the future to keep a wrapper in all cases.
        Considering using div instead of span, with a default inline CSS style. -->
   <xsl:choose>
-    <xsl:when test="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop |
-                    *[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass">
+    <xsl:when test="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop">
       <span>
         <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
@@ -911,7 +910,7 @@ See the accompanying LICENSE file for applicable license.
   <dt>
     <!-- Get xml:lang and ditaval styling from DLENTRY, then override with local -->
     <xsl:apply-templates select="../@xml:lang"/> 
-    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:for-each select="..">
       <xsl:call-template name="commonattributes"/>
     </xsl:for-each>
@@ -987,7 +986,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class, ' topic/dthd ')]" name="topic.dthd">
   <dt>
     <!-- Get ditaval style and xml:lang from DLHEAD, then override with local -->
-    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:apply-templates select="../@xml:lang"/>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
@@ -1003,7 +1002,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class, ' topic/ddhd ')]" name="topic.ddhd">
   <dd>
     <!-- Get ditaval style and xml:lang from DLHEAD, then override with local -->
-    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:apply-templates select="../@xml:lang"/>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
@@ -1905,10 +1904,10 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Process standard attributes that may appear anywhere. Previously this was "setclass" -->
 <xsl:template name="commonattributes">
-  <xsl:param name="default-output-class"/>
+  <xsl:param name="default-output-class" select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass"/>
   <xsl:apply-templates select="@xml:lang"/>
   <xsl:apply-templates select="@dir"/>
-  <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+  <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
   <xsl:apply-templates select="." mode="set-output-class">
     <xsl:with-param name="default" select="$default-output-class"/>
   </xsl:apply-templates>
@@ -2726,7 +2725,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Add all attributes. To add your own additional attributes, use mode="addAttributesToBody". -->
   <xsl:template match="*" mode="addAttributesToHtmlBodyElement">
     <!-- Already put xml:lang on <html>; do not copy to body with commonattributes -->
-    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <!--output parent or first "topic" tag's outputclass as class -->
     <xsl:if test="@outputclass">
       <xsl:attribute name="class" select="@outputclass"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
   version="2.0">
 
-  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style">
+  <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->
     <xsl:attribute name="style"><xsl:value-of select="."/></xsl:attribute>
   </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -246,7 +246,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class, ' topic/thead ')]" name="topic.thead">
   <thead>
     <!-- Get style from parent tgroup, then override with thead if specified locally -->
-    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:call-template name="commonattributes"/>
     
     
@@ -282,7 +282,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class, ' topic/tbody ')]" name="topic.tbody">
   <tbody>
     <!-- Get style from parent tgroup, then override with thead if specified locally -->
-    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+    <xsl:apply-templates select="../*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="style">
       <xsl:with-param name="contents">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -434,7 +434,7 @@ See the accompanying LICENSE file for applicable license.
   <thead>
     <tr>
       <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@outputclass" mode="add-ditaval-style"/>
+      <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
       <xsl:apply-templates select="*[contains(@class,' task/choptionhd ')]"/>
       <xsl:apply-templates select="*[contains(@class,' task/chdeschd ')]"/>
     </tr>

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -200,7 +200,7 @@ public class FilterUtilsTest {
 
     @Test
     public void testgetFlagsDefaultFlag() {
-        final Flag flag = new Flag("prop", "red", null, null, null, null, null);
+        final Flag flag = new Flag("prop", "red", null, null, null, null, null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, null), flag)
@@ -217,8 +217,8 @@ public class FilterUtilsTest {
 
     @Test
     public void testGetFlags() {
-        final Flag flag = new Flag("prop", "red", null, null, null, null, null);
-        final Flag revflag = new Flag("revprop", null, null, null, "solid", null, null);
+        final Flag flag = new Flag("prop", "red", null, null, null, null, null, null);
+        final Flag revflag = new Flag("revprop", null, null, null, "solid", null, null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, "unix"), flag)
@@ -364,8 +364,8 @@ public class FilterUtilsTest {
 
     @Test
     public void testGetFlagLabel() {
-        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null);
-        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null);
+        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null, null);
+        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null, null);
         
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
@@ -393,8 +393,8 @@ public class FilterUtilsTest {
 
     @Test
     public void testConflict() {
-        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null);
-        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null);
+        final Flag flagRed = new Flag("prop", "red", null, null, null, null, null, null);
+        final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null, null);
         final FilterUtils f = new FilterUtils(false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(OS, "amiga"), flagRed)
@@ -402,7 +402,7 @@ public class FilterUtilsTest {
                         .build(), "yellow", "green");
         f.setLogger(new TestUtils.TestLogger());
 
-        final Flag flagYellow = new Flag("prop", "yellow", null, null, null, null, null);
+        final Flag flagYellow = new Flag("prop", "yellow", null, null, null, null, null, null);
         assertEquals(
                 singleton(flagYellow),
                 f.getFlags(attr(PROPS, "os(amiga unix windows)"), new QName[][] {{PROPS, OS}}));

--- a/src/test/resources/map13_flag/exp/xhtml/topic4.html
+++ b/src/test/resources/map13_flag/exp/xhtml/topic4.html
@@ -19,11 +19,11 @@
 
     <div class="body">
 
-            <p style="color:red;background-color:blue;" class="p">This is LINUXplatform value is linux</p>
+            <p style="color:red;background-color:blue;" class="p important">This is LINUXplatform value is linux</p>
 
-            <p style="color:red;background-color:blue;" class="p">This is LINUXplatform value is redhat</p>
+            <p style="color:red;background-color:blue;" class="p important">This is LINUXplatform value is redhat</p>
 
-            <p style="color:red;background-color:blue;" class="p">This is LINUXplatform value is suse</p>
+            <p style="color:red;background-color:blue;" class="p important">This is LINUXplatform value is suse</p>
 
             <p class="p">platform value is mswin</p>
 

--- a/src/test/resources/map13_flag/src/flag.ditaval
+++ b/src/test/resources/map13_flag/src/flag.ditaval
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><val>
-    <prop action="flag" att="platform" backcolor="blue" color="red" val="linux">
+    <prop action="flag" att="platform" backcolor="blue" color="red" outputclass="important" val="linux">
     <startflag><alt-text>This is LINUX</alt-text></startflag>
     </prop>
    </val>


### PR DESCRIPTION
Add `@outputclass` to DITAVAL per https://github.com/oasis-tcs/dita/issues/252.

- [x] Content profiling in preprocess
- [x] HTML5
- [x] XHTML

Fixes #3463