### PR TITLE
Add Github Actions to build and deploy to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+# Build DITA-OT Docker image and deploy to ghcr.io
+name: Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'DITA-OT version'
+        required: true
+
+jobs:
+  docker:
+    name: Build and deploy Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in
+        run: |
+          echo $PAT | docker login ghcr.io --username ditaotbot --password-stdin
+        env:
+          PAT: ${{ secrets.COMMITTER_TOKEN }}
+      - name: Build image
+        run: |
+          docker build --tag ghcr.io/dita-ot/dita-ot:${VERSION} --build-arg VERSION=${VERSION} .
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+      - name: Deploy image
+        run: |
+          docker push ghcr.io/dita-ot/dita-ot:${VERSION}
+        env:
+          VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION

## Description
Add manually triggered Github Actions to build and deploy to ghcr.io

## Motivation and Context
Move to GitHub Actions and ghcr.io.

## Documentation and Compatibility
Update documentation to use ghcr.io instead of docker.pkg.github.com.