### PR TITLE
Fix OASIS table row span

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'signing'
 
 group = 'org.dita-ot'
 archivesBaseName = 'dost'
-version = '3.5.1'
+version = '3.5.2-SNAPSHOT'
 
 description = """DITA Open Toolkit"""
 

--- a/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
@@ -23,17 +23,19 @@ import static org.dita.dost.util.Constants.*;
  *   <li>Add column coordinates to entries</li>
  * </ul>
  */
-public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {
+public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
 
     private static final String ATTRIBUTE_NAME_COLSPAN = "colspan";
     private static final String ATTRIBUTE_NAME_ROWSPAN = "rowspan";
     private static final String ATTR_X = "x";
     private static final String ATTR_Y = "y";
 
+    /** DITA class stack */
     private final Deque<String> classStack = new LinkedList<>();
     private int depth;
     private final Map<String, String> ns = new HashMap<>();
 
+    /** Store row number */
     private int rowNumber;
     private ArrayList<Span> previousRow;
     private ArrayList<Span> currentRow;
@@ -41,6 +43,7 @@ public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {
 
     public NormalizeSimpleTableFilter() {
         super();
+        rowNumber = 0;
         depth = 0;
     }
 
@@ -61,7 +64,7 @@ public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {
             throws SAXException {
         depth++;
         if (depth == 1 && !ns.containsKey(DITA_OT_NS_PREFIX)) {
-            super.startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
+            startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
         }
 
         final AttributesImpl res = new AttributesImpl(atts);
@@ -132,7 +135,7 @@ public final class NormalizeSimpleTableFilter extends NormalizeTableFilter {
         }
 
         if (depth == 1) {
-            super.endPrefixMapping(DITA_OT_NS_PREFIX);
+            endPrefixMapping(DITA_OT_NS_PREFIX);
         }
         depth--;
     }

--- a/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
@@ -104,11 +104,7 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
             if (tableState.columnNumberEnd < tableState.cols && tableState.cols != -1) {
                 final int length = tableState.cols - tableState.totalColumns;
                 for (int i = 0; i < length; i++) {
-                    final AttributesImpl colspecAtts = new AttributesImpl();
-                    XMLUtils.addOrSetAttribute(colspecAtts, ATTRIBUTE_NAME_CLASS, TOPIC_COLSPEC.toString());
-                    processColspec(colspecAtts);
-                    getContentHandler().startElement(NULL_NS_URI, TOPIC_COLSPEC.localName, TOPIC_COLSPEC.localName, colspecAtts);
-                    getContentHandler().endElement(NULL_NS_URI, TOPIC_COLSPEC.localName, TOPIC_COLSPEC.localName);
+                    generateColSpec();
                 }
             }
         } else if (TOPIC_ROW.matches(cls)) {
@@ -125,6 +121,14 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
         }
 
         getContentHandler().startElement(uri, localName, qName, res);
+    }
+
+    private void generateColSpec() throws SAXException {
+        final AttributesImpl attr = new AttributesImpl();
+        XMLUtils.addOrSetAttribute(attr, ATTRIBUTE_NAME_CLASS, TOPIC_COLSPEC.toString());
+        processColspec(attr);
+        getContentHandler().startElement(NULL_NS_URI, TOPIC_COLSPEC.localName, TOPIC_COLSPEC.localName, attr);
+        getContentHandler().endElement(NULL_NS_URI, TOPIC_COLSPEC.localName, TOPIC_COLSPEC.localName);
     }
 
     private void processEntry(AttributesImpl res) {

--- a/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
@@ -24,6 +24,7 @@ import static org.dita.dost.util.Constants.*;
  *
  * <ul>
  *   <li>Rewrite table column names to {@code "col" num}, where {@code num} is the column number, and add column name to every entry.</li>
+ *   <li>Add column coordinates to entries</li>
  * </ul>
  */
 public class NormalizeTableFilter extends AbstractXMLFilter {
@@ -36,58 +37,18 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
     private static final String ATTR_X = "x";
     private static final String ATTR_Y = "y";
 
-    private Configuration.Mode processingMode;
-
-    private List<String> colSpec;
-    /** ColumnNumber is used to adjust column name */
-    private int columnNumber; //
-    /** columnNumberEnd is the end value for current entry */
-    private int columnNumberEnd;
-    /** Stack to store colspec list */
-    private final Deque<List<String>> colSpecStack;
-    /** Stack to store rowNum */
-    private final Deque<Integer> rowNumStack;
-    /** Stack to store columnNumber */
-    private final Deque<Integer> columnNumberStack;
-    /** Stack to store columnNumberEnd */
-    private final Deque<Integer> columnNumberEndStack;
-    /** Stack to store rowsMap */
-    private final Deque<Map<String, Integer>> rowsMapStack;
-    /** Stack to store colSpanMap */
-    private final Deque<Map<String, Integer>> colSpanMapStack;
-    /** Store row number */
-    private int rowNumber;
-    /** Store total column count */
-    private int totalColumns;
-    /** store morerows attribute */
-    private Map<String, Integer> rowsMap;
-    private Map<String, Integer> colSpanMap;
-    /** DITA class stack */
     private final Deque<String> classStack = new LinkedList<>();
-    /** Number of cols in tgroup */
-    private int cols;
-    private int depth;
+    /** DITA class stack */
     private final Map<String, String> ns = new HashMap<>();
+    private int depth;
+
+    private final Deque<TableState> tableStack = new LinkedList<>();
+    /** Cached table stack head */
+    private TableState tableState;
+    private Configuration.Mode processingMode;
 
     public NormalizeTableFilter() {
         super();
-        columnNumber = 1;
-        columnNumberEnd = 0;
-        // initialize row number
-        rowNumber = 0;
-        // initialize total column count
-        totalColumns = 0;
-        // initialize the map
-        rowsMap = new HashMap<>();
-        colSpanMap = new HashMap<>();
-        colSpec = null;
-        // initial the stack
-        colSpecStack = new ArrayDeque<>();
-        rowNumStack = new ArrayDeque<>();
-        columnNumberStack = new ArrayDeque<>();
-        columnNumberEndStack = new ArrayDeque<>();
-        rowsMapStack = new ArrayDeque<>();
-        colSpanMapStack = new ArrayDeque<>();
         depth = 0;
     }
 
@@ -124,51 +85,24 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
             throws SAXException {
         depth++;
         if (depth == 1 && !ns.containsKey(DITA_OT_NS_PREFIX)) {
-            super.startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
+            startPrefixMapping(DITA_OT_NS_PREFIX, DITA_OT_NS);
         }
 
         final AttributesImpl res = new AttributesImpl(atts);
         final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
         classStack.addFirst(cls);
-        if (TOPIC_TGROUP.matches(cls)) {
-            // push into the stack.
-            if (colSpec != null) {
-                colSpecStack.addFirst(colSpec);
-                rowNumStack.addFirst(rowNumber);
-                columnNumberStack.addFirst(columnNumber);
-                columnNumberEndStack.addFirst(columnNumberEnd);
-                rowsMapStack.addFirst(rowsMap);
-                colSpanMapStack.addFirst(colSpanMap);
-            }
-            columnNumber = 1; // initialize the column number
-            columnNumberEnd = 0;// totally columns
-            rowsMap = new HashMap<>();
-            colSpanMap = new HashMap<>();
-            // new table initialize the col list
-            colSpec = new ArrayList<>(16);
-            // new table initialize the col list
-            rowNumber = 0;
-            final String c = atts.getValue(ATTRIBUTE_NAME_COLS).trim();
-            try {
-                cols = Integer.parseInt(c);
-            } catch (final NumberFormatException e) {
-                if (processingMode == Configuration.Mode.STRICT) {
-                    throw new SAXException(MessageUtils.getMessage("DOTJ062E", ATTRIBUTE_NAME_COLS, c).setLocation(atts).toString());
-                } else {
-                    logger.error(MessageUtils.getMessage("DOTJ062E", ATTRIBUTE_NAME_COLS, c).setLocation(atts).toString());
-                }
-                cols = -1;
-            }
-        } else if (TOPIC_ROW.matches(cls)) {
-            columnNumber = 1; // initialize the column number
-            columnNumberEnd = 0;
-            // store the row number
-            rowNumber++;
+
+        if (TOPIC_TABLE.matches(cls)) {
+            tableState = new TableState();
+            tableStack.addFirst(tableState);
+        } else if (TOPIC_TGROUP.matches(cls)) {
+            tableState.cols = getColCount(atts);
+            tableState.colSpec = new ArrayList<>();
         } else if (TOPIC_COLSPEC.matches(cls)) {
             processColspec(res);
-        } else if (TOPIC_THEAD.matches(cls) || TOPIC_TBODY.matches(cls)) {
-            if (columnNumberEnd < cols && cols != -1) {
-                final int length = cols - totalColumns;
+        } else if (TOPIC_TBODY.matches(cls) || TOPIC_THEAD.matches(cls)) {
+            if (tableState.columnNumberEnd < tableState.cols && tableState.cols != -1) {
+                final int length = tableState.cols - tableState.totalColumns;
                 for (int i = 0; i < length; i++) {
                     final AttributesImpl colspecAtts = new AttributesImpl();
                     XMLUtils.addOrSetAttribute(colspecAtts, ATTRIBUTE_NAME_CLASS, TOPIC_COLSPEC.toString());
@@ -177,75 +111,138 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
                     getContentHandler().endElement(NULL_NS_URI, TOPIC_COLSPEC.localName, TOPIC_COLSPEC.localName);
                 }
             }
+        } else if (TOPIC_ROW.matches(cls)) {
+            // TODO: Inline me to (currentColumn + 1)
+            tableState.columnNumber = 1; // initialize the column number
+            tableState.columnNumberEnd = 0;
+            tableState.rowNumber++;
+            tableState.currentRow = tableState.previousRow != null
+                    ? new ArrayList<>(Arrays.asList(new Span[tableState.previousRow.size()]))
+                    : new ArrayList<>();
+            tableState.currentColumn = 0;
         } else if (TOPIC_ENTRY.matches(cls)) {
-            columnNumber = getStartNumber(atts, columnNumberEnd);
-            if (columnNumber > columnNumberEnd) {
-                if (rowNumber != 1) {
-                    int offset = 0;
-                    int currentCol = columnNumber;
-                    while (currentCol <= totalColumns) {
-                        int previous_offset = offset;
-                        // search from first row
-                        for (int row = 1; row < rowNumber; row++) {
-                            final String pos = Integer.toString(row) + "-" + Integer.toString(currentCol);
-                            if (rowsMap.containsKey(pos)) {
-                                // get total span rows
-                                final int totalSpanRows = rowsMap.get(pos);
-                                if (rowNumber <= totalSpanRows) {
-                                    offset += colSpanMap.get(pos);
-                                }
-                            }
-                        }
-                        if (offset > previous_offset) {
-                            currentCol = columnNumber + offset;
-                            previous_offset = offset;
-                        } else {
-                            break;
-                        }
-                    }
-                    columnNumber = columnNumber + offset;
-                    // if has morerows attribute
-                    if (atts.getValue(ATTRIBUTE_NAME_MOREROWS) != null) {
-                        final String pos = Integer.toString(rowNumber) + "-" + Integer.toString(columnNumber);
-                        // total span rows
-                        rowsMap.put(pos, Integer.parseInt(atts.getValue(ATTRIBUTE_NAME_MOREROWS)) + rowNumber);
-                        colSpanMap.put(pos, getColumnSpan(atts));
-                    }
-                }
-                XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNAME, COLUMN_NAME_COL + columnNumber);
-                if (atts.getValue(ATTRIBUTE_NAME_NAMEST) != null) {
-                    XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_NAMEST, COLUMN_NAME_COL + columnNumber);
-                }
-                if (atts.getValue(ATTRIBUTE_NAME_NAMEEND) != null) {
-                    XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_NAMEEND, COLUMN_NAME_COL + getEndNumber(atts, columnNumber));
-                    XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_MORECOLS, DITA_OT_NS_PREFIX + ":" + ATTR_MORECOLS, "CDATA", Integer.toString(getEndNumber(atts, columnNumber) - columnNumber));
-                }
-                // Add extensions
-                XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_X, DITA_OT_NS_PREFIX + ":" + ATTR_X, "CDATA", Integer.toString(columnNumber));
-                XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_Y, DITA_OT_NS_PREFIX + ":" + ATTR_Y, "CDATA", Integer.toString(rowNumber));
-            }
-            columnNumberEnd = getEndNumber(atts, columnNumber);
+            processEntry(res);
         }
 
         getContentHandler().startElement(uri, localName, qName, res);
     }
 
