### PR TITLE
Add missing terminal punctuation

### DIFF
--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -168,7 +168,7 @@ See the accompanying LICENSE file for applicable license.
       <val default="true">file</val>
       <val>memory</val>
     </param>
-    <param name="parallel" desc="Run processes in parallel when possible" type="enum">
+    <param name="parallel" desc="Run processes in parallel when possible." type="enum">
       <val>true</val>
       <val default="true">false</val>
     </param>


### PR DESCRIPTION
Information about default values is appended to the parameter description in the documentation, so it's important that each description is a complete sentence.

