### PR TITLE
Add immutable document to store

### DIFF
--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -347,7 +347,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
                 }
                 if (children != null) {
                     for (final URI childpath: children) {
-                        final Document childRoot = job.getStore().getDocument(job.getInputFile().resolve(childpath.getPath()));
+                        final Document childRoot = job.getStore().getImmutableDocument(job.getInputFile().resolve(childpath.getPath()));
                         mergeScheme(parentRoot, childRoot);
                         generateScheme(new File(job.tempDir, childpath.getPath() + SUBJECT_SCHEME_EXTENSION), childRoot);
                     }

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -10,6 +10,7 @@ package org.dita.dost.store;
 
 import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
 import org.xml.sax.ContentHandler;
@@ -61,6 +62,25 @@ public interface Store {
     Source getSource(URI path);
 
     /**
+     * Get immutable DOM document for file. If mutating methods are called,
+     * {@link UnsupportedOperationException} is thrown.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return document or null if not available
+     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
+     */
+    Document getImmutableDocument(URI path) throws IOException;
+
+    /**
+     * Get immutable XsdNode for file.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return document or null if not available
+     * @throws java.io.FileNotFoundException if file does not exist or cannot be read
+     */
+    XdmNode getImmutableNode(final URI path) throws IOException;
+
+    /**
      * Get DOM document for file.
      *
      * @param path temporary file URI, absolute or relative
@@ -77,6 +97,15 @@ public interface Store {
      * @throws IOException if serializing file fails
      */
     void writeDocument(Document doc, URI dst) throws IOException;
+
+    /**
+     * Write XdmNode to file.
+     *
+     * @param node XdmNode to store
+     * @param dst destination file URI, absolute or relative
+     * @throws IOException if serializing file fails
+     */
+    void writeDocument(XdmNode node, URI dst) throws IOException;
 
     /**
      * Get temporary file destination

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -47,6 +47,21 @@ public class StreamStore implements Store {
     }
 
     @Override
+    public Document getImmutableDocument(final URI path) throws IOException {
+//        return (Document) NodeOverNodeInfo.wrap(getImmutableNode(path).getUnderlyingNode());
+        return getDocument(path);
+    }
+
+    @Override
+    public XdmNode getImmutableNode(final URI path) throws IOException {
+        try {
+            return xmlUtils.getProcessor().newDocumentBuilder().build(new StreamSource(path.toString()));
+        } catch (SaxonApiException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
     public Document getDocument(final URI path) throws IOException {
         try {
             return XMLUtils.getDocumentBuilder().parse(path.toString());
@@ -57,10 +72,15 @@ public class StreamStore implements Store {
 
     @Override
     public void writeDocument(final Document doc, final URI dst) throws IOException {
+        final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
+        writeDocument(source, dst);
+    }
+
+    @Override
+    public void writeDocument(final XdmNode node, final URI dst) throws IOException {
         try {
             final Serializer serializer = getSerializer(dst);
-            final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
-            serializer.serializeNode(source);
+            serializer.serializeNode(node);
         } catch (SaxonApiException e) {
             throw new IOException(e);
         }

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -73,7 +73,7 @@ public final class DelayConrefUtils {
         }
         try {
             //load the file
-            final Document root = job.getStore().getDocument(absolutePathToFile.toURI());
+            final Document root = job.getStore().getImmutableDocument(absolutePathToFile.toURI());
 
             //get root element
             final Element doc = root.getDocumentElement();
@@ -122,7 +122,7 @@ public final class DelayConrefUtils {
         try {
             //load export.xml only once
             if (root == null) {
-                root = job.getStore().getDocument(exportFile.toURI());
+                root = job.getStore().getImmutableDocument(exportFile.toURI());
             }
             //get file node which contains the export node
             final Element fileNode = searchForKey(root.getDocumentElement(), href, "file");

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -860,9 +860,19 @@ public final class XMLUtils {
      * @throws IOException if serializing file fails
      */
     public void writeDocument(final Node doc, final ContentHandler dst) throws IOException {
+        writeDocument(processor.newDocumentBuilder().wrap(doc), dst);
+    }
+
+    /**
+     * Write XdmNode to SAX pipe.
+     *
+     * @param source XdmNode to store
+     * @param dst SAX pipe
+     * @throws IOException if serializing file fails
+     */
+    public void writeDocument(final XdmNode source, final ContentHandler dst) throws IOException {
         try {
             final SAXDestination destination = new SAXDestination(dst);
-            final XdmNode source = processor.newDocumentBuilder().wrap(doc);
             processor.writeXdmValue(source, destination);
         } catch (SaxonApiException e) {
             throw new IOException(e);


### PR DESCRIPTION
## Description
Add immutable document reader method to `Store`.

## Motivation and Context
Not all DOM document processing requires modifications to the document. DOM itself doesn't offer an unmodifiable/immutable document, but code can explicitly ask for a document that doesn't have to support mutation.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No end user documentation changes needed.