### PR TITLE
Catch exception from reading JPEG image #3604

### DIFF
--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -238,6 +238,9 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
                     in.close();
                 }
             }
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // Know issue when reading JPEG metadata
+            logger.error("Failed to read image " + imgInput + " metadata: " + e.getMessage(), e);
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {


### PR DESCRIPTION
Catch exception caused by reading JPEG image metadata. Fixes #3604