### PR TITLE
Initialize output dir in project processing

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -26,6 +26,7 @@
 
 package org.dita.dost.invoker;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.apache.tools.ant.*;
 import org.apache.tools.ant.input.DefaultInputHandler;
@@ -63,7 +64,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private static final String ANT_ARGS_INPUT = "args.input";
     static final String ANT_ARGS_RESOURCES = "args.resources";
     static final String ANT_ARGS_INPUTS = "args.inputs";
-    private static final String ANT_OUTPUT_DIR = "output.dir";
+    protected static final String ANT_OUTPUT_DIR = "output.dir";
     private static final String ANT_BASE_TEMP_DIR = "base.temp.dir";
     private static final String ANT_TRANSTYPE = "transtype";
     private static final String ANT_PLUGIN_FILE = "plugin.file";
@@ -394,13 +395,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     final Context context = deliverable.context;
                     final URI input = base.resolve(context.inputs.inputs.get(0).href);
                     props.put(ANT_ARGS_INPUT, input.toString());
-                    URI outputDir = new File(props.get(ANT_OUTPUT_DIR).toString()).toURI();
-                    outputDir = outputDir.getPath().endsWith("/")
-                            ? outputDir
-                            : URLUtils.setPath(outputDir, outputDir.getPath() + "/");
-                    final Path output = deliverable.output != null
-                            ? Paths.get(outputDir.resolve(deliverable.output))
-                            : Paths.get(outputDir);
+                    final Path output = getOutputDir(deliverable, props);
                     props.put(ANT_OUTPUT_DIR, output.toString());
                     final Publication publications = deliverable.publication;
                     props.put("transtype", publications.transtype);
@@ -447,6 +442,19 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         }
 
         return projectProps;
+    }
+
+    @VisibleForTesting
+    protected Path getOutputDir(final org.dita.dost.project.Project.Deliverable deliverable,
+                                final Map<String, Object> props) {
+        URI outputDir = new File(props.getOrDefault(ANT_OUTPUT_DIR, "out").toString())
+                .getAbsoluteFile().toURI();
+        outputDir = outputDir.getPath().endsWith("/")
+                ? outputDir
+                : URLUtils.setPath(outputDir, outputDir.getPath() + "/");
+        return Paths.get(deliverable.output != null
+                ? outputDir.resolve(deliverable.output)
+                : outputDir);
     }
 
     private org.dita.dost.project.Project readProjectFile(final File projectFile) throws BuildException {

--- a/src/test/java/org/dita/dost/invoker/MainTest.java
+++ b/src/test/java/org/dita/dost/invoker/MainTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.invoker;
+
+import org.dita.dost.project.Project.Deliverable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.dita.dost.invoker.Main.ANT_OUTPUT_DIR;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class MainTest {
+
+    @Parameters(name = "{1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"", "Without trailing slash"},
+                {"/", "With trailing slash"},
+        });
+    }
+
+    private final String suffix;
+
+    private Main main;
+    private Path current;
+
+    public MainTest(final String suffix, final String _desc) {
+        this.suffix = suffix;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        this.main = new Main();
+        this.current = new File("").getAbsoluteFile().toPath();
+    }
+
+    @Test
+    public void withoutEither() {
+        assertEquals(current.resolve("out"), getOutputDir(null, null));
+    }
+
+    @Test
+    public void relativeArgument() {
+        assertEquals(current.resolve("baz/qux"), getOutputDir(null, "baz/qux"));
+    }
+
+    @Test
+    public void absoluteArgument() {
+        assertEquals(Paths.get("/baz/qux"), getOutputDir(null, "/baz/qux"));
+    }
+
+    @Test
+    public void relativeProject() {
+        assertEquals(current.resolve("out/foo/bar"), getOutputDir("foo/bar", null));
+    }
+
+    @Test
+    public void absoluteProject() {
+        assertEquals(Paths.get("/foo/bar"), getOutputDir("/foo/bar", null));
+    }
+
+    @Test
+    public void relativeArgument_relativeProject() {
+        assertEquals(current.resolve("baz/qux/foo/bar"), getOutputDir("foo/bar", "baz/qux"));
+    }
+
+    @Test
+    public void absoluteArgument_relativeProject() {
+        assertEquals(Paths.get("/baz/qux/foo/bar"), getOutputDir("foo/bar", "/baz/qux"));
+    }
+
+    @Test
+    public void relativeArgument_absoluteProject() {
+        assertEquals(Paths.get("/foo/bar"), getOutputDir("/foo/bar", "baz/qux"));
+    }
+
+    @Test
+    public void absoluteArgument_absoluteProject() {
+        assertEquals(Paths.get("/foo/bar"), getOutputDir("/foo/bar", "/baz/qux"));
+    }
+
+    private Path getOutputDir(final String output, final String arg) {
+        final Deliverable deliverable = new Deliverable(
+                null, null, null,
+                output != null ? URI.create(output + suffix) : null,
+                null
+        );
+        final Map<String, Object> props = new HashMap<>();
+        if (arg != null) {
+            props.put(ANT_OUTPUT_DIR, arg + suffix);
+        }
+        return main.getOutputDir(deliverable, props);
+    }
+}


### PR DESCRIPTION
Initialize output directory value when running DITA-OT project with CLI without explicitly setting output directory with an option.

Fixes #3526