### PR TITLE
Add support for running module processing in parallel

### DIFF
--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -264,7 +264,6 @@ public final class ExtensibleAntInvoker extends Task {
                 }
             }
             final AbstractPipelineModule module = factory.createModule(m.getImplementation());
-            module.setParallel(m.parallel);
             module.setProcessingPipe(m.getFilters());
             if (!m.fileInfoFilters.isEmpty()) {
                 module.setFileInfoFilter(combine(m.fileInfoFilters));

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -245,6 +245,7 @@ public final class ExtensibleAntInvoker extends Task {
         } else if (m instanceof SaxPipeElem) {
             final SaxPipeElem fm = (SaxPipeElem) m;
             final XmlFilterModule module = new XmlFilterModule();
+            module.setParallel(fm.parallel);
             final List<FileInfoFilterElem> predicates = new ArrayList<>(fm.getFormat());
             predicates.addAll(m.fileInfoFilters);
             module.setFileInfoFilter(combine(predicates));
@@ -260,6 +261,7 @@ public final class ExtensibleAntInvoker extends Task {
                 }
             }
             final AbstractPipelineModule module = factory.createModule(m.getImplementation());
+            module.setParallel(m.parallel);
             module.setProcessingPipe(m.getFilters());
             if (!m.fileInfoFilters.isEmpty()) {
                 module.setFileInfoFilter(combine(m.fileInfoFilters));
@@ -401,7 +403,7 @@ public final class ExtensibleAntInvoker extends Task {
         public final Collection<FileInfoFilterElem> fileInfoFilters = new ArrayList<>();
         private Project project;
         private Location location;
-        private boolean parallel;
+        protected boolean parallel;
 
         public void setClass(final Class<? extends AbstractPipelineModule> cls) {
             this.cls = cls;

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -201,6 +201,9 @@ public final class ExtensibleAntInvoker extends Task {
             if (xm.reloadstylesheet && xm.parallel) {
                 throw new BuildException("Both reloadstylesheet and parallel cannot be true");
             }
+            if (xm.parallel && xm.xmlcatalog != null) {
+                throw new DITAOTException("Pipeline XSLT task with parallel=true cannot be used with Ant's xmlcatalog");
+            }
             final XsltModule module = new XsltModule();
             module.setStyle(xm.style);
             if (xm.in != null) {

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -273,6 +273,7 @@ public final class ExtensibleAntInvoker extends Task {
             if (!m.fileInfoFilters.isEmpty()) {
                 module.setFileInfoFilter(combine(m.fileInfoFilters));
             }
+            module.setParallel(m.parallel);
             return module;
         }
     }
@@ -409,6 +410,7 @@ public final class ExtensibleAntInvoker extends Task {
         public final Collection<FileInfoFilterElem> fileInfoFilters = new ArrayList<>();
         private Project project;
         private Location location;
+        private boolean parallel;
 
         public void setClass(final Class<? extends AbstractPipelineModule> cls) {
             this.cls = cls;
@@ -468,6 +470,11 @@ public final class ExtensibleAntInvoker extends Task {
         public Location getLocation() {
             return location;
         }
+
+        public void setParallel(final boolean parallel) {
+            this.parallel = parallel;
+        }
+
     }
 
     /**

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -199,6 +199,9 @@ public final class ExtensibleAntInvoker extends Task {
     private AbstractPipelineModule getPipelineModule(final ModuleElem m, final PipelineHashIO pipelineInput) throws DITAOTException {
         if (m instanceof XsltElem) {
             final XsltElem xm = (XsltElem) m;
+            if (xm.reloadstylesheet && xm.parallel) {
+                throw new BuildException("Both reloadstylesheet and parallel cannot be true");
+            }
             final XsltModule module = new XsltModule();
             module.setStyle(xm.style);
             if (xm.in != null) {
@@ -217,6 +220,7 @@ public final class ExtensibleAntInvoker extends Task {
             module.setFilenameParam(xm.filenameparameter);
             module.setFiledirParam(xm.filedirparameter);
             module.setReloadstylesheet(xm.reloadstylesheet);
+            module.setParallel(xm.parallel);
             module.setXMLCatalog(xm.xmlcatalog);
             if (xm.mapper != null) {
                 module.setMapper(xm.mapper.getImplementation());
@@ -487,6 +491,7 @@ public final class ExtensibleAntInvoker extends Task {
         private String filedirparameter;
         private XMLCatalog xmlcatalog;
         private boolean reloadstylesheet;
+        private boolean parallel;
 
         // Ant setters
 
@@ -515,6 +520,10 @@ public final class ExtensibleAntInvoker extends Task {
 
         public void setReloadstylesheet(final boolean reloadstylesheet) {
             this.reloadstylesheet = reloadstylesheet;
+        }
+
+        public void setParallel(final boolean parallel) {
+            this.parallel = parallel;
         }
 
         public void setIn(final File in) {

--- a/src/main/java/org/dita/dost/exception/UncheckedDITAOTException.java
+++ b/src/main/java/org/dita/dost/exception/UncheckedDITAOTException.java
@@ -8,6 +8,11 @@
 
 package org.dita.dost.exception;
 
+/**
+ * Wraps an {@link DITAOTException} with an unchecked exception.
+ *
+ * @since 3.6
+ */
 public class UncheckedDITAOTException extends RuntimeException {
 
     public UncheckedDITAOTException(DITAOTException err) {

--- a/src/main/java/org/dita/dost/exception/UncheckedDITAOTException.java
+++ b/src/main/java/org/dita/dost/exception/UncheckedDITAOTException.java
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.exception;
+
+public class UncheckedDITAOTException extends RuntimeException {
+
+    public UncheckedDITAOTException(DITAOTException err) {
+        super(err);
+    }
+
+    public DITAOTException getDITAOTException() {
+        return (DITAOTException) getCause();
+    }
+}

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -71,4 +71,5 @@ public interface AbstractPipelineModule {
     default void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {
     }
 
+    void setParallel(boolean parallel);
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -26,6 +26,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     protected DITAOTLogger logger;
     protected Job job;
     protected XMLUtils xmlUtils;
+    protected boolean parallel;
     Predicate<FileInfo> fileInfoFilter;
     List<XmlFilterModule.FilterPair> filters;
 
@@ -57,5 +58,9 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
     @Override
     public void setProcessingPipe(List<XmlFilterModule.FilterPair> filters) {
         this.filters = filters;
+    }
+
+    public void setParallel(boolean parallel) {
+        this.parallel = parallel;
     }
 }

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -296,7 +296,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
         for (final XmlFilterModule.FilterPair p : filters) {
             if (p.predicate.test(fi)) {
-                final AbstractXMLFilter f = p.filter;
+                final AbstractXMLFilter f = p.newInstance();
                 logger.debug("Configure filter " + f.getClass().getCanonicalName());
                 f.setCurrentFile(srcFile.toURI());
                 f.setJob(job);

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -71,8 +71,11 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
                         .map(f -> new File(job.tempDir, f.file.getPath()).getAbsoluteFile())
                         .forEach(filename -> {
                             final ImageMetadataFilter writer = pool.borrowObject();
-                            writer.write(filename);
-                            pool.returnObject(writer);
+                            try {
+                                writer.write(filename);
+                            } finally {
+                                pool.returnObject(writer);
+                            }
                         });
             } else {
                 final ImageMetadataFilter writer = new ImageMetadataFilter(outputDir, job, cache);

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -13,13 +13,18 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.Pool;
 import org.dita.dost.writer.ImageMetadataFilter;
+import org.xml.sax.Attributes;
 
 /**
  * Image metadata module.
@@ -49,17 +54,36 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
         final Collection<FileInfo> images = job.getFileInfo(f -> ATTR_FORMAT_VALUE_IMAGE.equals(f.format) || ATTR_FORMAT_VALUE_HTML.equals(f.format));
         if (!images.isEmpty()) {
             final File outputDir = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR));
-            final ImageMetadataFilter writer = new ImageMetadataFilter(outputDir, job);
-            writer.setLogger(logger);
-            writer.setJob(job);
             final Predicate<FileInfo> filter = fileInfoFilter != null
                     ? fileInfoFilter
                     : f -> !f.isResourceOnly && ATTR_FORMAT_VALUE_DITA.equals(f.format);
-            for (final FileInfo f : job.getFileInfo(filter)) {
-                writer.write(new File(job.tempDir, f.file.getPath()).getAbsoluteFile());
+            final Map<URI, Attributes> cache = new ConcurrentHashMap<>();
+
+            if (parallel) {
+                final Pool<ImageMetadataFilter> pool = new Pool<>(() -> {
+                    final ImageMetadataFilter writer = new ImageMetadataFilter(outputDir, job, cache);
+                    writer.setLogger(logger);
+                    writer.setJob(job);
+                    return writer;
+                });
+                job.getFileInfo(filter).stream()
+                        .parallel()
+                        .map(f -> new File(job.tempDir, f.file.getPath()).getAbsoluteFile())
+                        .forEach(filename -> {
+                            final ImageMetadataFilter writer = pool.borrowObject();
+                            writer.write(filename);
+                            pool.returnObject(writer);
+                        });
+            } else {
+                final ImageMetadataFilter writer = new ImageMetadataFilter(outputDir, job, cache);
+                writer.setLogger(logger);
+                writer.setJob(job);
+                for (final FileInfo f : job.getFileInfo(filter)) {
+                    writer.write(new File(job.tempDir, f.file.getPath()).getAbsoluteFile());
+                }
             }
 
-            storeImageFormat(writer.getImages(), outputDir);
+            storeImageFormat(cache.keySet(), outputDir);
 
             try {
                 job.write();

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -137,7 +137,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
         final List<XMLFilter> pipe = new ArrayList<>();
 
         for (XmlFilterModule.FilterPair pair : filters) {
-            final AbstractXMLFilter filter = pair.filter;
+            final AbstractXMLFilter filter = pair.newInstance();
             filter.setLogger(logger);
             filter.setJob(job);
             filter.setCurrentFile(fileToParse);

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -16,11 +16,12 @@ import org.xml.sax.XMLFilter;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Map processes topics through XML filters. Filters are reused and should reset internal state on
@@ -38,13 +39,25 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
     public AbstractPipelineOutput execute(final AbstractPipelineInput input)
             throws DITAOTException {
         final Collection<FileInfo> fis = job.getFileInfo(fileInfoFilter);
-        for (final FileInfo f: fis) {
-            final URI file = job.tempDirURI.resolve(f.uri);
-            logger.info("Processing " + file);
-            try {
-                job.getStore().transform(file, getProcessingPipe(f));
-            } catch (final DITAOTException e) {
-                logger.error("Failed to process XML filter: " + e.getMessage(), e);
+        if (parallel) {
+            fis.stream().parallel().forEach(f -> {
+                final URI file = job.tempDirURI.resolve(f.uri);
+                logger.info("Processing " + file);
+                try {
+                    job.getStore().transform(file, getProcessingPipe(f));
+                } catch (final DITAOTException e) {
+                    logger.error("Failed to process XML filter: " + e.getMessage(), e);
+                }
+            });
+        } else {
+            for (final FileInfo f : fis) {
+                final URI file = job.tempDirURI.resolve(f.uri);
+                logger.info("Processing " + file);
+                try {
+                    job.getStore().transform(file, getProcessingPipe(f));
+                } catch (final DITAOTException e) {
+                    logger.error("Failed to process XML filter: " + e.getMessage(), e);
+                }
             }
         }
         return null;
@@ -58,18 +71,17 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
     private List<XMLFilter> getProcessingPipe(final FileInfo fi) {
         final URI fileToParse = job.tempDirURI.resolve(fi.uri);
         assert fileToParse.isAbsolute();
-        final List<XMLFilter> res = new ArrayList<>();
-        for (final FilterPair p: filters) {
-            if (p.predicate.test(fi)) {
-                final AbstractXMLFilter f = p.newInstance();
-                logger.debug("Configure filter " + f.getClass().getCanonicalName());
-                f.setCurrentFile(fileToParse);
-                f.setJob(job);
-                f.setLogger(logger);
-                res.add(f);
-            }
-        }
-        return res;
+        return filters.stream()
+                .filter(p -> p.predicate.test(fi))
+                .map(FilterPair::newInstance)
+                .map(f -> {
+                    logger.debug("Configure filter " + f.getClass().getCanonicalName());
+                    f.setCurrentFile(fileToParse);
+                    f.setJob(job);
+                    f.setLogger(logger);
+                    return f;
+                })
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -10,7 +10,6 @@ package org.dita.dost.module;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
-import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.types.XMLCatalog;
 import org.apache.tools.ant.util.FileNameMapper;
 import org.apache.xml.resolver.tools.CatalogResolver;
@@ -77,12 +76,6 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
             catalog = catalogResolver;
         }
         uriResolver = new DelegatingURIResolver(catalog, job.getStore());
-//        final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
-//        if (catalog == null) {
-//            uriResolver = new DelegatingURIResolver(catalogResolver, job.getStore());
-//        } else {
-//            uriResolver = new DelegatingURIResolver(catalog, catalogResolver, job.getStore());
-//        }
 
         if (fileInfoFilter != null) {
             final Collection<Job.FileInfo> res = job.getFileInfo(fileInfoFilter);
@@ -114,7 +107,6 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         } catch (SaxonApiException e) {
             throw new RuntimeException("Failed to compile stylesheet '" + style.getAbsolutePath() + "': " + e.getMessage(), e);
         }
-//        long start = System.currentTimeMillis();
         if (in != null) {
             transform(in, out);
         } else if (parallel) {
@@ -163,8 +155,6 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                 transform(in, out);
             }
         }
-//        long end = System.currentTimeMillis();
-//        logger.info("Processing took " + (end - start) + " ms");
         return null;
     }
 

--- a/src/main/java/org/dita/dost/util/Pool.java
+++ b/src/main/java/org/dita/dost/util/Pool.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2020 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+public class Pool<T> {
+
+    private final Queue<T> objects;
+    private final Supplier<T> create;
+
+    public Pool(Supplier<T> create) {
+        this.create = create;
+        this.objects = new ConcurrentLinkedQueue<T>();
+    }
+
+    public T borrowObject() {
+        T t;
+        if ((t = objects.poll()) == null) {
+            t = create.get();
+        }
+        return t;
+    }
+
+    public void returnObject(T object) {
+        this.objects.offer(object);
+    }
+}

--- a/src/main/java/org/dita/dost/util/Pool.java
+++ b/src/main/java/org/dita/dost/util/Pool.java
@@ -12,6 +12,12 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
+/**
+ *
+ * Simple object pool.
+ *
+ * @since 3.6
+ */
 public class Pool<T> {
 
     private final Queue<T> objects;

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -54,7 +54,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     private final File tempDir;
     private final String uplevels;
     private int depth = 0;
-    private final Map<URI, Attributes> cache = new HashMap<>();
+    private final Map<URI, Attributes> cache;
     private final Job job;
     private final XMLReader reader;
     private final SvgMetadataReader svgMetadataReader;
@@ -64,11 +64,12 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     /**
      * Constructor.
      */
-    public ImageMetadataFilter(final File outputDir, final Job job) {
+    public ImageMetadataFilter(final File outputDir, final Job job, final Map<URI, Attributes> cache) {
         this.outputDir = outputDir;
         this.job = job;
         this.tempDir = job.tempDir;
         this.uplevels = job.getProperty("uplevels");
+        this.cache = cache;
         svgMetadataReader = new SvgMetadataReader();
         try {
             reader = XMLUtils.getXMLReader();
@@ -82,7 +83,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     // AbstractWriter methods --------------------------------------------------
 
     @Override
-    public void write(final File filename) throws DITAOTException {
+    public void write(final File filename) {
         // ignore in-exists file
         if (filename == null || !job.getStore().exists(filename.toURI())) {
             return;
@@ -98,6 +99,11 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
         }
     }
 
+    /**
+     * Get list of images.
+     * @deprecated since 3.6
+     */
+    @Deprecated
     public Collection<URI> getImages() {
         return ImmutableList.copyOf(cache.keySet());
     }

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -51,6 +51,7 @@ See the accompanying LICENSE file for applicable license.
                    log-arg"/>
 
   <target name="init-properties">
+    <property name="parallel" value="false"/>
     <property name="store-type" value="file"/>
     <property name="default.language" value="en"/>
     <property name="generate-debug-attributes" value="true"/>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -174,7 +174,7 @@ See the accompanying LICENSE file for applicable license.
     unless="preprocess.keyref.skip"
     description="Resolve input map files keyref">
     <pipeline message="Resolve keyref." taskname="keyref">
-      <module class="org.dita.dost.module.KeyrefModule">
+      <module class="org.dita.dost.module.KeyrefModule" parallel="${parallel}">
         <ditafileset format="ditamap" input="true"/>
         <ditafileset format="ditamap" inputResource="true"/>
         <param name="transtype" value="${transtype}"/>
@@ -276,7 +276,7 @@ See the accompanying LICENSE file for applicable license.
           unless="preprocess.keyref.skip"
           description="Resolve keyref">
     <pipeline message="Resolve keyref." taskname="keyref">
-      <module class="org.dita.dost.module.KeyrefModule">
+      <module class="org.dita.dost.module.KeyrefModule" parallel="${parallel}">
         <ditafileset format="dita"/>
         <param name="transtype" value="${transtype}"/>
       </module>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -217,7 +217,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -318,7 +318,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -409,7 +409,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if:set="onlytopic.in.map"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <dita:extension id="dita.preprocess.topicpull.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -209,7 +209,9 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
-        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/map-conref.xsl" filenameparameter="file-being-processed">
+        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/map-conref.xsl"
+        filenameparameter="file-being-processed"
+        parallel="${parallel}">
         <ditafileset format="ditamap" conref="true" input="true"/>
         <ditafileset format="ditamap" conref="true" inputResource="true"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
@@ -308,7 +310,9 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
-            style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl" filenameparameter="file-being-processed">
+            style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl"
+            filenameparameter="file-being-processed"
+            parallel="${parallel}">
         <ditafileset conref="true" format="dita"/>
         <ditafileset conref="true" format="ditamap"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
@@ -340,7 +344,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="preprocess2.topic-fragment"
           description="Normalize same topic fragment identifiers and table column names, and resolve coderef">
     <pipeline message="Resolve topic fragment." taskname="preprocess2.topic-fragment">
-      <sax>
+      <sax parallel="${parallel}">
         <ditafileset format="dita"/>
         <filter class="org.dita.dost.writer.TopicFragmentFilter">
           <param name="attributes" value="href"/>
@@ -397,7 +401,8 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Pull metadata for link and xref element" taskname="topicpull">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
-        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl">
+        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl"
+        parallel="${parallel}">
         <ditafileset format="dita" processingRole="normal"/>
         <param name="TABLELINK" expression="${args.tablelink.style}" if:set="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if:set="args.figurelink.style" />

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -217,7 +217,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -318,7 +317,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -409,7 +407,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="ONLYTOPICINMAP" expression="${onlytopic.in.map}" if:set="onlytopic.in.map"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <dita:extension id="dita.preprocess.topicpull.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -439,7 +439,7 @@ See the accompanying LICENSE file for applicable license.
           description="Clean preprocess">
     <pipeline message="Clean preprocess" taskname="clean-preprocess">
       <param name="use-result-filename" value="${clean-preprocess.use-result-filename}" if:set="clean-preprocess.use-result-filename"/>
-      <module class="org.dita.dost.module.CleanPreprocessModule">
+      <module class="org.dita.dost.module.CleanPreprocessModule" parallel="${parallel}">
         <param name="result.rewrite-rule.xsl" value="${result.rewrite-rule.xsl}" if:set="result.rewrite-rule.xsl"/>
         <param name="result.rewrite-rule.class" value="${result.rewrite-rule.class}" if:set="result.rewrite-rule.class"/>
       </module>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -248,7 +248,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -403,7 +402,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="defaultLanguage" expression="${default.language}"/>
         <param name="remove-broken-links" expression="${remove-broken-links}" if:set="remove-broken-links"/>
         <dita:extension id="dita.preprocess.topicpull.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -256,7 +256,7 @@ See the accompanying LICENSE file for applicable license.
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
           description="Normalize same topic fragment identifiers and table column names, and resolve coderef">
     <pipeline message="Resolve topic fragment." taskname="topic-fragment">
-      <sax format="dita" parallel="false"><!--${parallel}-->
+      <sax format="dita" parallel="${parallel}">
         <filter class="org.dita.dost.writer.TopicFragmentFilter">
           <param name="attributes" value="href"/>
         </filter>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -392,7 +392,8 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Pull metadata for link and xref element" taskname="topicpull">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.topicpull}"
-        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl">
+        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/topicpull.xsl"
+        parallel="${parallel}">
         <ditafileset format="dita" processingRole="normal"/>
         <param name="TABLELINK" expression="${args.tablelink.style}" if:set="args.tablelink.style" />
         <param name="FIGURELINK" expression="${args.figurelink.style}" if:set="args.figurelink.style" />

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -248,7 +248,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>
         <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>
@@ -310,8 +310,7 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"
-            filenameparameter="file-being-processed"
-            parallel="false">
+            filenameparameter="file-being-processed">
         <ditafileset format="ditamap" input="true"/>
         <param name="TRANSTYPE" expression="${transtype}" />
         <param name="child-topicref-warning" expression="false"/>
@@ -404,7 +403,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="defaultLanguage" expression="${default.language}"/>
         <param name="remove-broken-links" expression="${remove-broken-links}" if:set="remove-broken-links"/>
         <dita:extension id="dita.preprocess.topicpull.param" behavior="org.dita.dost.platform.InsertAction"/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
     </pipeline>
   </target>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -302,7 +302,7 @@ See the accompanying LICENSE file for applicable license.
     unless="preprocess.keyref.skip"
     description="Resolve keyref">
     <pipeline message="Resolve keyref." taskname="keyref">
-      <module class="org.dita.dost.module.KeyrefModule">
+      <module class="org.dita.dost.module.KeyrefModule" parallel="${parallel}">
         <param name="transtype" value="${transtype}"/>
       </module>
     </pipeline>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -241,7 +241,9 @@ See the accompanying LICENSE file for applicable license.
     <pipeline message="Resolve conref in input files" taskname="conref">
       <xslt basedir="${dita.temp.dir}"
         reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
-        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl" filenameparameter="file-being-processed">
+        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl"
+        filenameparameter="file-being-processed"
+        parallel="${parallel}">
         <ditafileset conref="true"/>
         <param name="EXPORTFILE" expression="${exportfile.url}"/>
         <param name="TRANSTYPE" expression="${transtype}"/>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -256,7 +256,7 @@ See the accompanying LICENSE file for applicable license.
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
           description="Normalize same topic fragment identifiers and table column names, and resolve coderef">
     <pipeline message="Resolve topic fragment." taskname="topic-fragment">
-      <sax format="dita">
+      <sax format="dita" parallel="false"><!--${parallel}-->
         <filter class="org.dita.dost.writer.TopicFragmentFilter">
           <param name="attributes" value="href"/>
         </filter>
@@ -281,7 +281,7 @@ See the accompanying LICENSE file for applicable license.
     <property name="dita.preprocess.reloadstylesheet.mapref" value="${dita.preprocess.reloadstylesheet}"/>
     <dirname property="mapref.workdir" file="${dita.temp.dir}/${user.input.file}" />
     <pipeline message="Resolve mapref in ditamap" taskname="mapref">
-      <module class="org.dita.dost.module.MaprefModule">
+      <module class="org.dita.dost.module.MaprefModule" parallel="false">
         <param name="style" location="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"/>
         <ditafileset format="ditamap"/>
         <dita:extension id="dita.preprocess.mapref.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -308,7 +308,8 @@ See the accompanying LICENSE file for applicable license.
       <xslt basedir="${dita.temp.dir}"
             reloadstylesheet="${dita.preprocess.reloadstylesheet.mapref}"
             style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/mapref.xsl"
-            filenameparameter="file-being-processed">
+            filenameparameter="file-being-processed"
+            parallel="false">
         <ditafileset format="ditamap" input="true"/>
         <param name="TRANSTYPE" expression="${transtype}" />
         <param name="child-topicref-warning" expression="false"/>
@@ -336,7 +337,7 @@ See the accompanying LICENSE file for applicable license.
     description="Process chunks">
     <pipeline message="Process chunks." taskname="chunk"
       inputmap="${user.input.file}">
-      <module class="org.dita.dost.module.ChunkModule">
+      <module class="org.dita.dost.module.ChunkModule" parallel="false">
         <param name="transtype" value="${transtype}"/>
         <param name="root-chunk-override" value="${root-chunk-override}" if:set="root-chunk-override"/>
       </module>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -168,6 +168,10 @@ See the accompanying LICENSE file for applicable license.
       <val default="true">file</val>
       <val>memory</val>
     </param>
+    <param name="parallel" desc="Run processes in parallel when possible" type="enum">
+      <val>true</val>
+      <val default="true">false</val>
+    </param>
   </transtype>
   <feature extension="dita.image.extensions" value=".gif"/>
   <feature extension="dita.image.extensions" value=".eps"/>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -121,7 +121,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="html5.image-metadata"
           unless="html5.image-metadata.skip" description="Read image metadata">
     <pipeline message="Read image metadata." taskname="image-metadata">
-      <module class="org.dita.dost.module.ImageMetadataModule">
+      <module class="org.dita.dost.module.ImageMetadataModule" parallel="${parallel}">
         <param name="outputdir" location="${dita.output.dir}"/>
       </module>
     </pipeline>
@@ -172,7 +172,8 @@ See the accompanying LICENSE file for applicable license.
             extension="${out.ext}"
             style="${args.xsl}"
             filenameparameter="FILENAME"
-            filedirparameter="FILEDIR">
+            filedirparameter="FILEDIR"
+            parallel="${parallel}">
         <ditafileset format="dita" processingRole="normal"/>
         <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile"/>
         <param name="CSS" expression="${args.css.file}" if:set="args.css.file"/>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -194,7 +194,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <params/>
-        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
       </pipeline>
     </sequential>

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -194,7 +194,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="OUTPUTDIR" expression="${dita.output.dir}"/>
         <param name="defaultLanguage" expression="${default.language}"/>
         <params/>
-        <xmlcatalog refid="dita.catalog"/>
+        <!--xmlcatalog refid="dita.catalog"/-->
       </xslt>
       </pipeline>
     </sequential>

--- a/src/test/java/org/dita/dost/module/DummyPipelineModule.java
+++ b/src/test/java/org/dita/dost/module/DummyPipelineModule.java
@@ -59,4 +59,8 @@ public class DummyPipelineModule implements AbstractPipelineModule {
         // Noop
     }
 
+    @Override
+    public void setParallel(final boolean parallel) {
+        // Noop
+    }
 }

--- a/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
@@ -13,8 +13,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.dita.dost.store.StreamStore;
@@ -22,6 +26,7 @@ import org.dita.dost.util.XMLUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -48,7 +53,8 @@ public class ImageMetadataFilterTest {
 
         final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", "");
-        final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job);
+        final Map<URI, Attributes> cache = new HashMap<>();
+        final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job, cache);
         filter.setLogger(new TestUtils.TestLogger());
         filter.setJob(job);
         filter.write(f.getAbsoluteFile());
@@ -58,7 +64,7 @@ public class ImageMetadataFilterTest {
         assertEquals(Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
                         .map(img -> new File(srcDir, img).toURI())
                         .collect(Collectors.toSet()),
-                new HashSet(filter.getImages()));
+                cache.keySet());
     }
 
     @Test
@@ -69,7 +75,8 @@ public class ImageMetadataFilterTest {
 
         final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         job.setProperty("uplevels", ".." + File.separator);
-        final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job);
+        final Map<URI, Attributes> cache = new HashMap<>();
+        final ImageMetadataFilter filter = new ImageMetadataFilter(srcDir, job, cache);
         filter.setLogger(new TestUtils.TestLogger());
         filter.setJob(job);
         filter.write(f.getAbsoluteFile());
@@ -79,7 +86,7 @@ public class ImageMetadataFilterTest {
         assertEquals(Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
                         .map(img -> new File(srcDir, img).toURI())
                         .collect(Collectors.toSet()),
-                new HashSet(filter.getImages()));
+                cache.keySet());
     }
 
     @AfterClass


### PR DESCRIPTION
## Description
Add support for running preprocessing module code in parallel when enabled.

## Motivation and Context
May make processing faster some types and sizes of input sets, depending on the processing platform.

Parallel processing is enabled by setting `parallel` property to `true`; default is `false`.

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

Default for this feature is backwards compatible because parallel processing is disabled.