### PR TITLE
Fix for #3558, update PDF libraries

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/build.gradle
+++ b/src/main/plugins/org.dita.pdf2.fop/build.gradle
@@ -13,19 +13,19 @@ repositories {
     }
 }
 dependencies {
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop', version: '2.4') {
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop', version: '2.5') {
         exclude group: 'xalan'
         exclude group: 'ant'
         exclude group: 'javax.servlet'
     }
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.12') {
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.13') {
         exclude group: 'xalan'
     }
     runtimeOnly group: 'xml-apis', name: 'xml-apis-ext', version: '1.3.04'
-    runtimeOnly group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25'
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop-pdf-images', version: '2.4') {
+    runtimeOnly group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.30'
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop-pdf-images', version: '2.5') {
     }
-    runtimeOnly group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.17'
+    runtimeOnly group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.21'
 }
 
 task copyInstall(type: Copy) {

--- a/src/main/plugins/org.dita.pdf2.fop/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/plugin.xml
@@ -11,15 +11,15 @@ See the accompanying LICENSE file for applicable license.
   <!-- extensions -->
   <feature extension="depend.org.dita.pdf2.init.pre" value="transform.fo2pdf.fop.init"/>
   <feature extension="depend.org.dita.pdf2.format" value="transform.fo2pdf.fop"/>
-  <feature extension="dita.conductor.lib.import" file="lib/batik-all-1.12.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/batik-all-1.13.jar"/>
 <!--  <feature extension="dita.conductor.lib.import" file="lib/commons-logging-1.2.jar"/>-->
-  <feature extension="dita.conductor.lib.import" file="lib/fontbox-2.0.17.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/fop-2.4.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/fop-pdf-images-2.4.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/jcl-over-slf4j-1.7.25.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fontbox-2.0.21.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fop-2.5.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fop-pdf-images-2.5.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/jcl-over-slf4j-1.7.30.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xml-apis-ext-1.3.04.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/pdfbox-2.0.17.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/slf4j-api-1.7.25.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/pdfbox-2.0.21.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/slf4j-api-1.7.30.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xmlgraphics-commons-2.4.jar"/>
   <transtype name="pdf" desc="PDF">
     <param name="pdf.formatter" desc="Specifies the XSL processor." type="enum">


### PR DESCRIPTION
Update Apache FOP to 2.5, Batik to 1.13, PDF Box to 2.0.21, fop-pdf-images to 2.5, jcl-over-slf4j to 1.7.30

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Update PDF plugin libraries to latest stable versions

---

## Description
Update PDF plugin libraries to latest stable versions
Update Apache FOP to 2.5, Batik to 1.13, PDF Box to 2.0.21, fop-pdf-images to 2.5, jcl-over-slf4j to 1.7.30

## Motivation and Context
Fix for #3558 

## How Has This Been Tested?
I tested on Mac producing PDFs from DITA topics containing SVG and PDF images, on both a small project and a larger one.

## Type of Changes
- Component update

## Documentation and Compatibility
Change in the user guide the version of the libraries listed for the PDF plugin.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
