### PR TITLE
Preserve topicref/topicmeta/navtitle when @locktitle is enabled

### DIFF
--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -54,6 +54,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_PUBLISHER.matcher
     )));
     private static final Set<String> metaSet = Collections.unmodifiableSet(new HashSet<>(asList(
+            TOPIC_NAVTITLE.matcher,
             MAP_SEARCHTITLE.matcher,
             TOPIC_SEARCHTITLE.matcher,
             TOPIC_AUTHOR.matcher,


### PR DESCRIPTION
Signed-off-by: Toshihiko Makita <tmakita@antenna.co.jp>

Preserve topicref/topicmeta/navtitle when @locktitle="yes".

## Description
This pull request fixes issue #3708.

## Motivation and Context
If `topicref/topicmeta/navtitle` is present with `topicref/@locktitle="yes"`, this navtitle should be honored instead of adopting `topic/title`. But current DITA-OT 3.6.1 does not follow this rule in some condition.
Fixes issue #3708.

## How Has This Been Tested?
Tested with Windows 10 with DITA-OT 3.6.1 and modified `develop` branch of DITA-OT repository.
[Original test data & result archive]

[20210504-navtitle.zip](https://github.com/dita-ot/dita-ot/files/6435242/20210504-navtitle.zip)

temp-3.6.1 and out-3.6.1 folder contains the DITA-OT 3.6.1 results. temp-3.6.1-develop and out-3.6.1-develop contains the updated result with DITA-OT `development` branch using newly built `dost.jar`.

The modification changes the private static data in MapMetaReader.java. So it does not effect to other area.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No document update will be needed.
However the content of `topicref/topicmeta/navtitle` will change according to the DITA 1.3 specification, it should be mentioned in the update log explicitly.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
