### PR TITLE
Add generator=DITA-OT metadata to HTML header

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -20,6 +20,8 @@ See the accompanying LICENSE file for applicable license.
      for most data except for attributes on topic, which will be current context.
     -->
   
+    <meta name="generator" content="DITA-OT"/>
+
     <!-- = = = = = = = = = = = CONTENT = = = = = = = = = = = -->
   
     <!-- CONTENT: Type -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
@@ -20,6 +20,8 @@ See the accompanying LICENSE file for applicable license.
  getMeta is issued from the topic/topic context, therefore it is looking DOWN
  for most data except for attributes on topic, which will be current context.
 -->
+  
+  <meta name="generator" content="DITA-OT"/>
 
   <!-- = = = = = = = = = = = CONTENT = = = = = = = = = = = -->
 

--- a/src/test/resources/bookmap1/exp/xhtml/index.html
+++ b/src/test/resources/bookmap1/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap1/exp/xhtml/p.html
+++ b/src/test/resources/bookmap1/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap1/exp/xhtml/task.html
+++ b/src/test/resources/bookmap1/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Graphic scaling improvement" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap1/exp/xhtml/u.html
+++ b/src/test/resources/bookmap1/exp/xhtml/u.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Bookmap Readme" />
 <meta name="DC.relation" scheme="URI" content="task.html" />

--- a/src/test/resources/bookmap2/exp/xhtml/colophon.html
+++ b/src/test/resources/bookmap2/exp/xhtml/colophon.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="About the installation guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap2/exp/xhtml/index.html
+++ b/src/test/resources/bookmap2/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap2/exp/xhtml/p.html
+++ b/src/test/resources/bookmap2/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap2/exp/xhtml/part.html
+++ b/src/test/resources/bookmap2/exp/xhtml/part.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="part.dita" />
 <meta name="abstract" content="You install components to make them available for your solution." />

--- a/src/test/resources/bookmap2/exp/xhtml/title.html
+++ b/src/test/resources/bookmap2/exp/xhtml/title.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="DITA Open Toolkit Installation Guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap3/exp/xhtml/chap.html
+++ b/src/test/resources/bookmap3/exp/xhtml/chap.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Supporting two file extensions in one DITA map" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap3/exp/xhtml/index.html
+++ b/src/test/resources/bookmap3/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap3/exp/xhtml/p.html
+++ b/src/test/resources/bookmap3/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.relation" scheme="URI" content="chap.html" />

--- a/src/test/resources/bookmap3/exp/xhtml/task.html
+++ b/src/test/resources/bookmap3/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Graphic scaling improvement" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap3/exp/xhtml/u.html
+++ b/src/test/resources/bookmap3/exp/xhtml/u.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Bookmap Readme" />
 <meta name="DC.relation" scheme="URI" content="chap.html" />

--- a/src/test/resources/bookmap4/exp/xhtml/appendix.html
+++ b/src/test/resources/bookmap4/exp/xhtml/appendix.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Building DITA output with Java command line" />
 <meta name="abstract" content="The DITA Open Toolkit release 1.0.2 or above provides a command line interface as an alternative for users with little knowledge of Ant to use the toolkit easily." />

--- a/src/test/resources/bookmap4/exp/xhtml/chap.html
+++ b/src/test/resources/bookmap4/exp/xhtml/chap.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Supporting two file extensions in one DITA map" />
 <meta name="DC.relation" scheme="URI" content="part.html" />

--- a/src/test/resources/bookmap4/exp/xhtml/colophon.html
+++ b/src/test/resources/bookmap4/exp/xhtml/colophon.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="About the installation guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap4/exp/xhtml/index.html
+++ b/src/test/resources/bookmap4/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap4/exp/xhtml/p.html
+++ b/src/test/resources/bookmap4/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap4/exp/xhtml/part.html
+++ b/src/test/resources/bookmap4/exp/xhtml/part.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="part.dita" />
 <meta name="abstract" content="You install components to make them available for your solution." />

