### PR TITLE
Restore call to table summary attribute stub

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -21,6 +21,10 @@ See the accompanying LICENSE file for applicable license.
          until OASIS provides a standard mechanism for setting. -->
   </xsl:template>
   
+  <xsl:template match="*[contains(@class, ' topic/simpletable ') ]" mode="table:common">
+    <xsl:apply-templates select="." mode="generate-table-summary-attribute"/>
+    <xsl:next-match/>
+  </xsl:template>
   
   <xsl:template name="dita2html:simpletable-cols">
     <xsl:variable name="col-count" as="xs:integer">

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -431,6 +431,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/desc ')]" mode="get-output-class">tabledesc</xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/table ') ]" mode="table:common">
+    <xsl:apply-templates select="." mode="generate-table-summary-attribute"/>
+    <xsl:next-match/>
+  </xsl:template>
 
   <xsl:template match="*" mode="table:common">
     <xsl:call-template name="commonattributes"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

For several releases, our code has had stub templates with `mode="generate-table-summary-attribute"` to allow you to add summary attributes to tables or simple tables. DITA doesn't explicitly define a way to encode the summary, but this is an accessibility requirement for many tables and authors have found different ways of specifying it in source.

This update ensures we call that stub, so that plugins have an easy way of supporting local conventions for that attribute.

## Motivation and Context

The stub was added many releases ago (not sure offhand when). At some point during refactoring of the XSL, any calls to the template were dropped, but the stub remained. This means any plugin that overrides the stub ... doesn't get anything for it, because we never called the template.

Restoring the call to the stub means that older plugins (and new plugins) can once again easily support the `table/@summary` attribute.

## How Has This Been Tested?

Added code into both the table and simple table stub that would generate a different summary value.

Verified that the proper summary was added to the proper table, and not to anything else.

## Type of Changes

Sort of a bug fix (restoring something we accidentally dropped), sort of an enhancement because the feature has been missing for a while.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
