### PR TITLE
Support fileset for style configuration

### DIFF
--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -53,7 +53,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
     private XsltExecutable templates;
     private final Map<String, String> params = new HashMap<>();
     private final Properties properties = new Properties();
-    private File style;
+    private Source style;
     private File in;
     private File out;
     private File destDir;
@@ -101,11 +101,11 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
         xsltCompiler.setURIResolver(uriResolver);
         xsltCompiler.setErrorReporter(toErrorReporter(logger));
-        logger.info("Loading stylesheet " + style.getAbsolutePath());
+        logger.info("Loading stylesheet " + style.getSystemId());
         try {
-            templates = xsltCompiler.compile(new StreamSource(style));
+            templates = xsltCompiler.compile(style);
         } catch (SaxonApiException e) {
-            throw new RuntimeException("Failed to compile stylesheet '" + style.getAbsolutePath() + "': " + e.getMessage(), e);
+            throw new RuntimeException("Failed to compile stylesheet '" + style.getSystemId() + "': " + e.getMessage(), e);
         }
         if (in != null) {
             transform(in, out);
@@ -192,7 +192,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
 
     private void transform(final File in, final File out) throws DITAOTException {
         if (reloadstylesheet || t == null) {
-            logger.info("Loading stylesheet " + style.getAbsolutePath());
+            logger.info("Loading stylesheet " + style.getSystemId());
             t = getTransformer();
         }
         transform(in, out, t);
@@ -295,7 +295,15 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
         }
     }
 
+    /**
+     * @deprecated use {@link #setStyle(Source)} instead
+     */
+    @Deprecated
     public void setStyle(final File style) {
+        this.style = new StreamSource(style);
+    }
+
+    public void setStyle(final Source style) {
         this.style = style;
     }
 


### PR DESCRIPTION
## Description
Support `<style>` element for pipeline XSLT task and `<param>` element with [Resource](https://ant.apache.org/manual/Types/resources.html) value.

## Motivation and Context
The built-in XSLT task supports defining XSLT with a `<style>` element and this PR adds support to match it. Supporting `<style>` enables passing the stylesheet as a Resource serves as initial support for classpath based plugin resources.

## How Has This Been Tested?
Existing tests pass.
## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

[Use custom <pipeline> elements](https://www.dita-ot.org/dev/topics/plugin-coding-conventions.html) documents use of `<pipeline>` element for XSLT transformations but doesn't include details about how it works. This PR makes pipeline XSLT module more consistent with Ant's XSLT task, so no new documentation is needed.