### PR TITLE
Fix setting html5.map.url property

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -110,12 +110,11 @@ See the accompanying LICENSE file for applicable license.
                    html5.topics.common.inner"/>
 
   <target name="html5.topic.init">
-    <pathconvert property="html5.map">
+    <pathconvert property="html5.map.url" unless:set="noMap">
       <first>
         <ditafileset format="ditamap" input="true"/>
       </first>
     </pathconvert>
-    <makeurl property="html5.map.url" file="${html5.map}" validate="no" unless:set="noMap"/>
     <makeurl file="${dita.input.valfile}" property="dita.input.valfile.url" validate="no" if:set="dita.input.valfile"/>
   </target>
 


### PR DESCRIPTION

## Description
Fix `html5.map.url` property declaration.

## Motivation and Context
Property was incorrectly set with `<makeurl>` that caused a URL to be resolved against a file path.


## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_
