### PR TITLE
  Fix simpletable row span

### DIFF
--- a/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
@@ -104,7 +104,6 @@ public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
                 for (int i = 0; i < prev.x; i++) {
                     tableState.currentColumn = tableState.currentColumn + 1; //prev.x - 1;
                     grow(tableState.currentRow, tableState.currentColumn + 1);
-                    tableState.currentRow.set(tableState.currentColumn, null);
                 }
             }
         } else {

--- a/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeTableFilter.java
@@ -152,7 +152,7 @@ public class NormalizeTableFilter extends AbstractXMLFilter {
                 for (int i = 0; i < prev.x; i++) {
                     tableState.currentColumn = tableState.currentColumn + 1; //prev.x - 1;
                     grow(tableState.currentRow, tableState.currentColumn + 1);
-                    tableState.currentRow.set(tableState.currentColumn, null);
+//                    tableState.currentRow.set(tableState.currentColumn, null);
                 }
             }
         } else {

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -54,6 +54,11 @@ public class NormalizeSimpleTableFilterTest {
         test("rowspan.dita");
     }
 
+    @Test
+    public void parallel() throws Exception {
+        test("parallel.dita");
+    }
+
     private void test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -44,6 +44,11 @@ public class NormalizeSimpleTableFilterTest {
         test("topic.dita");
     }
 
+    @Test
+    public void nested() throws Exception {
+        test("nested.dita");
+    }
+
     private void test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -25,18 +25,30 @@ import static org.dita.dost.TestUtils.assertXMLEqual;
 
 public class NormalizeSimpleTableFilterTest {
 
+    private final DocumentBuilderFactory dbf;
+    private final TransformerFactory tf;
+
+    public NormalizeSimpleTableFilterTest() {
+        dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        tf = TransformerFactory.newInstance();
+    }
+
     @Test
-    public void testNoFilter() throws Exception {
+    public void simple() throws Exception {
+        test("simple.dita");
+    }
+
+    @Test
+    public void topic() throws Exception {
         test("topic.dita");
     }
 
     private void test(final String file) throws Exception {
-        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
 
-        final Transformer t = TransformerFactory.newInstance().newTransformer();
+        final Transformer t = tf.newTransformer();
         final InputStream src = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
         final NormalizeSimpleTableFilter f = new NormalizeSimpleTableFilter();
         f.setParent(XMLUtils.getXMLReader());
@@ -45,7 +57,6 @@ public class NormalizeSimpleTableFilterTest {
 
         final Document act = db.newDocument();
         t.transform(s, new DOMResult(act));
-
         assertXMLEqual(db.parse(expStream), act);
     }
 

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -49,6 +49,11 @@ public class NormalizeSimpleTableFilterTest {
         test("nested.dita");
     }
 
+    @Test
+    public void rowspan() throws Exception {
+        test("rowspan.dita");
+    }
+
     private void test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);

--- a/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
@@ -59,6 +59,11 @@ public class NormalizeTableFilterTest {
         test("nested.dita");
     }
 
+    @Test
+    public void parallel() throws Exception {
+        test("parallel.dita");
+    }
+
     private void test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
         final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/nested.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/nested.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic " ditaarch:DITAArchVersion="2.0" id="topic1" specializations="">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/nested.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/nested.dita
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">
+          <simpletable class="- topic/simpletable ">
+            <sthead class="- topic/sthead ">
+              <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+              <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+            </sthead>
+            <strow class="- topic/strow ">
+              <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+              <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+            </strow>
+          </simpletable>
+        </stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/parallel.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/parallel.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
-  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " specializations="" id="topic1" ditaarch:DITAArchVersion="2.0">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <strow class="- topic/strow ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/parallel.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/parallel.dita
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1" rowspan="4">A1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1" rowspan="4">B2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">C1</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">C2</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="3">C3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="4">C4</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/rowspan.dita
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1" rowspan="4">s1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2" rowspan="2">e2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="3">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="4">e2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="4">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="5">e1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="5">e2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="5">e3</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/rowspan.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="2.0" specializations="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <strow class="- topic/strow ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/simple.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/simple.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic " ditaarch:DITAArchVersion="2.0" id="topic1" specializations="">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable " id="tab_foo3">
       <title class="- topic/title ">foo</title>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/simple.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/simple.dita
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
+        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-       xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" class="- topic/topic " ditaarch:DITAArchVersion="2.0" id="topic1" specializations="">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/exp/topic.dita
@@ -4,30 +4,6 @@
        ditaarch:DITAArchVersion="2.0" id="topic1" specializations="" xml:lang="en-us">
   <title class="- topic/title ">Topic 1</title>
   <body class="- topic/body ">
-    <simpletable class="- topic/simpletable " id="tab_foo1">
-      <title class="- topic/title ">foo</title>
-      <sthead class="- topic/sthead ">
-        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">foo1</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">foo2</stentry>
-      </sthead>
-      <strow class="- topic/strow ">
-        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
-      </strow>
-    </simpletable>
-    <simpletable class="- topic/simpletable " id="tab_foo3">
-      <title class="- topic/title ">foo</title>
-      <sthead class="- topic/sthead ">
-        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">s1</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="1">s2</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="1">s3</stentry>
-      </sthead>
-      <strow class="- topic/strow ">
-        <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="2">e1</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="2" dita-ot:y="2">e2</stentry>
-        <stentry class="- topic/stentry " dita-ot:x="3" dita-ot:y="2">e3</stentry>
-      </strow>
-    </simpletable>
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">
         <stentry class="- topic/stentry " dita-ot:x="1" dita-ot:y="1">1 1</stentry>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/nested.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/nested.dita
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">s1</stentry>
+        <stentry class="- topic/stentry ">
+          <simpletable class="- topic/simpletable ">
+            <sthead class="- topic/sthead ">
+              <stentry class="- topic/stentry ">s1</stentry>
+              <stentry class="- topic/stentry ">s2</stentry>
+            </sthead>
+            <strow class="- topic/strow ">
+              <stentry class="- topic/stentry ">e1</stentry>
+              <stentry class="- topic/stentry ">e2</stentry>
+            </strow>
+          </simpletable>
+        </stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e1</stentry>
+        <stentry class="- topic/stentry ">e2</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/nested.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/nested.dita
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="2.0" specializations="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/parallel.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/parallel.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
-  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " specializations="" id="topic1" ditaarch:DITAArchVersion="2.0">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <strow class="- topic/strow ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/parallel.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/parallel.dita
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " rowspan="4">A1</stentry>
+        <stentry class="- topic/stentry " rowspan="4">B2</stentry>
+        <stentry class="- topic/stentry ">C1</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">C2</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">C3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">C4</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/rowspan.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/rowspan.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "  specializations="" id="topic1" ditaarch:DITAArchVersion="2.0">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <strow class="- topic/strow ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/rowspan.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/rowspan.dita
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable ">
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " rowspan="4">s1</stentry>
+        <stentry class="- topic/stentry ">s2</stentry>
+        <stentry class="- topic/stentry ">s3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry " rowspan="2">e2</stentry>
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e2</stentry>
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e1</stentry>
+        <stentry class="- topic/stentry ">e2</stentry>
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/simple.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/simple.dita
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <simpletable class="- topic/simpletable " id="tab_foo3">
+      <title class="- topic/title ">foo</title>
+      <sthead class="- topic/sthead ">
+        <stentry class="- topic/stentry ">s1</stentry>
+        <stentry class="- topic/stentry ">s2</stentry>
+        <stentry class="- topic/stentry ">s3</stentry>
+      </sthead>
+      <strow class="- topic/strow ">
+        <stentry class="- topic/stentry ">e1</stentry>
+        <stentry class="- topic/stentry ">e2</stentry>
+        <stentry class="- topic/stentry ">e3</stentry>
+      </strow>
+    </simpletable>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/simple.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/simple.dita
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="2.0" specializations="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable " id="tab_foo3">
       <title class="- topic/title ">foo</title>

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-       ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="2.0" specializations="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">

--- a/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
+++ b/src/test/resources/NormalizeSimpleTableFilterTest/src/topic.dita
@@ -3,30 +3,6 @@
        ditaarch:DITAArchVersion="2.0" specializations="" id="topic1" xml:lang="en-us">
   <title class="- topic/title ">Topic 1</title>
   <body class="- topic/body ">
-    <simpletable class="- topic/simpletable " id="tab_foo1">
-      <title class="- topic/title ">foo</title>
-      <sthead class="- topic/sthead ">
-        <stentry class="- topic/stentry ">foo1</stentry>
-        <stentry class="- topic/stentry ">foo2</stentry>
-      </sthead>
-      <strow class="- topic/strow ">
-        <stentry class="- topic/stentry ">e1</stentry>
-        <stentry class="- topic/stentry ">e2</stentry>
-      </strow>
-    </simpletable>
-    <simpletable class="- topic/simpletable " id="tab_foo3">
-      <title class="- topic/title ">foo</title>
-      <sthead class="- topic/sthead ">
-        <stentry class="- topic/stentry ">s1</stentry>
-        <stentry class="- topic/stentry ">s2</stentry>
-        <stentry class="- topic/stentry ">s3</stentry>
-      </sthead>
-      <strow class="- topic/strow ">
-        <stentry class="- topic/stentry ">e1</stentry>
-        <stentry class="- topic/stentry ">e2</stentry>
-        <stentry class="- topic/stentry ">e3</stentry>
-      </strow>
-    </simpletable>
     <simpletable class="- topic/simpletable ">
       <sthead class="- topic/sthead ">
         <stentry class="- topic/stentry ">1 1</stentry>

--- a/src/test/resources/NormalizeTableFilterTest/exp/nested.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/nested.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="2">

--- a/src/test/resources/NormalizeTableFilterTest/exp/parallel.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/parallel.dita
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <title class="- topic/title ">Mapping sequence index to number of resampler output samples</title>
+      <tgroup class="- topic/tgroup " cols="3">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <colspec class="- topic/colspec " colname="col3" colnum="3"/>
+
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col1" dita-ot:x="1" dita-ot:y="1" morerows="3">A1</entry>
+            <entry class="- topic/entry " colname="col2" dita-ot:x="2" dita-ot:y="1" morerows="3">B2</entry>
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="1">C1</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="2">C2</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="3">C3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry " colname="col3" dita-ot:x="3" dita-ot:y="4">C4</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/exp/parallel.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/parallel.dita
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
-  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <title class="- topic/title ">Mapping sequence index to number of resampler output samples</title>

--- a/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/rowspan.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="3">

--- a/src/test/resources/NormalizeTableFilterTest/exp/simple.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/simple.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " id="tab_foo1">
       <title class="- topic/title ">foo</title>

--- a/src/test/resources/NormalizeTableFilterTest/exp/topic.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/topic.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " colsep="1" frame="all" rowsep="1">
       <tgroup class="- topic/tgroup " cols="5">

--- a/src/test/resources/NormalizeTableFilterTest/exp/withoutColSpec.dita
+++ b/src/test/resources/NormalizeTableFilterTest/exp/withoutColSpec.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " ditaarch:DITAArchVersion="1.3" domains="" id="topic1">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " id="tab_foo3">
       <title class="- topic/title ">foo</title>

--- a/src/test/resources/NormalizeTableFilterTest/src/nested.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/nested.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="2">

--- a/src/test/resources/NormalizeTableFilterTest/src/parallel.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/parallel.dita
@@ -1,7 +1,6 @@
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
-  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <title class="- topic/title ">Mapping sequence index to number of resampler output samples</title>
@@ -9,7 +8,6 @@
         <colspec class="- topic/colspec " colname="col1" colnum="1"/>
         <colspec class="- topic/colspec " colname="col2" colnum="2"/>
         <colspec class="- topic/colspec " colname="col3" colnum="3"/>
-
         <tbody class="- topic/tbody ">
           <row class="- topic/row ">
             <entry class="- topic/entry " morerows="3">A1</entry>

--- a/src/test/resources/NormalizeTableFilterTest/src/parallel.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/parallel.dita
@@ -1,0 +1,32 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
+  <title class="- topic/title ">Topic 1</title>
+  <body class="- topic/body ">
+    <table class="- topic/table ">
+      <title class="- topic/title ">Mapping sequence index to number of resampler output samples</title>
+      <tgroup class="- topic/tgroup " cols="3">
+        <colspec class="- topic/colspec " colname="col1" colnum="1"/>
+        <colspec class="- topic/colspec " colname="col2" colnum="2"/>
+        <colspec class="- topic/colspec " colname="col3" colnum="3"/>
+
+        <tbody class="- topic/tbody ">
+          <row class="- topic/row ">
+            <entry class="- topic/entry " morerows="3">A1</entry>
+            <entry class="- topic/entry " morerows="3">B2</entry>
+            <entry class="- topic/entry ">C1</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">C2</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">C3</entry>
+          </row>
+          <row class="- topic/row ">
+            <entry class="- topic/entry ">C4</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </body>
+</topic>

--- a/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/rowspan.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table ">
       <tgroup class="- topic/tgroup " cols="3">

--- a/src/test/resources/NormalizeTableFilterTest/src/simple.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/simple.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " id="tab_foo1">
       <title class="- topic/title ">foo</title>

--- a/src/test/resources/NormalizeTableFilterTest/src/topic.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/topic.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " colsep="1" frame="all" rowsep="1">
       <tgroup class="- topic/tgroup " cols="5">

--- a/src/test/resources/NormalizeTableFilterTest/src/withoutColSpec.dita
+++ b/src/test/resources/NormalizeTableFilterTest/src/withoutColSpec.dita
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    " id="topic1" ditaarch:DITAArchVersion="1.3" xml:lang="en-us">
-  <title class="- topic/title ">Topic 1</title>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="" id="topic1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title "/>
   <body class="- topic/body ">
     <table class="- topic/table " id="tab_foo3">
       <title class="- topic/title ">foo</title>


### PR DESCRIPTION
## Description

The `simpletable` element normalization calculates the coordinates incorrectly when a row span greater than 2 is used. This PR fixes the coordinate calculation in those cases.

Also fixes bug in parallel rowspans in OASIS table model.

## How Has This Been Tested?
Split old unit test into multiple test methods and add test cases for row spanning.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No documentation changes needed.

