### PR TITLE
Fix broken Slack badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -95,7 +95,7 @@ See the [documentation][docs] for arguments and [options].
 DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 
 [build]: https://travis-ci.org/dita-ot/dita-ot.svg?branch=develop
-[slack]: http://slack.dita-ot.org/badge.svg
+[slack]: https://img.shields.io/badge/Slack-Join%20us!-%234A154B?style=flat&logo=slack
 [site]: https://www.dita-ot.org/
 [dist]: https://www.dita-ot.org/download
 [support]: https://github.com/dita-ot/.github/blob/master/SUPPORT.md


### PR DESCRIPTION
After DNS settings were changed a while back, the previous badge is no longer available at [slack.dita-ot.org](http://slack.dita-ot.org), which previously pointed to a self-hosted app on Heroku, but now redirects to the native Slack invite form at [dita-ot.slack.com](https://dita-ot.slack.com).

This replaces the old badge with an SVG variant from https://shields.io: 

![](https://img.shields.io/badge/Slack-Join%20us!-%234A154B?style=flat&logo=slack)
