### PR TITLE
Throw warning on file reference that uses incorrect case

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -414,7 +414,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ082E" type="ERROR">
-    <reason>Resource %1 is referenced with incorrect path capitalization</reason>
+    <reason>The resource referenced as %1 is capitalized differently on disk</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -413,6 +413,11 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <message id="DOTJ082E" type="ERROR">
+    <reason>Resource %1 is referenced with incorrect path capitalization</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -17,8 +17,13 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import javax.xml.namespace.QName;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 import static javax.xml.XMLConstants.XML_NS_URI;
@@ -190,7 +195,35 @@ public final class ValidationFilter extends AbstractXMLFilter {
         final String href = atts.getValue(attrName);
         if (href != null) {
             try {
-                new URI(href);
+                final URI uri = new URI(href);
+                final URI abs = URLUtils.stripFragment(currentFile.resolve(uri)).normalize();
+                if (abs.getScheme() != null && abs.getScheme().equals("file")) {
+                    final File p = new File(abs);
+                    try {
+                        final File canFile = p.getCanonicalFile();
+                        final String absPath = p.getAbsolutePath();
+                        final String canPath = canFile.toString();
+                        if (!Objects.equals(absPath, canPath) && Objects.equals(absPath.toLowerCase(), canPath.toLowerCase())) {
+                            switch (processingMode) {
+                                case STRICT:
+                                    throw new RuntimeException(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString());
+                                case SKIP:
+                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using invalid value.");
+                                    break;
+                                case LAX:
+                                    final URI corrected = URLUtils.setFragment(currentFile.relativize(canFile.toURI()), uri.getFragment());
+                                    if (res == null) {
+                                        res = new AttributesImpl(atts);
+                                    }
+                                    res.setValue(res.getIndex(attrName), currentFile.toString());
+                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using " + corrected + " value.");
+                                    break;
+                            }
+                        }
+                    } catch (IOException e) {
+                        logger.debug(String.format("Failed to resolve real path for %s: %s", p, e.getMessage()), e);
+                    }
+                }
             } catch (final URISyntaxException e) {
                 switch (processingMode) {
                 case STRICT:

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -208,7 +208,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
                                 case STRICT:
                                     throw new RuntimeException(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString());
                                 case SKIP:
-                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using invalid value.");
+                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using authored value.");
                                     break;
                                 case LAX:
                                     final URI corrected = URLUtils.setFragment(currentFile.relativize(canFile.toURI()), uri.getFragment());
@@ -216,7 +216,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
                                         res = new AttributesImpl(atts);
                                     }
                                     res.setValue(res.getIndex(attrName), currentFile.toString());
-                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using " + corrected + " value.");
+                                    logger.error(MessageUtils.getMessage("DOTJ082E", abs.toString()).setLocation(locator).toString() + ", using " + corrected + ".");
                                     break;
                             }
                         }

--- a/src/test/resources/messages.xml
+++ b/src/test/resources/messages.xml
@@ -478,6 +478,11 @@
     <response></response>
   </message>
 
+  <message id="DOTJ082E" type="ERROR">
+    <reason>Resource %1 is referenced with incorrect path capitalization</reason>
+    <response/>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -181,3 +181,4 @@ DOTJ005F=Failed to create new instance for ''{0}''. Please ensure that ''{0}'' e
 DOTJ044W=There is a redundant conref action "pushbefore". Please make sure that "mark" and "pushbefore" occur in pairs.
 DOTA014W=Attribute @{0} is deprecated. Use attribute @{1} instead.
 DOTJ080W=Integrator configuration ''{0}'' has been deprecated. Use plugin configuration ''{0}'' instead.
+DOTJ082E=Resource {0} is referenced with incorrect path capitalization


### PR DESCRIPTION
## Description
Throw warning/error when file reference in DITA uses different case than the actual file in the file system. In strict processing mode this is considered a fatal error; in lax processing mode the file reference is rewritten to use the same case as the file system.

## Motivation and Context
When DITA map references e.g. `Topic.dita`, but the filename of the target on file system is actually `topic.dita`, we currently don't throw any error. However, this can lead to unexpected problems later on in the processing chain. By throwing a warning/error, we report issues early.

Oxygen has the same functionality in the editor, warning about the differente case.
