### PR TITLE
Fix typo in parameter description attribute

### DIFF
--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -164,7 +164,7 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="result.rewrite-rule.xsl" desc="Specifies the name of the XSLT file used to rewrite filenames." type="string"/>
     <param name="result.rewrite-rule.class" desc="Specifies the name of the Java class used to rewrite filenames." type="string"/>
-    <param name="store-type" desc="Temporary file store type" type="enum">
+    <param name="store-type" desc="Temporary file store type." type="enum">
       <val default="true">file</val>
       <val>memory</val>
     </param>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -164,7 +164,7 @@ See the accompanying LICENSE file for applicable license.
     </param>
     <param name="result.rewrite-rule.xsl" desc="Specifies the name of the XSLT file used to rewrite filenames." type="string"/>
     <param name="result.rewrite-rule.class" desc="Specifies the name of the Java class used to rewrite filenames." type="string"/>
-    <param name="store-type" deprecated="Temporary file store type" type="enum">
+    <param name="store-type" desc="Temporary file store type" type="enum">
       <val default="true">file</val>
       <val>memory</val>
     </param>


### PR DESCRIPTION
## Description

When the `store-type` parameter was added in dita-ot/dita-ot@b402e2f for #3548, it looks like the `@deprecated` attribute name may have been chosen from an IDE autocompletion process instead of the `@desc` attribute that provides the parameter description.

## Motivation and Context

This commit fixes the attribute name, so the _(currently missing)_ description will appear in the parameter documentation at 
<https://www.dita-ot.org/dev/parameters/parameters-base.html#base__store-type>.

## How Has This Been Tested?

 ✅ Built site output locally, parameter description is shown.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

- Fixing this in plug-in code will fix the docs.
