### PR TITLE
Refine Japanese font assignment for PDF2 output.

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/font-mappings.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/font-mappings.xml
@@ -59,7 +59,7 @@ See the accompanying LICENSE file for applicable license.
         <font-face>AdobeSongStd-Light, Arial Unicode MS, Batang, SimSun</font-face>
       </physical-font>
       <physical-font char-set="Japanese">
-        <font-face>KozMinProVI-Regular, Arial Unicode MS, Batang</font-face>
+        <font-face>MS-Gothic, Hiragino Kaku Gothic Pro, HiraKakuProN-W3, YuGothic, Arial Unicode MS</font-face>
       </physical-font>
       <physical-font char-set="Korean">
         <font-face>AdobeMyungjoStd-Medium, Arial Unicode MS, Batang</font-face>
@@ -85,7 +85,7 @@ See the accompanying LICENSE file for applicable license.
         <font-face>AdobeSongStd-Light, Arial Unicode MS, Batang, SimSun</font-face>
       </physical-font>
       <physical-font char-set="Japanese">
-        <font-face>KozMinProVI-Regular, Arial Unicode MS, Batang</font-face>
+        <font-face>MS-Mincho, Hiragino Mincho Pro, HiraMinProN-W3, YuMincho, Arial Unicode MS</font-face>
       </physical-font>
       <physical-font char-set="Korean">
         <font-face>AdobeMyungjoStd-Medium, Arial Unicode MS, Batang</font-face>
@@ -111,7 +111,7 @@ See the accompanying LICENSE file for applicable license.
         <font-face>AdobeSongStd-Light, Arial Unicode MS, Batang, SimSun</font-face>
       </physical-font>
       <physical-font char-set="Japanese">
-        <font-face>KozMinProVI-Regular, Arial Unicode MS, Batang</font-face>
+        <font-face>MS-Gothic, Hiragino Kaku Gothic Pro, HiraKakuProN-W3, YuGothic, Arial Unicode MS</font-face>
       </physical-font>
       <physical-font char-set="Korean">
         <font-face>AdobeMyungjoStd-Medium, Arial Unicode MS, Batang</font-face>


### PR DESCRIPTION
Signed-off-by: Toshihiko Makita <tmakita@antenna.co.jp>

## Description
Refine Japanese font assignment to avoid garbled glyph in output PDF

## Motivation and Context
Many Japanese new DITA-OT users test PDF output and all of them got the garbled glyph because original font-family assignment is not suitable current Windows or Mac.

## How Has This Been Tested?
Windows 10 DITA-OT 3.6.1

The test DITA instance is:
[https://github.com/AntennaHouse/pdf5-ml/tree/master/samples/sample_ja](https://github.com/AntennaHouse/pdf5-ml/tree/master/samples/sample_ja)

The result before modification:

[sample_ja-before.pdf](https://github.com/dita-ot/dita-ot/files/6702557/sample_ja-before.pdf)

The modification result:

[sample_ja-after.pdf](https://github.com/dita-ot/dita-ot/files/6702560/sample_ja-after.pdf)

## Type of Changes
- Refinement

## Documentation and Compatibility
None

## Checklist
This is only XML file change and no Java, XSLT coding conventions are applied.

- I have updated the unit tests to reflect the changes in my code.