--- a/src/test/resources/bookmap4/exp/xhtml/title.html
+++ b/src/test/resources/bookmap4/exp/xhtml/title.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="DITA Open Toolkit Installation Guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap5/exp/xhtml/index.html
+++ b/src/test/resources/bookmap5/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap5/exp/xhtml/p.html
+++ b/src/test/resources/bookmap5/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap5/exp/xhtml/part.html
+++ b/src/test/resources/bookmap5/exp/xhtml/part.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="part.dita" />
 <meta name="abstract" content="You install components to make them available for your solution." />

--- a/src/test/resources/bookmap5/exp/xhtml/task.html
+++ b/src/test/resources/bookmap5/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Graphic scaling improvement" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap5/exp/xhtml/topicmeta.html
+++ b/src/test/resources/bookmap5/exp/xhtml/topicmeta.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Run Setup.exe" />
 <meta name="abstract" content="As with any major program, you will need to run setup in order to install it." />

--- a/src/test/resources/bookmap5/exp/xhtml/u.html
+++ b/src/test/resources/bookmap5/exp/xhtml/u.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Bookmap Readme" />
 <meta name="DC.relation" scheme="URI" content="task.html" />

--- a/src/test/resources/bookmap6/exp/xhtml/chap.html
+++ b/src/test/resources/bookmap6/exp/xhtml/chap.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Supporting two file extensions in one DITA map" />
 <meta name="DC.relation" scheme="URI" content="part.html" />

--- a/src/test/resources/bookmap6/exp/xhtml/colophon.html
+++ b/src/test/resources/bookmap6/exp/xhtml/colophon.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="About the installation guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap6/exp/xhtml/index.html
+++ b/src/test/resources/bookmap6/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap6/exp/xhtml/p.html
+++ b/src/test/resources/bookmap6/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap6/exp/xhtml/part.html
+++ b/src/test/resources/bookmap6/exp/xhtml/part.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="part.dita" />
 <meta name="abstract" content="You install components to make them available for your solution." />

--- a/src/test/resources/bookmap6/exp/xhtml/row.html
+++ b/src/test/resources/bookmap6/exp/xhtml/row.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Maintaining" />
 <meta name="abstract" content="You maintain your solution to ensure that all components are operating at maximum efficiency." />

--- a/src/test/resources/bookmap6/exp/xhtml/title.html
+++ b/src/test/resources/bookmap6/exp/xhtml/title.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="DITA Open Toolkit Installation Guide" />
 <meta name="DC.creator" content="Batty Things R US Fred Mertz Jr" />

--- a/src/test/resources/bookmap7/exp/xhtml/index.html
+++ b/src/test/resources/bookmap7/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="bookmap" />
 <meta name="DC.title" content="Batty Things Caring for your fruit bat How to properly love and care for your bat." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/bookmap7/exp/xhtml/p.html
+++ b/src/test/resources/bookmap7/exp/xhtml/p.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="New element &lt;data&gt;" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap7/exp/xhtml/task.html
+++ b/src/test/resources/bookmap7/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Graphic scaling improvement" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/bookmap7/exp/xhtml/u.html
+++ b/src/test/resources/bookmap7/exp/xhtml/u.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Bookmap Readme" />
 <meta name="DC.relation" scheme="URI" content="u.html" />

