### PR TITLE
Take into account URI may not be file when checking its existence

### DIFF
--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -297,8 +297,13 @@ public class StreamStore extends AbstractStore implements Store {
 
     @Override
     public boolean exists(final URI path) {
-        final File d = new File(getUri(URLUtils.setFragment(path, null)));
-        return d.exists();
+    	try {
+    		final File d = new File(getUri(URLUtils.setFragment(path, null)));
+    		return d.exists();
+    	} catch(IllegalArgumentException ex) {
+    		//URI does not have file protocol, assume it does not exist
+    		return false;
+    	}
     }
 
     @Override

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -8,20 +8,24 @@
 
 package org.dita.dost.store;
 
-import com.google.common.io.Files;
-import net.sf.saxon.s9api.Destination;
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XdmNode;
-import org.apache.commons.io.FileUtils;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import java.io.File;
-import java.io.IOException;
+import com.google.common.io.Files;
+
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XdmNode;
 
 public class StreamStoreTest {
 
@@ -44,6 +48,11 @@ public class StreamStoreTest {
 
         final Serializer serializer = store.getSerializer(tmpDir.toURI().resolve("foo/bar"));
         serializer.serializeNode(source);
+    }
+    
+    @Test
+    public void getExists() throws IOException, SaxonApiException, URISyntaxException {
+    	assertFalse(store.exists(new URI("http://abc/def")));
     }
 
     @After

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -8,26 +8,29 @@
 
 package org.dita.dost.store;
 
-import static org.junit.Assert.assertFalse;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XdmNode;
+import org.dita.dost.util.XMLUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Files;
 
-import org.dita.dost.util.XMLUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
-import com.google.common.io.Files;
-
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XdmNode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StreamStoreTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private XMLUtils xmlUtils;
     private StreamStore store;
@@ -36,7 +39,7 @@ public class StreamStoreTest {
     @Before
     public void setUp() throws Exception {
         xmlUtils = new XMLUtils();
-        tmpDir = Files.createTempDir();
+        tmpDir = temporaryFolder.newFolder();
         store = new StreamStore(tmpDir, xmlUtils);
     }
 
@@ -51,13 +54,68 @@ public class StreamStoreTest {
     }
     
     @Test
-    public void getExists() throws IOException, SaxonApiException, URISyntaxException {
-    	assertFalse(store.exists(new URI("http://abc/def")));
+    public void exists_WhenFileExists_ShouldReturnTrue() throws IOException {
+        Files.write(tmpDir.toPath().resolve("dummy.xml"), "<dummy/>".getBytes(UTF_8));
+        assertTrue(store.exists(tmpDir.toPath().resolve("dummy.xml").toUri()));
     }
 
-    @After
-    public void tearDown() throws Exception {
-//        FileUtils.deleteDirectory(tmpDir);
-        System.out.println(tmpDir);
+    @Test
+    public void exists_WhenFileIsMissing_ShouldReturnFalse() {
+        assertFalse(store.exists(tmpDir.toPath().resolve("missing.xml").toUri()));
+    }
+
+    @Test
+    public void exists_WhenInputIsHttp_ShouldReturnFalse() {
+        assertFalse(store.exists(URI.create("http://abc/def")));
+    }
+
+    @Test
+    public void copy_WhenFileExists_ShouldCreateCopy() throws IOException {
+        Files.write(tmpDir.toPath().resolve("src.xml"), "<dummy/>".getBytes(UTF_8));
+
+        store.copy(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+
+        assertTrue(Files.exists(tmpDir.toPath().resolve("src.xml")));
+        assertTrue(Files.exists(tmpDir.toPath().resolve("dst.xml")));
+    }
+
+    @Test(expected = IOException.class)
+    public void copy_WhenFileIsMissing_ShouldThrowException() throws IOException {
+        store.copy(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+    }
+
+    @Test(expected = IOException.class)
+    public void copy_WhenSrcIsHttp_ShouldThrowException() throws IOException {
+        store.copy(URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
+    }
+
+    @Test(expected = IOException.class)
+    public void copy_WhenDstIsHttp_ShouldThrowException() throws IOException {
+        store.copy(tmpDir.toPath().resolve("src.xml").toUri(), URI.create("http://dst.xml"));
+    }
+
+    @Test
+    public void move_WhenFileExists_ShouldCreateCopy() throws IOException {
+        Files.write(tmpDir.toPath().resolve("src.xml"), "<dummy/>".getBytes(UTF_8));
+
+        store.move(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+
+        assertFalse(Files.exists(tmpDir.toPath().resolve("src.xml")));
+        assertTrue(Files.exists(tmpDir.toPath().resolve("dst.xml")));
+    }
+
+    @Test(expected = IOException.class)
+    public void move_WhenFileIsMissing_ShouldThrowException() throws IOException {
+        store.move(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+    }
+
+    @Test(expected = IOException.class)
+    public void move_WhenSrcIsHttp_ShouldThrowException() throws IOException {
+        store.move(URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
+    }
+
+    @Test(expected = IOException.class)
+    public void move_WhenDstIsHttp_ShouldThrowException() throws IOException {
+        store.move(tmpDir.toPath().resolve("src.xml").toUri(), URI.create("http://dst.xml"));
     }
 }


### PR DESCRIPTION
Fix for #3677
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Take into accounts some URIs cannot be converted to files

---

## Description
Take into account on the StreamStore.exists() method that URI may not be file.

## Motivation and Context
Fix for #3677

## How Has This Been Tested?
Automatic test

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
