### PR TITLE
Fix build crash when term refs missing doc

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/functions.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/functions.xsl
@@ -48,9 +48,12 @@ See the accompanying LICENSE file for applicable license.
   <xsl:function name="dita-ot:retrieve-href-target" as="node()?">
     <xsl:param name="href" as="attribute(href)"/>
 
-    <xsl:variable name="doc" as="document-node()"
-      select="doc(dita-ot:resolve-href-path($href))"/>
-
+    <xsl:variable name="resolved-href-path" select="dita-ot:resolve-href-path($href)" as="xs:anyURI"/>
+    <xsl:variable name="doc" as="document-node()?"
+      select="if (doc-available($resolved-href-path))
+      then (doc(dita-ot:resolve-href-path($href)))
+      else ()"/>
+    
     <xsl:sequence select="
         if (dita-ot:has-element-id($href))
       then $doc/key('id', dita-ot:get-element-id($href))


### PR DESCRIPTION
---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

I have a `<term>` element that uses `@keyref`, but the key is a broken link (the topic is missing).

Our key processing code for terms assumes that the document exists, tries to access it, and then the entire build crashes with I/O errors and unchecked XPATH exceptions, for trying to examine nodes inside a document that did not resolve.

The fix just updates the common function `resolved-href-path` to check that the document is available before loading it into a variable; this allows the build to finish (with expected errors about the missing doc / unresolved term reference).

## Motivation and Context

This actually came up in a case that likely highlights a bug in the chunking code -- a branch of the map was chunked, and for some reason moved the topic from a subdirectory into the map directory with a generated `Chunk1345.dita` type name. The resolved key on `term` was not updated, meaning the path was now broken; that broken path resulted in the issue described above. It was easily reproducible by creating a broken key in the root map.

## How Has This Been Tested?

Passes tests; actual test case attached.
[term.zip](https://github.com/dita-ot/dita-ot/files/4441243/term.zip)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

