### PR TITLE
Remove deprecated msgprefix parameter

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
@@ -8,21 +8,10 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <!--
-  Standard error message template for DITA processing in XSL. This
-  file should be included by any XSL program that uses the standard
-  message template. To include this file, you will need the following
-  two commands in your XSL:
-  
-  <xsl:include href="plugin:org.dita.base:xsl/common/output-message.xsl"/>           - Place with other included files
-  
-  <xsl:variable name="msgprefix">DOTX</xsl:variable> - Place with other variables
-  
-  
-  The template takes in the following parameters:
-  - msg    = the message to print in the log; default=***
-  - msgcat = message category, default is read from $msgprefix
-  - msgnum = the message number (3 digits); default=000
-  - msgsev = the severity (I, W, E, or F); default=I (Informational)
+  Standard error message template for DITA processing in XSL. 
+  Call output-message with an ID that corresponds to a declared
+  message in an installed plugin. Additional parameters to
+  the message are optional.
 -->
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -31,21 +20,9 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template name="output-message">
     <xsl:param name="ctx" select="." tunnel="yes"/>
+    <xsl:param name="id" as="xs:string"/>
     <xsl:param name="msg" select="'***'"/>
-    <!-- Deprecated since 2.3 -->
-    <xsl:param name="msgcat" select="$msgprefix"/>
-    <!-- Deprecated since 2.3 -->
-    <xsl:param name="msgnum" select="'000'"/>
-    <!-- Deprecated since 2.3 -->
-    <xsl:param name="msgsev" select="'I'"/>
-    <xsl:param name="msgparams" select="''"/>
-    <xsl:param name="id" as="xs:string">
-      <xsl:call-template name="output-message">
-        <xsl:with-param name="id" select="'DOTX071W'"/>
-        <xsl:with-param name="msgparams">%1=msgnum;%2=output-message;%3=id</xsl:with-param>
-      </xsl:call-template>
-      <xsl:value-of select="concat($msgcat, $msgnum, $msgsev)"/>
-    </xsl:param>
+    <xsl:param name="msgparams" select="''"/>    
     
     <xsl:variable name="msgdoc" select="document('platform:/config/messages.xml')" as="document-node()?"/>
     <xsl:variable name="msgcontent" as="xs:string*">
@@ -61,14 +38,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="msgseverity" as="xs:string*">
-      <xsl:choose>
-        <xsl:when test="$msgsev != 'I'">
-          <xsl:value-of select="$msg"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="$msgdoc/messages/message[@id = $id]/@type"/>    
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:value-of select="$msgdoc/messages/message[@id = $id]/@type"/>    
     </xsl:variable>
     <xsl:variable name="localclass" select="$ctx/@class" as="attribute(class)?"/>
     <xsl:variable name="xtrf" select="$ctx/@xtrf" as="attribute(xtrf)?"/>
@@ -94,7 +64,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:sequence select="$msgcontent"/>
     </xsl:variable>
     <xsl:choose>
-      <xsl:when test="$msgsev = 'F' or $msgseverity='FATAL'">
+      <xsl:when test="$msgseverity='FATAL'">
         <xsl:message terminate="yes">
           <xsl:value-of select="$m" separator=""/>
         </xsl:message>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
@@ -14,9 +14,6 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
-  
   <xsl:template match="node() | @*">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -16,9 +16,6 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
 
-  <!-- Define the error message prefix identifier -->
-  <xsl:variable name="msgprefix" select="'DOTX'"/>
-
   <xsl:param name="EXPORTFILE"/>
   <xsl:param name="TRANSTYPE"/>
   <!-- Deprecated since 2.4 -->
@@ -839,8 +836,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="ditamsg:missing-conrefend-target-error">
     <xsl:param name="conrefend" as="xs:string" tunnel="yes"/>
     <xsl:call-template name="output-message">
-      <xsl:with-param name="msgnum">071</xsl:with-param>
-      <xsl:with-param name="msgsev">E</xsl:with-param>
+      <xsl:with-param name="id" select="'DOTX071E'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$conrefend"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -41,9 +41,6 @@ See the accompanying LICENSE file for applicable license.
       <xsl:with-param name="path" select="$PATHTOMAP"/>
     </xsl:call-template>
   </xsl:variable>  
-
-  <!-- Define the error message prefix identifier -->
-  <xsl:variable name="msgprefix" select="'DOTX'"/>
     
   <xsl:template match="/">
     <xsl:variable name="map" as="document-node()">

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -43,8 +43,6 @@ Other modes can be found within the code, and may or may not prove useful for ov
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
-  <!-- Define the error message prefix identifier -->
-  <xsl:variable name="msgprefix" as="xs:string">DOTX</xsl:variable>
   <!-- If converting to PDF, never try to pull info from targets with print="no" -->
   <xsl:param name="FINALOUTPUTTYPE" select="''" as="xs:string"/>
   <xsl:param name="conserve-memory" select="'false'" as="xs:string"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -16,8 +16,6 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
 
   <xsl:param name="file-being-processed" as="xs:string"/>
   <xsl:param name="child-topicref-warning" as="xs:string" select="'true'"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -56,9 +56,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