--- a/src/test/resources/cascade_processingrole/exp/xhtml/index.html
+++ b/src/test/resources/cascade_processingrole/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/cascade_processingrole/exp/xhtml/topic2.html
+++ b/src/test/resources/cascade_processingrole/exp/xhtml/topic2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Generic Task" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/topic1.html
+++ b/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Conref push task using conkeyref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/topic2.html
+++ b/src/test/resources/cascade_processingrole/exp/xhtml_with_preprocess2/topic2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Generic Task" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_pushreplace/exp/xhtml/index.html
+++ b/src/test/resources/conref_pushreplace/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Testing conref push-replace" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-one-file.html
+++ b/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-one-file.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Push and Target in One File" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-push-target-ditaext.html
+++ b/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-push-target-ditaext.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Push Target with DITA extension" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-push-target.html
+++ b/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test-push-target.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Push Target" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test.html
+++ b/src/test/resources/conref_pushreplace/exp/xhtml/jandrew-test.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Push Source" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_topiconly/exp/xhtml/conref_to_self.html
+++ b/src/test/resources/conref_topiconly/exp/xhtml/conref_to_self.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Conref test for #2948" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml/common/conref-with-xref.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml/common/conref-with-xref.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Conref With Xrefs" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml/index.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/conref_with_xref/exp/xhtml/langref/conreffing-target.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml/langref/conreffing-target.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="User of Conref With Xref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml/langref/xref-target-topic.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml/langref/xref-target-topic.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="XRef Target Topic" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/common/conref-with-xref.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/common/conref-with-xref.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Conref With Xrefs" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/langref/conreffing-target.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/langref/conreffing-target.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="User of Conref With Xref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/langref/xref-target-topic.html
+++ b/src/test/resources/conref_with_xref/exp/xhtml_with_preprocess2/langref/xref-target-topic.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="XRef Target Topic" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/crawl_map/exp/xhtml/generate.html
+++ b/src/test/resources/crawl_map/exp/xhtml/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="localditalink.html" />

--- a/src/test/resources/crawl_map/exp/xhtml/index.html
+++ b/src/test/resources/crawl_map/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/crawl_map/exp/xhtml_with_preprocess2/generate.html
+++ b/src/test/resources/crawl_map/exp/xhtml_with_preprocess2/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="d93d199c01bf6b917f208be6b05ada9809f5eb58.html" />

--- a/src/test/resources/crawl_map/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/crawl_map/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/crawl_topic/exp/xhtml/generate.html
+++ b/src/test/resources/crawl_topic/exp/xhtml/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="localditalink.html" />

--- a/src/test/resources/crawl_topic/exp/xhtml/index.html
+++ b/src/test/resources/crawl_topic/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/crawl_topic/exp/xhtml/localditalink.html
+++ b/src/test/resources/crawl_topic/exp/xhtml/localditalink.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Local DITA link, evaluate but do not generate" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/crawl_topic/exp/xhtml/localditaxref.html
+++ b/src/test/resources/crawl_topic/exp/xhtml/localditaxref.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2018" />
 <meta name="DC.rights.owner" content="(C) Copyright 2018" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Local DITA xref, evaluate but do not generate" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/filterlist/exp/xhtml/index.html
+++ b/src/test/resources/filterlist/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/filterlist/exp/xhtml/simpletopic.html
+++ b/src/test/resources/filterlist/exp/xhtml/simpletopic.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic title" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/html5_css/exp/html5/topic.html
+++ b/src/test/resources/html5_css/exp/html5/topic.html
@@ -5,7 +5,8 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.type" content="topic">
+  <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="topic">
   <meta name="DC.format" content="HTML5">
   <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="commonltr.css">

--- a/src/test/resources/html5_cssExternal/exp/html5/topic.html
+++ b/src/test/resources/html5_cssExternal/exp/html5/topic.html
@@ -5,7 +5,8 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.type" content="topic">
+  <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="topic">
   <meta name="DC.format" content="HTML5">
   <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="https://example.com/styles/commonltr.css">

--- a/src/test/resources/html5_csspath/exp/html5/topic.html
+++ b/src/test/resources/html5_csspath/exp/html5/topic.html
@@ -5,7 +5,8 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2018">
   <meta name="DC.rights.owner" content="(C) Copyright 2018">
-  <meta name="DC.type" content="topic">
+  <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="topic">
   <meta name="DC.format" content="HTML5">
   <meta name="DC.identifier" content="topic">
   <link rel="stylesheet" type="text/css" href="styles/commonltr.css">

--- a/src/test/resources/html5_ditaval/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval/exp/html5/all.html
@@ -6,7 +6,8 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2019">
   <meta name="DC.rights.owner" content="(C) Copyright 2019">
-  <meta name="DC.type" content="topic">
+  <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="topic">
   <meta name="DC.format" content="HTML5">
   <meta name="DC.identifier" content="topic-1">
   <link rel="stylesheet" type="text/css" href="commonltr.css">

