### PR TITLE
Fix workdir-uri generation bug

### DIFF
--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -270,7 +270,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
                     }
                     break;
                 case PI_WORKDIR_TARGET_URI:
-                    d = workdir.toURI().toString();
+                    d = toDirURI(workdir).toString();
                     break;
                 case PI_PATH2PROJ_TARGET:
                     if (path2project != null) {

--- a/src/main/java/org/dita/dost/util/URLUtils.java
+++ b/src/main/java/org/dita/dost/util/URLUtils.java
@@ -763,4 +763,20 @@ public final class URLUtils {
         }
         return null;
     }
+
+    /**
+     * Convert File for a directory into URI.
+     *
+     * @param dir File for directory path
+     * @return URI representing this directory
+     * @since 3.6
+     */
+    public static URI toDirURI(final File dir) {
+        final URI res = dir.toURI();
+        if (res.getPath().endsWith("/")) {
+            return res;
+        } else {
+            return setPath(res, res.getPath() + "/");
+        }
+    }
 }

--- a/src/test/java/org/dita/dost/util/URLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/URLUtilsTest.java
@@ -7,14 +7,18 @@
  */
 package org.dita.dost.util;
 
+import static org.dita.dost.util.URLUtils.toDirURI;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class URLUtilsTest {
 
@@ -251,4 +255,20 @@ public class URLUtilsTest {
         } catch (final NullPointerException e) {}
     }
 
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void toDirURI_exists() throws IOException {
+        final File src = tempDir.newFolder();
+        final URI act = toDirURI(src);
+        assertTrue(act.toString().endsWith("/"));
+    }
+
+    @Test
+    public void toDirURI_missing() throws IOException {
+        final File src = new File(tempDir.newFolder(), "missing");
+        final URI act = toDirURI(src);
+        assertTrue(act.toString().endsWith("/"));
+    }
 }


### PR DESCRIPTION
## Description
Make sure URI for a directory will always end in a trailing slash. 

## Motivation and Context
If a `File` points to a path that doesn't exist, `File.toURI()` will not output a trailing slash.

## How Has This Been Tested?
Tests pass and added a new test for `toDirURI` function.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None
