### PR TITLE
Use BufferedWriter to output Job for 200 fold performance improvement

### DIFF
--- a/src/test/java/org/dita/dost/util/JobTest.java
+++ b/src/test/java/org/dita/dost/util/JobTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.dita.dost.store.StreamStore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.dita.dost.TestUtils;
@@ -70,6 +71,25 @@ public final class JobTest {
     @Test
     public void testGetValue() throws URISyntaxException {
         assertEquals(new URI("file:/foo/bar"), job.getInputDir());
+    }
+
+    @Test
+    @Ignore
+    public void write_performance_large() throws IOException {
+        for (int i = 0; i < 60_000; i++) {
+            job.add(Job.FileInfo.builder()
+                    .src(new File(tempDir, "topic_" + i + ".dita").toURI())
+                    .uri(new File("topic_" + i + ".dita").toURI())
+                    .result(new File(tempDir, "topic_" + i + ".html").toURI())
+                    .format("dita")
+                    .hasKeyref(true)
+                    .hasLink(true)
+                    .build());
+        }
+        final long start = System.currentTimeMillis();
+        job.write();
+        final long end = System.currentTimeMillis();
+        System.out.println(((end - start)) + " ms");
     }
 
     @AfterClass


### PR DESCRIPTION

## Description
Use a `BufferedWriter` instead of direct `FileOutputStream` to serialize`Job` objects. On ~23 MB `.job.xml` file, the serialization time is 200 times shorter. The poor performance seems to be caused by slow UTF-8 encoding used by `XMLOutput` implementation.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No documentation changes needed.
