### PR TITLE
Make XHTML object elements valid when there's fallback

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1510,32 +1510,31 @@ See the accompanying LICENSE file for applicable license.
   <!-- object, desc, & param -->
   <xsl:template match="*[contains(@class, ' topic/object ')]" name="topic.object">
    <object>
-     <xsl:copy-of select="@id | @declare | @codebase | @type | @archive | @height | @usemap | @tabindex | @classid | @data | @codetype | @standby | @width | @name"/>
-     <!-- In HTML5, <param> must precede any other fallback content -->
-     <xsl:apply-templates select="*[contains(@class, ' topic/param ')]"/>
-     
-     <xsl:if test="@longdescref or *[contains(@class, ' topic/longdescref ')]">
-       <xsl:apply-templates select="." mode="ditamsg:longdescref-on-object"/>
+    <xsl:copy-of select="@id | @declare | @codebase | @type | @archive | @height | @usemap | @tabindex | @classid | @data | @codetype | @standby | @width | @name"/>
+    <!-- In HTML5, <param> must precede any other fallback content -->
+    <xsl:apply-templates select="*[contains(@class, ' topic/param ')]"/>
+    <xsl:if test="@longdescref or *[contains(@class, ' topic/longdescref ')]">
+      <xsl:apply-templates select="." mode="ditamsg:longdescref-on-object"/>
+    </xsl:if>
+    <xsl:apply-templates select="node() except *[contains(@class, ' topic/param ')]"/>
+   <!-- Test for Flash movie; include EMBED statement for non-IE browsers -->
+   <xsl:if test="contains(@codebase, 'swflash.cab')">
+    <embed>
+     <xsl:if test="@id"><xsl:attribute name="name" select="@id"/></xsl:if>
+     <xsl:copy-of select="@height | @width"/>
+     <xsl:attribute name="type"><xsl:text>application/x-shockwave-flash</xsl:text></xsl:attribute>
+     <xsl:attribute name="pluginspage"><xsl:text>http://www.macromedia.com/go/getflashplayer</xsl:text></xsl:attribute>
+     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'movie'">
+      <xsl:attribute name="src" select="*[contains(@class, ' topic/param ')][@name = 'movie']/@value"/>
      </xsl:if>
-     <xsl:apply-templates select="node() except (*[contains(@class, ' topic/param ')])"/>
-     <!-- Test for Flash movie; include EMBED statement for non-IE browsers -->
-     <xsl:if test="contains(@codebase, 'swflash.cab')">
-      <embed>
-       <xsl:if test="@id"><xsl:attribute name="name" select="@id"/></xsl:if>
-       <xsl:copy-of select="@height | @width"/>
-       <xsl:attribute name="type"><xsl:text>application/x-shockwave-flash</xsl:text></xsl:attribute>
-       <xsl:attribute name="pluginspage"><xsl:text>http://www.macromedia.com/go/getflashplayer</xsl:text></xsl:attribute>
-       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'movie'">
-        <xsl:attribute name="src" select="*[contains(@class, ' topic/param ')][@name = 'movie']/@value"/>
-       </xsl:if>
-       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'quality'">
-        <xsl:attribute name="quality" select="*[contains(@class, ' topic/param ')][@name = 'quality']/@value"/>
-       </xsl:if>
-       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'bgcolor'">
-        <xsl:attribute name="bgcolor" select="*[contains(@class, ' topic/param ')][@name = 'bgcolor']/@value"/>
-       </xsl:if>
-      </embed>
+     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'quality'">
+      <xsl:attribute name="quality" select="*[contains(@class, ' topic/param ')][@name = 'quality']/@value"/>
      </xsl:if>
+     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'bgcolor'">
+      <xsl:attribute name="bgcolor" select="*[contains(@class, ' topic/param ')][@name = 'bgcolor']/@value"/>
+     </xsl:if>
+    </embed>
+   </xsl:if>
    </object>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1510,29 +1510,32 @@ See the accompanying LICENSE file for applicable license.
   <!-- object, desc, & param -->
   <xsl:template match="*[contains(@class, ' topic/object ')]" name="topic.object">
    <object>
