### PR TITLE
Add dependency org.xmlresolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation group: 'xerces', name: 'xercesImpl', version:'2.12.1'
     implementation group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
+    implementation group: 'org.xmlresolver', name: 'xmlresolver', version: '4.1.2'
     implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '10.6'
     implementation group: 'com.ibm.icu', name: 'icu4j', version:'70.1'
     implementation group: 'org.apache.ant', name: 'ant', version:'1.10.12'

--- a/gradle/dist.gradle
+++ b/gradle/dist.gradle
@@ -12,6 +12,7 @@ def licenses = [
         [name: 'commons-logging', title: 'Commons Logging', license: ['apache2.txt']],
         [name: 'xercesImpl', title: 'Xerces2 Java', license: ['apache2.txt']],
         [name: 'xml-apis', title: 'XML Commons External', license: ['apache2.txt', 'LICENSE.dom-documentation.txt', 'LICENSE.dom-software.txt', 'LICENSE.sax.txt']],
+        [name: 'xmlresolver', title: 'xmlresolver', license: ['apache2.txt']],
         [name: 'xml-resolver', title: 'Resolver', license: ['apache2.txt']],
         [name: 'Saxon-HE', title: 'Saxon-HE', license: ['mpl2.txt', 'CERN.txt', 'JAMESCLARK.txt', 'THAI.txt', 'UNICODE.txt']],
         [name: 'icu4j', title: 'ICU4J', license: ['icu.txt']],

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -423,6 +423,11 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <message id="DOTJ084W" type="WARN">
+    <reason>Invalid URI '%1'.</reason>
+    <response>Using normalized '%2'.</response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -12,7 +12,6 @@ import com.google.common.annotations.VisibleForTesting;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.commons.io.FileUtils;
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
@@ -25,6 +24,7 @@ import org.dita.dost.writer.LinkFilter;
 import org.dita.dost.writer.MapCleanFilter;
 import org.w3c.dom.Document;
 import org.xml.sax.XMLFilter;
+import org.xmlresolver.Resolver;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -67,7 +67,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
         useResultFilename = Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME))
                 .map(Boolean::parseBoolean)
                 .orElse(false);