--- a/src/test/resources/html5_ditaval/exp/html5/index.html
+++ b/src/test/resources/html5_ditaval/exp/html5/index.html
@@ -6,7 +6,8 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2019">
   <meta name="DC.rights.owner" content="(C) Copyright 2019">
-  <meta name="DC.type" content="map">
+  <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="map">
   <meta name="DC.format" content="HTML5"><link rel="stylesheet" type="text/css" href="commonltr.css"><title></title></head>
 <body>
 <nav xmlns:dita="http://dita-ot.sourceforge.net">

--- a/src/test/resources/image-scale/exp/xhtml/test.html
+++ b/src/test/resources/image-scale/exp/xhtml/test.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic title" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/image_extension_mixedcase/exp/xhtml/index.html
+++ b/src/test/resources/image_extension_mixedcase/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="BUG 3164866" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/image_extension_mixedcase/exp/xhtml/testpng.html
+++ b/src/test/resources/image_extension_mixedcase/exp/xhtml/testpng.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Test upper case PNG" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_All_tags/exp/xhtml/c.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.source" content="a1.dita" />

--- a/src/test/resources/keyref_All_tags/exp/xhtml/dita1.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/dita1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="HI" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_All_tags/exp/xhtml/index.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_All_tags/exp/xhtml/task.html
+++ b/src/test/resources/keyref_All_tags/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="task" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Keyword_links/exp/xhtml/abs.html
+++ b/src/test/resources/keyref_Keyword_links/exp/xhtml/abs.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="glossentry" />
 <meta name="DC.title" content="Anti-lock Braking System" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Keyword_links/exp/xhtml/aids.html
+++ b/src/test/resources/keyref_Keyword_links/exp/xhtml/aids.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="glossentry" />
 <meta name="DC.title" content="sindrom de inmuno-deficiencia adquirida" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Keyword_links/exp/xhtml/c.html
+++ b/src/test/resources/keyref_Keyword_links/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Keyword_links/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Keyword_links/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/a1.html
+++ b/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/a1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic a1" />
 <meta name="abstract" content="Learn how to care for your new pet bat." />

--- a/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/c.html
+++ b/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_conref_1/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/a2.html
+++ b/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/a2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic a2" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/c.html
+++ b/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_conref_2/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita1.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="HI" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/dita2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the second topic" />
 <meta name="DC.relation" scheme="URI" content="dita1.html" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_1/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the second topic" />
 <meta name="DC.relation" scheme="URI" content="dita3.html" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita3.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/dita3.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita3's title" />
 <meta name="abstract" content="When the author2 build, the &#34;dita2.dita&#34; will resolve to this dita. Dita3.dita" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_2/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/dita2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the second topic" />
 <meta name="DC.relation" scheme="URI" content="http://www.ibm.com" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_3/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/dita4.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/dita4.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Hi, I am topic4" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_4/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/dita5.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/dita5.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Hi, I am topic5" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_5/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita0.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita0.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Dita0 as the fallback." />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita2.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/dita2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the second topic" />
 <meta name="DC.relation" scheme="URI" content="dita0.html" />

--- a/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Redirect_link_or_xref_6/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/blatview.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/blatview.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the blatview dita file" />
 <meta name="abstract" content="blatview dita file" />

--- a/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/keyRef_blatexample.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_1/exp/xhtml/keyRef_blatexample.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Keyref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/blatexample.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/blatexample.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the blatexample topic" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/blatview.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/blatview.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the blatview dita file" />
 <meta name="abstract" content="blatview dita file" />

--- a/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/keyRef_blatexample.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_2/exp/xhtml/keyRef_blatexample.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Keyref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/footbars.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/footbars.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="this is the footbar dita file" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/keyRef_blatexample.html
+++ b/src/test/resources/keyref_Splitting_combining_targets_3/exp/xhtml/keyRef_blatexample.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Keyref" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Swap_out_variable_content/exp/xhtml/c.html
+++ b/src/test/resources/keyref_Swap_out_variable_content/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_Swap_out_variable_content/exp/xhtml/index.html
+++ b/src/test/resources/keyref_Swap_out_variable_content/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_dupkey/exp/xhtml/index.html
+++ b/src/test/resources/keyref_dupkey/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_dupkey/exp/xhtml/topic-01.html
+++ b/src/test/resources/keyref_dupkey/exp/xhtml/topic-01.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic One" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_modify/exp/xhtml/c.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="topic c" />
 <meta name="DC.source" content="a1.dita" />

