### PR TITLE
Avoid NPE for missing chunk

### DIFF
--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -227,7 +227,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final URI t = job.tempDirURI.relativize(output);
         final URI result = job.getInputDir().resolve(t);
         final URI temp = tempFileNameScheme.generateTempFileName(result);
-        final FileInfo.Builder b = currentParsingFile != null
+        final FileInfo.Builder b = (currentParsingFile != null && job.getFileInfo(stripFragment(currentParsingFile)) != null)
                 ? new FileInfo.Builder(job.getFileInfo(stripFragment(currentParsingFile)))
                 : new FileInfo.Builder();
         final FileInfo fi = b


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Fixes a null pointer error in the chunking module caused by bad input (missing document).

## Motivation and Context

I've had several cases that can be simplified down to this:
```
    <topicref href="parent.dita" chunk="to-content">
        <topicref href="parentpull-good.dita"/>
        <topicref href="parentpull-bad.dita"/>
```

When the "bad" topic is missing or cannot be parsed, we get a bunch of expected errors about the file. When the chunking module tries to combine the "bad" (actually missing) content with the parent topic, it throws a Null Pointer Error trying to create `FileInfo` from a file that did not exist.

The update just checks to see if `job.getFileInfo(stripFragment(currentParsingFile)) != null` before passing `job.getFileInfo(stripFragment(currentParsingFile))` into the file builder.

## How Has This Been Tested?

Test case:
[chunkfail.zip](https://github.com/dita-ot/dita-ot/files/4511642/chunkfail.zip)

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

