### PR TITLE
PDF: Fix redundant page numbers in German Preface headers

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/de.xml
@@ -30,8 +30,8 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 <vars xmlns="http://www.idiominc.com/opentopic/vars">
-  <variable id="Preface odd header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
-  <variable id="Preface even header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="pagenum"/></variable>
+  <variable id="Preface odd header"><param ref-name="prodname"/> | Einleitung | <param ref-name="pagenum"/></variable>
+  <variable id="Preface even header"><param ref-name="pagenum"/> | Einleitung | <param ref-name="prodname"/></variable>
   <variable id="Table of Contents">Inhalt</variable>
   <variable id="Index Continued String">Fortsetzung</variable>
   <variable id="Index See String">, Siehe </variable>


### PR DESCRIPTION
In the English source strings _(and all other translations)_, Preface headers include the `prodname` parameter and page numbers, but the German **Preface header** strings include the page numbers twice, and the `prodname` parameter is missing.

This PR resolves the inconsistency (which was introduced 2011-09-29 in 08a2d3a prior to the 1.5.4 release) and aligns the German strings to use the same pattern as other languages.

🎗️ Targeting the `develop` branch with this PR for now — but we might want to consider including it in an earlier hotfix if there are any other bugfixes that justify a 3.6.2 maintenance release.