### PR TITLE
Load custom CSS last to facilitate overrides

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2358,12 +2358,12 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="generateDefaultMeta"/> <!-- Standard meta for security, robots, etc -->
       <xsl:apply-templates select="." mode="getMeta"/> <!-- Process metadata from topic prolog -->
       <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
-      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
       <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element -->
       <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
       <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
       <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
       <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified -->
+      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
     </head>
   </xsl:template>
 


### PR DESCRIPTION
## Description

The HTML5 `chapterHead` template currently inserts the custom CSS file reference specified via `args.css` _before_ the contents of the custom header file specified via `args.hdf`.

This means that if the header file _(or any of the 3 preceding* template calls)_ is [used](https://github.com/infotexture/dita-bootstrap/blob/develop/includes/bootstrap.hdf.xml) to insert references to external CSS stylesheets for frameworks like [Bootstrap](https://getbootstrap.com/docs/5.0/getting-started/introduction/#css), the framework styles take precedence over any equivalent rules in the user's custom stylesheet.

This PR adjusts the order to ensure that custom stylesheets can be used to override any references included in the custom header file without resorting to increased selector specificity or `!important` hacks in the custom CSS.

### * Related question

If I'm reading the code right, in addition to the `processHDF` template that inserts the contents of the custom header file specified via `args.hdf`, there are **4** additional named templates that are all empty by default, but can be customized to insert content into the `<head>` element of the generated HTML files for each topic:

1. `copyright`
2. `gen-user-head`
4. `gen-user-scripts`
5. `gen-user-styles`

The same redundant approach appears to be used for running headers and footers that are inserted into the HTML `<body>` element:

- an empty `gen-user-header` template, followed by the `processHDR` template that inserts the contents of the custom header file specified via `args.hdr`
- an empty `gen-user-footer` template, followed by the `processFTR` template that inserts the contents of the custom footer file specified via `args.ftr`

@robander I assume the empty templates preceded the ability to insert content via external files and are retained for backwards compatibility, but is there any advantage to customizing these empty templates over the use of external `args.*` files?
