### PR TITLE
Fix build init order to initialise project after temp dir

### DIFF
--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -51,7 +51,6 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="init-properties">
     <property name="store-type" value="file"/>
-    <init-project storeType="${store-type}"/>
     <property name="default.language" value="en"/>
     <property name="generate-debug-attributes" value="true"/>
     <property name="processing-mode" value="lax"/>
@@ -69,6 +68,7 @@ See the accompanying LICENSE file for applicable license.
     <condition property="dita.output.dir" value="${dita.temp.dir}${file.separator}${temp.output.dir.name}" else="${output.dir}">
       <isset property="temp.output.dir.name"/>
     </condition>
+    <init-project storeType="${store-type}"/>
     <property environment="env" />
   </target>
 


### PR DESCRIPTION
## Description
Fix build initialisation order to define temp directory before project initialization.

## Motivation and Context
Fixes NPE in project initialisation caused by missing temp directory property.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None needed

