### PR TITLE
Fix mapper with external keys in subdirectory

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/functions.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/functions.xsl
@@ -60,6 +60,13 @@ See the accompanying LICENSE file for applicable license.
            else $doc
     "/>
   </xsl:function>
+  
+  <!-- $href (might be @href or @copy-to) has absolute or external value that should not be changed -->
+  <xsl:function name="dita-ot:is-external" as="xs:boolean">
+    <xsl:param name="href" as="attribute()"/>
+    <xsl:sequence select="contains($href,'://') or 
+        $href/../@scope = 'external'"></xsl:sequence>
+  </xsl:function>
 
   <!-- ID -->
 

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -263,7 +263,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:for-each select="@href | @copy-to">
         <xsl:choose>
           <xsl:when test=". = ''"/>
-          <xsl:when test="$relative-path = '#none#' or contains(.,'://')">
+          <xsl:when test="$relative-path = '#none#' or dita-ot:is-external(.)">
             <xsl:attribute name="{name()}">
               <xsl:value-of select="."/>
             </xsl:attribute>
@@ -468,11 +468,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="relative-path" as="xs:string" tunnel="yes">#none#</xsl:param>
     <xsl:attribute name="{name()}">
       <xsl:choose>
-        <xsl:when test="not(contains(.,'://') or ../@scope = 'external' or $relative-path = ('#none#', ''))">
-          <xsl:value-of select="dita-ot:normalize-uri(concat($relative-path, .))"/>
+        <xsl:when test="dita-ot:is-external(.) or $relative-path = ('#none#', '')">
+          <xsl:value-of select="."/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="."/>
+          <xsl:value-of select="dita-ot:normalize-uri(concat($relative-path, .))"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>

--- a/src/test/xsl/common/dita-utilities.xspec
+++ b/src/test/xsl/common/dita-utilities.xspec
@@ -672,6 +672,41 @@
     </x:scenario>
   </x:scenario>
   
+  <x:scenario label="dita-ot:is-external">
+    <x:scenario label="simple https uri">
+      <x:call function="dita-ot:is-external">
+        <x:param name="href" select="/foo/@href">
+          <foo href="https://www.dita-ot.org"/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="https with proper scope">
+      <x:call function="dita-ot:is-external">
+        <x:param name="href" select="/foo/@href">
+          <foo href="https://www.dita-ot.org" scope="external"/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="External absolute path">
+      <x:call function="dita-ot:is-external">
+        <x:param name="href" select="/foo/@href">
+          <foo href="/absolute/server/path" scope="external"/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="true()"/>
+    </x:scenario>
+    <x:scenario label="Local relative path">
+      <x:call function="dita-ot:is-external">
+        <x:param name="href" select="/foo/@href">
+          <foo href="path/to/file.dita"/>
+        </x:param>
+      </x:call>
+      <x:expect label="" select="false()"/>
+    </x:scenario>
+  </x:scenario>
+  
   <x:scenario label="dita-ot:matches-linktext-class">
     <x:scenario label="DITA 1.3 class">
       <x:call function="dita-ot:matches-linktext-class">


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes a defect with external keys that are defined in a map in a subdirectory.

For example, I have a map inside `common/` with this key definition:
`<keydef href="/this/is/absolute" scope="external" format="html">`

This is an external link, which resolves properly when the published HTML is loaded onto a web server. I've marked it as absolute, and it uses an absolute path. However, when `mapref` merges maps from the `common/` subdirectory, it treats this as a relative path and adds a `common/` prefix -- the merged map is updated to this, which breaks my keyref links:
`<keydef href="common/this/is/absolute" scope="external" format="html">`

The mapref code already checks for `://` in a URI as a way to avoid updating it during the merge; my update also checks for `@scope="external"`, for which we avoid updates in a lot of other places.

I moved that check (for `://` and scope) into a function so that we are consistent about which paths do not get updated, in normal map merging + relationship table merging.

These absolute paths beginning with `/` still result in quirky output if the scope is set to `peer` but I think that's OK (at least, the result is arguable, while we've always treated `scope="external"` as static).

## How Has This Been Tested?

Passes integration tests; test case included here.
[mapref.zip](https://github.com/dita-ot/dita-ot/files/4441179/mapref.zip)


## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
