### PR TITLE
Add support for multimedia oasis-tcs/dita#351

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1550,6 +1550,90 @@ See the accompanying LICENSE file for applicable license.
    </span>
   </xsl:template>
   
+  <!-- =========== DITA 2.0 multimedia elements -->
+  <xsl:template match="*[contains(@class,' topic/audio ')]">
+    <audio>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="@autoplay | @controls | @loop | @muted" mode="boolean-media-attribute"/>
+      <xsl:apply-templates select="@tabindex | @href | @format"/>
+      <xsl:call-template name="setid"/>
+      <xsl:apply-templates select="*[contains(@class,' topic/media-source ')],
+        *[contains(@class,' topic/media-track ')]"/>
+      <xsl:apply-templates select="text() | 
+        * except *[contains(@class,' topic/media-source') or contains(@class,' topic/media-track')]"/>
+    </audio>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/video ')]">
+    <video>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="@autoplay | @controls | @loop | @muted" mode="boolean-media-attribute"/>
+      <xsl:apply-templates select="@tabindex | @href | @format"/>
+      <xsl:apply-templates select="@poster"/>
+      <xsl:call-template name="setid"/>
+      <xsl:apply-templates select="*[contains(@class,' topic/media-source ')],
+        *[contains(@class,' topic/media-track ')]"/>
+      <xsl:apply-templates select="text() | 
+        * except *[contains(@class,' topic/media-source') or contains(@class,' topic/media-track')]"/>
+    </video>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/media-source ')]">
+    <source>
+      <xsl:apply-templates select="@href|@format"/>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setid"/>
+    </source>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/media-track ')]">
+    <xsl:variable name="label" as="xs:string?">
+      <!-- Current definition is #PCDATA but want to be future proof -->
+      <xsl:apply-templates select="." mode="text-only"/>
+    </xsl:variable>
+    <track>
+      <xsl:apply-templates select="@href"/>
+      <xsl:copy-of select="@kind | @srclang"/>
+      <xsl:if test="$label">
+        <xsl:attribute name="label" select="$label"/>
+      </xsl:if>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setid"/>
+    </track>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/audio ') or 
+    contains(@class,' topic/video ') or 
+    contains(@class,' topic/media-source ')]/@href">
+    <xsl:attribute name="src" select="."/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/audio ') or 
+    contains(@class,' topic/video ') or 
+    contains(@class,' topic/media-source ')]/@format">
+    <xsl:attribute name="type" select="."/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/audio ') or
+    contains(@class,' topic/video ')]/@tabindex">
+    <xsl:attribute name="tabindex" select="."/>
+  </xsl:template>
+  
+  <xsl:template match="@*" mode="boolean-media-attribute">
+    <xsl:if test=". = 'true'">
+      <xsl:attribute name="{name()}" select="'true'"/>
+    </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/audio ') or
+    contains(@class,' topic/video ')]/*[contains(@class,' topic/fallback ')]">
+    <xsl:apply-templates/>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' topic/video ')]/@poster">
+    <xsl:attribute name="poster" select="."/>
+  </xsl:template>
+  
   <!-- =========== FOOTNOTE =========== -->
   <xsl:template match="*[contains(@class, ' topic/fn ')]" name="topic.fn">
     <xsl:param name="xref"/>


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

---
name: Pull request
about: Propose changes to fix an issue or implement a new feature

---

## Description

Adds basic support for oasis-tcs/dita#351 the new `<audio>` and `<video>` elements. Markup is already supported, this creates the expected HTML5 content. PDF already (correctly) uses the fallback element content, and does not generate an error.

* `href` is rewritten to `src`
* `format` is rewritten to `type` (DITA 2.0 spec clarifies that a MIME type is acceptable in `@format`)
* media attributes are either copied as-is or (for boolean) added if true

## Motivation and Context

These elements were redesigned over the last few months to become base DITA elements in DITA 2.0, which maps closely to HTML5 structure. Without this PR, they generate a bunch of "unknown element" warnings in HTML5.

This basically just maps the DITA markup to the HTML5 markup for `<audio>`, `<video>`, `<source>`, and `<track>`.

The DITA order does not match HTML5, so it explicitly processes source, then track, then any fallback content.

## How Has This Been Tested?

Attaching test case here with the simple case (only href + format) and the complex case (all the multimedia attributes, plus source and track info). Tested HTML is as expected. The attached audio/video files are fake content (copy of a DITA file).
[media.zip](https://github.com/dita-ot/dita-ot/files/5712760/media.zip)
