### PR TITLE
Share latest from oasis-tcs/dita and oasis-tcs/dita-techcomm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,8 +171,8 @@ def bundled = [
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
         "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
-        "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20200417/org.oasis-open.dita.v2_0.zip",
-        "dita20-techcomm": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20200417/org.oasis-open.dita.techcomm.v2_0.zip",
+        "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20201027/org.oasis-open.dita.v2_0.zip",
+        "dita20-techcomm": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20201027/org.oasis-open.dita.techcomm.v2_0.zip",
         "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
         "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip"
 ]


### PR DESCRIPTION
Adds the latest DITA 2.0 beta doctypes from
https://github.com/oasis-tcs/dita
and
https://github.com/oasis-tcs/dita-techcomm

Fixes #3586, #3601 