### PR TITLE
Restore RELAX NG schemas to 'dita-ot.jar'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,6 @@ dependencies {
 jar {
     archiveName = "${project.name}.jar"
     exclude "catalog.xml"
-    exclude "plugin.rnc"
-    exclude "project.rnc"
 }
 
 processResources {


### PR DESCRIPTION
Without these schemas in the .jar file, builds with project files fail with the following error:

> Error: invalid input for CompactParseable

- Amends 09c1d94 from #3645
