### PR TITLE
Add support for disabling colour in CLI using TERM or NO_COLOR

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -118,6 +118,8 @@ abstract class Arguments {
             handleArgListener(args);
         } else if (isLongForm(arg, "-logger")) {
             handleArgLogger(args);
+        } else if (isLongForm(arg, "-no-color")) {
+            useColor = false;
         } else {
             throw new BuildException("Unsupported argument: %s", arg);
         }

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -88,6 +88,10 @@ abstract class Arguments {
         final String os = System.getProperty("os.name");
         if (os != null && os.startsWith("Windows")) {
             return false;
+        } else if (System.getenv("NO_COLOR") != null) {
+            return false;
+        } else if (Objects.equals(System.getenv("TERM"), "dumb")) {
+            return false;
         }
         return Boolean.parseBoolean(Configuration.configuration.getOrDefault("cli.color", "true"));
     }

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -161,8 +161,7 @@ public class ConversionArguments extends Arguments {
             } else if (isLongForm(arg, "-autoproxy")) {
                 proxy = true;
             } else if (arg.startsWith("-") || arg.startsWith("/")) {
-                // we don't have any more args to recognize!
-                throw new IllegalArgumentException(arg);
+                parseCommonOptions(arg, args);
             } else {
                 // if it's no other arg, it may be the target
                 targets.addElement(arg);

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -28,6 +28,7 @@ public class UsageBuilder {
         if (!compact) {
             options("d", "debug", null, locale.getString("help.option.debug"));
             options("v", "verbose", null, locale.getString("help.option.verbose"));
+            options(null, "no-color", null, locale.getString("help.option.no-color"));
         }
     }
 

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -9,6 +9,7 @@ error_msg=Error: %s
 help.option.help=Print help information
 help.option.debug=Enable debug logging
 help.option.verbose=Enable verbose logging
+help.option.no-color=Disable color in terminal
 # Version subcommand
 version=DITA-OT version %s
 version.usage=dita version [options]


### PR DESCRIPTION
## Description
Support disabling colour in CLI output with `TERM=dumb` or `NO_COLOR` environment variables and `--no-color` option.

## Motivation and Context
Follow conventions suggested in [12 Factor CLI Apps](https://medium.com/@jdxcode/12-factor-cli-apps-dd3c227a0e46#a808) for playing nice with common conventions.

## How Has This Been Tested?
Manual tests.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

TBD

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
