### PR TITLE
Recognize new class atts for link text, short description, search title

### DIFF
--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -406,7 +406,10 @@ public final class ChunkMapReader extends AbstractDomFilter {
         if (navtitle == null) {
             navtitle = getValue(topicref, ATTRIBUTE_NAME_NAVTITLE);
         }
-        final String shortDesc = getChildElementValueOfTopicmeta(topicref, MAP_SHORTDESC);
+        String shortDesc = getChildElementValueOfTopicmeta(topicref, TOPIC_SHORTDESC);
+        if (shortDesc == null) {
+            shortDesc = getChildElementValueOfTopicmeta(topicref, MAP_SHORTDESC);
+        }
 
         writeChunk(absTemp, name, navtitle, shortDesc);
 

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -39,7 +39,8 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_PERMISSIONS.matcher,
             TOPIC_PUBLISHER.matcher,
             TOPIC_SOURCE.matcher,
-            MAP_SEARCHTITLE.matcher
+            MAP_SEARCHTITLE.matcher,
+            TOPIC_SEARCHTITLE.matcher
     )));
     private static final Set<String> cascadeSet = Collections.unmodifiableSet(new HashSet<>(asList(
             TOPIC_AUDIENCE.matcher,
@@ -55,6 +56,7 @@ public final class MapMetaReader extends AbstractDomFilter {
     )));
     private static final Set<String> metaSet = Collections.unmodifiableSet(new HashSet<>(asList(
             MAP_SEARCHTITLE.matcher,
+            TOPIC_SEARCHTITLE.matcher,
             TOPIC_AUTHOR.matcher,
             TOPIC_SOURCE.matcher,
             TOPIC_PUBLISHER.matcher,
@@ -74,6 +76,7 @@ public final class MapMetaReader extends AbstractDomFilter {
     )));
     private static final List<String> metaPos = Collections.unmodifiableList(asList(
             MAP_SEARCHTITLE.matcher,
+            TOPIC_SEARCHTITLE.matcher,
             TOPIC_AUTHOR.matcher,
             TOPIC_SOURCE.matcher,
             TOPIC_PUBLISHER.matcher,
@@ -91,7 +94,9 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_FOREIGN.matcher,
             TOPIC_UNKNOWN.matcher,
             MAP_LINKTEXT.matcher,
+            TOPIC_LINKTEXT.matcher,
             MAP_SHORTDESC.matcher,
+            TOPIC_SHORTDESC.matcher,
             TOPIC_NAVTITLE.matcher,
             TOPIC_METADATA.matcher,
             DELAY_D_EXPORTANCHORS.matcher

--- a/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
@@ -29,7 +29,8 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
             TOPIC_PERMISSIONS,
             TOPIC_PUBLISHER,
             TOPIC_SOURCE,
-            MAP_SEARCHTITLE
+            MAP_SEARCHTITLE,
+            TOPIC_SEARCHTITLE
     )));
 
     private Map<String, Element> metaTable;

--- a/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
@@ -26,8 +26,11 @@ public final class DitaMapMetaWriter extends AbstractDitaMetaWriter {
     private static final List<DitaClass> topicmetaOrder = Collections.unmodifiableList(Arrays.asList(
             TOPIC_NAVTITLE,
             MAP_LINKTEXT,
+            TOPIC_LINKTEXT,
             MAP_SEARCHTITLE,
+            TOPIC_SEARCHTITLE,
             MAP_SHORTDESC,
+            TOPIC_SHORTDESC,
             TOPIC_AUTHOR,
             TOPIC_SOURCE,
             TOPIC_PUBLISHER,

--- a/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
@@ -25,7 +25,8 @@ public final class DitaMetaWriter extends AbstractDitaMetaWriter {
     ));
     private static final List<DitaClass> titlealtsOrder = Collections.unmodifiableList(Arrays.asList(
             TOPIC_NAVTITLE,
-            MAP_SEARCHTITLE
+            MAP_SEARCHTITLE,
+            TOPIC_SEARCHTITLE
     ));
     private static final List<DitaClass> prologPosition = Collections.unmodifiableList(Arrays.asList(
             TOPIC_TITLE,

--- a/src/main/plugins/org.dita.base/xsl/common/functions.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/functions.xsl
@@ -13,6 +13,23 @@ See the accompanying LICENSE file for applicable license.
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="xs dita-ot">
+  
+  <!-- DITA 1.3 and 2.0 compatibility -->
+  
+  <xsl:function name="dita-ot:matches-linktext-class" as="xs:boolean">
+    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:sequence select="contains($class, ' topic/linktext ') or contains($class, ' map/linktext ')"/>
+  </xsl:function>
+  
+  <xsl:function name="dita-ot:matches-shortdesc-class" as="xs:boolean">
+    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:sequence select="contains($class, ' topic/shortdesc ') or contains($class, ' map/shortdesc ')"/>
+  </xsl:function>
+  
+  <xsl:function name="dita-ot:matches-searchtitle-class" as="xs:boolean">
+    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:sequence select="contains($class, ' topic/searchtitle ') or contains($class, ' map/searchtitle ')"/>
+  </xsl:function>
 
   <!-- href -->
 

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -576,20 +576,20 @@ See the accompanying LICENSE file for applicable license.
         </xsl:if>
         <!--figure out the linktext and desc-->
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="add-props-to-link"/>
-        <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
+        <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
           <!--Do not output linktext when The final output type is PDF or IDD
             The target of the HREF is a local DITA file
             The user has not specified locktitle to override the title -->
           <xsl:if test="not(($FINALOUTPUTTYPE = 'PDF' or $FINALOUTPUTTYPE = 'IDD') and (not(@scope) or @scope = 'local') and (not(@format) or @format = 'dita') and (not(@locktitle) or @locktitle = 'no'))">
             <linktext class="- topic/linktext ">
               <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/processing-instruction()[name()='ditaot'][.='usertext' or .='gentext']"/>
-              <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]/node()"/>
+              <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]/node()"/>
             </linktext>
           </xsl:if>
         </xsl:if>
-        <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]">
+        <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]">
           <!-- add desc node and text -->
-          <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]"/>
+          <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]"/>
         </xsl:if>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="add-props-to-link"/>
       </link>