-    private void processColspec(final AttributesImpl res) {
-        columnNumber = columnNumberEnd + 1;
-        if (res.getValue(ATTRIBUTE_NAME_COLNAME) != null) {
-            colSpec.add(res.getValue(ATTRIBUTE_NAME_COLNAME));
+    private void processEntry(AttributesImpl res) {
+        tableState.columnNumber = getStartNumber(res, tableState.columnNumberEnd);
+        final int colspan = getColSpan(res);
+        final int rowspan = getRowSpan(res);
+        final Span prev;
+        if (tableState.previousRow != null) {
+            prev = tableState.previousRow.get(tableState.currentColumn);
+            if (prev != null && prev.y > 1) {
+                for (int i = 0; i < prev.x; i++) {
+                    tableState.currentColumn = tableState.currentColumn + 1; //prev.x - 1;
+                    grow(tableState.currentRow, tableState.currentColumn + 1);
+                    tableState.currentRow.set(tableState.currentColumn, null);
+                }
+            }
         } else {
-            colSpec.add(COLUMN_NAME_COL + columnNumber);
+            prev = new Span(1, 1);
         }
+        grow(tableState.currentRow, tableState.currentColumn + colspan);
+        final Span span = new Span(colspan, rowspan);
+
+        tableState.currentRow.set(tableState.currentColumn, span);
+
+        XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNAME, COLUMN_NAME_COL + (tableState.currentColumn + 1));
+        if (res.getValue(ATTRIBUTE_NAME_NAMEST) != null) {
+            XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_NAMEST, COLUMN_NAME_COL + tableState.columnNumber);
+        }
+        if (res.getValue(ATTRIBUTE_NAME_NAMEEND) != null) {
+            XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_NAMEEND, COLUMN_NAME_COL + getEndNumber(res, tableState.columnNumber));
+            XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_MORECOLS, DITA_OT_NS_PREFIX + ":" + ATTR_MORECOLS, "CDATA", Integer.toString(span.x - 1));
+        }
+        // Add extensions
+        XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_X, DITA_OT_NS_PREFIX + ":" + ATTR_X, "CDATA", Integer.toString(tableState.currentColumn + 1));
+        XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_Y, DITA_OT_NS_PREFIX + ":" + ATTR_Y, "CDATA", Integer.toString(tableState.rowNumber));
+
+        tableState.currentColumn = tableState.currentColumn + colspan;
+        tableState.columnNumberEnd = getEndNumber(res, tableState.columnNumber);
+    }
+
+    @Override
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+        getContentHandler().endElement(uri, localName, qName);
+        final String cls = classStack.removeFirst();
+        if (TOPIC_TABLE.matches(cls)) {
+            tableStack.removeFirst();
+            tableState = tableStack.peekFirst();
+        } else if (TOPIC_ROW.matches(cls)) {
+            tableState.previousRow = tableState.currentRow;
+            tableState.currentRow = null;
+            tableState.currentColumn = -1;
+        }
+
+        if (depth == 1) {
+            endPrefixMapping(DITA_OT_NS_PREFIX);
+        }
+        depth--;
+    }
+
+    private void grow(final List<?> array, final int size) {
+        while (array.size() < size) {
+            array.add(null);
+        }
+    }
+
+    private int getColSpan(final Attributes atts) {
+        final String start = atts.getValue(ATTRIBUTE_NAME_NAMEST);
+        final String end = atts.getValue(ATTRIBUTE_NAME_NAMEEND);
+        if (start != null && end != null) {
+            final int colnumStart = tableState.colSpec.indexOf(start);
+            final int colnumEnd = tableState.colSpec.indexOf(end);
+            // TODO: handle missing column definition
+            final int ret = colnumEnd - colnumStart + 1;
+            return ret <= 0 ? 1 : ret;
+        } else {
+            return 1;
+        }
+    }
+
+    private int getRowSpan(final Attributes atts) {
+        final String span = atts.getValue(ATTRIBUTE_NAME_MOREROWS);
+        if (span != null) {
+            return Integer.parseInt(span) + 1;
+        } else {
+            return 1;
+        }
+    }
+
+    private int getColCount(final Attributes atts) throws SAXException {
+        final String c = atts.getValue(ATTRIBUTE_NAME_COLS).trim();
+        try {
+            return Integer.parseInt(c);
+        } catch (final NumberFormatException e) {
+            if (processingMode == Configuration.Mode.STRICT) {
+                throw new SAXException(MessageUtils.getMessage("DOTJ062E", ATTRIBUTE_NAME_COLS, c).setLocation(atts).toString());
+            } else {
+                logger.error(MessageUtils.getMessage("DOTJ062E", ATTRIBUTE_NAME_COLS, c).setLocation(atts).toString());
+            }
+            return -1;
+        }
+    }
+
+    private void processColspec(final AttributesImpl res) {
+        tableState.columnNumber = tableState.columnNumberEnd + 1;
+        final String colName = res.getValue(ATTRIBUTE_NAME_COLNAME) != null ? res.getValue(ATTRIBUTE_NAME_COLNAME) : COLUMN_NAME_COL + tableState.columnNumber;
+        grow(tableState.colSpec, tableState.columnNumber);
+        tableState.colSpec.set(tableState.columnNumber - 1, colName);
+
         final String colNum = res.getValue(ATTRIBUTE_NAME_COLNUM);
         if (colNum == null || colNum.isEmpty()) {
-            XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNUM, Integer.toString(columnNumber));
+            XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNUM, Integer.toString(tableState.columnNumber));
         }
