### PR TITLE
 Prefer public IDs when comparing grammar descriptors

### DIFF
--- a/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
@@ -68,7 +68,12 @@ public final class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
             // return -1 for XSD grammar hashcode because we want to disable XSD grammar caching
             return -1;
         } else {
-            return desc.hashCode();
+        	//#3568 Prefer to hash the public ID if available
+        	if(desc.getPublicId() != null) {
+        		return desc.getPublicId().hashCode();
+        	} else {
+        		return desc.hashCode();
+        	}
         }
     }
 
@@ -94,7 +99,12 @@ public final class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
             // always return false for XSD grammar to disable XSD grammar caching
             return false;
         } else {
-            return desc1.equals(desc2);
+        	//#3568 Compare descriptions only by public ID if available.
+        	if(desc1.getPublicId() != null && desc2.getPublicId() != null) {
+        		return desc1.getPublicId().equals(desc2.getPublicId());
+        	} else {
+        		return desc1.equals(desc2);
+        	}
         }
     }
 

--- a/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
@@ -68,12 +68,11 @@ public final class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
             // return -1 for XSD grammar hashcode because we want to disable XSD grammar caching
             return -1;
         } else {
-        	//#3568 Prefer to hash the public ID if available
-        	if(desc.getPublicId() != null) {
-        		return desc.getPublicId().hashCode();
-        	} else {
-        		return desc.hashCode();
-        	}
+            if (desc.getPublicId() != null) {
+                return desc.getPublicId().hashCode();
+            } else {
+                return desc.hashCode();
+            }
         }
     }
 
@@ -99,12 +98,11 @@ public final class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
             // always return false for XSD grammar to disable XSD grammar caching
             return false;
         } else {
-        	//#3568 Compare descriptions only by public ID if available.
-        	if(desc1.getPublicId() != null && desc2.getPublicId() != null) {
-        		return desc1.getPublicId().equals(desc2.getPublicId());
-        	} else {
-        		return desc1.equals(desc2);
-        	}
+            if (desc1.getPublicId() != null && desc2.getPublicId() != null) {
+                return desc1.getPublicId().equals(desc2.getPublicId());
+            } else {
+                return desc1.equals(desc2);
+            }
         }
     }
 

--- a/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
@@ -7,77 +7,75 @@
  */
 package org.dita.dost.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.io.File;
-
 import org.apache.xerces.impl.dtd.DTDGrammar;
 import org.apache.xerces.impl.dtd.XMLDTDDescription;
 import org.apache.xerces.xni.grammars.Grammar;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 
 public class XMLGrammarPoolImplUtilsTest {
 
-	private XMLGrammarPoolImplUtils utils;
+    private XMLGrammarPoolImplUtils utils;
 
-	@Before
-	public void setUp() {
-		utils = new XMLGrammarPoolImplUtils();
-	}
+    @Before
+    public void setUp() {
+        utils = new XMLGrammarPoolImplUtils();
+    }
 
-	@Test
-	public void testCompareDescriptorsByPublicID_same() {
-		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
-		final DTDGrammar exp = new DTDGrammar(null, desc1);
-		utils.putGrammar(exp);
+    @Test
+    public void testCompareDescriptorsByPublicID_same() {
+        final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
+        final DTDGrammar exp = new DTDGrammar(null, desc1);
+        utils.putGrammar(exp);
 
-		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "publicID");
-		final Grammar act = utils.getGrammar(desc2);
+        final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "publicID");
+        final Grammar act = utils.getGrammar(desc2);
 
-		assertEquals(exp, act);
-	}
+        assertEquals(exp, act);
+    }
 
-	@Test
+    @Test
     public void testCompareDescriptorsByPublicID_different() {
-		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
-		final DTDGrammar exp = new DTDGrammar(null, desc1);
-    	utils.putGrammar(exp);
+        final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
+        final DTDGrammar exp = new DTDGrammar(null, desc1);
+        utils.putGrammar(exp);
 
-		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "differentId");
-		final Grammar act = utils.getGrammar(desc2);
+        final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "differentId");
+        final Grammar act = utils.getGrammar(desc2);
 
