### PR TITLE
Fix doc build errors with new class att matches

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
   exclude-result-prefixes="dita-ot"
   version="2.0">
 
-  <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[dita-ot:matches-searchtitle-class(@class)]" priority="10"/>
+  <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[@class][dita-ot:matches-searchtitle-class(@class)]" priority="10"/>
 
   <xsl:template match="*[contains(@class, ' map/topicmeta ')]">
     <!--

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -554,7 +554,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- For SF Bug 2879171: modify so that shortdesc is inline when inside
          abstract with only other text or inline markup. -->
-    <xsl:template match="*[contains(@class,' topic/shortdesc ')]">
+    <xsl:template match="*[not(contains(@class, ' topic/topic '))]/*[@class][dita-ot:matches-shortdesc-class(@class)]">
         <xsl:variable name="format-as-block" as="xs:boolean" select="dita-ot:formatShortdescAsBlock(.)"/>
         <xsl:choose>
             <xsl:when test="$format-as-block">
@@ -592,11 +592,7 @@ See the accompanying LICENSE file for applicable license.
         </fo:inline>
     </xsl:template>
 
-    <!-- Short description not as child of topic -->
-    <xsl:template match="*[dita-ot:matches-shortdesc-class(@class)]">
-        <xsl:apply-templates select="." mode="format-shortdesc-as-block"/>
-    </xsl:template>
-
+    <!-- Short description as child of topic -->
     <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class,' topic/shortdesc ')]" priority="1">
         <xsl:variable name="topicType" as="xs:string">
             <xsl:call-template name="determineTopicType"/>


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes two issues with doc builds that arose from #3483 

* It looks like something in our process is adding elements into `topicmeta` that do not have a `@class` attribute. This is unrelated to that pull request; however, the function that sends `@class` as a parameter threw an error because it's being called with a missing parameter. Explicitly matching only elements with `@class` resolves the error, but longer term we should figure out what is being added without a `@class` att.
* There is an ambiguous rule match for `topic/shortdesc` in `topic.xsl` for PDF. I've removed the extra generic match, which is already handled above by an existing match; I've also made that match more explicit, so `topic.xsl` has one match for shortdesc-in-topic and one for shortdesc-not-in-topic.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