-        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+        final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
         rewriteTransformer = Optional.ofNullable(input.get("result.rewrite-rule.xsl"))
                 .map(file -> {
                     try {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -406,7 +406,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
         try {
             final EntityResolver resolver = processingMode.equals(Mode.LAX)
-                    ? new LaxEntityResolver(CatalogUtils.getCatalogResolver())
+                    ? new LaxEntityResolver(CatalogUtils.getCatalogResolver(), logger)
                     : CatalogUtils.getCatalogResolver();
             XMLReader xmlSource = getXmlReader(ref.format);
             for (final XMLFilter f: getProcessingPipe(currentFile)) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -24,10 +24,7 @@ import org.dita.dost.util.*;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.ExportAnchorsFilter;
 import org.dita.dost.writer.ProfilingFilter;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.XMLFilter;
-import org.xml.sax.XMLReader;
+import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.*;
@@ -408,10 +405,13 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         final String[] params = { currentFile.toString() };
 
         try {
+            final EntityResolver resolver = processingMode.equals(Mode.LAX)
+                    ? new LaxEntityResolver(CatalogUtils.getCatalogResolver())
+                    : CatalogUtils.getCatalogResolver();
             XMLReader xmlSource = getXmlReader(ref.format);
             for (final XMLFilter f: getProcessingPipe(currentFile)) {
                 f.setParent(xmlSource);
-                f.setEntityResolver(CatalogUtils.getCatalogResolver());
+                f.setEntityResolver(resolver);
                 xmlSource = f;
             }
             xmlSource.setContentHandler(nullHandler);

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -9,13 +9,13 @@ package org.dita.dost.module;
 
 import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderFactory;
+import org.xmlresolver.Resolver;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -122,7 +122,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
             }
         }
 
-        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+        final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
         reader.setEntityResolver(catalogResolver);
 
         processor = xmlUtils.getProcessor();

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -12,7 +12,6 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
 import org.apache.tools.ant.types.XMLCatalog;
 import org.apache.tools.ant.util.FileNameMapper;
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.UncheckedDITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -20,6 +19,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
 import org.dita.dost.util.Job;
+import org.xmlresolver.Resolver;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.URIResolver;
@@ -72,7 +72,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
 
     private void init() {
         if (catalog == null) {
-            final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+            final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
             catalog = catalogResolver;
         }
         uriResolver = new DelegatingURIResolver(catalog, job.getStore());

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -25,6 +25,7 @@ import org.dita.dost.writer.TopicFragmentFilter;
 import org.xml.sax.*;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.DefaultHandler;
+import org.xmlresolver.Resolver;
 
 import javax.xml.namespace.QName;
 import java.io.*;
@@ -358,11 +359,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
 
         try {
+            final EntityResolver resolver = processingMode.equals(Mode.LAX)
+                    ? new LaxEntityResolver(CatalogUtils.getCatalogResolver(), logger)
+                    : CatalogUtils.getCatalogResolver();
             XMLReader parser = getXmlReader(ref.format);
             XMLReader xmlSource = parser;
             for (final XMLFilter f: getProcessingPipe(currentFile)) {
                 f.setParent(xmlSource);
-                f.setEntityResolver(CatalogUtils.getCatalogResolver());
+                f.setEntityResolver(resolver);
                 xmlSource = f;
             }
 

--- a/src/main/java/org/dita/dost/util/CatalogUtils.java
+++ b/src/main/java/org/dita/dost/util/CatalogUtils.java
@@ -49,15 +49,10 @@ public final class CatalogUtils {
     public static synchronized Resolver getCatalogResolver() {
         if (catalogResolver == null) {
             final XMLResolverConfiguration config = new XMLResolverConfiguration();
-//            manager.setIgnoreMissingProperties(true);
-//            manager.setUseStaticCatalog(false); // We'll use a private catalog.
-//            manager.setPreferPublic(true);
             config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
-//            final CatalogManager manager = new CatalogManager(config);
+//            config.setFeature(ResolverFeature.THROW_URI_EXCEPTIONS, true);
             final File catalogFilePath = new File(ditaDir, Configuration.pluginResourceDirs.get("org.dita.base") + File.separator + FILE_NAME_CATALOG);
-//            manager.setCatalogFiles(catalogFilePath.toURI().toASCIIString());
             config.addCatalog(catalogFilePath.toURI().toASCIIString());
-            //manager.setVerbosity(10);
             catalogResolver = new Resolver(config);
         }
 

--- a/src/main/java/org/dita/dost/util/CatalogUtils.java
+++ b/src/main/java/org/dita/dost/util/CatalogUtils.java
@@ -12,8 +12,7 @@ import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 
-import org.apache.xml.resolver.CatalogManager;
-import org.apache.xml.resolver.tools.CatalogResolver;
+import org.xmlresolver.*;
 
 /**
  * General catalog file resolving utilities.
@@ -24,7 +23,7 @@ import org.apache.xml.resolver.tools.CatalogResolver;
 public final class CatalogUtils {
 
     /**apache catalogResolver.*/
-    private static CatalogResolver catalogResolver = null;
+    private static Resolver catalogResolver = null;
     /** Absolute directory to find catalog-dita.xml.*/
     private static File ditaDir;
     /**
@@ -47,16 +46,19 @@ public final class CatalogUtils {
      * Get CatalogResolver.
      * @return CatalogResolver
      */
-    public static synchronized CatalogResolver getCatalogResolver() {
+    public static synchronized Resolver getCatalogResolver() {
         if (catalogResolver == null) {
-            final CatalogManager manager = new CatalogManager();
-            manager.setIgnoreMissingProperties(true);
-            manager.setUseStaticCatalog(false); // We'll use a private catalog.
-            manager.setPreferPublic(true);
+            final XMLResolverConfiguration config = new XMLResolverConfiguration();
+//            manager.setIgnoreMissingProperties(true);
+//            manager.setUseStaticCatalog(false); // We'll use a private catalog.
+//            manager.setPreferPublic(true);
+            config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
+//            final CatalogManager manager = new CatalogManager(config);
             final File catalogFilePath = new File(ditaDir, Configuration.pluginResourceDirs.get("org.dita.base") + File.separator + FILE_NAME_CATALOG);
-            manager.setCatalogFiles(catalogFilePath.toURI().toASCIIString());
+//            manager.setCatalogFiles(catalogFilePath.toURI().toASCIIString());
+            config.addCatalog(catalogFilePath.toURI().toASCIIString());
             //manager.setVerbosity(10);
-            catalogResolver = new CatalogResolver(manager);
+            catalogResolver = new Resolver(config);
         }
 
         return catalogResolver;

--- a/src/main/java/org/dita/dost/util/LaxEntityResolver.java
+++ b/src/main/java/org/dita/dost/util/LaxEntityResolver.java
@@ -8,6 +8,8 @@
 
 package org.dita.dost.util;
 
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -19,9 +21,11 @@ import java.net.URISyntaxException;
 
 public class LaxEntityResolver implements EntityResolver {
     private final EntityResolver parent;
+    private final DITAOTLogger logger;
 
-    public LaxEntityResolver(EntityResolver parent) {
+    public LaxEntityResolver(EntityResolver parent, DITAOTLogger logger) {
         this.parent = parent;
+        this.logger = logger;
     }
 
     @Override
@@ -31,6 +35,7 @@ public class LaxEntityResolver implements EntityResolver {
             new URI(systemId);
         } catch (URISyntaxException e) {
             normalized = URIUtils.normalizeURI(systemId);
+            logger.warn(MessageUtils.getMessage("DOTJ084W", systemId, normalized).toString());
         }
         return parent.resolveEntity(publicId, normalized);
     }

--- a/src/main/java/org/dita/dost/util/LaxEntityResolver.java
+++ b/src/main/java/org/dita/dost/util/LaxEntityResolver.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2022 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xmlresolver.utils.URIUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class LaxEntityResolver implements EntityResolver {
+    private final EntityResolver parent;
+
+    public LaxEntityResolver(EntityResolver parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        String normalized = systemId;
+        try {
+            new URI(systemId);
+        } catch (URISyntaxException e) {
+            normalized = URIUtils.normalizeURI(systemId);
+        }
+        return parent.resolveEntity(publicId, normalized);
+    }
+}

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -12,13 +12,13 @@ import net.sf.saxon.expr.instruct.TerminationException;
 import net.sf.saxon.lib.*;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.s9api.streams.Step;
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.saxon.DelegatingCollationUriResolver;
 import org.w3c.dom.*;
 import org.xml.sax.*;
 import org.xml.sax.helpers.AttributesImpl;
+import org.xmlresolver.Resolver;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -61,7 +61,7 @@ public final class XMLUtils {
         saxParserFactory.setNamespaceAware(true);
     }
     private DITAOTLogger logger;
-    private final CatalogResolver catalogResolver;
+    private final Resolver catalogResolver;
     private final Processor processor;
     private final XsltCompiler xsltCompiler;
 

--- a/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="msg" select="'***'"/>
     <xsl:param name="msgparams" select="''"/>    
     
-    <xsl:variable name="msgdoc" select="document('platform:/config/messages.xml')" as="document-node()?"/>
+    <xsl:variable name="msgdoc" select="document('platform:config/messages.xml')" as="document-node()?"/>
     <xsl:variable name="msgcontent" as="xs:string*">
       <xsl:choose>
         <xsl:when test="$msg != '***'">

--- a/src/main/plugins/org.dita.pdf2/build.gradle
+++ b/src/main/plugins/org.dita.pdf2/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation group: 'org.apache.ant', name: 'ant', version:'1.10.12'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
+    implementation group: 'org.xmlresolver', name: 'xmlresolver', version: '4.1.2'
 }
 sourceSets {
     main {

--- a/src/test/java/org/dita/dost/util/XSpecTest.java
+++ b/src/test/java/org/dita/dost/util/XSpecTest.java
@@ -7,7 +7,6 @@
  */
 package org.dita.dost.util;
 
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +15,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xmlresolver.Resolver;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -77,7 +77,7 @@ public class XSpecTest {
                 .orElse("src" + File.separator + "main"))
                 .getAbsoluteFile();
         CatalogUtils.setDitaDir(ditaDir);
-        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
+        final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
         resolver = new ClassPathResolver(catalogResolver);
         transformerFactory.setURIResolver(resolver);
         final Source stylesheet = resolver.resolve("classpath:///XSpec/generate-xspec-tests.xsl", "");

--- a/src/test/resources/bookmap7/src/p.dita
+++ b/src/test/resources/bookmap7/src/p.dita
@@ -6,7 +6,7 @@
   | (C) Copyright 2005 IBM Corporation - 2006
   *-->   
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 1.3 Concept//EN"
- "concept.dtd">
+ "\concept.dtd">
 <concept id="newelementdata" xml:lang="en-us">
 <title>New element &lt;data&gt;</title>
 <conbody>


### PR DESCRIPTION
## Description
Replace dependency Apache Resolver with org.xmlresolver.

## Motivation and Context
The [org.xmlresolver](https://github.com/ndw/xmlresolver) library has features the old Apache Resolver lacks and is under more active development.

## How Has This Been Tested?
Old tests pass.
## Type of Changes

- Breaking change because dependencies change from `CatalogResolver` to `Resolver` at Java level. This only affects plug-ins that use custom Java code that use the catalog resolver.

## Documentation and Compatibility
Plug-in developer migration documentation to use `Resolver` class instead of `CatalogResolver`.