-		assertNull(act);
+        assertNull(act);
     }
 
-	@Test
-	public void testCompareDescriptorsBySystemID_same() {
-		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
-		final DTDGrammar exp = new DTDGrammar(null, desc1);
-		utils.putGrammar(exp);
+    @Test
+    public void testCompareDescriptorsBySystemID_same() {
+        final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
+        final DTDGrammar exp = new DTDGrammar(null, desc1);
+        utils.putGrammar(exp);
 
-		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/foo/abc.dtd", null);
-		final Grammar act = utils.getGrammar(desc2);
+        final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/foo/abc.dtd", null);
+        final Grammar act = utils.getGrammar(desc2);
 
-		assertEquals(exp, act);
-	}
+        assertEquals(exp, act);
+    }
 
-	@Test
+    @Test
     public void testCompareDescriptorsBySystemID_different() {
-		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
-		final DTDGrammar exp = new DTDGrammar(null, desc1);
-    	utils.putGrammar(exp);
+        final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
+        final DTDGrammar exp = new DTDGrammar(null, desc1);
+        utils.putGrammar(exp);
 
-		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", null);
-		final Grammar act = utils.getGrammar(desc2);
+        final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", null);
+        final Grammar act = utils.getGrammar(desc2);
 
-    	assertNull(act);
+        assertNull(act);
     }
 
-	private XMLDTDDescription getXmldtdDescription(String base, String systemId, String publicId) {
-		return new XMLDTDDescription(publicId, "topic.dtd", base, systemId, "topic");
-	}
+    private XMLDTDDescription getXmldtdDescription(String base, String systemId, String publicId) {
+        return new XMLDTDDescription(publicId, "topic.dtd", base, systemId, "topic");
+    }
 
 }

--- a/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2011 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.apache.xerces.impl.dtd.DTDGrammar;
+import org.apache.xerces.impl.dtd.XMLDTDDescription;
+import org.apache.xerces.xni.grammars.Grammar;
+import org.junit.Test;
+
+
+public class XMLGrammarPoolImplUtilsTest {
+
+    @Test
+    public void testCompareDescriptorsByPublicID() {
+    	//#3568 We have two DITA topics located in different folders. The DOCTYPES are something like:
+    	//<!DOCTYPE "publicID" "topic.dita">
+    	//The DTD description for each of them has a different expanded system ID because the relative system ID
+    	//is made absolute to the XML file location
+    	//But the grammar will still be found because we consider the public ID to have more importance when comparing the descriptions.
+    	File base = new File("abc.xml");
+    	File expanded = new File("abc.dtd");
+    	XMLDTDDescription desc1 = new XMLDTDDescription("publicID", "topic.dtd", base.toURI().toASCIIString(), expanded.toURI().toASCIIString(), "topic");
+    	DTDGrammar grammar = new DTDGrammar(null, desc1);
+    	XMLGrammarPoolImplUtils utils = new XMLGrammarPoolImplUtils();
+    	utils.putGrammar(grammar);
+    	
+    	File base2 = new File("../abc.xml");
+    	File expanded2 = new File("../abc.dtd");
+    	XMLDTDDescription desc2 = new XMLDTDDescription("publicID", "topic.dtd", base2.toURI().toASCIIString(), expanded2.toURI().toASCIIString(), "topic");
+    	Grammar retrieved = utils.getGrammar(desc2);
+    	assertEquals("Should have retrieved the grammar, even though the expanded system ID differs", grammar, retrieved); 
+    }
+}

--- a/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
@@ -1,42 +1,83 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2011 Jarno Elovirta
+ * Copyright 2020 Radu Coravu
  *
  * See the accompanying LICENSE file for applicable license.
  */
 package org.dita.dost.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 
 import org.apache.xerces.impl.dtd.DTDGrammar;
 import org.apache.xerces.impl.dtd.XMLDTDDescription;
 import org.apache.xerces.xni.grammars.Grammar;
