### PR TITLE
Ignore foreign content in map link stylesheet

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -797,6 +797,9 @@ See the accompanying LICENSE file for applicable license.
   <!-- Do nothing when meet the title -->
   <xsl:template match="*[contains(@class, ' topic/title ')]"/>
   
+  <!-- Ignore foreign content -->
+  <xsl:template match="*[contains(@class, ' topic/foreign ')]"/>
+  
   <xsl:template name="get-file-uri">
     <xsl:param name="href" as="xs:string"/>
     <xsl:param name="file-prefix" as="xs:string"/>

--- a/src/test/xsl/preprocess/maplinkImpl.xspec
+++ b/src/test/xsl/preprocess/maplinkImpl.xspec
@@ -248,4 +248,41 @@
     </x:scenario>
   </x:scenario>
 
+  <x:scenario label="Flagged topicref">
+    <x:context>
+      <map xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+        xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="merge" class="- map/map "
+        ditaarch:DITAArchVersion="1.3" domains="(topic ditaot-d/)" specializations="@props/deliveryTarget">
+        <topicref class="- map/topicref " platform="mac" href="topic.dita" type="concept">
+          <topicmeta class="- map/topicmeta ">
+            <navtitle class="- topic/navtitle ">Ant</navtitle>
+          </topicmeta>
+          <ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop " style="color:red;">
+            <prop action="flag" color="red"/>
+          </ditaval-startprop>
+          <ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop ">
+            <prop action="flag" color="red"/>
+          </ditaval-endprop>
+        </topicref>
+      </map>
+    </x:context>
+    <x:expect label="should not throw errors">
+      <map xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+        xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" cascade="merge" class="- map/map "
+        ditaarch:DITAArchVersion="1.3" domains="(topic ditaot-d/)" specializations="@props/deliveryTarget">
+        <topicref class="- map/topicref " platform="mac" href="topic.dita" type="concept">
+          <topicmeta class="- map/topicmeta ">
+            <navtitle class="- topic/navtitle ">Ant</navtitle>
+          </topicmeta>
+          <ditaval-startprop class="+ topic/foreign ditaot-d/ditaval-startprop " style="color:red;">
+            <prop action="flag" color="red"/>
+          </ditaval-startprop>
+          <ditaval-endprop class="+ topic/foreign ditaot-d/ditaval-endprop ">
+            <prop action="flag" color="red"/>
+          </ditaval-endprop>
+        </topicref>
+      </map>
+    </x:expect>
+  </x:scenario>
+
 </x:description>


### PR DESCRIPTION
## Description

When map contains flagging, `<ditaval-startprop>` element will contain `<prop>` elements without `@class`. This will cause `dita-ot:matches-shortdesc-class()` in template patterns to throw errors due to missing `@class` attribute that the function is excepting.

## Motivation and Context
Remove error messages from Saxon that are caused by the assumption that all elements will contain a `@class` attribute.

>   [maplink] Warning at char 40 in xsl:template/\@match on line 610 column 119 of maplinkImpl.xsl:
  [maplink]   XPTY0004: An error occurred matching pattern
  [maplink]   {element()[Q{http://dita-ot.sourceforge.net/ns/201007/dita-ot}matches-shortdesc-class(exactly-one((attribute::attribute(Q{}class)) treat as attribute(Q{}class)))]}: An empty sequence is not allowed as the first argument of dita-ot:matches-shortdesc-class()

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None