--- a/src/test/resources/keyref_modify/exp/xhtml/dita1.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/dita1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="HI" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_modify/exp/xhtml/index.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_modify/exp/xhtml/task.html
+++ b/src/test/resources/keyref_modify/exp/xhtml/task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="task" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_to_keyref/exp/xhtml/index.html
+++ b/src/test/resources/keyref_to_keyref/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/keyref_to_keyref/exp/xhtml/topic-01.html
+++ b/src/test/resources/keyref_to_keyref/exp/xhtml/topic-01.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic One" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/keyref_to_keyref/exp/xhtml/topic-03.html
+++ b/src/test/resources/keyref_to_keyref/exp/xhtml/topic-03.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic Three" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/lang/exp/xhtml/index.html
+++ b/src/test/resources/lang/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="DITA Topic Map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/lang/exp/xhtml/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-areg.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml/lang-beby.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml/lang-bgbg.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml/lang-caes.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-concept.html
+++ b/src/test/resources/lang/exp/xhtml/lang-concept.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Concept for language test" />
 <meta name="abstract" content="this is the related concept" />

--- a/src/test/resources/lang/exp/xhtml/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml/lang-cscz.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dadk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dech.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml/lang-dede.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-elgr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enca.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml/lang-engb.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml/lang-enus.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml/lang-eses.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml/lang-etee.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-fifi.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frbe.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frca.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frch.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-frfr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml/lang-heil.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hiin.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-hrhr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml/lang-huhu.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml/lang-isis.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itch.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml/lang-itit.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-jajp.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-kokr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ltlt.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml/lang-lvlv.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-mkmk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-next.html
+++ b/src/test/resources/lang/exp/xhtml/lang-next.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Next topic link" />
 <meta name="abstract" content="This is the next topic in the language tests" />

--- a/src/test/resources/lang/exp/xhtml/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlbe.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nlnl.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml/lang-nono.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-parent.html
+++ b/src/test/resources/lang/exp/xhtml/lang-parent.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Parent topic for linking" />
 <meta name="abstract" content="This is the parent topic for generated text tests" />

--- a/src/test/resources/lang/exp/xhtml/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml/lang-plpl.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-prerequisite.html
+++ b/src/test/resources/lang/exp/xhtml/lang-prerequisite.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Prerequisite task" />
 <meta name="abstract" content="This should create a prerequisite link in the language test" />

--- a/src/test/resources/lang/exp/xhtml/lang-previous.html
+++ b/src/test/resources/lang/exp/xhtml/lang-previous.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Previous topic link" />
 <meta name="abstract" content="This is the previous topic for language tests" />

--- a/src/test/resources/lang/exp/xhtml/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptbr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ptpt.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-reference.html
+++ b/src/test/resources/lang/exp/xhtml/lang-reference.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="reference" />
 <meta name="DC.title" content="Reference link for language test" />
 <meta name="abstract" content="Reference for the related link" />

--- a/src/test/resources/lang/exp/xhtml/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml/lang-roro.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ruru.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-sksk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml/lang-slsi.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml/lang-srsp.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml/lang-svse.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-task.html
+++ b/src/test/resources/lang/exp/xhtml/lang-task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Task for related link" />
 <meta name="abstract" content="Description of the related task" />

