### PR TITLE
Use unfiltered source topic as basis for topic fileinfo features

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -821,7 +821,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             final FileInfo fileInfo = fileInfos.get(f);
             return fileInfo;
         } else {
-            final FileInfo prev = job.getFileInfo(f);
+            final FileInfo prev = job.getFileInfo(fi -> Objects.equals(fi.src, f) && Objects.equals(fi.result, f))
+                    .stream()
+                    .findFirst()
+                    .orElseGet(() -> job.getFileInfo(f));
             final FileInfo i;
             if (prev != null) {
                 FileInfo.Builder b = new FileInfo.Builder(prev);


### PR DESCRIPTION
When map contains branch filtered topics with preprocess2, in some cases the filtered topic is used as the base topic when storing topic features into Job state. In this case only the filtered topic gets the topic features info and the actual source topic is left with the defaults.

This PR attempts to fix the issue by by using topic features from the resource that has the same the source URI and result URI and matches the topic being processed.
