### PR TITLE
Add steps wrapper to single step task

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -131,9 +131,13 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="*[contains(@class,' task/step ')] and not(*[contains(@class,' task/step ')][2])">
           <!-- Single step. Process any stepsection before the step (cannot appear after). -->
           <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
-          <xsl:apply-templates select="*[contains(@class,' task/step ')]" mode="onestep">
-            <xsl:with-param name="step_expand" select="$step_expand"/>
-          </xsl:apply-templates>
+          <div>
+            <xsl:call-template name="commonattributes"/>
+            <xsl:call-template name="setid"/>
+            <xsl:apply-templates select="*[contains(@class,' task/step ')]" mode="onestep">
+              <xsl:with-param name="step_expand" select="$step_expand"/>
+            </xsl:apply-templates>            
+          </div>
         </xsl:when>
         <xsl:when test="not(*[contains(@class,' task/stepsection ')])">
           <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">


### PR DESCRIPTION
## Description
Add a wrapper element for `<steps>` element in single `<step>` task output.

## Motivation and Context
Without a wrapper, attributes like `@outputclass` or `@id` are not output to HTML in a single step task. The wrapper is a simple `<div>` element with no extra semantics.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
