### PR TITLE
Remove disabled pdf2.index.skip param and deprecate old PDF indexing

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -243,12 +243,14 @@ with those set forth herein.
     <property name="args.tablelink.style" value="NUMTITLE"/>
   </target>
 
+  <!-- Deprecated since 3.4 -->
   <target name="transform.topic2fo.index.init">
     <condition property="_pdf2.index.skip" value="true">
       <istrue value="${pdf2.index.skip}"/>
     </condition>
   </target>
 
+  <!-- Deprecated since 3.4 -->
   <target name="transform.topic2fo.index"
           depends="transform.topic2fo.index.init"
           unless="_pdf2.index.skip">

--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -54,10 +54,14 @@ See the accompanying LICENSE file for applicable license.
       <val desc="Enables chunk processing">true</val>
       <val desc="Disables chunk processing" default="true">false</val>
     </param>
+    <!-- Deprecated since 3.4 -->
+    <!-- Disable deprecated built-in indexing -->
+    <!--
     <param name="pdf2.index.skip" desc="Disable built-in index processing." type="enum">
       <val>yes</val>
       <val default="true">no</val>
     </param>
+    -->
   </transtype>
   <transtype name="pdf2" extends="pdf" desc="PDF2"/>
   <feature extension="dita.transtype.print" value="pdf"/>
@@ -67,6 +71,7 @@ See the accompanying LICENSE file for applicable license.
   <feature extension="dita.conductor.pdf2.formatter.check" value="ah"/>
   <feature extension="dita.xsl.strings" file="cfg/common/vars/strings.xml"/>
   <feature extension="dita.specialization.catalog.relative" file="cfg/catalog.xml"/>
+  <!-- Deprecated since 3.4 -->
   <!-- Disable deprecated built-in indexing -->
   <!--<feature extension="depend.org.dita.pdf2.index" value="transform.topic2fo.index"/>-->
   <template file="build_template.xml"/>

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexCollator.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexCollator.java
@@ -32,6 +32,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class IndexCollator {
 
     private com.ibm.icu.text.Collator icu4jCollator = null;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexComparator.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexComparator.java
@@ -35,6 +35,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 class IndexComparator implements Comparator<IndexEntry> {
 
     private final IndexCollator Collator;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexEntry.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexEntry.java
@@ -42,7 +42,9 @@ See the accompanying LICENSE file for applicable license.
  * <br><br>
  * Respresents the Adobe Framemaker's index entry<br>
  * <code>See "Adobe Framemaker 7.1" help, topic "Adding index markers" (page is "1_15_8_0.html") for details</code>
+ * @deprecated since 3.4
  */
+@Deprecated
 public interface IndexEntry {
 
     /**

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexEntryFoundListener.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexEntryFoundListener.java
@@ -31,6 +31,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public interface IndexEntryFoundListener {
     /**
      * Notifies that the new index entry was found

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexGroup.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexGroup.java
@@ -36,7 +36,9 @@ See the accompanying LICENSE file for applicable license.
  * Time: 10:38:48
  * <br><br>
  * Respresents index group.
+ * @deprecated since 3.4
  */
+@Deprecated
 public interface IndexGroup {
 
     /**

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexGroupProcessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexGroupProcessor.java
@@ -44,6 +44,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public final class IndexGroupProcessor {
     
     private DITAOTLogger logger;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessResult.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessResult.java
@@ -32,6 +32,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class IndexPreprocessResult {
     private final Document document;
     private final IndexEntry[] indexEntries;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
@@ -47,6 +47,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public final class IndexPreprocessor {
     
     /** Index term level separator. */

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
@@ -49,6 +49,11 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class IndexPreprocessorTask
 extends Task {
     //    private String input = null;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/ProcessException.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/ProcessException.java
@@ -30,6 +30,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class ProcessException
 extends Exception {
     public ProcessException() {

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/CharRange.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/CharRange.java
@@ -15,7 +15,9 @@ import com.idiominc.ws.opentopic.fo.index2.IndexCollator;
  * Date: 30/8/2007
  * Time: 18:34:32
  * To change this template use File | Settings | File Templates.
+ * @deprecated since 3.4
  */
+@Deprecated
 public class CharRange {
 
     private final String start;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ConfigEntry.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ConfigEntry.java
@@ -33,6 +33,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public interface ConfigEntry {
 
      /**

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ConfigEntryImpl.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ConfigEntryImpl.java
@@ -34,8 +34,12 @@ with those set forth herein.
 
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
- */class ConfigEntryImpl
- implements ConfigEntry {
+ */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
+class ConfigEntryImpl implements ConfigEntry {
      private final String label;
      private final String key;
      private final String[] members;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/IndexConfiguration.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/IndexConfiguration.java
@@ -37,7 +37,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
-
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class IndexConfiguration {
     private final List<ConfigEntry> entries = new ArrayList<ConfigEntry>();
     private static String message;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ParseException.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/configuration/ParseException.java
@@ -30,7 +30,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
-
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public class ParseException extends Exception {
     
     public ParseException() {

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexDitaProcessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexDitaProcessor.java
@@ -49,6 +49,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public final class IndexDitaProcessor {
     
     private static String elIndexRangeStartName = "start";

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexEntryImpl.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexEntryImpl.java
@@ -39,6 +39,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 class IndexEntryImpl implements IndexEntry {
     
     private final String value;

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexStringProcessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/util/IndexStringProcessor.java
@@ -41,6 +41,10 @@ with those set forth herein.
 This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
  */
+/**
+ * @deprecated since 3.4
+ */
+@Deprecated
 public abstract class IndexStringProcessor {
 
     /**


### PR DESCRIPTION
## Description
Remove disabled `pdf2.index.skip` parameter and deprecate old PDF indexing code.

## Motivation and Context
Original PDF indexing implementation was extracted to `org.dita.index` plug-in in DITA-OT 3.4. The code can still be enabled by reverting configuration, but the original implementation is deprecated. Deprecation comments are added to reflect this because they were missing from the original PR that enabled `org.dita.index`.