-        columnNumberEnd = columnNumber;
+
+        tableState.columnNumberEnd = tableState.columnNumber;
         // change the col name of colspec
-        XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNAME, COLUMN_NAME_COL + columnNumber);
+        XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_COLNAME, COLUMN_NAME_COL + tableState.columnNumber);
         // total columns count
-        totalColumns = columnNumberEnd;
+        tableState.totalColumns = tableState.columnNumberEnd;
         final String colWidth = res.getValue(ATTRIBUTE_NAME_COLWIDTH);
         // OASIS Table Model defaults to 1*, but that will disables automatic column layout
         if (colWidth == null) {
@@ -257,66 +254,12 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
         }
     }
 
-
-    @Override
-    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-        getContentHandler().endElement(uri, localName, qName);
-        if (TOPIC_TGROUP.matches(classStack.removeFirst())) {
-            // has tgroup tag
-            if (!colSpecStack.isEmpty()) {
-                colSpec = colSpecStack.peekFirst();
-                rowNumber = rowNumStack.peekFirst();
-                columnNumber = columnNumberStack.peekFirst();
-                columnNumberEnd = columnNumberEndStack.peekFirst();
-                rowsMap = rowsMapStack.peekFirst();
-                colSpanMap = colSpanMapStack.peekFirst();
-                colSpecStack.removeFirst();
-                rowNumStack.removeFirst();
-                columnNumberStack.removeFirst();
-                columnNumberEndStack.removeFirst();
-                rowsMapStack.removeFirst();
-                colSpanMapStack.removeFirst();
-            } else {
-                // no more tgroup tag
-                colSpec = null;
-                rowNumber = 0;
-                columnNumber = 1;
-                columnNumberEnd = 0;
-                rowsMap = null;
-                colSpanMap = null;
-            }
-            totalColumns = 0;
-        }
-
-        if (depth == 1) {
-            super.endPrefixMapping(DITA_OT_NS_PREFIX);
-        }
-        depth--;
-    }
-
-    // Private methods
-
-    private int getColumnSpan(final Attributes atts) {
-        final String start = atts.getValue(ATTRIBUTE_NAME_NAMEST);
-        final String end = atts.getValue(ATTRIBUTE_NAME_NAMEEND);
-        if (start == null || end == null) {
-            return 1;
-        } else {
-            final int ret = colSpec.indexOf(end) - colSpec.indexOf(start) + 1;
-            if (ret <= 0) {
-                return 1;
-            }
-            return ret;
-        }
-    }
-
     private int getEndNumber(final Attributes atts, final int columnStart) {
         final String end = atts.getValue(ATTRIBUTE_NAME_NAMEEND);
-        int ret;
         if (end == null) {
             return columnStart;
         } else {
-            ret = colSpec.indexOf(end) + 1;
+            int ret = tableState.colSpec.indexOf(end) + 1;
             if (ret == 0) {
                 return columnStart;
             }
@@ -331,13 +274,13 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
         if (num != null) {
             return Integer.parseInt(num);
         } else if (start != null) {
-            final int ret = colSpec.indexOf(start) + 1;
+            final int ret = tableState.colSpec.indexOf(start) + 1;
             if (ret == 0) {
                 return previousEnd + 1;
             }
             return ret;
         } else if (name != null) {
-            final int ret = colSpec.indexOf(name) + 1;
+            final int ret = tableState.colSpec.indexOf(name) + 1;
             if (ret == 0) {
                 return previousEnd + 1;
             }
@@ -347,4 +290,29 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
         }
     }
 
+    private static class Span {
+        public final int x;
+        public final int y;
+
+        private Span(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    private static class TableState {
+        public List<String> colSpec;
+        public int rowNumber = 0;
+        public ArrayList<Span> previousRow;
+        public ArrayList<Span> currentRow;
+        public int currentColumn;
+        /** ColumnNumber is used to adjust column name */
+        public int columnNumber = 1;
+        /** columnNumberEnd is the end value for current entry */
+        public int columnNumberEnd = 0;
+        /** Store total column count */
+        public int totalColumns = 0;
+        /** Number of cols in tgroup */
+        public int cols;
+    }
 }

--- a/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
@@ -25,18 +25,45 @@ import static org.dita.dost.TestUtils.assertXMLEqual;
 
 public class NormalizeTableFilterTest {
 
+    private final DocumentBuilderFactory dbf;
+    private final TransformerFactory tf;
+
+    public NormalizeTableFilterTest() {
+        dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        tf = TransformerFactory.newInstance();
+    }
+
     @Test
-    public void testNoFilter() throws Exception {
+    public void topic() throws Exception {
         test("topic.dita");
     }
 
+    @Test
+    public void simple() throws Exception {
+        test("simple.dita");
+    }
+
+    @Test
+    public void withoutColSpec() throws Exception {
+        test("withoutColSpec.dita");
+    }
+
+    @Test
+    public void rowspan() throws Exception {
+        test("rowspan.dita");
+    }
+
+    @Test
+    public void nested() throws Exception {
+        test("nested.dita");
+    }
+
     private void test(final String file) throws Exception {
-        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
 
-        final Transformer t = TransformerFactory.newInstance().newTransformer();
+        final Transformer t = tf.newTransformer();
         final InputStream src = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
         final NormalizeTableFilter f = new NormalizeTableFilter();
         f.setParent(XMLUtils.getXMLReader());

--- a/src/test/resources/NormalizeTableFilterTest/exp/nested.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/nested.dita
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <tgroup class="- topic/tgroup " cols="2">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">foo1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">
+              <table class="- topic/table ">
+                <tgroup class="- topic/tgroup " cols="2">
+                  <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+                  <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+                  <thead class="- topic/thead ">
+                    <row class="- topic/row ">
+                      <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">foo1</entry>
+                      <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">foo2</entry>
+                    </row>
+                  </thead>
+                  <tbody class="- topic/tbody ">
+                    <row class="- topic/row ">
+                      <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
+                      <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+                    </row>
+                  </tbody>
+                </tgroup>
+              </table>
+            </entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
@@ -14,8 +14,8 @@
             <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">s3</entry>
           </row>
           <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e2</entry>
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e3</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="2">e3</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <tgroup class="- topic/tgroup " cols="3">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <colspec class="- topic/colspec " colname="col3" colnum="3"/>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1" morerows="1">s1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">s2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">s3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e2</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e3</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
@@ -9,13 +9,25 @@
         <colspec class="- topic/colspec " colname="col3" colnum="3"/>
         <tbody class="- topic/tbody ">
           <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1" morerows="1">s1</entry>
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1" morerows="3">s1</entry>
             <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">s2</entry>
             <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">s3</entry>
           </row>
           <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2" morerows="1">e2</entry>
             <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="2">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="3">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="4">e2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="4">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="5">e1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="5">e2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="5">e3</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/test/resources/NormalizeTableFilterTest/exp/simple.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/simple.dita
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table " id="tab_foo1">
+      <title class="- topic/title ">foo</title>
+      <tgroup class="- topic/tgroup " cols="2">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">foo1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">foo2</entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/exp/topic.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/topic.dita
@@ -2,47 +2,6 @@
 <topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
   <title class="- topic/title ">Topic 1</title>
   <body class="- topic/body ">
-    <table class="- topic/table " id="tab_foo1">
-      <title class="- topic/title ">foo</title>
-      <tgroup class="- topic/tgroup " cols="2">
-        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
-        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
-        <thead class="- topic/thead ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">foo1</entry>
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">foo2</entry>
-          </row>
-        </thead>
-        <tbody class="- topic/tbody ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-    <table class="- topic/table " id="tab_foo3">
-      <title class="- topic/title ">foo</title>
-      <tgroup class="- topic/tgroup " cols="3">
-        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
-        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
-        <colspec class="- topic/colspec " colname="col3" colnum="3"/>
-        <thead class="- topic/thead ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">s1</entry>
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">s2</entry>
-            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">s3</entry>
-          </row>
-        </thead>
-        <tbody class="- topic/tbody ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
-            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
-            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="2">e3</entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
     <table class="- topic/table " colsep="1" frame="all" rowsep="1">
       <tgroup class="- topic/tgroup " cols="5">
         <colspec class="- topic/colspec " colname="col1" colnum="1" colwidth=" 1*  "/>

--- a/src/test/resources/NormalizeTableFilterTest/exp/withoutColSpec.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/withoutColSpec.dita
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <tgroup class="- topic/tgroup " cols="3">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <colspec class="- topic/colspec " colname="col3" colnum="3"/>
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1">s1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1">s2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">s3</entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="2">e1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="2">e2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="2">e3</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/src/nested.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/nested.dita
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <tgroup class="- topic/tgroup " cols="2">
+        <colspec class="- topic/colspec " colname="p1"/>
+        <colspec class="- topic/colspec " colname="p2"/>
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">foo1</entry>
+            <entry class="- topic/entry ">
+              <table class="- topic/table ">
+                <tgroup class="- topic/tgroup " cols="2">
+                  <colspec class="- topic/colspec " colname="c1"/>
+                  <colspec class="- topic/colspec " colname="c2"/>
+                  <thead class="- topic/thead ">
+                    <row class="- topic/row ">
+                      <entry class="- topic/entry ">foo1</entry>
+                      <entry class="- topic/entry ">foo2</entry>
+                    </row>
+                  </thead>
+                  <tbody class="- topic/tbody ">
+                    <row class="- topic/row ">
+                      <entry class="- topic/entry ">e1</entry>
+                      <entry class="- topic/entry ">e2</entry>
+                    </row>
+                  </tbody>
+                </tgroup>
+              </table>
+            </entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e1</entry>
+            <entry class="- topic/entry ">e2</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
@@ -9,11 +9,23 @@
         <colspec class="- topic/colspec " colname="col3"/>
         <tbody class="- topic/tbody ">
           <row class="- topic/row ">
-            <entry class="- topic/entry " morerows="1">s1</entry>
+            <entry class="- topic/entry " morerows="3">s1</entry>
             <entry class="- topic/entry ">s2</entry>
             <entry class="- topic/entry ">s3</entry>
           </row>
           <row class="- topic/row ">
+            <entry class="- topic/entry " morerows="1">e2</entry>
+            <entry class="- topic/entry ">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e2</entry>
+            <entry class="- topic/entry ">e3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e1</entry>
             <entry class="- topic/entry ">e2</entry>
             <entry class="- topic/entry ">e3</entry>
           </row>

--- a/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <tgroup class="- topic/tgroup " cols="3">
+        <colspec class="- topic/colspec " colname="col1"/>
+        <colspec class="- topic/colspec " colname="col2"/>
+        <colspec class="- topic/colspec " colname="col3"/>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " morerows="1">s1</entry>
+            <entry class="- topic/entry ">s2</entry>
+            <entry class="- topic/entry ">s3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e2</entry>
+            <entry class="- topic/entry ">e3</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/src/simple.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/simple.dita
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table " id="tab_foo1">
+      <title class="- topic/title ">foo</title>
+      <tgroup class="- topic/tgroup " cols="2">
+        <colspec class="- topic/colspec " colname="2"/>
+        <colspec class="- topic/colspec " colname="col1"/>
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="c2">foo1</entry>
+            <entry class="- topic/entry ">foo2</entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e1</entry>
+            <entry class="- topic/entry " colname="col1">e2</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/src/topic.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/topic.dita
@@ -2,42 +2,6 @@
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
   <title class="- topic/title ">Topic 1</title>
   <body class="- topic/body ">
-    <table class="- topic/table " id="tab_foo1">
-      <title class="- topic/title ">foo</title>
-      <tgroup class="- topic/tgroup " cols="2">
-        <thead class="- topic/thead ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry ">foo1</entry>
-            <entry class="- topic/entry ">foo2</entry>
-          </row>
-        </thead>
-        <tbody class="- topic/tbody ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry ">e1</entry>
-            <entry class="- topic/entry ">e2</entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
-    <table class="- topic/table " id="tab_foo3">
-      <title class="- topic/title ">foo</title>
-      <tgroup class="- topic/tgroup " cols="3">
-        <thead class="- topic/thead ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry ">s1</entry>
-            <entry class="- topic/entry ">s2</entry>
-            <entry class="- topic/entry ">s3</entry>
-          </row>
-        </thead>
-        <tbody class="- topic/tbody ">
-          <row class="- topic/row ">
-            <entry class="- topic/entry ">e1</entry>
-            <entry class="- topic/entry ">e2</entry>
-            <entry class="- topic/entry ">e3</entry>
-          </row>
-        </tbody>
-      </tgroup>
-    </table>
     <table class="- topic/table " colsep="1" frame="all" rowsep="1">
       <tgroup class="- topic/tgroup " cols="5">
         <colspec class="- topic/colspec " colname="c1" colwidth=" 1*  "></colspec>

--- a/src/test/resources/NormalizeTableFilterTest/src/withoutColSpec.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/withoutColSpec.dita
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <tgroup class="- topic/tgroup " cols="3">
+        <thead class="- topic/thead ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">s1</entry>
+            <entry class="- topic/entry ">s2</entry>
+            <entry class="- topic/entry ">s3</entry>
+          </row>
+        </thead>
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">e1</entry>
+            <entry class="- topic/entry ">e2</entry>
+            <entry class="- topic/entry ">e3</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>


### PR DESCRIPTION
## Description

The `table` element normalization calculates the coordinates incorrectly when row spanning is used. This fixes the coordinate calculation in those cases.



## How Has This Been Tested?
Split old unit test into multiple test methods and add test cases for row spanning.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No documentation changes needed.

