### PR TITLE
Move to Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Set tag name
         run: |
@@ -38,11 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Deploy Maven release
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Build distribution package
         run: |
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Maven snapshot deployment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
           cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17-jre
 ARG VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/README.markdown
+++ b/README.markdown
@@ -6,18 +6,17 @@ Visit the project website at [dita-ot.org][site] for documentation, information 
 
 For information on additional DITA and DITA-OT resources, see [SUPPORT]. To report a bug or suggest a feature, [create an issue][issue]. For more information on how you can help contribute to the project, see [CONTRIBUTING].
 
-- [Prerequisites: Java 8](#prerequisites-java-8)
+- [Prerequisites: Java 17](#prerequisites-java-17)
 - [Installing](#installing)
 - [Building output](#building-output)
 - [For developers](#for-developers)
 - [License](#license)
 
-## Prerequisites: Java 8
+## Prerequisites: Java 17
 
-- To _build_ DITA-OT, you’ll need Java Development Kit (JDK), version 8 or newer
-- To _run_ DITA-OT, the Java Runtime Environment (JRE) is sufficient
+To build and run DITA-OT, you’ll need Java Development Kit (JDK), version 17 or newer.
 
-You can download the Oracle JRE or JDK from [oracle.com/technetwork/java][java].
+You can download the OpenJDK from [AdoptOpenJDK][adoptopenjdk].
 
 ## Installing
 
@@ -99,7 +98,7 @@ DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 [site]: https://www.dita-ot.org/
 [dist]: https://www.dita-ot.org/download
 [support]: https://github.com/dita-ot/.github/blob/master/SUPPORT.md
-[java]: http://www.oracle.com/technetwork/java/javase/downloads
+[adoptopenjdk]: https://adoptopenjdk.net/
 [homebrew]: https://brew.sh
 [docs]: https://www.dita-ot.org/dev/
 [options]: https://www.dita-ot.org/dev/topics/build-using-dita-command.html

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ version = '4.0.0-SNAPSHOT'
 
 description = """DITA Open Toolkit"""
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Description
Move minimum Java version to 17.

## Motivation and Context

Java LTS is currently version 17.

Fixes #3359

## Documentation and Compatibility
Updates to minimum Java version in install requirements.