### PR TITLE
Fix: 'Warning' notes could not be styled separately

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -861,7 +861,7 @@ See the accompanying LICENSE file for applicable license.
                         </fo:inline>
                     </xsl:when>
                     <xsl:when test="@type='warning'">
-                        <fo:inline xsl:use-attribute-sets="note__label__danger">
+                        <fo:inline xsl:use-attribute-sets="note__label__warning">
                             <xsl:call-template name="getVariable">
                                 <xsl:with-param name="id" select="'Warning'"/>
                             </xsl:call-template>


### PR DESCRIPTION
## Description

This commit fixes DITA-OT incapability to style «Warning» notes separatedly.

## Motivation and Context

IMO all the elements have to be styled explicitly (hidden dependencies are bad). Elements implicitly inheriting other styles («Danger» styling in this case) seem wrong.

## How Has This Been Tested?

Fixed my styling issues.

## Type of Changes

- Bug fix

## Documentation and Compatibility

I'm not aware of existing DITA-OT documentation that needs to be changed. But, this should be explicitly noted on new release changelog.

- Will this change affect backwards compatibility or other users' overrides?

**Yes, it will affect workflow for those who have styled «Danger» notes and used «Warning» notes instead.**

## Checklist

- My code follows the code style of this project.
- I have **NOT** updated the unit tests.