+import org.junit.Before;
 import org.junit.Test;
 
 
 public class XMLGrammarPoolImplUtilsTest {
 
-    @Test
-    public void testCompareDescriptorsByPublicID() {
-    	//#3568 We have two DITA topics located in different folders. The DOCTYPES are something like:
-    	//<!DOCTYPE "publicID" "topic.dita">
-    	//The DTD description for each of them has a different expanded system ID because the relative system ID
-    	//is made absolute to the XML file location
-    	//But the grammar will still be found because we consider the public ID to have more importance when comparing the descriptions.
-    	File base = new File("abc.xml");
-    	File expanded = new File("abc.dtd");
-    	XMLDTDDescription desc1 = new XMLDTDDescription("publicID", "topic.dtd", base.toURI().toASCIIString(), expanded.toURI().toASCIIString(), "topic");
-    	DTDGrammar grammar = new DTDGrammar(null, desc1);
-    	XMLGrammarPoolImplUtils utils = new XMLGrammarPoolImplUtils();
-    	utils.putGrammar(grammar);
-    	
-    	File base2 = new File("../abc.xml");
-    	File expanded2 = new File("../abc.dtd");
-    	XMLDTDDescription desc2 = new XMLDTDDescription("publicID", "topic.dtd", base2.toURI().toASCIIString(), expanded2.toURI().toASCIIString(), "topic");
-    	Grammar retrieved = utils.getGrammar(desc2);
-    	assertEquals("Should have retrieved the grammar, even though the expanded system ID differs", grammar, retrieved); 
+	private XMLGrammarPoolImplUtils utils;
+
+	@Before
+	public void setUp() {
+		utils = new XMLGrammarPoolImplUtils();
+	}
+
+	@Test
+	public void testCompareDescriptorsByPublicID_same() {
+		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
+		final DTDGrammar exp = new DTDGrammar(null, desc1);
+		utils.putGrammar(exp);
+
+		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "publicID");
+		final Grammar act = utils.getGrammar(desc2);
+
+		assertEquals(exp, act);
+	}
+
+	@Test
+    public void testCompareDescriptorsByPublicID_different() {
+		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", "publicID");
+		final DTDGrammar exp = new DTDGrammar(null, desc1);
+    	utils.putGrammar(exp);
+
+		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", "differentId");
+		final Grammar act = utils.getGrammar(desc2);
+
+		assertNull(act);
     }
+
+	@Test
+	public void testCompareDescriptorsBySystemID_same() {
+		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
+		final DTDGrammar exp = new DTDGrammar(null, desc1);
+		utils.putGrammar(exp);
+
+		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/foo/abc.dtd", null);
+		final Grammar act = utils.getGrammar(desc2);
+
+		assertEquals(exp, act);
+	}
+
+	@Test
+    public void testCompareDescriptorsBySystemID_different() {
+		final XMLDTDDescription desc1 = getXmldtdDescription("file:/foo/abc.xml", "file:/foo/abc.dtd", null);
+		final DTDGrammar exp = new DTDGrammar(null, desc1);
+    	utils.putGrammar(exp);
+
+		final XMLDTDDescription desc2 = getXmldtdDescription("file:/abc.xml", "file:/abc.dtd", null);
+		final Grammar act = utils.getGrammar(desc2);
+
+    	assertNull(act);
+    }
+
+	private XMLDTDDescription getXmldtdDescription(String base, String systemId, String publicId) {
+		return new XMLDTDDescription(publicId, "topic.dtd", base, systemId, "topic");
+	}
+
 }


### PR DESCRIPTION
Fix for #3568  Prefer public IDs when comparing descriptions for grammars stored in grammar cache.
If we have DTD-based DITA topics located in different folders using public IDs to refer to the DTDs the parser should be able to re-use the DTD grammars between them. 

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, add a link to the issue number: Fixes #1234. -->

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that changes existing functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  _(Provide links to existing documentation topics that will require updates)_
- Will this change affect backwards compatibility or other users' overrides?

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
