### PR TITLE
Switch rotated table entries to 'vertical-rl' mode

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_tables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_tables.scss
@@ -97,7 +97,7 @@ $valign: top bottom middle;
 
 .entry {
   &.rotate {
-     writing-mode: sideways-lr;
+    writing-mode: vertical-rl;
   }
 }
 


### PR DESCRIPTION
## Description

The `sideways-lr` writing mode implemented in #3541 for #3448 is only supported in Firefox.

Switching the writing mode to `vertical-rl` should (theoretically) allow rotated text to appear in Chrome & Safari in the future as well.

## Background

While the initial `sideways-lr` implementation rotates the cell contents 90° _counterclockwise_ as stipulated by the [DITA 1.3 spec](http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/base/entry.html#entry), if that writing mode value is currently only supported in Firefox, it seems better to rotate 90° _clockwise_ with `vertical-rl` instead, which [should be supported by more browsers (except IE)](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode).

## Caveats

However, in local testing, the result is currently the same: **cell content is only rotated in Firefox**. 

Both Safari and Crome recognize the `vertical-rl` writing mode, but apparently override it with the default `horizontal-tb` setting.

![Safari_writing-mode_vertical-rl_as_horizontal-tb](https://user-images.githubusercontent.com/129995/102017987-a04a8c80-3d6a-11eb-94c1-8a5e02774bb8.png)

This is apparently a [known issue](https://stackoverflow.com/questions/59024097/vertical-text-in-table-cell-using-css3-writing-mode-in-chrome), so it seems like the right way to implement rotation, and with a bit of luck browser support will catch up one day.

