### PR TITLE
Feature/html5 charset

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
@@ -12,10 +12,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5Impl.xsl"/>
   
   <xsl:output method="html"
-              encoding="UTF-8"
-              indent="no"
-              doctype-system="about:legacy-compat"
-              omit-xml-declaration="yes"/>
+    include-content-type="no"
+    indent="no"
+    doctype-system="about:legacy-compat"
+    omit-xml-declaration="yes"/>
 
   <!-- root rule -->
   <xsl:template match="/">

--- a/src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.html5:xsl/map2html5-coverImpl.xsl"/>
 
   <xsl:output method="html"
-              encoding="UTF-8"
+              include-content-type="no"
               doctype-system="about:legacy-compat"
               omit-xml-declaration="yes"/>
 

--- a/src/main/plugins/org.dita.pdf2/build.gradle
+++ b/src/main/plugins/org.dita.pdf2/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.9.1-7'
     implementation group: 'org.apache.ant', name: 'ant', version:'1.10.9'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-    implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
 }
 sourceSets {
     main {

--- a/src/main/plugins/org.dita.pdf2/build.gradle
+++ b/src/main/plugins/org.dita.pdf2/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '9.9.1-7'
     implementation group: 'org.apache.ant', name: 'ant', version:'1.10.9'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
 }
 sourceSets {
     main {

--- a/src/test/resources/html5_css/exp/html5/topic.html
+++ b/src/test/resources/html5_css/exp/html5/topic.html
@@ -1,19 +1,19 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
 <html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta charset="UTF-8">
-  <meta name="copyright" content="(C) Copyright 2018">
-  <meta name="generator" content="DITA-OT"/>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
-  <link rel="stylesheet" type="text/css" href="custom.css">
-  <title>Topic</title>
-</head>
-<body id="topic">
-<main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
-    <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
-  </article>
-</main>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="copyright" content="(C) Copyright 2021">
+    <meta name="generator" content="DITA-OT">
+    <link rel="stylesheet" type="text/css" href="commonltr.css">
+    <link rel="stylesheet" type="text/css" href="custom.css">
+    <title>Topic</title>
+  </head>
+  <body id="topic">
+    <main role="main">
+      <article role="article" aria-labelledby="ariaid-title1">
+        <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
+      </article>
+    </main>
+  </body>
 </html>

--- a/src/test/resources/html5_cssExternal/exp/html5/topic.html
+++ b/src/test/resources/html5_cssExternal/exp/html5/topic.html
@@ -1,19 +1,19 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
 <html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta charset="UTF-8">
-  <meta name="copyright" content="(C) Copyright 2018">
-  <meta name="generator" content="DITA-OT"/>
-  <link rel="stylesheet" type="text/css" href="https://example.com/styles/commonltr.css">
-  <link rel="stylesheet" type="text/css" href="https://example.com/styles/custom.css">
-  <title>Topic</title>
-</head>
-<body id="topic">
-<main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
-    <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
-  </article>
-</main>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="copyright" content="(C) Copyright 2021">
+    <meta name="generator" content="DITA-OT">
+    <link rel="stylesheet" type="text/css" href="https://example.com/styles/commonltr.css">
+    <link rel="stylesheet" type="text/css" href="https://example.com/styles/custom.css">
+    <title>Topic</title>
+  </head>
+  <body id="topic">
+    <main role="main">
+      <article role="article" aria-labelledby="ariaid-title1">
+        <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
+      </article>
+    </main>
+  </body>
 </html>

--- a/src/test/resources/html5_csspath/exp/html5/topic.html
+++ b/src/test/resources/html5_csspath/exp/html5/topic.html
@@ -1,19 +1,19 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
 <html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta charset="UTF-8">
-  <meta name="copyright" content="(C) Copyright 2018">
-  <meta name="generator" content="DITA-OT"/>
-  <link rel="stylesheet" type="text/css" href="styles/commonltr.css">
-  <link rel="stylesheet" type="text/css" href="styles/custom.css">
-  <title>Topic</title>
-</head>
-<body id="topic">
-<main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
-    <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
-  </article>
-</main>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="copyright" content="(C) Copyright 2021">
+    <meta name="generator" content="DITA-OT">
+    <link rel="stylesheet" type="text/css" href="styles/commonltr.css">
+    <link rel="stylesheet" type="text/css" href="styles/custom.css">
+    <title>Topic</title>
+  </head>
+  <body id="topic">
+    <main role="main">
+      <article role="article" aria-labelledby="ariaid-title1">
+        <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
+      </article>
+    </main>
+  </body>
 </html>

--- a/src/test/resources/html5_ditaval/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval/exp/html5/all.html
@@ -1,23 +1,9 @@
 <!DOCTYPE html
-    SYSTEM "about:legacy-compat">
-<html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta charset="UTF-8">
-  <meta name="copyright" content="(C) Copyright 2019">
-  <meta name="generator" content="DITA-OT"/>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
-  <title>Topic title</title></head>
-<body id="topic-1">
-<main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
-    <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
-    <div class="body">
-      <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel" data-product="notepad"
-         data-os="win"></p>
-      <p class="p" data-props="audience(expert) deliveryTarget(print) platform(intel) product(notepad) os(win)"></p>
-    </div>
-  </article>
-</main>
-</body>
-</html>
+  SYSTEM "about:legacy-compat">
+<html lang="en"><head><meta charset="UTF-8"><meta name="copyright" content="(C) Copyright 2021"><meta name="generator" content="DITA-OT"><link rel="stylesheet" type="text/css" href="commonltr.css"><title>Topic title</title></head><body id="topic-1"><main role="main"><article role="article" aria-labelledby="ariaid-title1">
+  <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
+  <div class="body">
+    <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel" data-product="notepad" data-os="win"></p>
+    <p class="p" data-props="audience(expert) deliveryTarget(print) platform(intel) product(notepad) os(win)"></p>
+  </div>
+</article></main></body></html>

--- a/src/test/resources/html5_ditaval/exp/html5/index.html
+++ b/src/test/resources/html5_ditaval/exp/html5/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html
-    SYSTEM "about:legacy-compat">
+  SYSTEM "about:legacy-compat">
 <html lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta charset="UTF-8">
-  <meta name="copyright" content="(C) Copyright 2019">
-  <meta name="generator" content="DITA-OT"/>
-  <link rel="stylesheet" type="text/css" href="commonltr.css"><title></title></head>
-<body>
-<nav xmlns:dita="http://dita-ot.sourceforge.net">
-  <ul class="map">
-    <li class="topicref"><a href="all.html">Topic title</a></li>
-  </ul>
-</nav>
-</body>
+   <head>
+      <meta charset="UTF-8">
+      <meta name="copyright" content="(C) Copyright 2021">
+      <meta name="generator" content="DITA-OT">
+      <link rel="stylesheet" type="text/css" href="commonltr.css">
+      <title></title>
+   </head>
+   <body>
+      <nav>
+         <ul class="map">
+            <li class="topicref"><a href="all.html">Topic title</a></li>
+         </ul>
+      </nav>
+   </body>
 </html>


### PR DESCRIPTION
## Description
#3715: HTML5 index.html reported as invalid by W3C validator.

Removes "&lt;xsl:call-template name="generateCharset"/&gt;" from org.dita.html5/xsl/topic.xsl

## Motivation and Context
Fixes #3715.

## How Has This Been Tested?
Built and run locally. Passes existing tests after test files modified.

## Type of Changes
<!-- What type of changes does your code introduce? -->

Deleted "&lt;xsl:call-template name="generateCharset"/&gt;" from:
- org.dita.html5/xsl/topic.xsl

Removed redundant "&lt;meta charset="UTF-8"/&gt;" from test files:
- src/test/resources/html5_css/exp/html5/topic.html
- src/test/resources/html5_cssExternal/exp/html5/topic.html
- src/test/resources/html5_csspath/exp/html5/topic.html
- src/test/resources/html5_ditaval/exp/html5/all.html
- src/test/resources/html5_ditaval/exp/html5/index.html