### PR TITLE
dita-ot:generate-stable-id(): Handle input element is not within a topic

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -48,12 +48,18 @@ See the accompanying LICENSE file for applicable license.
   <xsl:function name="dita-ot:generate-stable-id" as="xs:string">
     <xsl:param name="element" as="element()"/>
     
-    <xsl:variable name="topic" select="$element/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]" as="element()"/>
-    <xsl:variable name="parent-element" select="$element/ancestor-or-self::*[@id][1][not(. is $topic)]" as="element()?"/>
-    <xsl:variable name="closest" select="($parent-element, $topic)[1]" as="element()"/>
-    <xsl:variable name="index" select="count($closest/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
-    
-    <xsl:sequence select="dita-ot:generate-id($topic/@id, string-join(($parent-element/@id, local-name($element), string($index)), $HTML_ID_SEPARATOR))"/>
+    <xsl:variable name="topic" select="$element/ancestor-or-self::*[contains(@class, ' topic/topic ')][1]" as="element()?"/>
+    <xsl:choose>
+      <xsl:when test="empty($topic)">
+        <xsl:sequence select="generate-id($element)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="parent-element" select="$element/ancestor-or-self::*[@id][1][not(. is $topic)]" as="element()?"/>
+        <xsl:variable name="closest" select="($parent-element, $topic)[1]" as="element()"/>
+        <xsl:variable name="index" select="count($closest/descendant::*[local-name() = local-name($element)][. &lt;&lt; $element]) + 1" as="xs:integer"/>
+        <xsl:sequence select="dita-ot:generate-id($topic/@id, string-join(($parent-element/@id, local-name($element), string($index)), $HTML_ID_SEPARATOR))"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
 
   <xsl:function name="table:is-tbody-entry" as="xs:boolean">

--- a/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
-  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl">
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" 
+  stylesheet="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl">
 
   <x:scenario label="dita-ot:get-prefixed-id">
     <x:scenario label="p in topic">
@@ -36,6 +37,22 @@
         </x:param>
       </x:call>
 
+      <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
+    </x:scenario>
+    <x:scenario label="generated element">
+      <x:call function="dita-ot:generate-html-id">
+        <x:param name="element" select="(//p)[1]">
+          <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+            domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d) "
+            id="topic" ditaarch:DITAArchVersion="1.3">
+            <title class="- topic/title ">Title</title>
+            <body class="- topic/body ">
+              <p class="- topic/p " id="p">para</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+      
       <x:expect label="return element id prefixed with topic id" select="'topic__p'"/>
     </x:scenario>
     <x:scenario label="element without id">

--- a/src/test/xsl/plugins/org.dita.html5/xsl/generate-stable-id.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/generate-stable-id.xspec
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" 
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" 
+  xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" 
+  stylesheet="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl"> 
+  
+  <x:variable name="generated" as="element()" select="/*/*[1]">
+    <gen>
+      <parmhead class="- topic/sthead "></parmhead>
+    </gen>    
+  </x:variable>
+  
+  <x:scenario label="dita-ot:generate-stable-id"> 
+    <x:scenario label="element with topic parent">
+      <x:call function="dita-ot:generate-stable-id">
+        <x:param name="element" as="element()">
+          <topic id="topic-01" class="- topic/topic ">
+            <title class="- topic/title ">Test Topic</title>
+            <body class="- topic/body ">
+              <p class="- topic/p ">A paragraph</p>
+            </body>
+          </topic>
+        </x:param>
+      </x:call>
+      <x:expect label="Expect a non-empty value"
+        test="not(matches(., '^\s*$'))"
+        select="true()"
+      />
+    </x:scenario>
+    <x:scenario label="generated element (no topic parent)">
+      <x:call function="dita-ot:generate-stable-id">
+        <x:param name="element" as="element()" select="$generated"/>        
+      </x:call>
+      <x:expect label="Expect a non-empty value"
+        test="not(matches(., '^\s*$'))"
+        select="true()"
+      />      
+    </x:scenario>
+  </x:scenario>
+</x:description>


### PR DESCRIPTION

## Description

Added check for empty $topic and in that case use generate-id() on the input element.

## Motivation and Context

Fixes runtime error resulting from generation of simple table head for properties tables.

## How Has This Been Tested?

Tested in 3.6.1 using test document that fails with unmodified code.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

Fixes runtime failure for properties tables (and possibly all simple tables) that do not have explicit headers. 
More generally, fixes failure for any case that generated content ends up using dita-ot:generate-stable-id().

## Documentation and Compatibility
- What documentation changes are needed for this feature?
  No documentation change
- Will this change affect backwards compatibility or other users' overrides?
  No
## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
  Added unit test generate-stable-id.xspec
