### PR TITLE
Create attribute set note__image to store attributes for note image

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -266,6 +266,13 @@ See the accompanying LICENSE file for applicable license.
         <xsl:attribute name="start-indent">0pt</xsl:attribute>
     </xsl:attribute-set>
 
+    <xsl:attribute-set name="note__image">
+        <xsl:attribute name="content-height">2em</xsl:attribute>
+        <xsl:attribute name="padding-right">3pt</xsl:attribute>
+        <xsl:attribute name="vertical-align">middle</xsl:attribute>
+        <xsl:attribute name="baseline-shift">baseline</xsl:attribute>
+    </xsl:attribute-set>
+
     <xsl:attribute-set name="note__text__entry">
         <xsl:attribute name="start-indent">0pt</xsl:attribute>
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -927,10 +927,8 @@ See the accompanying LICENSE file for applicable license.
                         <fo:table-row>
                                 <fo:table-cell xsl:use-attribute-sets="note__image__entry">
                                     <fo:block>
-                                        <fo:external-graphic src="url('{concat($artworkPrefix, $noteImagePath)}')" 
-                                                             content-height="2em" padding-right="3pt"
-                                                             vertical-align="middle"
-                                                             baseline-shift="baseline"/>
+                                        <fo:external-graphic src="url('{concat($artworkPrefix, $noteImagePath)}')"
+                                                            xsl:use-attribute-sets="note__image"/>
                                     </fo:block>
                                 </fo:table-cell>
                                 <fo:table-cell xsl:use-attribute-sets="note__text__entry">


### PR DESCRIPTION
Create and use attribute set to reuse attributes for note icon.

Signed-off-by: Jake Bourne <jake.bourne@gmail.com>



## Description
Add attribute set for note icon attributes.

## Motivation and Context
Allow attributes for note icon to be reused on different tags.
Fixes issue #3529.


## Type of Changes
Reusability of common attributes.
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No update to documentation necessary.
Backwards compatibility is maintained.

