### PR TITLE
Properly compute absolute locations in merge map and topic parsers

### DIFF
--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -32,6 +32,7 @@ import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.MergeUtils;
+import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils;
 
 import org.xml.sax.Attributes;
@@ -198,7 +199,7 @@ public final class MergeMapParser extends XMLFilterImpl {
                     if (copyToValue != null && !copyToValue.toString().isEmpty()) {
                         attValue = copyToValue;
                     }
-                    final URI absTarget = dirPath.toURI().resolve(attValue);
+                    final URI absTarget = URLUtils.toDirURI(dirPath).resolve(attValue);
                     XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OHREF, ohref.toString());
                     if (util.isVisited(absTarget)) {
                         attValue = toURI(SHARP + util.getIdValue(absTarget));
@@ -224,7 +225,7 @@ public final class MergeMapParser extends XMLFilterImpl {
                             }
                             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_FIRST_TOPIC_ID, firstTopicId.toString());
                         } else {
-                            final URI fileName = dirPath.toURI().resolve(attValue);
+                        	final URI fileName = URLUtils.toDirURI(dirPath).resolve(attValue);
                             logger.error(MessageUtils.getMessage("DOTX008E", fileName.toString()).toString());
                         }
                     }

--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -225,7 +225,7 @@ public final class MergeMapParser extends XMLFilterImpl {
                             }
                             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_FIRST_TOPIC_ID, firstTopicId.toString());
                         } else {
-                        	final URI fileName = URLUtils.toDirURI(dirPath).resolve(attValue);
+                            final URI fileName = URLUtils.toDirURI(dirPath).resolve(attValue);
                             logger.error(MessageUtils.getMessage("DOTX008E", fileName.toString()).toString());
                         }
                     }

--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -13,6 +13,7 @@ import static org.dita.dost.reader.MergeMapParser.*;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.FileUtils.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.URLUtils.setFragment;
 
 import java.io.File;
 import java.net.URI;
@@ -20,6 +21,7 @@ import java.net.URI;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.MergeUtils;
+import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -97,7 +99,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
         String idValue = atts.getValue(ATTRIBUTE_NAME_ID);
         if (idValue != null) {
             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OID, idValue);