--- a/src/test/resources/lang/exp/xhtml/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml/lang-thth.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml/lang-trtr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml/lang-ukua.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml/lang-urpk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhcn.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml/lang-zhtw.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2016" />
 <meta name="DC.rights.owner" content="(C) Copyright 2016" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="DITA Topic Map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-areg.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-areg.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-beby.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-beby.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-bgbg.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-bgbg.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-caes.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-caes.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-common.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-common.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-concept.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-concept.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="concept" />
 <meta name="DC.title" content="Concept for language test" />
 <meta name="abstract" content="this is the related concept" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-cscz.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-cscz.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dadk.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dadk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dech.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dech.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dede.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-dede.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-elgr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-elgr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-enca.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-enca.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-engb.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-engb.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-enus.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-enus.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-eses.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-eses.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-etee.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-etee.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-fifi.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-fifi.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frbe.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frbe.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frca.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frca.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frch.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frch.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frfr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-frfr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-heil.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-heil.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-hiin.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-hiin.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-hrhr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-hrhr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-huhu.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-huhu.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-isis.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-isis.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-itch.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-itch.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-itit.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-itit.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-jajp.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-jajp.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-kokr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-kokr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ltlt.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ltlt.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-lvlv.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-lvlv.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-mkmk.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-mkmk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-next.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-next.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Next topic link" />
 <meta name="abstract" content="This is the next topic in the language tests" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nlbe.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nlbe.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nlnl.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nlnl.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nono.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-nono.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-parent.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-parent.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Parent topic for linking" />
 <meta name="abstract" content="This is the parent topic for generated text tests" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-plpl.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-plpl.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-prerequisite.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-prerequisite.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Prerequisite task" />
 <meta name="abstract" content="This should create a prerequisite link in the language test" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-previous.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-previous.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Previous topic link" />
 <meta name="abstract" content="This is the previous topic for language tests" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ptbr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ptbr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ptpt.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ptpt.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-reference.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-reference.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="reference" />
 <meta name="DC.title" content="Reference link for language test" />
 <meta name="abstract" content="Reference for the related link" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-roro.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-roro.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ruru.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ruru.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-sksk.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-sksk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-slsi.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-slsi.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-srsp.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-srsp.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-svse.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-svse.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-task.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-task.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="task" />
 <meta name="DC.title" content="Task for related link" />
 <meta name="abstract" content="Description of the related task" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-thth.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-thth.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-trtr.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-trtr.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ukua.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-ukua.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-urpk.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-urpk.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-zhcn.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-zhcn.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-zhtw.html
+++ b/src/test/resources/lang/exp/xhtml_with_preprocess2/lang-zhtw.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic elements with generated text" />
 <meta name="DC.subject" content="a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 1, +, $, ?" />

--- a/src/test/resources/link_parentchild/exp/xhtml/index.html
+++ b/src/test/resources/link_parentchild/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <meta name="DC.identifier" content="UC03TC" />

--- a/src/test/resources/link_parentchild/exp/xhtml/t1.html
+++ b/src/test/resources/link_parentchild/exp/xhtml/t1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="test 1" />
 <meta name="DC.relation" scheme="URI" content="t2.html" />

--- a/src/test/resources/link_parentchild/exp/xhtml/t2.html
+++ b/src/test/resources/link_parentchild/exp/xhtml/t2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="test 2" />
 <meta name="DC.relation" scheme="URI" content="t1.html" />

--- a/src/test/resources/link_xref_extensiontest/exp/xhtml/index.html
+++ b/src/test/resources/link_xref_extensiontest/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/link_xref_extensiontest/exp/xhtml/testtopic.html
+++ b/src/test/resources/link_xref_extensiontest/exp/xhtml/testtopic.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Bug 3059256" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/link_xref_extensiontest/exp/xhtml/topic1.html
+++ b/src/test/resources/link_xref_extensiontest/exp/xhtml/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic One" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/link_xref_extensiontest/exp/xhtml/topic2.html
+++ b/src/test/resources/link_xref_extensiontest/exp/xhtml/topic2.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic Two" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map13_flag/exp/xhtml/index.html
+++ b/src/test/resources/map13_flag/exp/xhtml/index.html
@@ -7,7 +7,8 @@
 
     <meta name="copyright" content="(C) Copyright 2014" />
     <meta name="DC.rights.owner" content="(C) Copyright 2014" />
