### PR TITLE
#3720 [fix] preprocess.copy-html.skip is missing from org.dita.pdf2

### DIFF
--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -55,6 +55,7 @@ with those set forth herein.
     </dita-ot-fail>
     
     <property name="preprocess.copy-image.skip" value="true"/>
+      <property name="preprocess.copy-html.skip" value="true"/>
     <property name="preprocess.copy-flag.skip" value="true"/>
     <property name="clean-preprocess.use-result-filename" value="false"/>
     <condition property="preprocess.chunk.skip" value="true">


### PR DESCRIPTION
Signed-off-by: thendarion <16006640+thendarion@users.noreply.github.com>