### PR TITLE
Fix current file directory URI resolution when file doesn't exist

### DIFF
--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -292,8 +292,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
     private void writeToContentChunk(final String tmpContent, final URI outputFileName, final boolean needWriteDitaTag) throws IOException {
         assert outputFileName.isAbsolute();
         logger.info("Writing " + outputFileName);
-        try (OutputStream out = job.getStore().getOutputStream(outputFileName);
-             OutputStreamWriter ditaFileOutput = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+        try (Writer ditaFileOutput = new OutputStreamWriter(job.getStore().getOutputStream(outputFileName), StandardCharsets.UTF_8)) {
             if (outputFileName.equals(changeTable.get(outputFileName))) {
                 // if the output file is newly generated file
                 // write the xml header and workdir PI into new file

--- a/src/main/java/org/dita/dost/writer/TopicRefWriter.java
+++ b/src/main/java/org/dita/dost/writer/TopicRefWriter.java
@@ -31,6 +31,7 @@ public final class TopicRefWriter extends AbstractXMLFilter {
     private Map<URI, URI> changeTable = null;
     private Map<URI, URI> conflictTable = null;
     private File currentFileDir = null;
+    private URI currentFileDirURI = null;
     /** Using for rectify relative path of xml */
     private String fixpath = null;
 
@@ -38,6 +39,8 @@ public final class TopicRefWriter extends AbstractXMLFilter {
     public void write(final File outputFilename) throws DITAOTException {
         setCurrentFile(outputFilename.toURI());
         currentFileDir = outputFilename.getParentFile();
+        currentFileDirURI = outputFilename.toURI().resolve(".");
+        logger.info("Process " + outputFilename.toURI());
         super.write(outputFilename);
     }
 
@@ -159,7 +162,8 @@ public final class TopicRefWriter extends AbstractXMLFilter {
         if (isLocalDita(atts)) {
             // replace the href value if it's referenced topic is extracted.
             final URI rootPathName = currentFile;
-            URI changeTargetkey = stripFragment(currentFileDir.toURI().resolve(hrefValue));
+            URI target = currentFile.resolve(hrefValue);
+            URI changeTargetkey = stripFragment(target);
             URI changeTarget = changeTable.get(changeTargetkey);
 
             final String topicID = getTopicID(toURI(hrefValue));


### PR DESCRIPTION

## Description
When using in-memory store, chunk reference rewrite filter incorrectly resolves references.

## Motivation and Context
This PR files base URI initialization to correctly result in base URI that ends in slash.

Fixes error messages reported in #3621

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