-    <xsl:copy-of select="@id | @declare | @codebase | @type | @archive | @height | @usemap | @tabindex | @classid | @data | @codetype | @standby | @width | @name"/>
-    <xsl:if test="@longdescref or *[contains(@class, ' topic/longdescref ')]">
-      <xsl:apply-templates select="." mode="ditamsg:longdescref-on-object"/>
-    </xsl:if>
-    <xsl:apply-templates/>
-   <!-- Test for Flash movie; include EMBED statement for non-IE browsers -->
-   <xsl:if test="contains(@codebase, 'swflash.cab')">
-    <embed>
-     <xsl:if test="@id"><xsl:attribute name="name" select="@id"/></xsl:if>
-     <xsl:copy-of select="@height | @width"/>
-     <xsl:attribute name="type"><xsl:text>application/x-shockwave-flash</xsl:text></xsl:attribute>
-     <xsl:attribute name="pluginspage"><xsl:text>http://www.macromedia.com/go/getflashplayer</xsl:text></xsl:attribute>
-     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'movie'">
-      <xsl:attribute name="src" select="*[contains(@class, ' topic/param ')][@name = 'movie']/@value"/>
+     <xsl:copy-of select="@id | @declare | @codebase | @type | @archive | @height | @usemap | @tabindex | @classid | @data | @codetype | @standby | @width | @name"/>
+     <!-- In HTML5, <param> must precede any other fallback content -->
+     <xsl:apply-templates select="*[contains(@class, ' topic/param ')]"/>
+     
+     <xsl:if test="@longdescref or *[contains(@class, ' topic/longdescref ')]">
+       <xsl:apply-templates select="." mode="ditamsg:longdescref-on-object"/>
      </xsl:if>
-     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'quality'">
-      <xsl:attribute name="quality" select="*[contains(@class, ' topic/param ')][@name = 'quality']/@value"/>
+     <xsl:apply-templates select="node() except (*[contains(@class, ' topic/param ')])"/>
+     <!-- Test for Flash movie; include EMBED statement for non-IE browsers -->
+     <xsl:if test="contains(@codebase, 'swflash.cab')">
+      <embed>
+       <xsl:if test="@id"><xsl:attribute name="name" select="@id"/></xsl:if>
+       <xsl:copy-of select="@height | @width"/>
+       <xsl:attribute name="type"><xsl:text>application/x-shockwave-flash</xsl:text></xsl:attribute>
+       <xsl:attribute name="pluginspage"><xsl:text>http://www.macromedia.com/go/getflashplayer</xsl:text></xsl:attribute>
+       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'movie'">
+        <xsl:attribute name="src" select="*[contains(@class, ' topic/param ')][@name = 'movie']/@value"/>
+       </xsl:if>
+       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'quality'">
+        <xsl:attribute name="quality" select="*[contains(@class, ' topic/param ')][@name = 'quality']/@value"/>
+       </xsl:if>
+       <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'bgcolor'">
+        <xsl:attribute name="bgcolor" select="*[contains(@class, ' topic/param ')][@name = 'bgcolor']/@value"/>
+       </xsl:if>
+      </embed>
      </xsl:if>
-     <xsl:if test="*[contains(@class, ' topic/param ')]/@name = 'bgcolor'">
-      <xsl:attribute name="bgcolor" select="*[contains(@class, ' topic/param ')][@name = 'bgcolor']/@value"/>
-     </xsl:if>
-    </embed>
-   </xsl:if>
    </object>
   </xsl:template>
   

--- a/src/test/xsl/plugins/org.dita.html5/xsl/object.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/object.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+                xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
+                xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
+                version="2.0"
+                exclude-result-prefixes="xs dita-ot table simpletable">
+  
+  
+  <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/output-message.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/dita-utilities.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/functions.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/related-links.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/rel-links.xsl"/>
+  <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/topic.xsl"/>
+
+  <!-- Mocks -->
+  
+  <xsl:param name="DEFAULTLANG" as="xs:string" select="'en'"/>
+ 
+</xsl:stylesheet>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/object.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/object.xsl
@@ -8,7 +8,6 @@
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
   
-  
   <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/output-message.xsl"/>
   <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/dita-utilities.xsl"/>
   <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/functions.xsl"/>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/object.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/object.xspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="object.xsl"
+  >
+
+  <x:scenario label="object-with-desc">
+    <x:context select="/object">
+      <object class="- topic/object ">
+        <desc class="- topic/desc ">This is the description</desc>
+        <param name="param1" class="- topic/param " value="This is param1"/>
+      </object>
+    </x:context>
+    <x:expect label="Fallback follows params">
+      <object>
+        <param name="param1" value="This is param1" />
+        <span>This is the description</span>
+      </object>
+    </x:expect>
+  </x:scenario>
+
+
+</x:description>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/object.xspec
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/object.xspec
@@ -2,7 +2,8 @@
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
-  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable" stylesheet="object.xsl"
+  xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
+  stylesheet="object.xsl"
   >
 
   <x:scenario label="object-with-desc">
@@ -19,6 +20,5 @@
       </object>
     </x:expect>
   </x:scenario>
-
 
 </x:description>


### PR DESCRIPTION
Refactored topic/object to ensure params come before any fallback content

Implemented unit test for topic/object param placement behavior

Signed-off-by: Eliot Kimber <ekimber@contrext.com>

## Description

Refined processing for topic/object so any desc or longdesc content is output after any param elements.
HTML5 requires param to occur before any other elements.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Fixes generation of invalid XHTML. Found this when running epubcheck on XHTML generated
for use in EPUBs.

## How Has This Been Tested?

Implemented unit test html5/object.xspec

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

Ensures correct order of generated XHTML element within <object>

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?

None

- Will this change affect backwards compatibility or other users' overrides?

It should not.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
