### PR TITLE
Fix development build folder name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ def cleanVersion = project.version.split('\\.').toList()[2] == "0" ?
         project.version.split('\\.').toList().subList(0, 2).join('.').toString() :
         project.version
 def distVersion = project.hasProperty("commit") && (!project.hasProperty("tag") || tag.empty) ?
-                  "${project.version}+${commit.substring(0, 7)}" :
+                  "${project.version}@${commit.substring(0, 7)}" :
                   "${cleanVersion}"
 def distFileName = (project.hasProperty("tag") && tag.empty) ?
                    "develop" :


### PR DESCRIPTION
Development versions of the distribution package are downloaded as `dita-ot-develop.zip`, which unpacks to reveal a folder named with the current version number and a suffix with the commit hash that the package is based on, such as `dita-ot-3.6.0-SNAPSHOT+61f95e5`

Builds fail when run from this folder as @eerohele described in #2414.

This commit changes the commit hash separator to the `@` sign, so the folder name is generated as `dita-ot-3.6.0-SNAPSHOT@61f95e5`, which allows builds to run from the folder without errors, and follows the convention GitHub uses to represent commits, such as `dita-ot/dita-ot@61f95e5` to point to 61f95e5.

In https://github.com/dita-ot/dita-ot/issues/2414#issuecomment-432958719, @jelovirt expressed a preference for resolving the underlying issue rather than a workaround, but until that happens, we should ensure that our dev build packages can be run without renaming the folder.

Fixes #2414.

Signed-off-by: Roger Sheen <roger@infotexture.net>
