### PR TITLE
Update PDF2 dependency FOP 2.6

### DIFF
--- a/src/main/plugins/org.dita.pdf2.fop/build.gradle
+++ b/src/main/plugins/org.dita.pdf2.fop/build.gradle
@@ -13,19 +13,20 @@ repositories {
     }
 }
 dependencies {
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop', version: '2.5') {
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop', version: '2.6') {
         exclude group: 'xalan'
         exclude group: 'ant'
         exclude group: 'javax.servlet'
     }
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.13') {
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'batik-all', version: '1.14') {
         exclude group: 'xalan'
     }
     runtimeOnly group: 'xml-apis', name: 'xml-apis-ext', version: '1.3.04'
     runtimeOnly group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.30'
-    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop-pdf-images', version: '2.5') {
+    runtimeOnly(group: 'org.apache.xmlgraphics', name: 'fop-pdf-images', version: '2.6') {
+        exclude group: 'xalan'
     }
-    runtimeOnly group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.21'
+    runtimeOnly group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.24'
 }
 
 task copyInstall(type: Copy) {

--- a/src/main/plugins/org.dita.pdf2.fop/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2.fop/plugin.xml
@@ -11,16 +11,16 @@ See the accompanying LICENSE file for applicable license.
   <!-- extensions -->
   <feature extension="depend.org.dita.pdf2.init.pre" value="transform.fo2pdf.fop.init"/>
   <feature extension="depend.org.dita.pdf2.format" value="transform.fo2pdf.fop"/>
-  <feature extension="dita.conductor.lib.import" file="lib/batik-all-1.13.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/batik-all-1.14.jar"/>
 <!--  <feature extension="dita.conductor.lib.import" file="lib/commons-logging-1.2.jar"/>-->
-  <feature extension="dita.conductor.lib.import" file="lib/fontbox-2.0.21.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/fop-2.5.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/fop-pdf-images-2.5.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fontbox-2.0.24.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fop-2.6.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/fop-pdf-images-2.6.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/jcl-over-slf4j-1.7.30.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/xml-apis-ext-1.3.04.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/pdfbox-2.0.21.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/pdfbox-2.0.24.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/slf4j-api-1.7.30.jar"/>
-  <feature extension="dita.conductor.lib.import" file="lib/xmlgraphics-commons-2.4.jar"/>
+  <feature extension="dita.conductor.lib.import" file="lib/xmlgraphics-commons-2.6.jar"/>
   <transtype name="pdf" desc="PDF">
     <param name="pdf.formatter" desc="Specifies the XSL processor." type="enum">
       <val desc="Apache FOP" default="true">fop</val>


### PR DESCRIPTION

## Description
Update PDF2 dependency [FOP to version 2.6](https://xmlgraphics.apache.org/fop/2.6/releaseNotes_2.6.html).

## Motivation and Context
Contains bug fixes and keep up with latest FOP version.

## How Has This Been Tested?
Tests pass.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Mention in release notes.

