### PR TITLE
Fix copy of topicmeta between keydef and keyref

### DIFF
--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -426,7 +426,7 @@ public final class KeyrefReader implements AbstractReader {
                         }
                     });
                 }
-                resMeta.select(child()).forEach(child -> {
+                 defMeta.select(child()).forEach(child -> {
                     try {
                         receiver.append(child.getUnderlyingNode());
                     } catch (XPathException e) {

--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -426,7 +426,7 @@ public final class KeyrefReader implements AbstractReader {
                         }
                     });
                 }
-                 defMeta.select(child()).forEach(child -> {
+                defMeta.select(child()).forEach(child -> {
                     try {
                         receiver.append(child.getUnderlyingNode());
                     } catch (XPathException e) {

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -594,7 +594,7 @@ public class TestKeyrefReader {
         assertEquals("topic-copy.dita", root.get("copy").href.toString());
     }
     
-	@Test
+    @Test
     public void testIntermediaryKeyRefCopyMetadata() throws DITAOTException {
         final File filename = new File(srcDir, "intermediaryKeyref.ditamap");
         keyrefreader.read(filename.toURI(), readMap(filename));

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -43,6 +43,7 @@ import static java.util.Collections.*;
 import static junit.framework.Assert.assertEquals;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestKeyrefReader {
 
@@ -591,6 +592,15 @@ public class TestKeyrefReader {
 
         assertEquals("topic-original.dita", root.get("original").href.toString());
         assertEquals("topic-copy.dita", root.get("copy").href.toString());
+    }
+    
+	@Test
+    public void testIntermediaryKeyRefCopyMetadata() throws DITAOTException {
+        final File filename = new File(srcDir, "intermediaryKeyref.ditamap");
+        keyrefreader.read(filename.toURI(), readMap(filename));
+        final KeyScope root = keyrefreader.getKeyDefinition();
+        KeyDef keyDef = root.keyDefinition.get("b");
+        assertTrue(keyDef.element.toString().contains("Product A"));
     }
 
     private void log(final KeyScope scope, final String indent) {

--- a/src/test/resources/TestKeyrefReader/src/intermediaryKeyref.ditamap
+++ b/src/test/resources/TestKeyrefReader/src/intermediaryKeyref.ditamap
@@ -1,0 +1,13 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Root map</title>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="a" processing-role="resource-only">
+  	<topicmeta class="- map/topicmeta ">
+                <keywords class="- topic/keywords ">
+                    <keyword class="- topic/keyword ">Product A</keyword>
+                </keywords>
+            </topicmeta>
+  </keydef>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="b" keyref="a" processing-role="resource-only"/>
+</map>


### PR DESCRIPTION
Fix for #3694
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

---
name: Pull request
about: Fix copy of topicmeta between keydef and keyref

---

## Description
Fix copy of topicmeta between keydef and keyref

## Motivation and Context
Fixes #3694

## How Has This Been Tested?
Automatic test

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
