### PR TITLE
Fix typo for service mark in PDF2 I18N configuration

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ar.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ar.xml
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/be.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/be.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/bg.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/bg.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/bs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/bs.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ca.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ca.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/cs.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/cs.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/da.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/da.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/de.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/de.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/el.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/el.xml
@@ -22,7 +22,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/en.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/es.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/es.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/et.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/et.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/fi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/fi.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/fr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/fr.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/he.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/he.xml
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hi.xml
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hr.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hu.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/hu.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/id.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/id.xml
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/is.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/is.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/it.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/it.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/kk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/kk.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ko.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ko.xml
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/lt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/lt.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/lv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/lv.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/mk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/mk.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ms.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ms.xml
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/nl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/nl.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/no.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/no.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pl.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pt.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pt.xml
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pt_BR.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/pt_BR.xml
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ro.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ro.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ru.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ru.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sk.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sl.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sl.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr_latn_ME.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr_latn_ME.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr_latn_RS.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sr_latn_RS.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sv.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/sv.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/th.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/th.xml
@@ -22,7 +22,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/tr.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/tr.xml
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/uk.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/uk.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ur.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/ur.xml
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/vi.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/vi.xml
@@ -152,7 +152,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- Trademark -->
       <character>&#8482;</character>
       <!-- Service mark -->
-      <character>&#2120;</character>
+      <character>&#x2120;</character>
     </character-set>
   </alphabet>
   <alphabet char-set="SubmenuSymbol">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/zh_CN.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/zh_CN.xml
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/zh_TW.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/i18n/zh_TW.xml
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
             <!-- Trademark -->
             <character>&#8482;</character>
             <!-- Service mark -->
-            <character>&#2120;</character>
+            <character>&#x2120;</character>
         </character-set>
     </alphabet>
 


### PR DESCRIPTION
Signed-off-by: Eric Sirois <easirois@rogers.com>

## Description
update service mark character from &#2120; -> &#x2120;

## Motivation and Context
This will appear as U+0848 MANDAIC LETTER ATT instead of U+2120 SERVICE MARK.

Fixes #3753.

## How Has This Been Tested?
Validated the "SM" character shows up properly in oXygen Author Mode.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that changes existing functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->
N/A

- What documentation changes are needed for this feature?
  _(Provide links to existing documentation topics that will require updates)_
- Will this change affect backwards compatibility or other users' overrides?

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
