### PR TITLE
Issue #3433 No warning for broken in-topic link

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -79,6 +79,10 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:call-template name="href"/><!--use href text-->
+                  <xsl:call-template name="output-message">
+                    <xsl:with-param name="id" select="'DOTX032E'"/>
+                    <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
+                  </xsl:call-template>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -79,10 +79,7 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:when>
                 <xsl:otherwise>
                   <xsl:call-template name="href"/><!--use href text-->
-                  <xsl:call-template name="output-message">
-                    <xsl:with-param name="id" select="'DOTX032E'"/>
-                    <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
-                  </xsl:call-template>
+                  <xsl:apply-templates select="." mode="ditamsg:missing-title-in-link"/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>
@@ -744,6 +741,13 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX043I'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$href"/>;%2=<xsl:value-of select="$outfile"/></xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="*" mode="ditamsg:missing-title-in-link">
+    <xsl:call-template name="output-message">
+      <xsl:with-param name="id" select="'DOTX032E'"/>
+      <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 


### PR DESCRIPTION
Added error DOTX032E. Seemed most relevant for this issue.
The error is raised only when the problematic xref doesn't have a text
node, and is not possible to reference in current topic. I don't know
if a warning should be created for this situation, I just found the
position where the error message could be generated for this issue.

Signed-off-by: Konstantinos Tsiligkiris <ktsiligkiris@outlook.com>

---
name: Pull request
about: Propose changes to fix an issue

---

## Description
Added the error message DOTX032E in xslt code, during the rendering of an xref in html5, where the error is activated when the rendered link has a local href that doesn't return a title and the xref itself doesn't have a text node.

## Motivation and Context
This is about issue #3433 which seemed easy to fix, and this is my first pull request.
## How Has This Been Tested?
I rendered the dita example given in the issue and checked that the error message is reported only when the link is broken, not when the link is correct.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

- I am not sure if error messages are included in the documentation, and I don't think that this breaks previous releases.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project. YES
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code. (Not sure about how to do this, it's my first pull request.)