-  <!-- Define the error message prefix identifier -->
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
   <!-- Deprecated since 2.4 -->
   <xsl:param name="DBG" select="'no'"/>
 

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -172,10 +172,6 @@ See the accompanying LICENSE file for applicable license.
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    
-  <!-- Define the error message prefix identifier -->
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
   
   <!-- these elements are never processed in a conventional presentation. can be overridden. -->
   <xsl:template match="*[contains(@class, ' topic/no-topic-nesting ')]"/>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
@@ -30,10 +30,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
-
-<!-- Set the prefix for error message numbers -->
-<!-- Deprecated since 2.3 -->
-<xsl:variable name="msgprefix">DOTX</xsl:variable>
+sgprefix">DOTX</xsl:variable>
 
 <xsl:variable name="newline"><xsl:text>
 </xsl:text></xsl:variable>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhpImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhpImpl.xsl
@@ -32,10 +32,6 @@ See the accompanying LICENSE file for applicable license.
 <!-- Include error message template -->
 <xsl:include href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 
-<!-- Set the prefix for error message numbers -->
-<!-- Deprecated since 2.3 -->
-<xsl:variable name="msgprefix">DOTX</xsl:variable>
-
 <!-- *************************** Command line parameters *********************** -->
 <xsl:param name="OUTEXT" select="'.html'"/>
 <xsl:param name="WORKDIR" select="'./'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -43,8 +43,6 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix" select="'PDFX'"/>
   <xsl:variable name="separator" select="'_Connect_42_'"/>
     
   <xsl:variable name="originalMap" as="element()"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -78,9 +78,6 @@ See the accompanying LICENSE file for applicable license.
                     *[contains(@class,' topic/fn ') and empty(@callout)]"
               use="tokenize(@class, ' ')"/>
 
-    <!-- Deprecated since 2.3 -->
-    <xsl:variable name="msgprefix" select="'PDFX'"/>
-
     <xsl:variable name="id.toc" select="'ID_TOC_00-0F-EA-40-0D-4D'"/>
     <xsl:variable name="id.index" select="'ID_INDEX_00-0F-EA-40-0D-4D'"/>
     <xsl:variable name="id.lot" select="'ID_LOT_00-0F-EA-40-0D-4D'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
@@ -51,8 +51,6 @@ See the accompanying LICENSE file for applicable license.
   
 
     <xsl:param name="debug-enabled" select="'false'"/>
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix" select="'PDFX'"/>
 
     <xsl:variable name="font-mappings" select="document('cfg:fo/font-mappings.xml')/font-mappings"/>
   <xsl:variable name="default-font" select="$font-mappings/font-table/aliases/alias[. = 'Normal']/@name"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -46,9 +46,6 @@ See the accompanying LICENSE file for applicable license.
   <xsl:param name="figurelink.style" select="'NUMTITLE'"/>
   <xsl:param name="tablelink.style" select="'NUMTITLE'"/>
 
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
-  
     <xsl:key name="key_anchor" match="*[@id][not(contains(@class,' map/topicref '))]" use="@id"/>
 <!--[not(contains(@class,' map/topicref '))]-->
     <xsl:template name="insertLinkShortDesc">

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
@@ -11,9 +11,6 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="2.0"
                 exclude-result-prefixes="dita-ot ditamsg">
 
-  <!-- Deprecated since 2.3 -->
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
-
   <xsl:param name="OUTEXT" select="'.html'"/>
   <xsl:param name="WORKDIR">
     <xsl:apply-templates select="/processing-instruction('workdir-uri')[1]" mode="get-work-dir"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -235,10 +235,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:variable>
   
-<!-- Define the error message prefix identifier -->
-<!-- Deprecated since 2.3 -->
-<xsl:variable name="msgprefix">DOTX</xsl:variable>
-
 <!-- Filler for A-name anchors  - was &nbsp;-->
 <xsl:variable name="afill"></xsl:variable>
 

--- a/src/test/xsl/common/dita-utilities.xsl
+++ b/src/test/xsl/common/dita-utilities.xsl
@@ -7,6 +7,4 @@
   <xsl:import href="../../../main/plugins/org.dita.base/xsl/common/dita-utilities.xsl"/>
   <xsl:import href="../../../main/plugins/org.dita.base/xsl/common/output-message.xsl"/>
   
-  <xsl:variable name="msgprefix">DOTX</xsl:variable>
-  
 </xsl:stylesheet>


### PR DESCRIPTION
## Description

The `msgprefix` variable used by `output-message` was deprecated in 2.3, along with `magnum`, `msgcat`, and `msgsev` parameters in that template. Until it's removed, every program including or importing `output-message.xsl` has to declare the deprecated variable.

This pull request finally removes the deprecated parameters. It also fixes one lingering message in `conref` processing that still used the old method.

## Motivation and Context

Minor annoyance for many years finally caught up with me when I had to make a new step recently, and someone not familiar with DITA-OT asked why I was declaring that variable but not using it.

## How Has This Been Tested?

Tests initially failed because of the message in `conref` that still used the old parameters; tests all pass after that message was updated to use the proper syntax.

## Type of Changes

I think this counts as a breaking change; even though the old style was deprecated in 2.3, it still worked before this change, as demonstrated by the old call in conref processing.

## Documentation and Compatibility

Requires an item in the migration topic for the next release.