### PR TITLE
#3785 Convert width and height values in pixels to avoid NaN if values with units.

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1423,11 +1423,19 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- AM: handling for scale attribute -->
   <xsl:template match="*[contains(@class, ' topic/image ')]/@scale">
-      <xsl:variable name="width" select="../@dita-ot:image-width"/>
-      <xsl:variable name="height" select="../@dita-ot:image-height"/>
+      <xsl:variable name="width-in-pixel">
+        <xsl:call-template name="length-to-pixels">
+          <xsl:with-param name="dimen" select="../@dita-ot:image-width"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <xsl:variable name="height-in-pixel">
+        <xsl:call-template name="length-to-pixels">
+          <xsl:with-param name="dimen" select="../@dita-ot:image-height"/>
+        </xsl:call-template>
+      </xsl:variable>
       <xsl:if test="not(../@width) and not(../@height)">
-        <xsl:attribute name="height" select="floor(number($height) * number(.) div 100)"/>
-        <xsl:attribute name="width" select="floor(number($width) * number(.) div 100)"/>
+        <xsl:attribute name="height" select="floor(number($height-in-pixel) * number(.) div 100)"/>
+        <xsl:attribute name="width" select="floor(number($width-in-pixel) * number(.) div 100)"/>
       </xsl:if>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1591,8 +1591,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not(../@width) and not(../@height)">
-      <xsl:attribute name="height" select="floor(number($height) * number(.) div 100)"/>
-      <xsl:attribute name="width" select="floor(number($width) * number(.) div 100)"/>
+      <xsl:attribute name="height" select="floor(number($height-in-pixel) * number(.) div 100)"/>
+      <xsl:attribute name="width" select="floor(number($width-in-pixel) * number(.) div 100)"/>
     </xsl:if>
 </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1580,8 +1580,16 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- AM: handling for scale attribute -->
 <xsl:template match="*[contains(@class, ' topic/image ')]/@scale">
-    <xsl:variable name="width" select="../@dita-ot:image-width"/>
-    <xsl:variable name="height" select="../@dita-ot:image-height"/>
+    <xsl:variable name="width-in-pixel">
+      <xsl:call-template name="length-to-pixels">
+        <xsl:with-param name="dimen" select="../@dita-ot:image-width"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="height-in-pixel">
+      <xsl:call-template name="length-to-pixels">
+        <xsl:with-param name="dimen" select="../@dita-ot:image-height"/>
+      </xsl:call-template>
+    </xsl:variable>
     <xsl:if test="not(../@width) and not(../@height)">
       <xsl:attribute name="height" select="floor(number($height) * number(.) div 100)"/>
       <xsl:attribute name="width" select="floor(number($width) * number(.) div 100)"/>


### PR DESCRIPTION
## Description
Add a conversion to pixels before creating width/height attributes during conversion DITA to HTML5 and DITA to XHTML.

## Motivation and Context
Fix for #3785

## Type of Changes
- Bug fix

## Documentation and Compatibility
N/A

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.

Signed-off-by: Julien Lacour julien@sync.ro