### PR TITLE
Add GitHub Actions for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,5 @@ jobs:
       run: ./gradlew check --info --stacktrace --no-daemon
     - name: Run end to end tests
       run: ./gradlew e2eTest --info --stacktrace --no-daemon
-
+    - name: Run integration tests
+      run: ./gradlew integrationTest --info --stacktrace --no-daemon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew
+    - name: Run unit tests
+      run: ./gradlew check --info --stacktrace --no-daemon
+    - name: Run end to end tests
+      run: ./gradlew e2eTest --info --stacktrace --no-daemon
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - JAVA_OPTS="-Xmx2048M"
     - GRADLE_OPTS="-Xmx2048M"
 stages:
-  - name: test
+#  - name: test
   - name: snapshot
     if: repo = dita-ot/dita-ot AND branch = develop AND type != pull_request
   - name: release
@@ -16,14 +16,14 @@ stages:
     if: repo = dita-ot/dita-ot AND tag IS present AND type != pull_request
 jobs:
   include:
-    # Test
-    - stage: test
-      name: "Unit and E2E tests"
-      install: "./gradlew"
-      script: "./gradlew check e2eTest   --info --stacktrace --no-daemon"
-    - install: "./gradlew"
-      name: "Integration tests"
-      script: "./gradlew integrationTest --info --stacktrace --no-daemon"
+#    # Test
+#    - stage: test
+#      name: "Unit and E2E tests"
+#      install: "./gradlew"
+#      script: "./gradlew check e2eTest   --info --stacktrace --no-daemon"
+#    - install: "./gradlew"
+#      name: "Integration tests"
+#      script: "./gradlew integrationTest --info --stacktrace --no-daemon"
     # Snapshot
     - stage: snapshot
       name: "Snapshot distribution package deployment"


### PR DESCRIPTION
Add GitHub Actions for unit tests because Travis CI seems to be winding down for OSS projects and has been a lot slower than before.