### PR TITLE
Add rotate outputclass to entry output in HTML5

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_tables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_tables.scss
@@ -97,7 +97,7 @@ $valign: top bottom middle;
 
 .entry {
   &.rotate {
-     writing-mode: vertical-lr;
+     writing-mode: sideways-lr;
   }
 }
 

--- a/src/main/plugins/org.dita.html5/sass/_tables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_tables.scss
@@ -95,6 +95,12 @@ $valign: top bottom middle;
   border-bottom: 1px solid;
 }
 
+.entry {
+  &.rotate {
+     writing-mode: vertical-lr;
+  }
+}
+
 // simpletable
 
 .stentry {

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -523,6 +523,13 @@ See the accompanying LICENSE file for applicable license.
     <xsl:sequence select="dita-ot:css-class((), .)"/>
   </xsl:template>
 
+  <xsl:template match="@rotate" mode="css-class">
+    <xsl:if test=". = 1">
+      <xsl:value-of select="name()"/>
+    </xsl:if>
+  </xsl:template>
+  
+
   <xsl:template match="*[contains(@class, ' topic/tgroup ')]/*" mode="css-class">
     <xsl:apply-templates select="@valign" mode="#current"/>
   </xsl:template>
@@ -535,7 +542,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="colsep" as="attribute(colsep)?" select="table:get-entry-colsep(.)"/>
     <xsl:variable name="rowsep" as="attribute(rowsep)?" select="table:get-entry-rowsep(.)"/>
     <xsl:apply-templates mode="#current" select="
-      table:get-entry-align(.), $colsep, $rowsep, @valign
+      table:get-entry-align(.), $colsep, $rowsep, @valign, @rotate
     "/>
   </xsl:template>
 


### PR DESCRIPTION
Fixes #3448

## Description
Add `@rotate` support for OASIS table entry in HTML5 plug-in. The rotation is implemented using CSS `writing-mode:sideways-lr` because `transform:rotate(270deg)` would make the entry content overflow.

## Motivation and Context
Add parity with PDF2 in supporting the `@rotate` attribute.

