### PR TITLE
Add language mapping for Norwegian Bokmål

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/common-strings.xml
+++ b/src/main/plugins/org.dita.base/xsl/common/common-strings.xml
@@ -77,6 +77,7 @@ See the accompanying LICENSE file for applicable license.
   <lang xml:lang="nl-nl" filename="strings-nl-nl.xml"/>
   <lang xml:lang="no"    filename="strings-no-no.xml"/>
   <lang xml:lang="no-no" filename="strings-no-no.xml"/>
+  <lang xml:lang="nb-no" filename="strings-no-no.xml"/>
   <lang xml:lang="pl"    filename="strings-pl-pl.xml"/>
   <lang xml:lang="pl-pl" filename="strings-pl-pl.xml"/>
   <lang xml:lang="pt"    filename="strings-pt-pt.xml"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/strings.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/strings.xml
@@ -38,6 +38,7 @@ See the accompanying LICENSE file for applicable license.
   <lang filename="ms.xml" xml:lang="ms"/>
   <lang filename="nl.xml" xml:lang="nl"/>
   <lang filename="no.xml" xml:lang="no"/>
+  <lang filename="no.xml" xml:lang="nb-no"/>
   <lang filename="pl.xml" xml:lang="pl"/>
   <lang filename="pt.xml" xml:lang="pt"/>
   <lang filename="pt_BR.xml" xml:lang="pt-br"/>


### PR DESCRIPTION
This change appears simple enough to consider for 3.5.

Fixes #3478.