### PR TITLE
Fix repeat count in install and uninstall subcommands

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -284,6 +284,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         final Map<String, Object> definedProps = new HashMap<>(args.definedProps);
         projectProps = Collections.singletonList(definedProps);
         buildFile = args.buildFile;
+        repeat = 1;
 
         if (args.justPrintUsage) {
             args.printUsage(false);
@@ -370,7 +371,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         }
 
         // make sure buildfile exists
-        if (!args.buildFile.exists() || buildFile.isDirectory()) {
+        if (!buildFile.exists() || buildFile.isDirectory()) {
             System.out.println("Buildfile " + buildFile + " does not exist!");
             throw new BuildException("Build failed");
         }


### PR DESCRIPTION
## Description
Fix repeat count initialization in install and uninstall subcommands.

## Motivation and Context
Repeat count was set to zero in install and uninstall subcommands and resulted in process not being run a single time. This initializes the count to one, so the process is run once.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation

No need to add to release notes for 3.6, because this was broken in PR for repeated conversion that is part of 3.6.
