### PR TITLE
Copyedit 3.5 CLI help

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -353,16 +353,16 @@ public class ConversionArguments extends Arguments {
                 .subcommands("transtypes")
                 .subcommands("uninstall")
                 .subcommands("version")
-                .arguments("i", "input", "file", "input file")
-                .arguments("f", "format", "name", "output format (transformation type)")
-                .arguments("p", "project", "name", "run project file")
-                .options("r", "resource", "file", "resource file")
-                .options(null, "filter", "files", "filter and flagging files")
-                .options("l", "logfile", "file", "use given file for log")
-                .options("o", "output", "dir", "output directory")
+                .arguments("i", "input", "file", "Input file")
+                .arguments("f", "format", "name", "Output format (transformation type)")
+                .arguments("p", "project", "name", "Publish a project file with multiple deliverables")
+                .options("r", "resource", "file", "Additional input resources")
+                .options(null, "filter", "files", "Filter and flagging files")
+                .options("l", "logfile", "file", "Write log messages to file")
+                .options("o", "output", "dir", "Output directory")
 //                .options(null, "<property>", "value", "use value for given property")
-                .options(null, "propertyfile", "file", "load all properties from file")
-                .options("t", "temp", "dir", "temporary directory");
+                .options(null, "propertyfile", "file", "Load all properties from file")
+                .options("t", "temp", "dir", "Temporary directory");
         final Set<String> builtin = ARGUMENTS.values().stream().map(arg -> arg.property).collect(Collectors.toSet());
         final List<Element> params = toList(Plugins.getPluginConfiguration().getElementsByTagName("param"));
         params.stream()

--- a/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
@@ -67,7 +67,7 @@ public class DeliverablesArguments extends Arguments {
     void printUsage() {
         UsageBuilder.builder()
                 .usage("dita deliverables <file> [options]")
-                .arguments(null, null, "file", "project file")
+                .arguments(null, null, "file", "Project file")
                 .print();
     }
 

--- a/src/main/java/org/dita/dost/invoker/InstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/InstallArguments.java
@@ -77,10 +77,10 @@ public class InstallArguments extends Arguments {
     void printUsage() {
         UsageBuilder.builder()
                 .usage("dita install [<file> | <url> | <id>]")
-                .arguments(null, null, "file", "install plug-in from a local ZIP file")
-                .arguments(null, null, "url", "install plug-in from a URL")
-                .arguments(null, null, "id", "install plug-in from plugin registry")
-                .options(null, "force", null, "force install plug-in")
+                .arguments(null, null, "file", "Install plug-in from a local ZIP file")
+                .arguments(null, null, "url", "Install plug-in from a URL")
+                .arguments(null, null, "id", "Install specified plug-in ID from registry")
+                .options(null, "force", null, "Force-install plug-in (overwrite existing version)")
                 .print();
     }
 

--- a/src/main/java/org/dita/dost/invoker/UninstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/UninstallArguments.java
@@ -55,7 +55,7 @@ public class UninstallArguments extends Arguments {
             }
         }
         if (value == null) {
-            throw new BuildException("You must specify a installation package when using the --uninstall argument");
+            throw new BuildException("You must specify an installation package when using the --uninstall argument");
         }
         uninstallId = value;
     }
@@ -75,7 +75,7 @@ public class UninstallArguments extends Arguments {
     void printUsage() {
         UsageBuilder.builder()
                 .usage("dita uninstall <id>")
-                .arguments(null, null, "id", "uninstall plug-in with the ID")
+                .arguments(null, null, "id", "Uninstall plug-in with the specified ID")
                 .print();
     }
 

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -22,9 +22,9 @@ public class UsageBuilder {
     private final Map<Key, String> arguments = new HashMap<>();
 
     private UsageBuilder() {
-        options("d", "debug", null, "print debugging information");
-        options("h", "help", null, "print this message");
-        options("v", "verbose", null, "verbose logging");
+        options("d", "debug", null, "Print debugging information");
+        options("h", "help", null, "Print this message");
+        options("v", "verbose", null, "Enable verbose logging");
     }
 
     public static UsageBuilder builder() {

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -124,7 +124,7 @@ See the accompanying LICENSE file for applicable license.
       <val>true</val>
       <val default="true">false</val>
     </param>
-    <param name="generate.copy.outer" desc="Specifies whether to generate output files for content that is not located in or beneath the directory containing the DITA map file." type="enum">
+    <param name="generate.copy.outer" desc="Adjust how output is generated for content that is located outside the directory containing the DITA map." type="enum">
       <val desc="Do not generate output for content that is located outside the DITA map directory." default="true">1</val>
       <val desc="Shift the output directory so that it contains all output for the publication.">3</val>
     </param>
@@ -132,7 +132,7 @@ See the accompanying LICENSE file for applicable license.
       <val>true</val>
       <val default="true">false</val>
     </param>
-    <param name="outer.control" desc="Specifies how DITA-OT handles content files that are not located in or below the directory containing the master DITA map." type="enum">
+    <param name="outer.control" desc="Specifies whether to warn or fail if content is located outside the directory containing the DITA map." type="enum">
       <val desc="Fail quickly if files are going to be generated or copied outside of the directory.">fail</val>
       <val desc="Complete the operation if files will be generated or copied outside of the directory, but log a warning." default="true">warn</val>
       <val desc="Quietly finish without generating warnings or errors.">quiet</val>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -153,7 +153,7 @@ See the accompanying LICENSE file for applicable license.
       <val desc="When an error is encountered, DITA-OT attempts to recover from it" default="true">lax</val>
       <val desc="When an error is encountered, DITA-OT continues processing but does not attempt error recovery">skip</val>
     </param>
-    <param name="conserve-memory" desc="Conserve memory at the expense of processing speed" type="enum">
+    <param name="conserve-memory" desc="Conserve memory at the expense of processing speed." type="enum">
       <val>true</val>
       <val default="true">false</val>
     </param>
@@ -162,8 +162,8 @@ See the accompanying LICENSE file for applicable license.
       <val>true</val>
       <val default="true">false</val>
     </param>
-    <param name="result.rewrite-rule.xsl" desc="Specifies the name of the XSLT file used to rewrite filenames" type="string"/>
-    <param name="result.rewrite-rule.class" desc="Specifies the name of the Java class used to rewrite filenames" type="string"/>
+    <param name="result.rewrite-rule.xsl" desc="Specifies the name of the XSLT file used to rewrite filenames." type="string"/>
+    <param name="result.rewrite-rule.class" desc="Specifies the name of the Java class used to rewrite filenames." type="string"/>
   </transtype>
   <feature extension="dita.image.extensions" value=".gif"/>
   <feature extension="dita.image.extensions" value=".eps"/>

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -28,7 +28,7 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.cssroot" desc="Specifies the directory that contains the custom .css file." type="string"/>
     <param name="args.dita.locale" desc="Specifies the language locale file to use for sorting index entries." type="string"/>
     <param name="args.ftr" desc="Specifies an XML file that contains content for a running footer." type="file"/>
-    <param name="args.gen.default.meta" desc="Specifies whether to generate extra metadata that targets parental control scanners, meta elements with name=&#34;security&#34; and name=&#34;Robots&#34;." type="enum">
+    <param name="args.gen.default.meta" desc="Generate metadata for parental control scanners, meta elements with name=&#34;security&#34; and name=&#34;Robots&#34;." type="enum">
       <val>yes</val>
       <val default="true">no</val>
     </param>

--- a/src/main/plugins/org.dita.xhtml/plugin.xml
+++ b/src/main/plugins/org.dita.xhtml/plugin.xml
@@ -30,7 +30,7 @@ See the accompanying LICENSE file for applicable license.
     <param name="args.dita.locale" desc="Specifies the language locale file to use for sorting index entries." type="string"/>
     <param name="args.ftr" desc="Specifies an XML file that contains content for a running footer." type="file"/>
     <param name="args.gen.default.meta"
-      desc="Specifies whether to generate extra metadata that targets parental control scanners, meta elements with name=&#34;security&#34; and name=&#34;Robots&#34;." type="enum">
+      desc="Generate metadata for parental control scanners, meta elements with name=&#34;security&#34; and name=&#34;Robots&#34;." type="enum">
       <val>yes</val>
       <val default="true">no</val>
     </param>


### PR DESCRIPTION
## Description

Now that the `dita help` subcommand includes the list of available parameters (🎉) , output appears inconsistent with regard to initial capitalization of each line. 

The majority of entries are parameter descriptions in sentence case, so c7529a7 capitalizes the remaining arguments & options to align with this precedent, and clarifies a few descriptions in the process.

1bf9c0d: Copyedit parameter descriptions

- Reduce maximum line length to minimize line wrapping
- Clarify purpose of "outer" options
