### PR TITLE
Remove obsolete key processing from XHTML

### DIFF
--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -19,7 +19,6 @@ import net.sf.saxon.s9api.streams.Predicates;
 import net.sf.saxon.serialize.SerializationProperties;
 import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
-import net.sf.saxon.type.BuiltInAtomicType;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -34,7 +33,6 @@ import org.dita.dost.writer.KeyrefPaser;
 import org.dita.dost.writer.TopicFragmentFilter;
 import org.xml.sax.XMLFilter;
 
-import javax.management.openmbean.SimpleType;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -46,14 +44,13 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toMap;
 import static net.sf.saxon.event.ReceiverOptions.REJECT_DUPLICATES;
 import static net.sf.saxon.expr.parser.ExplicitLocation.UNKNOWN_LOCATION;
-import static net.sf.saxon.s9api.streams.Predicates.*;
+import static net.sf.saxon.s9api.streams.Predicates.attributeEq;
 import static net.sf.saxon.s9api.streams.Steps.ancestorOrSelf;
 import static net.sf.saxon.s9api.streams.Steps.attribute;
 import static net.sf.saxon.type.BuiltInAtomicType.STRING;
 import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.Job.FileInfo;
-import static org.dita.dost.util.Job.KEYDEF_LIST_FILE;
 import static org.dita.dost.util.URLUtils.*;
 
 /**
@@ -514,19 +511,6 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             normalProcessingRole.addAll(parser.getNormalProcessingRoleTargets());
         } catch (final DITAOTException e) {
             logger.error("Failed to process key references: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Add key definition to job configuration
-     *
-     * @param keydefs key defintions to add
-     */
-    private void writeKeyDefinition(final Map<String, KeyDef> keydefs) {
-        try {
-            KeyDef.writeKeydef(new File(job.tempDir, KEYDEF_LIST_FILE), keydefs.values());
-        } catch (final DITAOTException e) {
-            logger.error("Failed to write key definition file: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -91,8 +91,6 @@ public final class Job {
     private static final String PROPERTY_INPUT_MAP = "InputMapDir";
     private static final String PROPERTY_INPUT_MAP_URI = "InputMapDir.uri";
 
-    /** File name for key definition file */
-    public static final String KEYDEF_LIST_FILE = "keydef.xml";
     /** File name for temporary input file list file */
     public static final String USER_INPUT_FILE_LIST_FILE = "usr.input.file.list";
 

--- a/src/main/java/org/dita/dost/util/KeyDef.java
+++ b/src/main/java/org/dita/dost/util/KeyDef.java
@@ -7,14 +7,9 @@
  */
 package org.dita.dost.util;
 
-import static org.dita.dost.util.Constants.*;
+import net.sf.saxon.s9api.XdmNode;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
-import java.util.Collection;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -23,19 +18,12 @@ import javax.xml.stream.XMLStreamWriter;
 import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Element;
+import static org.dita.dost.util.Constants.*;
 
 /**
  * Key definition.
  */
 public class KeyDef {
-
-    public static final String ELEMENT_STUB = "stub";
-    private static final String ATTRIBUTE_SOURCE = "source";
-    private static final String ATTRIBUTE_HREF = "href";
-    private static final String ATTRIBUTE_SCOPE = "scope";
-    private static final String ATTRIBUTE_FORMAT = "format";
-    private static final String ATTRIBUTE_KEYS = "keys";
-    private static final String ELEMENT_KEYDEF = "keydef";
 
     /** Space delimited list of key names */
     public final String keys;
@@ -76,49 +64,6 @@ public class KeyDef {
             buf.append(LEFT_BRACKET).append(source.toString()).append(RIGHT_BRACKET);
         }
         return buf.toString();
-    }
-
-    /**
-     * Write key definition XML configuration file
-     *
-     * @param keydefFile key definition file
-     * @param keydefs list of key definitions
-     * @throws DITAOTException if writing configuration file failed
-     */
-    public static void writeKeydef(final File keydefFile, final Collection<KeyDef> keydefs) throws DITAOTException {
-        XMLStreamWriter keydef = null;
-        try (OutputStream out = new FileOutputStream(keydefFile)) {
-            keydef = XMLOutputFactory.newInstance().createXMLStreamWriter(out, "UTF-8");
-            keydef.writeStartDocument();
-            keydef.writeStartElement(ELEMENT_STUB);
-            for (final KeyDef k : keydefs) {
-                keydef.writeStartElement(ELEMENT_KEYDEF);
-                keydef.writeAttribute(ATTRIBUTE_KEYS, k.keys);
-                if (k.href != null) {
-                    keydef.writeAttribute(ATTRIBUTE_HREF, k.href.toString());
-                }
-                if (k.scope != null) {
-                    keydef.writeAttribute(ATTRIBUTE_SCOPE, k.scope);
-                }
-                if (k.format != null) {
-                    keydef.writeAttribute(ATTRIBUTE_FORMAT, k.format);
-                }
-                if (k.source != null) {
-                    keydef.writeAttribute(ATTRIBUTE_SOURCE, k.source.toString());
-                }
-                keydef.writeEndElement();
-            }
-            keydef.writeEndDocument();
-        } catch (final XMLStreamException | IOException e) {
-            throw new DITAOTException("Failed to write key definition file " + keydefFile + ": " + e.getMessage(), e);
-        } finally {
-            if (keydef != null) {
-                try {
-                    keydef.close();
-                } catch (final XMLStreamException e) {
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -108,12 +108,6 @@ See the accompanying LICENSE file for applicable license.
 <!-- Switch to enable or disable the generation of default meta message in html header -->
 <xsl:param name="genDefMeta" select="'no'"/>
 
-<!-- Name of the keyref file that contains key definitions -->
-<!-- Deprecated since 2.1 -->
-<xsl:param name="KEYREF-FILE" select="concat($WORKDIR, $PATH2PROJ, 'keydef.xml')"/>
-<!-- Deprecated since 2.1 -->
-<xsl:variable name="keydefs" select="document($KEYREF-FILE)"/>
-  
 <xsl:param name="BASEDIR"/>
   
 <xsl:param name="OUTPUTDIR"/>
@@ -2883,43 +2877,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
 
-  <!-- Deprecated since 2.1 -->
-  <!-- This template pulls in topic/title -->
-  <!-- 20090330: Add error checking to ensre $keys is defined, that the key
-                 is defined in KEYREF-FILE, and that $target != '' -->
-  <xsl:template match="*" mode="pull-in-title">
-    <xsl:param name="type"/>
-    <xsl:param name="displaytext" select="''"/>
-    <xsl:param name="keys" select="@keyref"/>
-    
-    <xsl:call-template name="output-message">
-      <xsl:with-param name="id" select="'DOTX069W'"/>
-      <xsl:with-param name="msgparams">%1=pull-in-title</xsl:with-param>
-    </xsl:call-template>
-    <xsl:choose>
-      <xsl:when test="$displaytext = '' and $keys != ''">
-        <xsl:variable name="target">
-          <xsl:variable name="keydef" select="$keydefs//*[@keys = $keys]"/>
-          <xsl:if test="$keydef">
-            <xsl:choose>
-              <xsl:when test="contains($keydef/@href, '#')">
-                <xsl:value-of select="substring-before($keydef/@href, '#')"/>
-              </xsl:when>
-              <xsl:when test="$keydef/@href">
-                <xsl:value-of select="$keydef/@href"/>
-              </xsl:when>
-            </xsl:choose>
-          </xsl:if>
-        </xsl:variable>
-        <xsl:if test="not($target = '' or contains($target, '://'))">
-          <xsl:value-of select="(document(concat($WORKDIR, $PATH2PROJ, $target))//*[contains(@class, ' topic/title ')][normalize-space(.) != ''])[1]"/>
-        </xsl:if>
-      </xsl:when>
-      <xsl:when test="normalize-space(.) = ''">
-        <xsl:value-of select="$displaytext"/>
-      </xsl:when>
-    </xsl:choose>
-  </xsl:template>
   <!-- This template converts phrase-like elements into links based on keyref. -->
   <!-- 20090331: Update to ensure cite with keyref continues to use <cite>,
                  plus move common code to single template -->


### PR DESCRIPTION
## Description
Remove obsolete key processing code from XHTML.

## Motivation and Context
Remove code that's been obsolete since 2.1.

## How Has This Been Tested?
Tests pass.

## Type of Changes

- New feature _(non-breaking change which removes deprecated code)_