-    <meta name="DC.type" content="map" />
+    <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="map" />
     <meta name="DC.title" content="map13: A hierarchy of CVF(correct value of platform attribute)" />
     <meta name="DC.format" content="XHTML" />
     <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/map13_flag/exp/xhtml/topic1.html
+++ b/src/test/resources/map13_flag/exp/xhtml/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="The correct values of platform" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map13_flag/exp/xhtml/topic4.html
+++ b/src/test/resources/map13_flag/exp/xhtml/topic4.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="A hierarchy of CVF test" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map13_flag2/exp/xhtml/index.html
+++ b/src/test/resources/map13_flag2/exp/xhtml/index.html
@@ -7,7 +7,8 @@
 
     <meta name="copyright" content="(C) Copyright 2014" />
     <meta name="DC.rights.owner" content="(C) Copyright 2014" />
-    <meta name="DC.type" content="map" />
+    <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="map" />
     <meta name="DC.title" content="map13: A hierarchy of CVF(correct value of platform attribute)" />
     <meta name="DC.format" content="XHTML" />
     <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/map13_flag2/exp/xhtml/topic1.html
+++ b/src/test/resources/map13_flag2/exp/xhtml/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="The correct values of platform" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map13_flag2/exp/xhtml/topic4.html
+++ b/src/test/resources/map13_flag2/exp/xhtml/topic4.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="A hierarchy of CVF test" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map33_flag/exp/xhtml/index.html
+++ b/src/test/resources/map33_flag/exp/xhtml/index.html
@@ -7,7 +7,8 @@
 
     <meta name="copyright" content="(C) Copyright 2014" />
     <meta name="DC.rights.owner" content="(C) Copyright 2014" />
-    <meta name="DC.type" content="map" />
+    <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="map" />
     <meta name="DC.title" content="Test audience attibute(wrong use)" />
     <meta name="DC.format" content="XHTML" />
     <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/map33_flag/exp/xhtml/topic1.html
+++ b/src/test/resources/map33_flag/exp/xhtml/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="The correct values of platform" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map33_flag/exp/xhtml/topic4.html
+++ b/src/test/resources/map33_flag/exp/xhtml/topic4.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="A hierarchy of CVF test" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map33_flag2/exp/xhtml/index.html
+++ b/src/test/resources/map33_flag2/exp/xhtml/index.html
@@ -7,7 +7,8 @@
 
     <meta name="copyright" content="(C) Copyright 2014" />
     <meta name="DC.rights.owner" content="(C) Copyright 2014" />
-    <meta name="DC.type" content="map" />
+    <meta name="generator" content="DITA-OT"/>
+<meta name="DC.type" content="map" />
     <meta name="DC.title" content="Test audience attibute(wrong use)" />
     <meta name="DC.format" content="XHTML" />
     <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/map33_flag2/exp/xhtml/topic1.html
+++ b/src/test/resources/map33_flag2/exp/xhtml/topic1.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="The correct values of platform" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/map33_flag2/exp/xhtml/topic4.html
+++ b/src/test/resources/map33_flag2/exp/xhtml/topic4.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="A hierarchy of CVF test" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="localditalink.html" />

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/index.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditalink.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditalink.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Local DITA link, evaluate but do not generate" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditaxref.html
+++ b/src/test/resources/onlytopic.in.map.false/exp/xhtml/localditaxref.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Local DITA xref, evaluate but do not generate" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="localditalink.html" />

--- a/src/test/resources/onlytopic.in.map/exp/xhtml/index.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/onlytopic.in.map/exp/xhtml_with_preprocess2/generate.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml_with_preprocess2/generate.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title" />
 <meta name="DC.relation" scheme="URI" content="1da760f9460d338047d674c3f1ae6d5eed1a4624.html" />

--- a/src/test/resources/onlytopic.in.map/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/onlytopic.in.map/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="Test onlytopic.in.map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/subjectschema_case/exp/xhtml/index.html
+++ b/src/test/resources/subjectschema_case/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/subjectschema_case/exp/xhtml/simpletopic.html
+++ b/src/test/resources/subjectschema_case/exp/xhtml/simpletopic.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Topic title" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/title_includes_markup/exp/xhtml/index.html
+++ b/src/test/resources/title_includes_markup/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.format" content="XHTML" />
 <link rel="stylesheet" type="text/css" href="commonltr.css" />

