### PR TITLE
Refactor to use store for all temp IO

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -307,7 +307,7 @@ public final class ExtensibleAntInvoker extends Task {
         Job job = project.getReference(ANT_REFERENCE_JOB);
         if (job != null) {
             if (job.isStale()) {
-                project.log("Reload stale job configuration reference", Project.MSG_VERBOSE);
+                project.log("Reload stale job configuration reference", Project.MSG_ERR);
                 try {
                     job = new Job(tempDir, job.getStore());
                 } catch (final IOException ioe) {
@@ -316,10 +316,16 @@ public final class ExtensibleAntInvoker extends Task {
                 project.addReference(ANT_REFERENCE_JOB, job);
             }
         } else {
+            XMLUtils xmlUtils = project.getReference(ANT_REFERENCE_XML_UTILS);
+            if (xmlUtils == null) {
+                project.log("XML utils not found from Ant project reference", Project.MSG_ERR);
+                xmlUtils = new XMLUtils();
+                xmlUtils.setLogger(new DITAOTAntLogger(project));
+            }
             Store store = project.getReference(ANT_REFERENCE_STORE);
             if (store == null) {
-                project.log("Store not found from Ant project reference", Project.MSG_VERBOSE);
-                store = new StreamStore( new XMLUtils());
+                project.log("Store not found from Ant project reference", Project.MSG_ERR);
+                store = new StreamStore(job.tempDir, xmlUtils);
             }
             project.log("Job not found from Ant project reference", Project.MSG_VERBOSE);
             try {

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -12,14 +12,14 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.store.Store;
-import org.dita.dost.store.StreamStore;
+import org.dita.dost.store.StoreBuilder;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
 
 import java.io.File;
+import java.util.ServiceLoader;
 
-import static org.dita.dost.util.Constants.ANT_REFERENCE_STORE;
-import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
+import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toFile;
 
 /**
@@ -28,6 +28,11 @@ import static org.dita.dost.util.URLUtils.toFile;
  * @since 3.5
  */
 public final class InitializeProjectTask extends Task {
+
+    private static ServiceLoader<StoreBuilder> storeBuilderLoader = ServiceLoader.load(StoreBuilder.class);
+
+    private String storeType = "file";
+
     @Override
     public void execute() throws BuildException {
         log("Initializing project", Project.MSG_INFO);
@@ -42,10 +47,28 @@ public final class InitializeProjectTask extends Task {
             xmlUtils.setLogger(new DITAOTAntLogger(getProject()));
             getProject().addReference(ANT_REFERENCE_XML_UTILS, xmlUtils);
         }
+        final Store store = getStore(xmlUtils);
+        getProject().addReference(ANT_REFERENCE_STORE, store);
+    }
+
+    private Store getStore(XMLUtils xmlUtils) {
         Store store = getProject().getReference(ANT_REFERENCE_STORE);
-        if (store == null) {
-            store = new StreamStore(xmlUtils);
-            getProject().addReference(ANT_REFERENCE_STORE, store);
+        if (store != null) {
+            return store;
         }
+        File tempDir = toFile(getProject().getUserProperty(ANT_TEMP_DIR));
+        if (tempDir == null) {
+            tempDir = toFile(getProject().getProperty(ANT_TEMP_DIR));
+        }
+        for (StoreBuilder storeBuilder : storeBuilderLoader) {
+            if (storeBuilder.getType().equals(storeType)) {
+                return storeBuilder.setTempDir(tempDir).setXmlUtils(xmlUtils).build();
+            }
+        }
+        throw new BuildException(String.format("Unsupported store type %s", storeType));
+    }
+
+    public void setStoreType(final String storeType) {
+        this.storeType = storeType;
     }
 }

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -20,6 +20,7 @@ import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.URLResource;
 import org.dita.dost.ant.ExtensibleAntInvoker;
+import org.dita.dost.store.ant.types.StoreResource;
 import org.dita.dost.util.Constants;
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
@@ -58,9 +59,9 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
             for (final FileInfo f : job.getFileInfo(this::filter)) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
                 final File tempFile = new File(job.tempDir, f.file.getPath());
-                if (tempFile.exists()) {
+                if (job.getStore().exists(tempFile.toURI())) {
                     log("Found temporary directory file " + tempFile, Project.MSG_VERBOSE);
-                    res.add(new FileResource(job.tempDir, f.file.toString()));
+                    res.add(new StoreResource(job, job.tempDirURI.relativize(f.uri)));
                 } else if (f.src.getScheme().equals("file")) {
                     final File srcFile = new File(f.src);
                     if (srcFile.exists()) {

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -145,6 +145,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
         logger.debug("Writing " + currentFile);
 
         try {
+            doc.setDocumentURI(currentFile.toString());
             job.getStore().writeDocument(doc, currentFile);
         } catch (final IOException e) {
             logger.error("Failed to serialize " + map.toString() + ": " + e.getMessage(), e);
@@ -374,10 +375,6 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
                 writer.setCurrentFile(dstAbsUri);
                 final List<XMLFilter> pipe = singletonList(writer);
 
-                final File dstDirUri = new File(dstAbsUri.resolve("."));
-                if (!dstDirUri.exists() && !dstDirUri.mkdirs()) {
-                    logger.error("Failed to create directory " + dstDirUri);
-                }
                 try {
                     job.getStore().transform(srcAbsUri, dstAbsUri, pipe);
                 } catch (final DITAOTException e) {

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -19,6 +19,7 @@ import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.dita.dost.writer.LinkFilter;
 import org.dita.dost.writer.MapCleanFilter;
@@ -129,7 +130,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
                         logger.debug("Skip format " + fi.format);
                     } else {
                         final File srcFile = new File(job.tempDirURI.resolve(fi.uri));
-                        if (srcFile.exists()) {
+                        if (job.getStore().exists(srcFile.toURI())) {
                             final File destFile = new File(job.tempDirURI.resolve(fi.result));
                             final List<XMLFilter> processingPipe = getProcessingPipe(fi, srcFile, destFile);
                             if (!processingPipe.isEmpty()) {
@@ -196,12 +197,12 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
     private Document serialize(final Collection<FileInfo> fis) throws IOException {
         try {
-            final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            final Document doc = XMLUtils.getDocumentBuilder().newDocument();
             final DOMResult result = new DOMResult(doc);
             XMLStreamWriter out = XMLOutputFactory.newInstance().createXMLStreamWriter(result);
             job.serialize(out, emptyMap(), fis);
             return (Document) result.getNode();
-        } catch (final XMLStreamException | ParserConfigurationException e) {
+        } catch (final XMLStreamException e) {
             throw new IOException("Failed to serialize job file: " + e.getMessage());
         }
     }

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -39,13 +39,13 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
             reader.setJob(job);
             for (final FileInfo f: fis) {
                 final File file = new File(job.tempDir, f.file.getPath());
-                logger.info("Reading  " + file.getAbsolutePath());
+                logger.info("Reading " + file.toURI());
                 //FIXME: this reader calculate parent directory
                 reader.read(file.getAbsoluteFile());
             }
             final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = reader.getPushMap();
             for (final Map.Entry<File, Hashtable<MoveKey, DocumentFragment>> entry: pushSet.entrySet()) {
-                logger.info("Processing " + entry.getKey().getAbsolutePath());
+//                logger.info("Processing " + entry.getKey().toURI());
                 final ConrefPushParser parser = new ConrefPushParser();
                 parser.setJob(job);
                 parser.setLogger(logger);

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -158,7 +158,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             final URI srcFile = job.tempDirURI.resolve(copytoSource);
             final URI targetFile = job.tempDirURI.resolve(copytoTarget);
 
-            if (new File(targetFile).exists()) {
+            if (job.getStore().exists(targetFile)) {
                 logger.warn(MessageUtils.getMessage("DOTX064W", copytoTarget.getPath()).toString());
             } else {
                 final FileInfo input = job.getFileInfo(fi -> fi.isInput).iterator().next();
@@ -193,10 +193,6 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
         assert !copytoTargetFilename.isAbsolute();
         assert inputMapInTemp.isAbsolute();
         final File workdir = new File(target).getParentFile();
-        if (!workdir.exists() && !workdir.mkdirs()) {
-            logger.error("Failed to create copy-to target directory " + workdir.toURI());
-            return;
-        }
         final File path2project = getPathtoProject(copytoTargetFilename, target, inputMapInTemp, job);
         final File path2rootmap = getPathtoRootmap(target, inputMapInTemp);
         XMLFilter filter = new CopyToFilter(workdir, path2project, path2rootmap, src, target);

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -8,7 +8,6 @@
  */
 package org.dita.dost.module;
 
-import net.sf.saxon.s9api.Serializer;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -121,11 +120,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             return;
         }
         outputFile = new File(job.tempDir, f.file.getPath());
-        final File outputDir = outputFile.getParentFile();
-        if (!outputDir.exists() && !outputDir.mkdirs()) {
-            logger.error("Failed to create output directory " + outputDir.getAbsolutePath());
-            return;
-        }
         logger.info("Processing " + f.src + " to " + outputFile.toURI());
 
         final Set<URI> schemaSet = dic.get(f.uri);
@@ -167,9 +161,9 @@ public final class DebugAndFilterModule extends SourceReaderModule {
 
             in = new InputSource(f.src.toString());
 
-            final Serializer result = processor.newSerializer(outputFile);
+            final ContentHandler result = job.getStore().getContentHandler(outputFile.toURI());
 
-            xmlSource.setContentHandler(result.getContentHandler());
+            xmlSource.setContentHandler(result);
             xmlSource.parse(in);
         } catch (final RuntimeException e) {
             throw e;
@@ -476,10 +470,6 @@ public final class DebugAndFilterModule extends SourceReaderModule {
      * @throws DITAOTException if generation fails
      */
     private void generateScheme(final File filename, final Document root) throws DITAOTException {
-        final File p = filename.getParentFile();
-        if (!p.exists() && !p.mkdirs()) {
-            throw new DITAOTException("Failed to make directory " + p.getAbsolutePath());
-        }
         try {
             job.getStore().writeDocument(root, filename.toURI());
         } catch (final IOException e) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -885,9 +885,6 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
         try {
             logger.info("Serializing job specification");
-            if (!job.tempDir.exists() && !job.tempDir.mkdirs()) {
-                throw new DITAOTException("Failed to create " + job.tempDir + " directory");
-            }
             job.write();
         } catch (final IOException e) {
             throw new DITAOTException("Failed to serialize job configuration files: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -440,6 +440,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     private void writeMap(final FileInfo in, final Document doc) throws DITAOTException {
         try {
             final URI file = job.tempDirURI.resolve(in.uri);
+            doc.setDocumentURI(file.toString());
             job.getStore().writeDocument(doc, file);
         } catch (final IOException e) {
             throw new DITAOTException("Failed to write map: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -13,6 +13,8 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.CatalogUtils;
+import org.dita.dost.util.DelegatingURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.DitaLinksWriter;
@@ -60,6 +62,8 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
 
             final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
             transformer.setErrorListener(toErrorListener(logger));
+            transformer.setURIResolver(new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), job.getStore()));
+
             if (input.getAttribute("include.rellinks") != null) {
                 transformer.setParameter(new QName("include.rellinks"),
                         XdmItem.makeValue(input.getAttribute("include.rellinks")));

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -10,23 +10,18 @@ package org.dita.dost.module;
 
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
-import org.apache.tools.ant.util.FileUtils;
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MapMetaReader;
 import org.dita.dost.util.CatalogUtils;
-import org.dita.dost.util.Configuration;
+import org.dita.dost.util.DelegatingURIResolver;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.XMLUtils;
-import org.dita.dost.util.XMLUtils.DebugURIResolver;
 import org.dita.dost.writer.DitaMapMetaWriter;
 import org.dita.dost.writer.DitaMetaWriter;
 import org.w3c.dom.Element;
 
-import javax.xml.transform.*;
-import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +34,6 @@ import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.stripFragment;
 import static org.dita.dost.util.URLUtils.toFile;
 import static org.dita.dost.util.XMLUtils.toErrorListener;
-import static org.dita.dost.util.XMLUtils.withLogger;
 
 /**
  * Cascades metadata from maps to topics and then from topics to maps.
@@ -88,15 +82,13 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         for (final FileInfo f : fis) {
             final File inputFile = new File(job.tempDir, f.file.getPath());
             final File tmp = new File(inputFile.getAbsolutePath() + ".tmp" + Long.toString(System.currentTimeMillis()));
-            if (!tmp.getParentFile().exists() && !tmp.getParentFile().mkdirs()) {
-                throw new DITAOTException("Failed to create directory " + tmp.getParent());
-            }
             logger.info("Processing " + inputFile.toURI());
             logger.debug("Processing " + inputFile.toURI() + " to " + tmp.toURI());
 
             try {
                 final XsltTransformer transformer = xsltExecutable.load();
                 transformer.setErrorListener(toErrorListener(logger));
+                transformer.setURIResolver(new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), job.getStore()));
 
                 for (Entry<String, String> e : input.getAttributes().entrySet()) {
                     logger.debug("Set parameter " + e.getKey() + " to '" + e.getValue() + "'");
@@ -106,6 +98,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final Source source = job.getStore().getSource(inputFile.toURI());
                 transformer.setSource(source);
                 final Destination result = job.getStore().getDestination(tmp.toURI());
+                result.setDestinationBaseURI(inputFile.toURI());
                 transformer.setDestination(result);
                 transformer.transform();
             } catch (final UncheckedXPathException e) {
@@ -119,17 +112,9 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
             }
             try {
                 logger.debug("Moving " + tmp.toURI() + " to " + inputFile.toURI());
-                if (!inputFile.delete()) {
-                    throw new IOException("Failed to to delete input file " + inputFile.toURI());
-                }
-                if (!tmp.renameTo(inputFile)) {
-                    throw new IOException("Failed to to replace input file " + inputFile.toURI());
-                }
+                job.getStore().move(tmp.toURI(), inputFile.toURI());
             } catch (final IOException e) {
                 throw new DITAOTException("Failed to replace document: " + e.getMessage(), e);
-            } finally {
-                logger.debug("Remove " + tmp.toURI());
-                FileUtils.delete(tmp);
             }
         }
     }
@@ -154,7 +139,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 assert targetFileName.isAbsolute();
                 if (fi.format != null && ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
                     mapInserter.setMetaTable(entry.getValue());
-                    if (toFile(targetFileName).exists()) {
+                    if (job.getStore().exists(targetFileName)) {
                         try {
                             mapInserter.read(toFile(targetFileName));
                         } catch (DITAOTException e) {
@@ -163,7 +148,6 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                     } else {
                         logger.error("File " + targetFileName + " does not exist");
                     }
-
                 }
             }
             //process topic
@@ -183,16 +167,11 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                     final String topicid = entry.getKey().getFragment();
                     topicInserter.setTopicId(topicid);
                     topicInserter.setMetaTable(entry.getValue());
-                    if (toFile(targetFileName).exists()) {
-                        try {
-                            topicInserter.read(toFile(targetFileName));
-                        } catch (DITAOTException e) {
-                            logger.error("Failed to read " + targetFileName + ": " + e.getMessage(), e);
-                        }
-                    } else {
-                        logger.error("File " + targetFileName + " does not exist");
+                    try {
+                        topicInserter.read(toFile(targetFileName));
+                    } catch (DITAOTException e) {
+                        logger.error("Failed to read " + targetFileName + ": " + e.getMessage(), e);
                     }
-
                 }
             }
         }

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -161,7 +161,7 @@ public class SubjectSchemeReader {
      */
     public void loadSubjectScheme(final File scheme) {
         assert scheme.isAbsolute();
-        if (!scheme.exists()) {
+        if (!job.getStore().exists(scheme.toURI())) {
             throw new IllegalStateException();
         }
         logger.debug("Load subject scheme " + scheme);

--- a/src/main/java/org/dita/dost/store/AbstractStore.java
+++ b/src/main/java/org/dita/dost/store/AbstractStore.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import net.sf.saxon.s9api.XsltTransformer;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.XMLUtils;
+import org.xml.sax.XMLFilter;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
+import static org.dita.dost.util.URLUtils.toURI;
+
+/**
+ * Common base class for store implementations.
+ */
+public abstract class AbstractStore implements Store {
+
+    protected final XMLUtils xmlUtils;
+    public final File tempDir;
+    public final URI tempDirUri;
+
+    public AbstractStore(final File tempDir, final XMLUtils xmlUtils) {
+        if (!tempDir.isAbsolute()) {
+            throw new IllegalArgumentException("Temporary directory " + tempDir + " must be absolute");
+        }
+        this.tempDirUri = tempDir.toURI();
+        this.tempDir = tempDir;
+        this.xmlUtils = xmlUtils;
+    }
+
+    @Override
+    public URI getUri(final URI path) {
+        return tempDirUri.resolve(path).normalize();
+    }
+
+    protected boolean isTempFile(final URI f) {
+        return f.toString().startsWith(tempDirUri.toString());
+    }
+
+    @Override
+    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+        final URI src = input.normalize();
+        final URI dst = output.normalize();
+        if (src.equals(dst)) {
+            transform(src, filters);
+        } else {
+            transformURI(src, dst, filters);
+        }
+    }
+
+    @Override
+    public void transform(final URI src, final List<XMLFilter> filters) throws DITAOTException {
+        final URI dst = toURI(src.toString() + FILE_EXTENSION_TEMP).normalize();
+        transformURI(src, dst, filters);
+        try {
+            move(dst, src);
+        } catch (final RuntimeException e) {
+            throw e;
+        } catch (final IOException e) {
+            throw new DITAOTException("Failed to replace " + src + ": " + e.getMessage());
+        }
+    }
+
+    abstract void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException;
+
+    abstract void transformUri(final URI input, final URI output, final XsltTransformer transformer) throws DITAOTException;
+
+}

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -11,22 +11,40 @@ package org.dita.dost.store;
 import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XsltTransformer;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.XMLFilter;
 
 import javax.xml.transform.Source;
+import javax.xml.transform.URIResolver;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 
 /**
  * Abstract XML I/O.
  *
+ * <p>The following file-system like operations are provided:</p>
+ * <ul>
+ * <li>read</li>
+ * <li>write</li>
+ * <li>test for existence</li>
+ * </ul>
+ * <p>The following convenience operations are provided:</p>
+ * <ul>
+ * <li>copy</li>
+ * <li>move</li>
+ * <li>transform</li>
+ * </ul>
+ *
  * @since 3.5
  */
-public interface Store {
+public interface Store extends URIResolver {
 
     /**
      * Read XML into SAX pipe.
@@ -54,6 +72,23 @@ public interface Store {
     void transform(final URI src, final URI dst, final List<XMLFilter> filters) throws DITAOTException;
 
     /**
+     * Transform file with XSLT.
+     *
+     * @param src file to transform and replace
+     * @param transformer XSLT transformer to transform file with
+     */
+    void transform(final URI src, final XsltTransformer transformer) throws DITAOTException;
+
+    /**
+     * Transform file with XSLT.
+     *
+     * @param src input file
+     * @param dst output file
+     * @param transformer XSLT transformer to transform file with
+     */
+    void transform(final URI src, final URI dst, final XsltTransformer transformer) throws DITAOTException;
+
+    /**
      * Get temporary file source
      *
      * @param path temporary file URI, absolute or relative
@@ -62,7 +97,7 @@ public interface Store {
     Source getSource(URI path);
 
     /**
-     * Get immutable DOM document for file. If mutating methods are called,
+     * Get immutable DOM document for resource. If mutating methods are called,
      * {@link UnsupportedOperationException} is thrown.
      *
      * @param path temporary file URI, absolute or relative
@@ -72,7 +107,7 @@ public interface Store {
     Document getImmutableDocument(URI path) throws IOException;
 
     /**
-     * Get immutable XsdNode for file.
+     * Get immutable XsdNode for resource.
      *
      * @param path temporary file URI, absolute or relative
      * @return document or null if not available
@@ -81,7 +116,7 @@ public interface Store {
     XdmNode getImmutableNode(final URI path) throws IOException;
 
     /**
-     * Get DOM document for file.
+     * Get DOM document for resource.
      *
      * @param path temporary file URI, absolute or relative
      * @return document or null if not available
@@ -90,13 +125,31 @@ public interface Store {
     Document getDocument(URI path) throws IOException;
 
     /**
-     * Write DOM document to file.
+     * Write DOM document to store.
      *
      * @param doc document to store
      * @param dst destination file URI, absolute or relative
      * @throws IOException if serializing file fails
      */
     void writeDocument(Document doc, URI dst) throws IOException;
+
+    /**
+     * Write DOM document to SAX pipe.
+     *
+     * @param doc document to save
+     * @param dst SAX pipe to write to
+     * @throws IOException if serializing file fails
+     */
+    void writeDocument(Node doc, final ContentHandler dst) throws IOException;
+
+    /**
+     * Write XsdNode to store.
+     *
+     * @param node document to save
+     * @param dst destination file URI, absolute or relative
+     * @throws IOException if serializing file fails
+     */
+    void writeDocument(XdmNode node, final ContentHandler dst) throws IOException;
 
     /**
      * Write XdmNode to file.
@@ -123,4 +176,62 @@ public interface Store {
      * @throws SaxonApiException if creating serializer fails
      */
     ContentHandler getContentHandler(URI path) throws SaxonApiException, IOException;
+
+    /**
+     * Get temporary file absolute URI
+     *
+     * @param path temporary file relative URI
+     * @return absolute URI to temporary file
+     */
+    URI getUri(URI path);
+
+    /**
+     * Delete temporary file
+     *
+     * @param file file to delete, absolute or relative
+     * @throws java.io.IOException if deleting failed
+     */
+    void delete(URI file) throws IOException;
+
+    /**
+     * Copy temporary file
+     *
+     * @param src source file, absolute or relative
+     * @param dst destination file, absolute or relative
+     * @throws java.io.IOException if copying failed
+     */
+    void copy(URI src, URI dst) throws IOException;
+
+    /**
+     * Check if file exits
+     *
+     * @param path file to test, absolute or relative
+     * @return {@code true} if file exists, otherwise {@code false}
+     */
+    boolean exists(URI path);
+
+    /**
+     * Move temporary file
+     *
+     * @param src source file, absolute or relative
+     * @param dst destination file, absolute or relative
+     * @throws java.io.IOException if moving failed
+     */
+    void move(URI src, URI dst) throws IOException;
+
+    /**
+     * Get input stream. Intended for non-XML sources.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return input stream for temporary file
+     */
+    InputStream getInputStream(URI path) throws IOException;
+
+    /**
+     * Get output stream. Intended for non-XML sources.
+     *
+     * @param path temporary file URI, absolute or relative
+     * @return output stream for temporary file
+     */
+    OutputStream getOutputStream(URI path) throws IOException;
 }

--- a/src/main/java/org/dita/dost/store/StoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/StoreBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import org.dita.dost.util.XMLUtils;
+
+import java.io.File;
+
+public interface StoreBuilder {
+    String getType();
+
+    StoreBuilder setTempDir(File tempDir);
+
+    StoreBuilder setXmlUtils(XMLUtils xmlUtils);
+
+    Store build();
+}

--- a/src/main/java/org/dita/dost/store/StreamStoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/StreamStoreBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import org.dita.dost.util.XMLUtils;
+
+import java.io.File;
+
+/**
+ * File store builder
+ *
+ * @since 3.5
+ */
+public class StreamStoreBuilder implements StoreBuilder {
+
+    private File tempDir;
+    private XMLUtils xmlUtils;
+
+    @Override
+    public String getType() {
+        return "file";
+    }
+
+    @Override
+    public StoreBuilder setTempDir(File tempDir) {
+        this.tempDir = tempDir;
+        return this;
+    }
+
+    @Override
+    public StoreBuilder setXmlUtils(XMLUtils xmlUtils) {
+        this.xmlUtils = xmlUtils;
+        return this;
+    }
+
+    @Override
+    public Store build() {
+        return new StreamStore(tempDir, xmlUtils);
+    }
+}

--- a/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
+++ b/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.store.ant.types;
+
+import org.apache.tools.ant.types.Resource;
+import org.dita.dost.util.Job;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Objects;
+
+public class StoreResource extends Resource {
+
+    private URI file;
+    private Job job;
+
+    public StoreResource(Job job, URI file) {
+        this.job = job;
+        this.file = file;
+    }
+
+    /**
+     * Get the name of this StoreResource.  If the basedir is set,
+     * the name will be relative to that.  Otherwise the basename
+     * only will be returned.
+     * @return the name of this resource.
+     */
+    @Override
+    public String getName() {
+        return file.getPath();
+    }
+
+    /**
+     * Learn whether this file exists.
+     * @return true if this resource exists.
+     */
+    @Override
+    public boolean isExists() {
+        return job.getStore().exists(job.tempDirURI.resolve(file));
+    }
+
+    /**
+     * Get the modification time in milliseconds since 01.01.1970 .
+     * @return 0 if the resource does not exist.
+     */
+    @Override
+    public long getLastModified() {
+        // TODO: Add long lastModified entry to cache Store
+        return -1;
+    }
+
+    /**
+     * Learn whether the resource is a directory.
+     * @return boolean flag indicating if the resource is a directory.
+     */
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    /**
+     * Get the size of this Resource.
+     * @return the size, as a long, 0 if the Resource does not exist.
+     */
+    @Override
+    public long getSize() {
+        return -1;
+    }
+
+    /**
+     * Return an InputStream for reading the contents of this Resource.
+     * @return an InputStream object.
+     * @throws IOException if an error occurs.
+     */
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return job.getStore().getInputStream(job.tempDirURI.resolve(file));
+    }
+
+    /**
+     * Get an OutputStream for the Resource.
+     * @return an OutputStream to which content can be written.
+     * @throws IOException if unable to provide the content of this
+     *         Resource as a stream.
+     * @throws UnsupportedOperationException if OutputStreams are not
+     *         supported for this Resource type.
+     */
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return job.getStore().getOutputStream(job.tempDirURI.resolve(file));
+    }
+
+    /**
+     * Compare this StoreResource to another Resource.
+     * @param another the other Resource against which to compare.
+     * @return a negative integer, zero, or a positive integer as this StoreResource
+     *         is less than, equal to, or greater than the specified Resource.
+     */
+    @Override
+    public int compareTo(Resource another) {
+        // TODO add a way to compare resources
+        return -1;
+    }
+
+    /**
+     * Compare another Object to this StoreResource for equality.
+     * @param another the other Object to compare.
+     * @return true if another is a StoreResource representing the same file.
+     */
+    @Override
+    public boolean equals(Object another) {
+        if (this == another) {
+            return true;
+        }
+        if (another == null || !(another.getClass().equals(getClass()))) {
+            return false;
+        }
+        StoreResource otherfr = (StoreResource) another;
+        return Objects.equals(file, otherfr.file);
+    }
+
+    /**
+     * Get the hash code for this Resource.
+     * @return hash code as int.
+     */
+    @Override
+    public int hashCode() {
+        return file.hashCode();
+    }
+
+    /**
+     * Get the string representation of this Resource.
+     * @return this StoreResource formatted as a String.
+     */
+    @Override
+    public String toString() {
+        return job.tempDirURI.resolve(file).toString();
+    }
+
+    /**
+     * Fulfill the ResourceCollection contract.
+     * @return whether this Resource is a StoreResource.
+     */
+    @Override
+    public boolean isFilesystemOnly() {
+        return true;
+    }
+
+    @Override
+    protected StoreResource getRef() {
+        return getCheckedRef(StoreResource.class);
+    }
+}

--- a/src/main/java/org/dita/dost/util/DelayConrefUtils.java
+++ b/src/main/java/org/dita/dost/util/DelayConrefUtils.java
@@ -67,8 +67,7 @@ public final class DelayConrefUtils {
      * @return true if id find and false otherwise
      */
     public boolean findTopicId(final File absolutePathToFile, final String id) {
-
-        if (!absolutePathToFile.exists()) {
+        if (!job.getStore().exists(absolutePathToFile.toURI())) {
             return false;
         }
         try {

--- a/src/main/java/org/dita/dost/util/DelegatingURIResolver.java
+++ b/src/main/java/org/dita/dost/util/DelegatingURIResolver.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+
+/**
+ * URI resolver that folds over multiple resolvers and returns the final result.
+ */
+public class DelegatingURIResolver implements URIResolver {
+
+    private final URIResolver[] resolvers;
+
+    public DelegatingURIResolver(URIResolver... resolvers) {
+        this.resolvers = resolvers;
+    }
+
+    @Override
+    public Source resolve(String href, String base) throws TransformerException {
+//        System.out.println(" DelegatingURIResolver resolve: " + href);
+        Source src = null;
+        for (final URIResolver resolver : resolvers) {
+            // XXX: This will create a redundant XMLReader for each call to resolve
+            final Source res = resolver.resolve(src != null ? src.getSystemId() : href, base);
+            if (res != null) {
+                src = res;
+            }
+        }
+        return src;
+    }
+}

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -7,29 +7,14 @@
  */
 package org.dita.dost.util;
 
-import static org.dita.dost.util.Configuration.configuration;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-
-import com.google.common.annotations.VisibleForTesting;
+import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.store.Store;
-import org.dita.dost.store.StreamStore;
 import org.w3c.dom.Document;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.net.URI;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -37,12 +22,18 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.dom.DOMResult;
+import java.io.*;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-import org.dita.dost.module.reader.TempFileNameScheme;
-import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
+import static org.dita.dost.util.Configuration.configuration;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
 
 /**
  * Definition of current job.
@@ -158,11 +149,6 @@ public final class Job {
                 prop.put(e.getKey(), e.getValue());
             }
         }
-    }
-
-    @VisibleForTesting
-    public Job(final File tempDir) throws IOException {
-        this(tempDir, new StreamStore(new XMLUtils()));
     }
 
     public Job(final Job job, final Map<String, Object> prop, final Collection<FileInfo> files) {
@@ -326,6 +312,9 @@ public final class Job {
      * @throws IOException if writing configuration files failed
      */
     public void write() throws IOException {
+        if (!tempDir.exists() && !tempDir.mkdirs()) {
+            throw new IOException("Failed to create " + tempDir + " directory");
+        }
         OutputStream outStream = null;
         XMLStreamWriter out = null;
         try {

--- a/src/main/java/org/dita/dost/util/MergeUtils.java
+++ b/src/main/java/org/dita/dost/util/MergeUtils.java
@@ -31,6 +31,7 @@ public final class MergeUtils {
     /** Set of visited topic files. */
     private final Set<URI> visitSet;
     private DITAOTLogger logger;
+    private Job job;
 
     /**
      * Default Constructor
@@ -40,6 +41,10 @@ public final class MergeUtils {
         idMap = new ConcurrentHashMap<>();
         visitSet = Collections.synchronizedSet(new HashSet<>(256));
         index = 0;
+    }
+
+    public void setJob(final Job job) {
+        this.job = job;
     }
 
     public void setLogger(final DITAOTLogger logger) {
@@ -135,18 +140,13 @@ public final class MergeUtils {
      */
     public String getFirstTopicId(final URI file, final boolean useCatalog) {
         assert file.isAbsolute();
-        if (!(new File(file).exists())) {
+        if (!job.getStore().exists(file)) {
             return null;
         }
         final StringBuilder firstTopicId = new StringBuilder();
         final TopicIdParser parser = new TopicIdParser(firstTopicId);
         try {
-            final XMLReader reader = XMLUtils.getXMLReader();
-            reader.setContentHandler(parser);
-            if (useCatalog) {
-                reader.setEntityResolver(CatalogUtils.getCatalogResolver());
-            }
-            reader.parse(file.toString());
+            job.getStore().transform(file, parser);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e) ;
         }

--- a/src/main/java/org/dita/dost/util/TopicIdParser.java
+++ b/src/main/java/org/dita/dost/util/TopicIdParser.java
@@ -18,7 +18,9 @@ import org.xml.sax.SAXException;
 /**
  * SAX Parser that handles topic id identification.
  *
+ * @deprecated use DOM parsing instead
  */
+@Deprecated
 public final class TopicIdParser implements ContentHandler {
     private boolean isFirstId = true;
     private StringBuilder firstId = null;

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -242,7 +242,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final FileInfo cfi = job.getFileInfo(stripFragment(currentParsingFile));
         URI result = cfi.result.resolve(id + FILE_EXTENSION_DITA);
         URI temp = tempFileNameScheme.generateTempFileName(result);
-        if (id == null || new File(job.tempDirURI.resolve(temp)).exists()) { //job.getFileInfo(result) != null
+        if (id == null || job.getStore().exists(job.tempDirURI.resolve(temp))) { //job.getFileInfo(result) != null
             final URI t = temp;
 
             result = cfi.result.resolve(generateFilename());

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -22,13 +22,8 @@ import java.io.IOException;
  */
 public abstract class AbstractDomFilter implements AbstractReader {
 
-    protected final XMLUtils xmlUtils;
     protected DITAOTLogger logger;
     protected Job job;
-
-    public AbstractDomFilter() {
-        xmlUtils = new XMLUtils();
-    }
 
     @Override
     public void read(final File filename) throws DITAOTException {
@@ -48,6 +43,7 @@ public abstract class AbstractDomFilter implements AbstractReader {
         if (resDoc != null) {
             try {
                 logger.debug("Writing " + filename.toURI());
+                resDoc.setDocumentURI(filename.toURI().toString());
                 job.getStore().writeDocument(resDoc, filename.toURI());
             } catch (final IOException e) {
                 throw new DITAOTException("Failed to serialize " + filename.getAbsolutePath() + ": " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
@@ -28,7 +28,6 @@ import org.xml.sax.helpers.XMLFilterImpl;
 public abstract class AbstractXMLFilter extends XMLFilterImpl implements AbstractWriter {
 
     protected DITAOTLogger logger;
-    protected final XMLUtils xmlUtils = new XMLUtils();
     protected Job job;
     /** Absolute temporary directory URI to file being processed */
     protected URI currentFile;
@@ -43,7 +42,6 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
     @Override
     public void setLogger(final DITAOTLogger logger) {
         this.logger = logger;
-        xmlUtils.setLogger(logger);
     }
 
     @Override

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -15,7 +15,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.*;
@@ -39,8 +38,6 @@ import static org.dita.dost.util.XMLUtils.*;
  * Not reusable and not thread-safe.
  */
 public final class ChunkTopicParser extends AbstractChunkTopicParser {
-
-//    private final XMLReader reader;
 
     /**
      * Constructor.
@@ -149,7 +146,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                     }
 
                     // Check if there is any conflict
-                    if (new File(outputFileName).exists() && !MAP_MAP.matches(classValue)) {
+                    if (job.getStore().exists(outputFileName) && !MAP_MAP.matches(classValue)) {
                         final URI t = outputFileName;
                         outputFileName = generateOutputFile(currentFile);
                         conflictTable.put(outputFileName, t);
@@ -295,7 +292,8 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
     private void writeToContentChunk(final String tmpContent, final URI outputFileName, final boolean needWriteDitaTag) throws IOException {
         assert outputFileName.isAbsolute();
         logger.info("Writing " + outputFileName);
-        try (OutputStreamWriter ditaFileOutput = new OutputStreamWriter(new FileOutputStream(new File(outputFileName)), StandardCharsets.UTF_8)) {
+        try (OutputStream out = job.getStore().getOutputStream(outputFileName);
+             OutputStreamWriter ditaFileOutput = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
             if (outputFileName.equals(changeTable.get(outputFileName))) {
                 // if the output file is newly generated file
                 // write the xml header and workdir PI into new file

--- a/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
@@ -78,7 +78,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
 
     @Override
     public void write(final File filename) throws DITAOTException {
-        if (filename == null || !filename.exists()) {
+        if (filename == null || !job.getStore().exists(filename.toURI())) {
             return;
         }
         curMatchTopic = indexEntries.containsKey(SHARP) ? SHARP : null;
@@ -162,7 +162,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
             final NodeList children = root.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 final Node links = rewriteLinks((Element) children.item(i));
-                xmlUtils.writeDocument(links, handler);
+                job.getStore().writeDocument(links, handler);
             }
         } catch (IOException e) {
             throw new SAXException("Failed to serialize DOM node to SAX: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -104,7 +104,7 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
             getContentHandler().processingInstruction(PI_WORKDIR_TARGET, UNIX_SEPARATOR + outputFile.getParentFile().getAbsolutePath());
         }
         getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
-        getContentHandler().processingInstruction(PI_WORKDIR_TARGET_URI, outputFile.getParentFile().toURI().toASCIIString());
+        getContentHandler().processingInstruction(PI_WORKDIR_TARGET_URI, outputFile.toURI().resolve(".").toString());
         getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
         if (path2Project != null) {
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET, path2Project.getPath() + File.separator);

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -84,7 +84,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     @Override
     public void write(final File filename) throws DITAOTException {
         // ignore in-exists file
-        if (filename == null || !filename.exists()) {
+        if (filename == null || !job.getStore().exists(filename.toURI())) {
             return;
         }
         svgMetadataReader.setLogger(logger);

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -193,6 +193,12 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         mergeUtils.setLogger(logger);
     }
 
+    @Override
+    public void setJob(final Job job) {
+        super.setJob(job);
+        mergeUtils.setJob(job);
+    }
+
     public void setKeyDefinition(final KeyScope definitionMap) {
         this.definitionMaps.push(definitionMap);
     }

--- a/src/main/java/org/dita/dost/writer/include/IncludeXml.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeXml.java
@@ -31,15 +31,12 @@ final class IncludeXml {
     private final URI currentFile;
     private final ContentHandler contentHandler;
     private final DITAOTLogger logger;
-    private final XMLUtils xmlUtils;
 
     IncludeXml(Job job, URI currentFile, ContentHandler contentHandler, DITAOTLogger logger) {
         this.job = job;
         this.currentFile = currentFile;
         this.contentHandler = contentHandler;
         this.logger = logger;
-        this.xmlUtils = new XMLUtils();
-        xmlUtils.setLogger(logger);
     }
 
     boolean include(final Attributes atts) {
@@ -56,7 +53,7 @@ final class IncludeXml {
                 src = doc;
             }
 
-            xmlUtils.writeDocument(src, new IncludeFilter(contentHandler));
+            job.getStore().writeDocument(src, new IncludeFilter(contentHandler));
         } catch (IOException e) {
             logger.error("Failed to process include {}", fileInfo.src, e);
             return false;

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -50,7 +50,8 @@ See the accompanying LICENSE file for applicable license.
                    log-arg"/>
 
   <target name="init-properties">
-    <init-project/>
+    <property name="store-type" value="file"/>
+    <init-project storeType="${store-type}"/>
     <property name="default.language" value="en"/>
     <property name="generate-debug-attributes" value="true"/>
     <property name="processing-mode" value="lax"/>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -164,6 +164,10 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="result.rewrite-rule.xsl" desc="Specifies the name of the XSLT file used to rewrite filenames." type="string"/>
     <param name="result.rewrite-rule.class" desc="Specifies the name of the Java class used to rewrite filenames." type="string"/>
+    <param name="store-type" deprecated="Temporary file store type" type="enum">
+      <val default="true">file</val>
+      <val>memory</val>
+    </param>
   </transtype>
   <feature extension="dita.image.extensions" value=".gif"/>
   <feature extension="dita.image.extensions" value=".eps"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -194,7 +194,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
           <xsl:otherwise>
             
             <xsl:variable name="targetDoc" as="document-node()?"
-              select="document($resourcePart, if(exists($baseContextElement)) then $baseContextElement else $linkElement)"/>
+              select="document($resourcePart, root(if(exists($baseContextElement)) then $baseContextElement else $linkElement))"/>
             <xsl:choose>
               <xsl:when test="empty($targetDoc)">
                 <!-- Report the failure to resolve the URI -->
@@ -310,10 +310,18 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
        Templates
        ======================== -->
   
+  <xsl:template match="/">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()">
+        <xsl:with-param name="baseContextElement" select="*" tunnel="yes"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+
   <!-- Process a link in the related-links section. Retrieve link text, type, and
        description if possible (and not already specified locally). -->
   <xsl:template match="*[contains(@class, ' topic/link ')]">    
-    <xsl:param name="baseContextElement" as="element()*" tunnel="yes"/>
+    <xsl:param name="baseContextElement" as="element()?" tunnel="yes"/>
     <xsl:if test="@href=''">
       <xsl:apply-templates select="." mode="ditamsg:empty-href"/>
     </xsl:if>
@@ -570,7 +578,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
        If specified locally, use the local value, otherwise retrieve from target. -->
   <xsl:template match="*" mode="topicpull:get-stuff">
     <xsl:param name="localtype" as="xs:string?"/>
-    <xsl:param name="baseContextElement" as="element()*" tunnel="yes"/>
+    <xsl:param name="baseContextElement" as="element()?" tunnel="yes"/>
     <xsl:param name="targetElement" as="element()?"
       select="dita-ot:getTargetElement(., $baseContextElement)"/>
     
@@ -697,12 +705,12 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       <xsl:when test="empty($targetElement)"/>
       <!--otherwise try pulling shortdesc from target-->
       <xsl:otherwise>
-        <xsl:variable name="shortdesc">
+        <xsl:variable name="shortdesc" as="node()*">
           <xsl:apply-templates select="." mode="topicpull:getshortdesc">
             <xsl:with-param name="targetElement" as="element()" select="$targetElement"/>
           </xsl:apply-templates>
         </xsl:variable>
-        <xsl:if test="exists($shortdesc) and not(normalize-space($shortdesc) = '')">
+        <xsl:if test="exists($shortdesc) and not(normalize-space(string-join($shortdesc)) = '')">
           <xsl:apply-templates select="." mode="topicpull:add-genshortdesc-PI"/>
           <desc class="- topic/desc ">
             <xsl:apply-templates select="$shortdesc">

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
         <headfilter lines="1"/>
       </filterchain>
     </loadfile>
-    <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}" unless:set="noMap"/>
+    <makeurl property="html5.map.url" file="${dita.temp.dir}/${html5.map}" validate="no" unless:set="noMap"/>
     <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no" if:set="dita.input.valfile"/>
   </target>
 

--- a/src/main/plugins/org.dita.htmlhelp/src/test/java/org/dita/dost/module/IndexTermExtractModuleTest.java
+++ b/src/main/plugins/org.dita.htmlhelp/src/test/java/org/dita/dost/module/IndexTermExtractModuleTest.java
@@ -11,8 +11,10 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo.Builder;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.CHMIndexWriter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +50,7 @@ public class IndexTermExtractModuleTest {
     @Test
     public void testWrite() throws DITAOTException, SAXException, IOException {
 
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", "");
         job.setInputDir(srcDir.toURI());
         job.add(new Builder()

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -295,7 +295,7 @@ with those set forth herein.
     <copy file="${inputFile}" tofile="${dita.temp.dir}/stage1.xml" unless:set="_stage1.exists"/>
 
     <!--makeurl seems to output file:/C: style instead of file:///C:, but xep, fop, and ah all accept it.-->
-    <makeurl property="artworkPrefixUrl" file="${artworkPrefix}"/>
+    <makeurl property="artworkPrefixUrl" file="${artworkPrefix}" validate="no"/>
     <makeurl property="dita.map.output.dir.url" file="${pdf2.temp.dir}" validate="no"/>
     <makeurl property="work.dir.url" file="${dita.temp.dir}" validate="no"/>
     <makeurl property="customization.dir.url" file="${customization.dir}" validate="no"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -78,11 +78,13 @@ See the accompanying LICENSE file for applicable license.
 
 
     <xsl:template match="dita-merge">
-        <xsl:variable name="map" select="(*[contains(@class,' map/map ')])[1]"/>
-        <xsl:element name="{name($map)}">
-          <xsl:copy-of select="$map/@*"/>
-          <xsl:apply-templates select="$map" mode="build-tree"/>
-        </xsl:element>
+      <xsl:variable name="map" select="(*[contains(@class,' map/map ')])[1]" as="element()?"/>
+      <xsl:for-each select="$map">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="." mode="build-tree"/>
+        </xsl:copy>
+      </xsl:for-each>
     </xsl:template>
     
     <xsl:template match="*[contains(@class,' map/topicref ')][@first_topic_id]" mode="resolve-root-dita">

--- a/src/main/resources/META-INF/services/org.dita.dost.store.StoreBuilder
+++ b/src/main/resources/META-INF/services/org.dita.dost.store.StoreBuilder
@@ -1,0 +1,1 @@
+org.dita.dost.store.StreamStoreBuilder

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -12,7 +12,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import nu.validator.htmlparser.dom.HtmlDocumentBuilder;
 import org.apache.tools.ant.*;
+import org.dita.dost.store.Store;
 import org.dita.dost.util.FileUtils;
+import org.dita.dost.util.Job;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.w3c.dom.*;
@@ -21,6 +23,9 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.*;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -428,6 +433,8 @@ public abstract class AbstractIntegrationTest {
                 ts.addAll(Arrays.asList(transtype.targets));
             }
             project.executeTargets(ts);
+
+            final Store store = project.getReference(ANT_REFERENCE_STORE);
 
             return listener.messages;
         } finally {

--- a/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
+++ b/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
@@ -12,7 +12,9 @@ import com.google.common.io.Files;
 import org.apache.tools.ant.types.Resource;
 import org.dita.dost.TestUtils;
 import org.dita.dost.ant.types.JobSourceSet.SelectorElem;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -37,7 +39,7 @@ public class JobSourceSetTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         tempDir = TestUtils.createTempDir(JobSourceSetTest.class);
-        job = new Job(tempDir);
+        job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         for (String ext : Arrays.asList("dita", "ditamap", "jpg", "html")) {
             final String file = "a." + ext;
             Files.touch(new File(tempDir, file));

--- a/src/test/java/org/dita/dost/module/AbstractModuleTest.java
+++ b/src/test/java/org/dita/dost/module/AbstractModuleTest.java
@@ -13,7 +13,9 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.w3c.dom.Document;
@@ -104,7 +106,7 @@ public abstract class AbstractModuleTest {
         final File expDir = new File(expBaseDir, testName);
         try {
             final AbstractPipelineModule chunkModule = getModule(tempDir);
-            final Job job = new Job(tempDir);
+            final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
             chunkModule.setJob(job);
             final CachingLogger logger = new CachingLogger(true);
             chunkModule.setLogger(logger);

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -9,6 +9,7 @@ package org.dita.dost.module;
 
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.After;
@@ -42,7 +43,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
     }
 
     private Job getJob() throws IOException {
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(tempDir.toURI());
         job.add(new Job.FileInfo.Builder()
                 .src(new File(tempDir, "input.ditamap").toURI())
@@ -76,7 +77,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
     }
     
     private Job getUplevelsJob(File uplevelsTempDir) throws IOException {
-        final Job job = new Job(uplevelsTempDir);
+        final Job job = new Job(uplevelsTempDir, new StreamStore(uplevelsTempDir, new XMLUtils()));
         job.setInputDir(uplevelsTempDir.toURI());
         job.add(new Job.FileInfo.Builder()
                 .src(new File(uplevelsTempDir, "main/testuplevels.ditamap").toURI())
@@ -270,7 +271,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
     @Test
     public void testDuplicateTopic() throws IOException, SAXException {
         final BranchFilterModule m = new BranchFilterModule();
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(tempDir.toURI());
         job.addAll(getDuplicateTopicFileInfos());
         m.setJob(job);

--- a/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
@@ -11,7 +11,9 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FilenameUtils;
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.ChunkMapReader;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1136,7 +1138,7 @@ public class ChunkMapReaderTest {
             final ChunkMapReader mapReader = new ChunkMapReader();
             final TestUtils.CachingLogger logger = new TestUtils.CachingLogger(true);
             mapReader.setLogger(logger);
-            final Job job = new Job(tempDir);
+            final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
             mapReader.setJob(job);
             mapReader.supportToNavigation(false);
 

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -8,8 +8,10 @@
 
 package org.dita.dost.module;
 
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo.Builder;
+import org.dita.dost.util.XMLUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -33,7 +35,8 @@ public class CleanPreprocessModuleTest {
 
     @Test
     public void getBaseDir() throws Exception {
-        final Job job = new Job(new File("").getAbsoluteFile());
+        final File tempDir = new File("").getAbsoluteFile();
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(URI.create("file:/foo/bar/"));
         job.add(new Builder()
                 .uri(create("map.ditamap"))
@@ -61,7 +64,8 @@ public class CleanPreprocessModuleTest {
 
     @Test
     public void getBaseDirExternal() throws Exception {
-        final Job job = new Job(new File("").getAbsoluteFile());
+        final File tempDir = new File("").getAbsoluteFile();
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(URI.create("file:/foo/bar/"));
         job.add(new Builder()
                 .uri(create("map.ditamap"))
@@ -78,7 +82,8 @@ public class CleanPreprocessModuleTest {
 
     @Test
     public void getBaseDirSubdir() throws Exception {
-        final Job job = new Job(new File("").getAbsoluteFile());
+        final File tempDir = new File("").getAbsoluteFile();
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(URI.create("file:/foo/bar/maps/"));
         job.add(new Builder()
                 .uri(create("maps/map.ditamap"))
@@ -95,7 +100,8 @@ public class CleanPreprocessModuleTest {
 
     @Test
     public void getBaseDirSupdir() throws Exception {
-        final Job job = new Job(new File("").getAbsoluteFile());
+        final File tempDir = new File("").getAbsoluteFile();
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(URI.create("file:/foo/bar/maps/"));
         job.add(new Builder()
                 .uri(create("maps/map.ditamap"))

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +61,7 @@ public class DebugAndFilterModuleTest {
         final File outDir = new File(tempDir, "out");
         tmpDir = new File(tempDir, "temp");
         TestUtils.copy(new File(resourceDir, "temp"), tmpDir);
-        final Job job = new Job(tmpDir);
+        final Job job = new Job(tmpDir, new StreamStore(tmpDir, new XMLUtils()));
         for (final Job.FileInfo fi: job.getFileInfo()) {
             job.add(new Job.FileInfo.Builder(fi).src(inputDir.toURI().resolve(fi.uri)).build());
         }

--- a/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
@@ -11,8 +11,10 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo.Builder;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.ImageMetadataFilterTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +50,7 @@ public class ImageMetadataModuleTest {
         final File f = new File(tempDir, "test.dita");
         copyFile(new File(srcDir, "test.dita"), f);
 
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", "");
         job.setInputDir(srcDir.toURI());
         job.addAll(asList("img.xxx", "img.png", "img.gif", "img.jpg").stream()

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -33,11 +33,13 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.TestLogger;
 import org.dita.dost.module.KeyrefModule.ResolveTask;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.Job.FileInfo.Builder;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,9 +68,10 @@ public class KeyrefModuleTest {
         tempDir = createTempDir(KeyrefModuleTest.class);
 
         module = new KeyrefModule();
-        job = new Job(tempDir);
+        job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(new File(baseDir, "src").toURI());
-        job.add(new FileInfo.Builder()
+        job.setInputMap(URI.create("test.ditamap"));
+        job.add(new Job.FileInfo.Builder()
                 .uri(URI.create("submap.ditamap"))
                 .src(new File(baseDir, "src" + File.separator + "submap.ditamap").toURI())
                 .result(new File(baseDir, "src" + File.separator + "submap.ditamap").toURI())

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -10,6 +10,7 @@ package org.dita.dost.module;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.After;
@@ -61,7 +62,7 @@ public class TestGenMapAndTopicListModule {
 
         final GenMapAndTopicListModule module = new GenMapAndTopicListModule();
         module.setLogger(new TestUtils.TestLogger());
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         module.setJob(job);
         module.setXmlUtils(new XMLUtils());
         module.execute(pipelineInput);
@@ -145,7 +146,7 @@ public class TestGenMapAndTopicListModule {
                     "maps/root-map-01.ditamap")),
                 readLines(new File(e, "usr.input.file.list")));
         
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         assertEquals(".." + File.separator, job.getProperty("uplevels"));
 
         assertEquals(5, job.getFileInfo().size());
@@ -246,7 +247,7 @@ public class TestGenMapAndTopicListModule {
                     "root-map-02.ditamap")),
                 readLines(new File(e, "usr.input.file.list")));
                 
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         assertEquals("", job.getProperty("uplevels"));
 
         assertEquals(5, job.getFileInfo().size());

--- a/src/test/java/org/dita/dost/module/TestTopicMergeModule.java
+++ b/src/test/java/org/dita/dost/module/TestTopicMergeModule.java
@@ -22,7 +22,9 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.module.TopicMergeModule;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class TestTopicMergeModule {
         srcDir.mkdirs();
         TestUtils.copy(new File(resourceDir, "temp"), temporaryDir);
 
-        job = new Job(temporaryDir);
+        job = new Job(temporaryDir, new StreamStore(temporaryDir, new XMLUtils()));
         job.setInputMap(URI.create("test.ditamap"));
         job.add(new Job.FileInfo.Builder()
                 .src(new File(srcDir, "test.ditamap").toURI())

--- a/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
@@ -10,6 +10,7 @@ package org.dita.dost.module.filter;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.module.BranchFilterModule.Branch;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -48,7 +49,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
     }
 
     private Job getJob() throws IOException {
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(tempDir.toURI());
         job.add(new FileInfo.Builder()
                 .src(new File(tempDir, "input.ditamap").toURI())
@@ -192,7 +193,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
     @Test
     public void testDuplicateTopic() throws IOException, SAXException {
         final MapBranchFilterModule m = new MapBranchFilterModule();
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(tempDir.toURI());
         job.addAll(getDuplicateTopicFileInfos());
         m.setJob(job);

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -11,7 +11,9 @@ package org.dita.dost.module.reader;
 import org.dita.dost.TestUtils;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.reader.GenListModuleReader;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,7 +37,7 @@ public class TopicReaderModuleTest {
     public void setUp() throws SAXException, IOException {
         reader = new TopicReaderModule();
         reader.setLogger(new TestUtils.TestLogger());
-        final Job job = new Job(tempDir.getRoot());
+        final Job job = new Job(tempDir.getRoot(), new StreamStore(tempDir.getRoot(), new XMLUtils()));
         job.setInputFile(URI.create("file:///foo/bar/baz.ditamap"));
         job.setInputMap(URI.create("baz.ditamap"));
         job.setInputDir(URI.create("file:///foo/bar/"));

--- a/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
@@ -10,7 +10,9 @@ package org.dita.dost.reader;
 import com.google.common.collect.ImmutableMap;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +49,7 @@ public class ChunkMapReaderTest {
 
     @Test
     public void testRead() throws Exception {
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(srcDir.toURI());
         job.setInputMap(URI.create("maps/gen.ditamap"));
 
@@ -150,7 +152,7 @@ public class ChunkMapReaderTest {
     }
 
     private Job createJob(final String map, final String... topics) throws IOException {
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setInputDir(srcDir.toURI());
         job.setInputMap(URI.create(map));
 

--- a/src/test/java/org/dita/dost/reader/CopyToReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/CopyToReaderTest.java
@@ -12,6 +12,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.log.MessageUtils;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
@@ -43,7 +44,7 @@ public class CopyToReaderTest {
         logger = new CachingLogger();
 
         reader = new CopyToReader();
-        reader.setJob(new Job(srcDir));
+        reader.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
         reader.setLogger(logger);
         reader.setContentHandler(new DefaultHandler());
 

--- a/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
+++ b/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class KeydefFilterTest {
         reader.setLogger(new TestUtils.TestLogger());
         reader.setCurrentFile(rootFile.toURI());
         reader.setCurrentDir(inputDir.toURI());
-        reader.setJob(new Job(tempDir));
+        reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         
         reader.setContentHandler(new DefaultHandler());
         

--- a/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
@@ -9,6 +9,7 @@ package org.dita.dost.reader;
 
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
@@ -43,7 +44,7 @@ public class MapMetaReaderTest {
 
         reader = new MapMetaReader();
         reader.setLogger(new TestUtils.TestLogger());
-        reader.setJob(new Job(tempDir));
+        reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
 
         final File mapFile = new File(tempDir, "test.ditamap");
         reader.read(mapFile.getAbsoluteFile());

--- a/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
@@ -15,6 +15,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.xml.sax.SAXException;
 import org.xml.sax.InputSource;
@@ -36,7 +38,7 @@ public class MergeMapParserTest {
     public void testReadStringString() throws SAXException, IOException {
         final MergeMapParser parser = new MergeMapParser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(srcDir));
+        parser.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write("<wrapper>".getBytes(UTF8));
         parser.setOutputStream(output);
@@ -50,7 +52,7 @@ public class MergeMapParserTest {
     public void testReadSpace() throws SAXException, IOException {
         final MergeMapParser parser = new MergeMapParser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(srcDir));
+        parser.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write("<wrapper>".getBytes(UTF8));
         parser.setOutputStream(output);
@@ -64,7 +66,7 @@ public class MergeMapParserTest {
     public void testComposite() throws SAXException, IOException {
         final MergeMapParser parser = new MergeMapParser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(srcDir));
+        parser.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write("<wrapper>".getBytes(UTF8));
         parser.setOutputStream(output);
@@ -79,7 +81,7 @@ public class MergeMapParserTest {
     public void testSubtopic() throws SAXException, IOException {
         final MergeMapParser parser = new MergeMapParser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(srcDir));
+        parser.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write("<wrapper>".getBytes(UTF8));
         parser.setOutputStream(output);

--- a/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
+++ b/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
@@ -9,7 +9,9 @@ package org.dita.dost.reader;
 
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +52,7 @@ public class TestConrefPushReader {
     public void testRead() throws IOException {
         final File filename = new File(srcDir, "conrefpush_stub.xml");
         final ConrefPushReader pushReader = new ConrefPushReader();
-        pushReader.setJob(new Job(tempDir));
+        pushReader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         pushReader.read(filename.getAbsoluteFile());
 
         final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = pushReader.getPushMap();

--- a/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
+++ b/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.FileUtils;
 import org.dita.dost.TestUtils;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.reader.GenListModuleReader.Reference;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
@@ -60,7 +61,7 @@ public class TestGenListModuleReader {
     public void setUp() throws IOException {
         reader = new GenListModuleReader();
         reader.setLogger(new TestUtils.TestLogger());
-        reader.setJob(new Job(tempDir));
+        reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         reader.setContentHandler(new DefaultHandler());
         final URI currentFile = new File(inputDir, "root-map-01.ditamap").toURI();
         reader.setCurrentFile(currentFile);

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -11,6 +11,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
@@ -49,7 +50,7 @@ public class TestKeyrefReader {
 //        set.add("nested");
         final KeyrefReader keyrefreader = new KeyrefReader();
         keyrefreader.setLogger(new TestUtils.TestLogger());
-        keyrefreader.setJob(new Job(srcDir));
+        keyrefreader.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
 //        keyrefreader.setKeys(set);
         keyrefreader.read(filename.toURI(), readMap(filename));
         final KeyScope act = keyrefreader.getKeyDefinition();

--- a/src/test/java/org/dita/dost/store/StoreTest.java
+++ b/src/test/java/org/dita/dost/store/StoreTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2019 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.store;
+
+import static org.junit.Assert.*;
+import static org.dita.dost.util.URLUtils.*;
+
+import java.io.File;
+import java.net.URI;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+
+import org.dita.dost.TestUtils;
+import org.dita.dost.util.XMLUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StoreTest {
+
+    private final File resourceDir = TestUtils.getResourceDir(StoreTest.class);
+    private final File srcDir = new File(resourceDir, "src").getAbsoluteFile();
+    private final URI srcDirUri = srcDir.toURI();
+    
+    private Store store;
+    
+    @Before
+    public void setup() {
+        store = new StreamStore(srcDir, new XMLUtils());
+    }
+    
+    @Test
+    public void testGetPath() {
+        // fail("Not yet implemented");
+    }
+
+//    @Test
+//    public void testGetFile() {
+//        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File("root.xml")));
+//        assertEquals(new File(srcDir, "folder" + File.separator + "leaf.xml"), store.getFile(new File("folder" + File.separator + "leaf.xml")));
+//        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File(srcDir, "root.xml")));
+//    }
+
+    @Test
+    public void testGetUri() {
+        assertEquals(srcDirUri.resolve("root.xml"), store.getUri(toURI("root.xml")));
+        assertEquals(srcDirUri.resolve("folder/leaf.xml"), store.getUri(toURI("folder/leaf.xml")));
+        assertEquals(srcDirUri.resolve("root.xml"), store.getUri(srcDirUri.resolve("root.xml")));
+
+    }
+
+    @Test
+    public void testResolve() throws TransformerException {
+        final Source s = store.resolve("root.xml", srcDirUri.toString());
+        assertEquals(srcDirUri.resolve("root.xml"), toURI(s.getSystemId()));
+        
+//        assertNull(store.resolve("root.xml", "file:/dummy/"));
+    }
+
+    @Test
+    public void testGetSourceFile() {
+        // fail("Not yet implemented");
+    }
+
+    @Test
+    public void testGetSourceURI() {
+        // fail("Not yet implemented");
+    }
+
+    @Test
+    public void testGetResultFile() {
+        // fail("Not yet implemented");
+    }
+
+    @Test
+    public void testGetResultURI() {
+        // fail("Not yet implemented");
+    }
+
+}

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -32,8 +32,8 @@ public class StreamStoreTest {
     @Before
     public void setUp() throws Exception {
         xmlUtils = new XMLUtils();
-        store = new StreamStore(xmlUtils);
         tmpDir = Files.createTempDir();
+        store = new StreamStore(tmpDir, xmlUtils);
     }
 
     @Test

--- a/src/test/java/org/dita/dost/util/JobTest.java
+++ b/src/test/java/org/dita/dost/util/JobTest.java
@@ -18,6 +18,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.dita.dost.store.StreamStore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public final class JobTest {
     public static void setUp() throws IOException {
         tempDir = TestUtils.createTempDir(JobTest.class);
         TestUtils.copy(srcDir, tempDir);
-        job = new Job(tempDir);
+        job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
     }
 
     @Test

--- a/src/test/java/org/dita/dost/util/TestMergeUtils.java
+++ b/src/test/java/org/dita/dost/util/TestMergeUtils.java
@@ -16,7 +16,9 @@ import static org.junit.Assert.fail;
 import static org.dita.dost.util.URLUtils.*;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.dita.dost.store.StreamStore;
 import org.junit.After;
 
 import org.dita.dost.TestUtils;
@@ -33,8 +35,9 @@ public class TestMergeUtils {
     public static MergeUtils mergeUtils;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws IOException {
         mergeUtils = new MergeUtils();
+        mergeUtils.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
     }
 
     @After
@@ -98,7 +101,6 @@ public class TestMergeUtils {
 
     @Test
     public void testGetFirstTopicId() {
-        final MergeUtils mergeUtils = new MergeUtils();
         //assertEquals("task",mergeUtils.getFirstTopicId("stub.xml", "TEST_STUB"));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), false));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), true));

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -11,9 +11,12 @@ import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.CollationURIResolver;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.trans.SymbolicName;
+import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.module.DelegatingCollationUriResolverTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMImplementation;
@@ -30,6 +33,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Deque;
@@ -40,6 +45,17 @@ import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.junit.Assert.*;
 
 public class XMLUtilsTest {
+
+    private static final File resourceDir = TestUtils.getResourceDir(XMLUtilsTest.class);
+    private static final File srcDir = new File(resourceDir, "src");
+    private static final File expDir = new File(resourceDir, "exp");
+    private static File tempDir;
+
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        tempDir = TestUtils.createTempDir(XMLUtilsTest.class);
+    }
 
     @Test
     public void configureCollationResolvers() {
@@ -268,10 +284,83 @@ public class XMLUtilsTest {
                         new StreamResult(new ByteArrayOutputStream()));
 
         assertEquals(Arrays.asList(
-                    new Message(Message.Level.WARN, "info", null),
-                    new Message(Message.Level.WARN, "<info/>", null)
+                new Message(Message.Level.WARN, "info", null),
+                new Message(Message.Level.WARN, "<info/>", null)
                 ),
                 logger.getMessages());
+    }
+
+//    @Test
+//    public void transform() throws Exception {
+//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+//        final Job job = new Job(tempDir);
+//        final URI src = new File(tempDir, "test.dita").toURI();
+//
+//        // two filters that assume processing order
+//        final URI act = new File(tempDir, "order.dita").toURI();
+//        job.transform(src, act, Arrays.asList(
+//            (XMLFilter) new XMLFilterImpl() {
+//                @Override
+//                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+//                    getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
+//                }
+//                @Override
+//                public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+//                    getContentHandler().endElement(uri, localName + "_x", qName + "_x");
+//                }
+//            },
+//            (XMLFilter) new XMLFilterImpl() {
+//                @Override
+//                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+//                    getContentHandler().startElement(uri, localName + "_y", qName + "_y", atts);
+//                }
+//                @Override
+//                public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+//                    getContentHandler().endElement(uri, localName + "_y", qName + "_y");
+//                }
+//            }));
+//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "order.dita").toURI().toString()),
+//                new InputSource(new File(tempDir, "order.dita").toURI().toString()));
+//    }
+//
+//    @Test
+//    public void transform_single() throws Exception {
+//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+//        final Job job = new Job(tempDir);
+//        final URI src = new File(tempDir, "test.dita").toURI();
+//
+//        // single filter that prefixes each element name
+//        final URI act = new File(tempDir, "single.dita").toURI();
+//        job.transform(src, act, Arrays.asList((XMLFilter) new XMLFilterImpl() {
+//            @Override
+//            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+//                getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
+//            }
+//            @Override
+//            public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+//                getContentHandler().endElement(uri, localName + "_x", qName + "_x");
+//            }
+//        }));
+//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "single.dita").toURI().toString()),
+//                       new InputSource(new File(tempDir, "single.dita").toURI().toString()));
+//    }
+//
+//    @Test
+//    public void transform_empty() throws Exception {
+//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+//        final Job job = new Job(tempDir);
+//        final URI src = new File(tempDir, "test.dita").toURI();
+//
+//        // identity without a filter
+//        final URI act = new File(tempDir, "identity.dita").toURI();
+//        job.transform(src, act, Collections.EMPTY_LIST);
+//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "identity.dita").toURI().toString()),
+//                       new InputSource(new File(tempDir, "identity.dita").toURI().toString()));
+//    }
+
+    @AfterClass
+    public static void tearDown() throws IOException {
+        TestUtils.forceDelete(tempDir);
     }
 
 }

--- a/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
@@ -9,9 +9,11 @@ package org.dita.dost.writer;
 
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +51,8 @@ public class ConkeyrefFilterTest {
 
     @Before
     public void setUp() throws IOException {
-        job = new Job(new File(System.getProperty("java.io.tmpdir")));
+        final File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         srcDir = new File(".").getCanonicalFile().toURI();
     }
 

--- a/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
@@ -11,9 +11,11 @@ import com.google.common.collect.ImmutableMap;
 import org.dita.dost.TestUtils;
 import org.dita.dost.module.reader.DefaultTempFileScheme;
 import org.dita.dost.module.reader.TempFileNameScheme;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.Job.FileInfo.Builder;
+import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -44,7 +46,7 @@ public class ForceUniqueFilterTest {
 
     @Before
     public void setUp() throws Exception {
-        job = new Job(srcDir);
+        job = new Job(srcDir, new StreamStore(srcDir, new XMLUtils()));
         job.setInputDir(srcDir.toURI());
         job.add(new Builder()
                 .src(srcDir.toURI().resolve("test.ditamap"))

--- a/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
@@ -17,6 +17,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.XMLUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,7 +46,7 @@ public class ImageMetadataFilterTest {
         final File f = new File(tempDir, "test.dita");
         copyFile(new File(srcDir, "test.dita"), f);
 
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", "");
         final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job);
         filter.setLogger(new TestUtils.TestLogger());
@@ -65,7 +67,7 @@ public class ImageMetadataFilterTest {
         f.getParentFile().mkdirs();
         copyFile(new File(srcDir, "test.dita"), f);
 
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", ".." + File.separator);
         final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job);
         filter.setLogger(new TestUtils.TestLogger());

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -33,10 +33,8 @@ import javax.xml.transform.sax.TransformerHandler;
 
 import org.apache.commons.io.IOUtils;
 import org.dita.dost.reader.KeyrefReader;
-import org.dita.dost.util.FileUtils;
-import org.dita.dost.util.Job;
-import org.dita.dost.util.KeyDef;
-import org.dita.dost.util.KeyScope;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +72,7 @@ public class KeyrefPaserTest {
     public void testTopicWrite() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File(tempDir, "a.xml").toURI());
         parser.write(new File(tempDir, "a.xml"));
@@ -87,7 +85,7 @@ public class KeyrefPaserTest {
     public void testTopicWriteSubdir() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         final String tempSubDir = tempDir + File.separator + "subdir";
         parser.setCurrentFile(new File(tempSubDir, "subdirtopic.xml").toURI());
@@ -101,7 +99,7 @@ public class KeyrefPaserTest {
     public void testFragment() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File(tempDir, "id.xml").toURI());
         parser.write(new File(tempDir, "id.xml"));
@@ -114,7 +112,7 @@ public class KeyrefPaserTest {
     public void testFallback() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File(tempDir, "fallback.xml").toURI());
         parser.write(new File(tempDir, "fallback.xml"));
@@ -127,7 +125,7 @@ public class KeyrefPaserTest {
     public void testMapWrite() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File(tempDir, "b.ditamap").toURI());
         parser.write(new File(tempDir, "b.ditamap"));
@@ -140,7 +138,7 @@ public class KeyrefPaserTest {
     public void testUpLevelMapWrite() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(readKeyMap(Paths.get("subdir", "c.ditamap")));
         parser.setCurrentFile(new File(tempDir, "subdir"+ File.separator +"c.ditamap").toURI());
         parser.write(new File(tempDir, "subdir"+ File.separator +"c.ditamap"));
@@ -153,7 +151,7 @@ public class KeyrefPaserTest {
     public void testMapWithKeyScopes() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(keyDefinition);
         parser.setCurrentFile(new File(tempDir, "d.ditamap").toURI());
         parser.write(new File(tempDir, "d.ditamap"));

--- a/src/test/java/org/dita/dost/writer/LinkFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/LinkFilterTest.java
@@ -8,7 +8,9 @@
 
 package org.dita.dost.writer;
 
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,7 +50,7 @@ public class LinkFilterTest {
 
     private Job getJob() {
         try {
-            final Job job = new Job(new File(tempDir));
+            final Job job = new Job(new File(tempDir), new StreamStore(new File(tempDir), new XMLUtils()));
             job.add(new Job.FileInfo.Builder()
                     .uri(URI.create("abc.dita"))
                     .src(srcDir.resolve("topics/topic.dita"))

--- a/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
+++ b/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
@@ -10,7 +10,9 @@ package org.dita.dost.writer;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +55,7 @@ public class TestConrefPushParser {
 
         final ConrefPushParser parser = new ConrefPushParser();
         parser.setLogger(new TestUtils.TestLogger());
-        parser.setJob(new Job(tempDir));
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setMoveTable(pushActions);
         parser.read(targetFile);
 

--- a/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
+++ b/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
@@ -10,8 +10,10 @@ package org.dita.dost.writer.include;
 import com.google.common.io.Files;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo.Builder;
+import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.CoderefResolver;
 import org.junit.After;
 import org.junit.Before;
@@ -72,7 +74,7 @@ public class IncludeResolverTest {
 
         filter = new CoderefResolver();
         filter.setLogger(new TestUtils.TestLogger());
-        final Job job = new Job(tempDir);
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.addAll(Stream.of("topic.dita", test)
                 .map(p -> new Builder()
                         .uri(create(p))

--- a/src/test/resources/StoreTest/src/folder/leaf.xml
+++ b/src/test/resources/StoreTest/src/folder/leaf.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic/>

--- a/src/test/resources/StoreTest/src/root.xml
+++ b/src/test/resources/StoreTest/src/root.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic/>

--- a/src/test/resources/XMLUtilsTest/exp/identity.dita
+++ b/src/test/resources/XMLUtilsTest/exp/identity.dita
@@ -1,0 +1,3 @@
+<foo id="foo">
+  <bar>baz</bar>
+</foo>

--- a/src/test/resources/XMLUtilsTest/exp/order.dita
+++ b/src/test/resources/XMLUtilsTest/exp/order.dita
@@ -1,0 +1,3 @@
+<foo_x_y id="foo">
+  <bar_x_y>baz</bar_x_y>
+</foo_x_y>

--- a/src/test/resources/XMLUtilsTest/exp/single.dita
+++ b/src/test/resources/XMLUtilsTest/exp/single.dita
@@ -1,0 +1,3 @@
+<foo_x id="foo">
+  <bar_x>baz</bar_x>
+</foo_x>

--- a/src/test/resources/XMLUtilsTest/src/test.dita
+++ b/src/test/resources/XMLUtilsTest/src/test.dita
@@ -1,0 +1,3 @@
+<foo id="foo">
+  <bar>baz</bar>
+</foo>


### PR DESCRIPTION
## Description
Refactor to use `Store` for all temporary IO processing. Enable contributing `Store` implementations via service loader. Changes are not be visible to end users.

## Motivation and Context
This separates refactoring needed for #3439. Then the in-memory and caching `Store` implementation can be merged without refactoring changes.

## How Has This Been Tested?
All existing tests pass.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Contributing alternative `Store` implementations via `org.dita.dost.store.StoreBuilder` service loader _may_ be documented, but it's very unlikely that plugin contributed `Store` implementations will be used.