### PR TITLE
HTML5: Move hard-coded styles to Sass partials

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/commonltr.scss
+++ b/src/main/plugins/org.dita.html5/sass/commonltr.scss
@@ -9,8 +9,8 @@
 // Import variables first to ensure they are available to subsequent partials
 @import 'variables';
 
-@import 'domains';
 @import 'display-attr';
+@import 'domains';
 @import 'figures';
 @import 'headings';
 @import 'indexterms';

--- a/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
@@ -9,12 +9,14 @@
 }
 
 .line-through {
+  text-decoration: line-through;
 }
 
 .i {
 }
 
 .overline {
+  text-decoration: overline;
 }
 
 .sub {

--- a/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_pr-d.scss
@@ -40,6 +40,11 @@
 }
 
 .syntaxdiagram {
+  border: 1 black solid;
+  color: maroon;
+  display: block;
+  margin-bottom: 6pt;
+  padding: 2pt;
 }
 
 // inline

--- a/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
@@ -141,6 +141,9 @@
 }
 
 .lq {
+  div {
+    text-align: right;
+  }
 }
 
 .metadata {

--- a/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_topic.scss
@@ -280,6 +280,7 @@
 
 // inline
 .boolean {
+  color: green;
 }
 
 .cite {
@@ -307,6 +308,7 @@
 }
 
 .state {
+  color: red;
 }
 
 .term {

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -63,7 +63,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' hi-d/line-through ')]" name="topic.hi-d.line-through">
-    <span style="text-decoration:line-through">
+    <span>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates/>
@@ -71,7 +71,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' hi-d/overline ')]" name="topic.hi-d.overline">
-    <span style="text-decoration:overline">
+    <span>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -12,7 +12,8 @@ See the accompanying LICENSE file for applicable license.
   <!-- Logical containers -->
   
   <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ')]">
-    <div style="display: block; border: 1 black solid; padding: 2pt; color: maroon; margin-bottom: 6pt;">
+    <div>
+    <xsl:call-template name="commonattributes"/>
     <xsl:apply-templates mode="process-syntaxdiagram"/>
     </div>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -585,7 +585,7 @@ See the accompanying LICENSE file for applicable license.
             </xsl:choose></cite></a></div>
         </xsl:when>
         <xsl:when test="@reftitle"> <!-- Insert citation text -->
-          <br/><div style="text-align:right"><cite><xsl:value-of select="@reftitle"/></cite></div>
+          <br/><div><cite><xsl:value-of select="@reftitle"/></cite></div>
         </xsl:when>
         <xsl:otherwise><!--nop - do nothing--></xsl:otherwise>
       </xsl:choose>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -569,7 +569,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates/>
       <xsl:choose>
         <xsl:when test="@href">
-          <br/><div style="text-align:right"><a>
+          <br/><div><a>
             <xsl:attribute name="href">
               <xsl:call-template name="href"/>
             </xsl:attribute>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1224,7 +1224,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Use color to indicate these types for now -->
   <!-- output the tag & it's state -->
   <xsl:template match="*[contains(@class, ' topic/boolean ')]" name="topic.boolean">
-   <span style="color:green">
+   <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:value-of select="name()"/><xsl:text>: </xsl:text><xsl:value-of select="@state"/>
@@ -1233,7 +1233,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- output the tag, it's name & value -->
   <xsl:template match="*[contains(@class, ' topic/state ')]" name="topic.state">
-  <span style="color:red">
+  <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:value-of select="name()"/><xsl:text>: </xsl:text><xsl:value-of select="@name"/><xsl:text>=</xsl:text><xsl:value-of select="@value"/>


### PR DESCRIPTION
In several places, the HTML5 code still hard-codes inline style attributes, which prevent users from customizing the presentation of the corresponding elements when these are emitted to HTML5 output, including:

- line-through and overline elements
- syntax diagrams
- long quote citations
- Boolean states

These changes move the default presentation rules to CSS to allow users to override presentation in custom stylesheets.

The output is visually equivalent to the results generated by previous toolkit versions.