--- a/src/test/resources/title_includes_markup/exp/xhtml/topic-with-markup-in-title.html
+++ b/src/test/resources/title_includes_markup/exp/xhtml/topic-with-markup-in-title.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2014" />
 <meta name="DC.rights.owner" content="(C) Copyright 2014" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="Title With Markup This is in &lt;ph&gt;. Here is a footnote: (1)" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/uplevels1/exp/xhtml/a.html
+++ b/src/test/resources/uplevels1/exp/xhtml/a.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="a" />
 <meta name="DC.relation" scheme="URI" content="b.html" />

--- a/src/test/resources/uplevels1/exp/xhtml/b.html
+++ b/src/test/resources/uplevels1/exp/xhtml/b.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="b" />
 <meta name="DC.relation" scheme="URI" content="a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml/index.html
+++ b/src/test/resources/uplevels1/exp/xhtml/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="DITA Topic Map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/uplevels1/exp/xhtml/maps/e.html
+++ b/src/test/resources/uplevels1/exp/xhtml/maps/e.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="e" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml/maps/f.html
+++ b/src/test/resources/uplevels1/exp/xhtml/maps/f.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="f" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml/topics/c.html
+++ b/src/test/resources/uplevels1/exp/xhtml/topics/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="c" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml/topics/d.html
+++ b/src/test/resources/uplevels1/exp/xhtml/topics/d.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="d" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/a.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/a.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="a" />
 <meta name="DC.relation" scheme="URI" content="b.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/b.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/b.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="b" />
 <meta name="DC.relation" scheme="URI" content="a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/index.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="DITA Topic Map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/maps/e.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/maps/e.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="e" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/maps/f.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/maps/f.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="f" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/topics/c.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/topics/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="c" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/topics/d.html
+++ b/src/test/resources/uplevels1/exp/xhtml_with_preprocess2/topics/d.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2019" />
 <meta name="DC.rights.owner" content="(C) Copyright 2019" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="d" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/a.html
+++ b/src/test/resources/uplevels3/exp/xhtml/a.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="a" />
 <meta name="DC.relation" scheme="URI" content="b.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/b.html
+++ b/src/test/resources/uplevels3/exp/xhtml/b.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="b" />
 <meta name="DC.relation" scheme="URI" content="a.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/maps/e.html
+++ b/src/test/resources/uplevels3/exp/xhtml/maps/e.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="e" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/maps/f.html
+++ b/src/test/resources/uplevels3/exp/xhtml/maps/f.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="f" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/maps/index.html
+++ b/src/test/resources/uplevels3/exp/xhtml/maps/index.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="map" />
 <meta name="DC.title" content="DITA Topic Map" />
 <meta name="DC.format" content="XHTML" />

--- a/src/test/resources/uplevels3/exp/xhtml/topics/c.html
+++ b/src/test/resources/uplevels3/exp/xhtml/topics/c.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="c" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />

--- a/src/test/resources/uplevels3/exp/xhtml/topics/d.html
+++ b/src/test/resources/uplevels3/exp/xhtml/topics/d.html
@@ -6,6 +6,7 @@
 
 <meta name="copyright" content="(C) Copyright 2017" />
 <meta name="DC.rights.owner" content="(C) Copyright 2017" />
+<meta name="generator" content="DITA-OT"/>
 <meta name="DC.type" content="topic" />
 <meta name="DC.title" content="d" />
 <meta name="DC.relation" scheme="URI" content="../a.html" />


### PR DESCRIPTION
## Description
Add `<meta name="generator" content="DITA-OT">` metadata to HTML header.

## Motivation and Context
This allows us to get a better understanding how much DITA-OT is used to publish to HTML. Users can remove the `generator` metadata using a plug-in.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This doesn't affect HTML output consumption, so it requires no documentation from that perspective.