@@ -607,7 +607,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <!-- create a template to get child nodes and text -->
-  <xsl:template match="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]" name="node">
+  <xsl:template match="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]" name="node">
     <xsl:copy-of select="../processing-instruction()[name() = 'ditaot'][. = 'usershortdesc' or . = 'genshortdesc']"/>
     <desc class="- topic/desc ">
       <!-- get child node and text -->
@@ -816,7 +816,7 @@ See the accompanying LICENSE file for applicable license.
       select="
         (
           ($el/@href and not($el/@href = '')) or
-          $el/*/*[contains(@class, ' map/linktext ') or contains(@class, ' topic/linktext ')]
+          $el/*/*[dita-ot:matches-linktext-class(@class)]
         ) and
         not($el/@linking = ('none', 'sourceonly'))"
     />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -589,8 +589,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]">
             <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]/node()"/>
           </xsl:when>
-          <xsl:when test="*/*[contains(@class,' map/linktext ')]">
-            <xsl:value-of select="*/*[contains(@class,' map/linktext ')]"/>
+          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of select="@href"/>
@@ -606,8 +606,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="@navtitle">
             <xsl:value-of select="@navtitle"/>
           </xsl:when>
-          <xsl:when test="*/*[contains(@class,' map/linktext ')]">
-            <xsl:value-of select="*/*[contains(@class,' map/linktext ')]"/>
+          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:otherwise>#none#</xsl:otherwise>
         </xsl:choose>
@@ -620,8 +620,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="@navtitle">
             <xsl:value-of select="@navtitle"/>
           </xsl:when>
-          <xsl:when test="*/*[contains(@class,' map/linktext ')]">
-            <xsl:value-of select="*/*[contains(@class,' map/linktext ')]"/>
+          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:text>#none#</xsl:text>
@@ -809,8 +809,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
   <xsl:template match="*" mode="mappull:navtitle-fallback" as="xs:string?">
     <xsl:choose>
       <xsl:when test="@navtitle"><xsl:value-of select="@navtitle"/></xsl:when>
-      <xsl:when test="*/*[contains(@class,' map/linktext ')]">
-        <xsl:value-of select="*/*[contains(@class,' map/linktext ')]"/>
+      <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
+        <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
         <xsl:apply-templates select="." mode="ditamsg:using-linktext-for-navtitle"/>
       </xsl:when>
       <xsl:otherwise>
@@ -863,9 +863,9 @@ Other modes can be found within the code, and may or may not prove useful for ov
     <xsl:param name="doc" as="document-node()?"/>
     <xsl:choose>
       <!-- If linktext is already specified, use that -->
-      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
+      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
         <xsl:apply-templates select="." mode="mappull:add-usertext-PI"/>
-        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]"/>
+        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:variable name="linktext" as="xs:string?">
@@ -988,10 +988,10 @@ Other modes can be found within the code, and may or may not prove useful for ov
     <xsl:param name="doc" as="document-node()?"/>
     <xsl:variable name="map-uri" as="xs:anyURI" select="base-uri(.)"/>
     <xsl:choose>
