### PR TITLE
Add RELAX NG schemas to resources catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
 jar {
     archiveName = "${project.name}.jar"
+    exclude "catalog.xml"
     exclude "plugin.rnc"
     exclude "project.rnc"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,11 @@ dependencies {
     testCompile group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.0'
 }
 
-jar.archiveName = "${project.name}.jar"
+jar {
+    archiveName = "${project.name}.jar"
+    exclude "plugin.rnc"
+    exclude "project.rnc"
+}
 
 processResources {
     filter ReplaceTokens, tokens: [

--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,7 @@ task copyDistTemp(type: Copy, dependsOn: initDist) {
         include "plugins/org.oasis-open.dita.v1_3/**"
         exclude "temp"
         include "config/**"
+        include "resources/catalog.xml"
         include "resources/plugin.rnc"
         include "resources/project.rnc"
         // legacy build scripts

--- a/src/main/plugins/org.dita.base/catalog-dita_template.xml
+++ b/src/main/plugins/org.dita.base/catalog-dita_template.xml
@@ -14,9 +14,11 @@ See the accompanying LICENSE file for applicable license.
   <dita:extension id="dita.catalog.plugin-info"
     behavior="org.dita.dost.platform.ImportPluginCatalogAction"/>
 
-   <dita:extension id="dita.specialization.catalog"
-                   behavior="org.dita.dost.platform.InsertAction"/>
-   <dita:extension id="dita.specialization.catalog.relative"
-                   behavior="org.dita.dost.platform.ImportCatalogActionRelative"/>
-  
+  <dita:extension id="dita.specialization.catalog"
+                  behavior="org.dita.dost.platform.InsertAction"/>
+  <dita:extension id="dita.specialization.catalog.relative"
+                  behavior="org.dita.dost.platform.ImportCatalogActionRelative"/>
+
+  <nextCatalog catalog="../../resources/catalog.xml"/>
+
 </catalog>

--- a/src/main/resources/catalog.xml
+++ b/src/main/resources/catalog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+
+  <!-- Map absolute RELAX NG schema references to files in this folder -->
+  <uri name="https://www.dita-ot.org/rng/project.rnc" uri="project.rnc"/>
+  <uri name="https://www.dita-ot.org/rng/plugin.rnc" uri="plugin.rnc"/>
+
+</catalog>


### PR DESCRIPTION
## Description

We currently ship 2 RELAX NG schemas that can be used to validate plug-ins and project files:

- `resources/project.rnc`
- `resources/plugin.rnc`

In https://github.com/dita-ot/website/pull/455, these schemas were published to public URLs, and https://github.com/dita-ot/docs/commit/08e4f4ea6aab69d18a089b98a1ae77cac7aeac62 updated the corresponding `<?xml-model>` processing instructions in the docs to allow editors to validate these files when stored outside of DITA-OT.

## Motivation and Context

This PR adds a catalog to the `resources` folder that maps these public URLs to the local resources and extends the base `catalog-dita.xml` with this new catalog entry so that catalog-aware editors will load the local resource instead of accessing the public URL over the network.

## How Has This Been Tested?

Ran the distribution build in a [fresh worktree](https://github.com/dita-ot/dita-ot/wiki/Fresh-dist-worktree), and verified that the catalog is added and included in `plugins/org.dita.base/catalog-dita.xml`.

## Type of Changes

- Enhancement _(non-breaking change which improves existing functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  _Release Notes_ entry
- Will this change affect backwards compatibility or other users' overrides?
  No.

Fixes #3641.
