### PR TITLE
Feature/bump homebrew formula

### DIFF
--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -3,8 +3,11 @@
 
 # Controls when the action will run. Triggers the workflow when new tags are pushed
 on:
-  push:
-    tags: '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'DITA-OT version'
+        required: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -18,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Set download URL
-        run: echo ::set-output name=url::https://github.com/dita-ot/dita-ot/releases/download/${GITHUB_REF:10}/dita-ot-${GITHUB_REF:10}.zip
+        run: echo ::set-output name=url::https://github.com/dita-ot/dita-ot/releases/download/${{ github.event.inputs.version }}/dita-ot-${{ github.event.inputs.version }}.zip
         id: download-url
       - name: Create pull-request
         uses: mislav/bump-homebrew-formula-action@v1.6

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -28,7 +28,7 @@ jobs:
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: dita-ot
-          homebrew-tap: Homebrew/homebrew-core
+          homebrew-tap: jelovirt/homebrew-core
           base-branch: master
           download-url: ${{ steps.download-url.outputs.url }}
           commit-message: |

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -1,0 +1,34 @@
+# Automatically bump Homebrew formula after each release
+# https://github.com/mislav/bump-homebrew-formula-action
+
+# Controls when the action will run. Triggers the workflow when new tags are pushed
+on:
+  push:
+    tags: '*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  # This workflow contains a single job called "homebrew"
+  homebrew:
+    name: Bump Homebrew formula
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1.6
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          formula-name: dita-ot
+          homebrew-tap: Homebrew/homebrew-core
+          base-branch: master
+          download-url: https://github.com/dita-ot/dita-ot/releases/download/3.4/dita-ot-3.4.zip
+          commit-message: |
+            {{formulaName}} {{version}}
+            
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          # Access token added as secret to repo settings
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -17,13 +17,17 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v1.6
+      - name: Set download URL
+        run: echo ::set-output name=url::https://github.com/dita-ot/dita-ot/releases/download/${GITHUB_REF:10}/dita-ot-${GITHUB_REF:10}.zip
+        id: download-url
+      - name: Create pull-request
+        uses: mislav/bump-homebrew-formula-action@v1.6
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: dita-ot
           homebrew-tap: Homebrew/homebrew-core
           base-branch: master
-          download-url: https://github.com/dita-ot/dita-ot/releases/download/3.4/dita-ot-3.4.zip
+          download-url: ${{ steps.download-url.outputs.url }}
           commit-message: |
             {{formulaName}} {{version}}
             

--- a/.github/workflows/bump-homebrew-formula.yml
+++ b/.github/workflows/bump-homebrew-formula.yml
@@ -24,17 +24,16 @@ jobs:
         run: echo ::set-output name=url::https://github.com/dita-ot/dita-ot/releases/download/${{ github.event.inputs.version }}/dita-ot-${{ github.event.inputs.version }}.zip
         id: download-url
       - name: Create pull-request
-        uses: mislav/bump-homebrew-formula-action@v1.6
+        uses: jelovirt/bump-homebrew-formula-action@2a4990c
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: dita-ot
+          formula-version: ${{ github.event.inputs.version }}
           homebrew-tap: jelovirt/homebrew-core
           base-branch: master
           download-url: ${{ steps.download-url.outputs.url }}
           commit-message: |
             {{formulaName}} {{version}}
-            
-            Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
           # Access token added as secret to repo settings
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds a GitHub Action script to automatically bump the [DITA-OT Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/dita-ot.rb) whenever a new release tag is pushed to the DITA-OT repo.

This PR is a copy of #3477. A new PR had to be opened because the old one could not be reopened.

## Motivation and Context

Currently the Homebrew formula is updated manually after each release.

This configures an existing action from the GitHub Actions Marketplace to update the DITA-OT formula: https://github.com/mislav/bump-homebrew-formula-action.

A new `COMMITTER_TOKEN` secret has been added to the core repo to authenticate the action.

## How Has This Been Tested?

I'm afraid there may be no other way to test this than to merge it and verify whether it works when a new tag is created. 

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

- What documentation changes are needed for this feature? _NONE_
- Will this change affect backwards compatibility or other users' overrides? _NO_