-      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]">
+      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]">
         <xsl:apply-templates select="." mode="mappull:add-usershortdesc-PI"/>
         <xsl:apply-templates
-          select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/shortdesc ')]"/>
+          select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]"/>
       </xsl:when>
       <xsl:when
         test="$scope='external' or $scope='peer' or not($format='#none#' or $format='dita')">
@@ -1083,7 +1083,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
     </xsl:apply-templates>
     <!--metadata to be written - if we add logic at some point to pull metadata from topics into the map-->
     <xsl:apply-templates
-      select="*[contains(@class, ' map/topicmeta ')]/*[not(contains(@class, ' map/linktext '))][not(contains(@class, ' map/shortdesc '))][not(contains(@class, ' topic/navtitle '))]|
+      select="*[contains(@class, ' map/topicmeta ')]/*[not(dita-ot:matches-linktext-class(@class))][not(dita-ot:matches-shortdesc-class(@class))][not(contains(@class, ' topic/navtitle '))]|
       *[contains(@class, ' map/topicmeta ')]/processing-instruction()"
     />
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
@@ -134,8 +134,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:value-of select="@navtitle"/>
       </xsl:when>
       <!-- If there is no title and none can be retrieved, check for <linktext> -->
-      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
-        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]"
+      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]"
                              mode="dita-ot:text-only"/>
       </xsl:when>
       <!-- No local title, and not targeting a DITA file. Could be just a container setting

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
@@ -107,7 +107,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:when>
     <!-- If this this a container (no href or href='', no title), just process children -->
     <xsl:when test="(not(@href) or @href='') and not(@navtitle) and not(*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]) and
-                    not(*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')])">
+                    not(*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)])">
       <xsl:apply-templates select="*[contains(@class, ' map/topicref ')][not(contains(@toc,'no'))][not(@processing-role='resource-only')]">
         <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
       </xsl:apply-templates>
@@ -198,8 +198,8 @@ See the accompanying LICENSE file for applicable license.
              <xsl:choose>
                <xsl:when test="not($TargetFile)">   <!-- DITA file does not exist -->
                  <xsl:choose>
-                   <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">  <!-- attempt to recover by using linktext -->
-                     <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]" mode="dita-ot:text-only"/>
+                   <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">  <!-- attempt to recover by using linktext -->
+                     <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]" mode="dita-ot:text-only"/>
                    </xsl:when>
                    <xsl:otherwise>
                      <xsl:call-template name="output-message">
@@ -226,8 +226,8 @@ See the accompanying LICENSE file for applicable license.
                  <xsl:apply-templates select="$TargetFile/dita/*[contains(@class,' topic/topic ')]/*[contains(@class,' topic/title ')]" mode="dita-ot:text-only"/>
                </xsl:when>
                <!-- Last choice: use the linktext specified within the topicref -->
-               <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
-                 <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]" mode="dita-ot:text-only"/>
+               <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
+                 <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]" mode="dita-ot:text-only"/>
                </xsl:when>
                <xsl:otherwise>
                  <xsl:call-template name="output-message">
@@ -240,8 +240,8 @@ See the accompanying LICENSE file for applicable license.
            </xsl:when>
 
            <!-- If there is no title and none can be retrieved, check for <linktext> -->
-           <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
-             <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]" mode="dita-ot:text-only"/>
+           <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
+             <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]" mode="dita-ot:text-only"/>
            </xsl:when>
 
            <!-- No local title, and not targeting a DITA file. Could be just a container setting

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
@@ -8,9 +8,11 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  exclude-result-prefixes="dita-ot"
   version="2.0">
 
-  <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[contains(@class,' map/searchtitle ')]"/>
+  <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[dita-ot:matches-searchtitle-class(@class)]" priority="10"/>
 
   <xsl:template match="*[contains(@class, ' map/topicmeta ')]">
     <!--

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -182,9 +182,9 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="/" mode="dita-ot:subject-metadata" as="xs:string?">
     <xsl:choose>
-      <xsl:when test="exists($map/*[contains(@class, ' bookmap/bookmeta ')]/*[contains(@class, ' map/shortdesc ')])">
+      <xsl:when test="exists($map/*[contains(@class, ' bookmap/bookmeta ')]/*[dita-ot:matches-shortdesc-class(@class)])">
         <xsl:value-of>