-            final URI value = setFragment(dirPath.toURI().resolve(toURI(filePath)), idValue);
+            final URI value = setFragment(URLUtils.toDirURI(dirPath).resolve(toURI(filePath)), idValue);
             if (util.findId(value)) {
                 idValue = util.getIdValue(value);
             } else {
@@ -128,7 +130,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
             final String topicID = getTopicID(attValue.getFragment());
             final int index = attValue.toString().indexOf(SLASH, sharpIndex);
             final String elementId = index != -1 ? attValue.toString().substring(index) : "";
-            final URI pathWithTopicID = setFragment(dirPath.toURI().resolve(pathFromMap), topicID);
+            final URI pathWithTopicID = setFragment(URLUtils.toDirURI(dirPath).resolve(pathFromMap), topicID);
             if (util.findId(pathWithTopicID)) {// topicId found
                 retAttValue = toURI(SHARP + util.getIdValue(pathWithTopicID) + elementId);
             } else {// topicId not found
@@ -136,7 +138,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
             }
         } else { // href value refer to a topic
             pathFromMap = toURI(filePath).resolve(attValue.toString());
-            URI absolutePath = dirPath.toURI().resolve(pathFromMap);
+            URI absolutePath = URLUtils.toDirURI(dirPath).resolve(pathFromMap);
             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_OHREF, pathFromMap.toString());
             if (util.findId(absolutePath)) {
                 retAttValue = toURI(SHARP + util.getIdValue(absolutePath));

--- a/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
@@ -7,18 +7,6 @@
  */
 package org.dita.dost.reader;
 
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.UTF8;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.dita.dost.TestUtils;
 import org.dita.dost.store.CacheStore;
 import org.dita.dost.store.StreamStore;
@@ -29,6 +17,17 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.UTF8;
 
 public class MergeMapParserTest {
 
@@ -53,7 +52,7 @@ public class MergeMapParserTest {
         assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
-    
+
     @Test
     public void testReadSpace() throws SAXException, IOException {
         final MergeMapParser parser = new MergeMapParser();
@@ -97,21 +96,19 @@ public class MergeMapParserTest {
         assertXMLEqual(new InputSource(new File(expDir, "mergedsub.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
-    
+
     @Test
     public void testCacheStore() throws SAXException, IOException, ParserConfigurationException {
         final MergeMapParser parser = new MergeMapParser();
         parser.setLogger(new TestUtils.TestLogger());
-        File tmpDir = new File(resourceDir, "tmpRandom");
-        CacheStore store = new CacheStore(tmpDir, new XMLUtils());
-        Job job = new Job(tmpDir, store);
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        Document doc = builder.parse(new File(srcDir, "test.ditamap"));
-        store.writeDocument(doc, new File(tmpDir, "test.ditamap").toURI());
-        doc = builder.parse(new File(srcDir, "test.xml"));
-        store.writeDocument(doc, new File(tmpDir, "test.xml").toURI());
-        doc = builder.parse(new File(srcDir, "test2.xml"));
-        store.writeDocument(doc, new File(tmpDir, "test2.xml").toURI());
+        final File tmpDir = new File(resourceDir, "tmpRandom");
+        final CacheStore store = new CacheStore(tmpDir, new XMLUtils());
+        final Job job = new Job(tmpDir, store);
+        final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        for (String child : new String[]{"test.ditamap", "test.xml", "test2.xml"}) {
+            final Document doc = builder.parse(new File(srcDir, child));
+            store.writeDocument(doc, new File(tmpDir, child).toURI());
+        }
         parser.setJob(job);
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         output.write("<wrapper>".getBytes(UTF8));
@@ -121,5 +118,5 @@ public class MergeMapParserTest {
         assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
-    
+
 }

--- a/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
@@ -8,21 +8,27 @@
 package org.dita.dost.reader;
 
 import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Constants.UTF8;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.dita.dost.TestUtils;
+import org.dita.dost.store.CacheStore;
 import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
-import org.xml.sax.SAXException;
-import org.xml.sax.InputSource;
-import org.dita.dost.TestUtils;
-import org.dita.dost.util.Job;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 public class MergeMapParserTest {
 
@@ -89,6 +95,30 @@ public class MergeMapParserTest {
         output.write("</wrapper>".getBytes(UTF8));
 
         assertXMLEqual(new InputSource(new File(expDir, "mergedsub.xml").toURI().toString()),
+                new InputSource(new ByteArrayInputStream(output.toByteArray())));
+    }
+    
+    @Test
+    public void testCacheStore() throws SAXException, IOException, ParserConfigurationException {
+        final MergeMapParser parser = new MergeMapParser();
+        parser.setLogger(new TestUtils.TestLogger());
+        File tmpDir = new File(resourceDir, "tmpRandom");
+        CacheStore store = new CacheStore(tmpDir, new XMLUtils());
+        Job job = new Job(tmpDir, store);
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.parse(new File(srcDir, "test.ditamap"));
+        store.writeDocument(doc, new File(tmpDir, "test.ditamap").toURI());
+        doc = builder.parse(new File(srcDir, "test.xml"));
+        store.writeDocument(doc, new File(tmpDir, "test.xml").toURI());
+        doc = builder.parse(new File(srcDir, "test2.xml"));
+        store.writeDocument(doc, new File(tmpDir, "test2.xml").toURI());
+        parser.setJob(job);
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write("<wrapper>".getBytes(UTF8));
+        parser.setOutputStream(output);
+        parser.read(new File(tmpDir, "test.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
+        output.write("</wrapper>".getBytes(UTF8));
+        assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
     

--- a/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
@@ -7,16 +7,18 @@
  */
 package org.dita.dost.reader;
 
-import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.junit.Assert.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.URI;
+import org.dita.dost.TestUtils;
+import org.dita.dost.store.CacheStore;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.MergeUtils;
+import org.dita.dost.util.XMLUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.DefaultHandler;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -24,21 +26,14 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
-import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
 
-import org.dita.dost.store.CacheStore;
-import org.dita.dost.store.StreamStore;
-import org.dita.dost.util.Job;
-import org.dita.dost.util.XMLUtils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.helpers.AttributesImpl;
-import org.xml.sax.helpers.DefaultHandler;
-import org.dita.dost.TestUtils;
-import org.dita.dost.util.MergeUtils;
-import org.junit.Test;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
 
 public class MergeTopicParserTest {
 
@@ -48,7 +43,7 @@ public class MergeTopicParserTest {
 
     private static SAXTransformerFactory stf;
     private MergeTopicParser parser;
-    
+
     @BeforeClass
     public static void setupClass() {
         final TransformerFactory tf = TransformerFactory.newInstance();
@@ -91,7 +86,7 @@ public class MergeTopicParserTest {
         final DocumentBuilder builder = factory.newDocumentBuilder();
         final Document output = builder.newDocument();
         final TransformerHandler s = stf.newTransformerHandler();
-        s.getTransformer().setOutputProperty(OMIT_XML_DECLARATION , "yes");
+        s.getTransformer().setOutputProperty(OMIT_XML_DECLARATION, "yes");
         s.setResult(new DOMResult(output));
         parser.setContentHandler(s);
         parser.setLogger(new TestUtils.TestLogger());
@@ -109,7 +104,7 @@ public class MergeTopicParserTest {
         parser.parse("test.xml", srcDir.getAbsoluteFile());
         final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalHref", URI.class);
         method.setAccessible(true);
-        
+
         parser.parse("test.xml", srcDir.getAbsoluteFile());
         assertEquals(new URI("test.jpg"), method.invoke(parser, new URI("test.jpg")));
         assertEquals(new URI("test.jpg#foo"), method.invoke(parser, new URI("test.jpg#foo")));
@@ -117,43 +112,43 @@ public class MergeTopicParserTest {
         assertEquals(new URI("images/test.jpg"), method.invoke(parser, new URI("images/test.jpg")));
         assertEquals(new URI("images/test.jpg#foo"), method.invoke(parser, new URI("images/test.jpg#foo")));
         assertEquals(new URI("../test.jpg"), method.invoke(parser, new URI("../test.jpg")));
-        
+
         parser.setOutput(new File(srcDir, "test.xml"));
         parser.parse("src" + File.separator + "test.xml", resourceDir.getAbsoluteFile());
         assertEquals(new URI("test.jpg"), method.invoke(parser, new URI("test.jpg")));
         assertEquals(new URI("images/test.jpg"), method.invoke(parser, new URI("images/test.jpg")));
         assertEquals(new URI("../test.jpg"), method.invoke(parser, new URI("../test.jpg")));
     }
-    
+
     @Test
     public void testHandleLocalHrefCacheStore() throws Exception {
-    	File tmpDir = new File(resourceDir, "tmpRandom");
-    	CacheStore store = new CacheStore(tmpDir, new XMLUtils());
-    	Job job = new Job(srcDir, store);
+        final File tmpDir = new File(resourceDir, "tmpRandom");
+        final CacheStore store = new CacheStore(tmpDir, new XMLUtils());
+        final Job job = new Job(srcDir, store);
         TestUtils.TestLogger logger = new TestUtils.TestLogger();
-    	final MergeUtils util = new MergeUtils();
-    	util.setLogger(logger);
-    	util.setJob(job);
-    	MergeTopicParser parser = new MergeTopicParser(util);
-    	parser.setLogger(logger);
-    	parser.setJob(job);
-    	parser.setContentHandler(new DefaultHandler());
-    	DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        Document doc = builder.parse(new File(srcDir, "test.xml"));
-        URI uri = new File(tmpDir, "test.xml").toURI();
+        final MergeUtils util = new MergeUtils();
+        util.setLogger(logger);
+        util.setJob(job);
+        final MergeTopicParser parser = new MergeTopicParser(util);
+        parser.setLogger(logger);
+        parser.setJob(job);
+        parser.setContentHandler(new DefaultHandler());
+        final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        final Document doc = builder.parse(new File(srcDir, "test.xml"));
+        final URI uri = new File(tmpDir, "test.xml").toURI();
         store.writeDocument(doc, uri);
-    	
-    	parser.setOutput(new File(tmpDir, "test.xml"));
-    	final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalDita", URI.class, AttributesImpl.class);
-    	method.setAccessible(true);
 
-    	parser.parse("test.xml", tmpDir.getAbsoluteFile());
-    	AttributesImpl attrs = new AttributesImpl();
-    	URI val = (URI) method.invoke(parser, new URI("test.jpg"), attrs);
-    	String original = attrs.getValue("ohref");
-    	assertEquals("test.jpg", original);
-    	assertEquals("#unique_7", val.toString());
-    	assertEquals("unique_7", util.getIdValue(new File(tmpDir, "test.jpg").toURI()));
+        parser.setOutput(new File(tmpDir, "test.xml"));
+        final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalDita", URI.class, AttributesImpl.class);
+        method.setAccessible(true);
+
+        parser.parse("test.xml", tmpDir.getAbsoluteFile());
+        final AttributesImpl attrs = new AttributesImpl();
+        final URI val = (URI) method.invoke(parser, new URI("test.jpg"), attrs);
+        final String original = attrs.getValue("ohref");
+        assertEquals("test.jpg", original);
+        assertEquals("#unique_7", val.toString());
+        assertEquals("unique_7", util.getIdValue(new File(tmpDir, "test.jpg").toURI()));
     }
-    
+
 }


### PR DESCRIPTION
Fix for #3687
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Properly compute absolute locations in merge map and topic parsers

---

## Description
References to resources were not properly computed when merging content in the DITA Map (PDF transforms) with store-type=memory

## Motivation and Context
Fix for #3687

## How Has This Been Tested?
Automatic tests

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
