### PR TITLE
Issue 3762 - Keep footnotes together with topic when content is chunked

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -249,6 +249,7 @@ See the accompanying LICENSE file for applicable license.
    <xsl:call-template name="gen-toc-id"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
+    <xsl:call-template name="gen-endnotes"/>
   </xsl:template>
   
   
@@ -2137,7 +2138,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- render any contained footnotes as endnotes.  Links back to reference point -->
   <xsl:template name="gen-endnotes">
     <!-- Skip any footnotes that are in draft elements when draft = no -->
-    <xsl:apply-templates select="//*[contains(@class, ' topic/fn ')][not( (ancestor::*[contains(@class, ' topic/draft-comment ')] or ancestor::*[contains(@class, ' topic/required-cleanup ')]) and $DRAFT = 'no')]" mode="genEndnote"/>
+    <xsl:apply-templates select=".//child::*[contains(@class, ' topic/fn ')][not( (ancestor::*[contains(@class, ' topic/draft-comment ')] or ancestor::*[contains(@class, ' topic/required-cleanup ')]) and $DRAFT = 'no')]" mode="genEndnote"/>
   
   </xsl:template>
   
@@ -2558,7 +2559,6 @@ See the accompanying LICENSE file for applicable license.
                                <!-- followed by body content, again by fall-through in document order -->
                                <!-- followed by related links -->
                                <!-- followed by child topics by fall-through -->
-        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes -->
         <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
       </article>
     </main>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -311,6 +311,7 @@ See the accompanying LICENSE file for applicable license.
  <xsl:call-template name="gen-toc-id"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
+  <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes -->
 </xsl:template>
 
 
@@ -2262,7 +2263,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- render any contained footnotes as endnotes.  Links back to reference point -->
 <xsl:template name="gen-endnotes">
   <!-- Skip any footnotes that are in draft elements when draft = no -->
-  <xsl:apply-templates select="//*[contains(@class, ' topic/fn ')][not( (ancestor::*[contains(@class, ' topic/draft-comment ')] or ancestor::*[contains(@class, ' topic/required-cleanup ')]) and $DRAFT = 'no')]" mode="genEndnote"/>
+  <xsl:apply-templates select=".//child::*[contains(@class, ' topic/fn ')][not( (ancestor::*[contains(@class, ' topic/draft-comment ')] or ancestor::*[contains(@class, ' topic/required-cleanup ')]) and $DRAFT = 'no')]" mode="genEndnote"/>
 
 </xsl:template>
 
@@ -2774,7 +2775,6 @@ See the accompanying LICENSE file for applicable license.
                                <!-- followed by body content, again by fall-through in document order -->
                                <!-- followed by related links -->
                                <!-- followed by child topics by fall-through -->
-        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes -->
         <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
       </article>
     </main>


### PR DESCRIPTION
## Description
The current behaviour when not chunking content is the footnotes to appear at the end of each topic. When that content is chunked, then all those footnotes appear at the end of the chunked content away from its context.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, add a link to the issue number: Fixes #1234. -->
#3762 

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->
Used the provided sample map in the ticket original ticket to validate the footnotes appeared at the end of individual topics rather than at the end of the whole topic.  Also validated that footnotes appeared in the right spot when the topics are not chunked.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->
Move the call for gen-endnotes from addContentToHtmlBodyElement to gen-topic.
Modify the xpath to only look at footnotes within the context of the current topic.

- Bug fix _(non-breaking change which fixes an issue)_


## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  _(Provide links to existing documentation topics that will require updates)_
- Will this change affect backwards compatibility or other users' overrides?

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.