-          <xsl:apply-templates select="$map/*[contains(@class, ' bookmap/bookmeta ')]/*[contains(@class, ' map/shortdesc ')]" mode="dita-ot:text-only"/>
+          <xsl:apply-templates select="$map/*[contains(@class, ' bookmap/bookmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]" mode="dita-ot:text-only"/>
         </xsl:value-of>
       </xsl:when>
       <xsl:when test="exists($map/*[contains(@class, ' topic/shortdesc ')])">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -502,10 +502,7 @@ See the accompanying LICENSE file for applicable license.
         </fo:block>
     </xsl:template>
 
-    <!-- Map uses map/searchtitle, topic uses topic/searchtitle. This will likely be changed
-         to a single value in DITA 2.0, but for now, recognize both. -->
-    <xsl:template match="*[contains(@class,' topic/titlealts ')]/*[contains(@class,' topic/searchtitle ')] |
-                         *[contains(@class,' topic/titlealts ')]/*[contains(@class,' map/searchtitle ')]">
+    <xsl:template match="*[contains(@class,' topic/titlealts ')]/*[dita-ot:matches-searchtitle-class(@class)]">
         <fo:block xsl:use-attribute-sets="searchtitle">
             <xsl:call-template name="commonattributes"/>
             <fo:inline xsl:use-attribute-sets="searchtitle__label">
@@ -595,7 +592,8 @@ See the accompanying LICENSE file for applicable license.
         </fo:inline>
     </xsl:template>
 
-    <xsl:template match="*[contains(@class,' map/shortdesc ')]">
+    <!-- Short description not as child of topic -->
+    <xsl:template match="*[dita-ot:matches-shortdesc-class(@class)]">
         <xsl:apply-templates select="." mode="format-shortdesc-as-block"/>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
@@ -137,8 +137,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:value-of select="@navtitle"/>
       </xsl:when>
       <!-- If there is no title and none can be retrieved, check for <linktext> -->
-      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]">
-        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' map/linktext ')]"
+      <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]"
                              mode="dita-ot:text-only"/>
       </xsl:when>
       <!-- No local title, and not targeting a DITA file. Could be just a container setting

--- a/src/test/xsl/common/dita-utilities.xspec
+++ b/src/test/xsl/common/dita-utilities.xspec
@@ -672,4 +672,85 @@
     </x:scenario>
   </x:scenario>
   
+  <x:scenario label="dita-ot:matches-linktext-class">
+    <x:scenario label="DITA 1.3 class">
+      <x:call function="dita-ot:matches-linktext-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- map/linktext foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="DITA 2.0 class">
+      <x:call function="dita-ot:matches-linktext-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/linktext foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="Test fail condition">
+      <x:call function="dita-ot:matches-linktext-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/title foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>
+  </x:scenario>
+  
+  <x:scenario label="dita-ot:matches-shortdesc-class">
+    <x:scenario label="DITA 1.3 class">
+      <x:call function="dita-ot:matches-shortdesc-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- map/shortdesc foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="DITA 2.0 class">
+      <x:call function="dita-ot:matches-shortdesc-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/shortdesc foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="Test fail condition">
+      <x:call function="dita-ot:matches-shortdesc-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/title foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>
+  </x:scenario>
+  
+  <x:scenario label="dita-ot:matches-searchtitle-class">
+    <x:scenario label="DITA 1.3 class">
+      <x:call function="dita-ot:matches-searchtitle-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- map/searchtitle foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="DITA 2.0 class">
+      <x:call function="dita-ot:matches-searchtitle-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/searchtitle foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="Test fail condition">
+      <x:call function="dita-ot:matches-searchtitle-class">
+        <x:param name="class" select="/foobar/@class">
+          <foobar class="- topic/title foo/foobar "/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>
+  </x:scenario>
+  
 </x:description>


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

DITA 2.0 changes the class attributes for 3 elements in maps, which also appear in topics:
`map/linktext` ==> `topic/linktext`
`map/shortdesc` ==> `topic/shortdesc`
`map/searchtitle` ==> `topic/searchtitle`

This update allows both the 1.3 and 2.0 values to function. For map processing link in `mappull` it recognizes either value. It continues to write out `map/*` values for now when creating new elements, so that the code is backwards compatible / still based on the latest stable release.

## Motivation and Context

Ensures that testing / formatting with the new DITA 2.0 grammar files works properly for these elements in a map.

## How Has This Been Tested?

Created XSPEC tests for new XSL functions that check both class attributes.

Also: 
* Made a simple update to `hierarchy.ditamap` to add in link text and short descriptions
* Verified output with current processing (child links use the link text and short desc from map)
* Made explicit attributes of `topic/linktext` and `topic/shortdesc` on those elements
* Without the code update, those elements are ignored; with the code update, the child links work the same as with the default class values

## Type of Changes

Minor enhancement

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
