### PR TITLE
Fix build on ARM: Compile CSS with Dart Sass

### DIFF
--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -6,8 +6,6 @@
  * See the accompanying LICENSE file for applicable license.
  */
 
-// https://github.com/EtienneMiret/sass-gradle-plugin
-
 plugins {
     id 'io.miret.etienne.sass' version '1.1.1'
 }

--- a/src/main/plugins/org.dita.html5/build.gradle
+++ b/src/main/plugins/org.dita.html5/build.gradle
@@ -5,63 +5,48 @@
  *
  * See the accompanying LICENSE file for applicable license.
  */
-buildscript {
-    dependencies {
-        classpath 'io.bit3:jsass:5.5.3'
-    }
 
-    repositories {
-        mavenCentral()
-        jcenter()
-    }
+// https://github.com/EtienneMiret/sass-gradle-plugin
+
+plugins {
+    id 'io.miret.etienne.sass' version '1.1.1'
 }
 
-apply plugin: 'java'
+sass {
+    // dart-sass version to use:
+    version = '1.32.0'
 
-File cssDir = file('css')
-File sassDir = file('sass')
+    // Directory where to install dart-sass:
+    directory = file ("${rootDir}/.gradle/sass")
 
-import io.bit3.jsass.CompilationException
-import io.bit3.jsass.Compiler
-import io.bit3.jsass.Options
-import io.bit3.jsass.OutputStyle
-
-import java.nio.charset.Charset
-import java.nio.file.Files
-
-def sass(FileCollection files, File outputDir) {
-    if (!outputDir.exists() && !outputDir.mkdir()) {
-        throw new IOException("Failed to create ${outputDir}")
-    }
-
-    files.each {
-        def compiler = new Compiler()
-        def options = new Options()
-        options.setOutputStyle(OutputStyle.EXPANDED)
-
-        def basename = it.getName().substring(0, it.getName().lastIndexOf('.'))
-        def outputFile = new File(outputDir, basename + '.css')
-
-        try {
-            logger.info("Compiling ${it}")
-            def output = compiler.compileFile(it.toURI(), outputFile.toURI(), options)
-            Files.write(outputFile.toPath(), output.getCss().getBytes(Charset.forName("UTF-8")))
-        } catch (CompilationException e) {
-            logger.error(e.getMessage())
-        } catch (IOException e) {
-            logger.error("Compilation failed: ${e.getMessage()}")
-        }
-    }
+    // Base URL where to download dart-sass from:
+    baseUrl = 'https://github.com/sass/dart-sass/releases/download'
 }
 
-task compileSass {
-    inputs.dir sassDir
-    outputs.dir cssDir
+compileSass {
+    // Directory where to output generated CSS:
+    outputDir = project.file ("${projectDir}/css")
 
-    doLast {
-        sass(
-                fileTree(dir: 'sass', includes: ['commonltr.scss', 'commonrtl.scss']),
-                cssDir
-        )
-    }
+    // Source directory containing sass to compile:
+    sourceDir = project.file ("${projectDir}/sass")
+
+    // Set the output style:
+    // Possible values are “expanded” and “compressed”, default is “expanded”.
+    style = expanded
+
+    // Don’t emit a @charset for CSS with non-ASCII chars (default to emit):
+    // noCharset ()
+
+    // When an error occurs, do not emit a stylesheet describing it:
+    // (Default to emit)
+    noErrorCss ()
+
+    // Watch sass files in sourceDir for changes
+    // watch ()
+
+    // Source map style:
+    //  - file: output source map in a separate file (default)
+    //  - embed: embed source map in CSS
+    //  - none: do not emit source map.
+    sourceMap = none
 }


### PR DESCRIPTION
The `jsass` compiler used up to DITA-OT 3.6 relies on LibSass, which has been [deprecated in favor of Dart Sass](https://sass-lang.com/blog/libsass-is-deprecated) and throws errors when building on the 64-bit extension of the ARM architecture (`aarch64`).

These changes replace `jsass` with the [Sass Compile plugin for Gradle](https://github.com/EtienneMiret/sass-gradle-plugin), which compiles sass or scss files using the official [Dart Sass](https://sass-lang.com/dart-sass) compiler.

Signed-off-by: Roger Sheen <roger@infotexture.net>

## How Has This Been Tested?

Built toolkit with Gradle wrapper, build succeeds on macOS Big Sur Version 11.1 system with Apple M1 chip.

Generated CSS is functionally equivalent to the CSS files shipped with DITA-OT 3.6, with minor differences:

- Empty lines that precede nested rules in the SCSS source files are removed
  _(empty lines preceding other rules are preserved — only nested rules are affected)_
- Values in rules with attribute selectors are no longer quoted, but this is a [stylistic issue](https://stylelint.io/user-guide/rules/selector-attribute-quotes)

    ```diff
    - *[compact="yes"] > li {
    + *[compact=yes] > li {
      margin-top: 0;
    }
    ```

### Test environment

```
------------------------------------------------------------
Gradle 6.7
------------------------------------------------------------

Build time:   2020-10-14 16:13:12 UTC
Revision:     312ba9e0f4f8a02d01854d1ed743b79ed996dfd3

Kotlin:       1.3.72
Groovy:       2.5.12
Ant:          Apache Ant(TM) version 1.10.8 compiled on May 10 2020
JVM:          11.0.9.1 (Azul Systems, Inc. 11.0.9.1+1-LTS)
OS:           Mac OS X 11.1 aarch64
```

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

- What documentation changes are needed for this feature?
  _(none)_
- Will this change affect backwards compatibility or other users' overrides?
  _(no)_
