### PR TITLE
Add extension point dita.build.html5.after.preprocess to HTML5

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -15,6 +15,7 @@ See the accompanying LICENSE file for applicable license.
           depends="html5.init,
                    build-init,
                    preprocess,
+                   html5.after.preprocess,
                    html5.topic,
                    html5.map,
                    html5.css"/>
@@ -101,6 +102,10 @@ See the accompanying LICENSE file for applicable license.
     <!-- Set to "true" if you get out-of-memory errors during preprocess
     while processing very large (thousands of files) document sets. -->
     <property name="dita.html5.reloadstylesheet" value="false"/>
+  </target>
+
+  <target name="html5.after.preprocess">
+    <dita:extension id="dita.build.html5.after.preprocess" behavior="org.dita.dost.platform.InsertAction"/>
   </target>
 
   <target name="html5.topic"

--- a/src/main/plugins/org.dita.html5/plugin.xml
+++ b/src/main/plugins/org.dita.html5/plugin.xml
@@ -13,6 +13,7 @@ See the accompanying LICENSE file for applicable license.
   <extension-point id="dita.conductor.html5.toc.param" name="HTML/XSLT XSLT parameter"/>
   <extension-point id="dita.xsl.html5.toc" name="HTML5 TOC XSLT import"/>
   <extension-point id="dita.xsl.html5.cover" name="HTML5 Cover XSLT import"/>
+  <extension-point id="dita.build.html5.after.preprocess" name="HTML5 build inclusion after preprocess"/>
   <!-- extensions -->
   <transtype name="html5" desc="HTML5">
     <param name="args.artlbl" desc="Specifies whether to generate a label for each image; the label will contain the image file name." type="enum">


### PR DESCRIPTION
Signed-off-by: Toshihiko Makita <tmakita@antenna.co.jp>

## Description
Add extension point "dita.build.html5.after.preprocess" to HTML5

## Motivation and Context
Implement #3771

## How Has This Been Tested?
Tested with DITA-OT 3.6.1 on Windows 10.

Sample plug-in: org.acme.html5.header
[org.acme.html5.header.zip](https://github.com/dita-ot/dita-ot/files/6797693/org.acme.html5.header.zip)

Sample file and test result: dita-samples.zip
[dita-samples.zip](https://github.com/dita-ot/dita-ot/files/6797698/dita-samples.zip)

## Type of Changes
- New feature: Add extension point. 

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  I searched "doc" folder. But relevant documentation is not found.
- Will this change affect backwards compatibility or other users' overrides? : Yes

## Checklist
- My code follows the code style of this project.: OK
- I have updated the unit tests to reflect the changes in my code.: OK
