### PR TITLE
Use sax source directly instead of toString() representation

### DIFF
--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -81,7 +81,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
                         final Processor processor = xmlUtils.getProcessor();
                         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
                         xsltCompiler.setErrorListener(toErrorListener(logger));
-                        final XsltExecutable xsltExecutable = xsltCompiler.compile(new StreamSource(f.toString()));
+                        final XsltExecutable xsltExecutable = xsltCompiler.compile(f);
                         return xsltExecutable.load();
                     } catch (UncheckedXPathException e) {
                         throw new RuntimeException("Failed to compile XSLT: " + e.getXPathException().getMessageAndLocation(), e);


### PR DESCRIPTION
Fix for #3689
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Make support for "result.rewrite-rule.xsl" parameter work again.

---

## Description
Properly use existing source.

## Motivation and Context
Fixes #3689

## How Has This Been Tested?
Automatic test

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc


## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
