### PR TITLE
Fix errors for <mapref scope="peer"> references

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -621,6 +621,9 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
             <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
+          <xsl:when test="$format = 'ditamap'">
+            <!-- don't complain - peer maps don't need a navtitle -->
+          </xsl:when>
           <xsl:otherwise>
             <xsl:text>#none#</xsl:text>
             <xsl:apply-templates select="." mode="ditamsg:missing-navtitle-peer"/>
@@ -966,6 +969,9 @@ Other modes can be found within the code, and may or may not prove useful for ov
       <xsl:when test="@navtitle"><xsl:value-of select="@navtitle"/></xsl:when>
       <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]">
         <xsl:apply-templates select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]" mode="text-only"/>
+      </xsl:when>
+      <xsl:when test="@format = 'ditamap'">
+        <!-- don't complain - peer maps don't need link text -->
       </xsl:when>
       <xsl:otherwise>
         <xsl:text>#none#</xsl:text>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -409,7 +409,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
         </xsl:call-template>
       </xsl:when>
-      <xsl:when test="not($linking='none') and @href and not(contains(@href,'#'))">
+      <xsl:when test="not($linking='none') and @href and not(contains(@href,'#')) and not(@scope = 'peer')">
         <xsl:variable name="update-id-path" select="($mapref-id-path, generate-id(.))"/>
         <xsl:variable name="href" select="@href" as="xs:string?"/>
         <xsl:apply-templates select="document($href, /)/*[contains(@class,' map/map ')]" mode="mapref">

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -474,7 +474,7 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
-                .errorCount(2)
+                .errorCount(0)
                 .test();
     }
 

--- a/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
@@ -71,7 +71,7 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
-                .errorCount(5)
+                .errorCount(3)
                 .warnCount(1)
                 .test();
     }

--- a/src/test/java/org/dita/dost/IntegrationTestXhtml.java
+++ b/src/test/java/org/dita/dost/IntegrationTestXhtml.java
@@ -362,7 +362,7 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
-                .errorCount(2)
+                .errorCount(0)
                 .test();
     }
 

--- a/src/test/resources/mapref/exp/preprocess/test.ditamap
+++ b/src/test/resources/mapref/exp/preprocess/test.ditamap
@@ -39,8 +39,13 @@
         <linktext class="- map/linktext ">title</linktext>
       </topicmeta>
     </topicref>
-    <mapref class="+ map/topicref mapgroup-d/mapref " format="ditamap" scope="peer" href="peer.ditamap" audience="novice">
-      <topicmeta class="- map/topicmeta "/>
+    <mapref class="+ map/topicref mapgroup-d/mapref " format="ditamap" scope="peer" href="peer.ditamap"
+      audience="novice">
+      <topicmeta class="- map/topicmeta ">
+        <navtitle class="- topic/navtitle "/>
+        <?ditaot gentext?>
+        <linktext class="- map/linktext "/>
+      </topicmeta>
     </mapref>
   </topicgroup>
 </map>

--- a/src/test/resources/mapref/exp/preprocess2/test.ditamap
+++ b/src/test/resources/mapref/exp/preprocess2/test.ditamap
@@ -39,8 +39,13 @@
         <linktext class="- map/linktext ">title</linktext>
       </topicmeta>
     </topicref>
-    <mapref class="+ map/topicref mapgroup-d/mapref " format="ditamap" scope="peer" href="peer.ditamap" audience="novice">
-      <topicmeta class="- map/topicmeta "/>
+    <mapref class="+ map/topicref mapgroup-d/mapref " format="ditamap" scope="peer" href="peer.ditamap"
+      audience="novice">
+      <topicmeta class="- map/topicmeta ">
+        <navtitle class="- topic/navtitle "/>
+        <?ditaot gentext?>
+        <linktext class="- map/linktext "/>
+      </topicmeta>
     </mapref>
   </topicgroup>
 </map>


### PR DESCRIPTION
## Description
This pull request seeks to fix incorrect errors that occur when `<mapref scope="peer">` references are used.

## Motivation and Context
We have books that reference each other. They can be published independently, so they have `@scope="peer"` references between them:

![book_level](https://user-images.githubusercontent.com/50950969/129492944-4e5a5279-2814-4e11-91f8-f34faeb0fd53.png)

With the current DITA-OT code, when an individual book is published, errors occur for missing file, linktext, and navtitle information for the peer maps (which is true, as peer map files are not copied for processing):

```
   [mapref] Warning at char 9 in xsl:apply-templates/@select on line 421 column 104 of maprefImpl.xsl:
   [mapref]   FODC0002: I/O error reported by XML parser processing
   [mapref]   file:/tmp/temp20210813092127883/book2.ditamap: /tmp/temp20210813092127883/book1.ditamap
   [mapref]   (No such file or directory)
   [mapref] Warning at char 9 in xsl:apply-templates/@select on line 421 column 104 of maprefImpl.xsl:
   [mapref]   FODC0002: I/O error reported by XML parser processing
   [mapref]   file:/tmp/temp20210813092127883/book3.ditamap: /tmp/temp20210813092127883/book1.ditamap
   [mapref]   (No such file or directory)
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:6:101: [DOTX020E][ERROR]: Missing navtitle attribute or element for peer topic "book2.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:6:101: [DOTX024E][ERROR]: Missing linktext and navtitle for peer topic "book2.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:7:101: [DOTX020E][ERROR]: Missing navtitle attribute or element for peer topic "book3.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:7:101: [DOTX024E][ERROR]: Missing linktext and navtitle for peer topic "book3.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
```

These books can also be published as submaps in a larger help collection:

![olh_level](https://user-images.githubusercontent.com/50950969/129492948-9e7bde09-81e2-4924-80d5-34e55244d879.png)

With the current DITA-OT code, when the top-level OLH map is published, the peer map references are treated as content references, resulting in infinite content inclusion dependency loop errors (because their maps are now copied for processing):

```
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:6:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book2.ditamap'.
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book1.ditamap:7:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book3.ditamap'.
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book2.ditamap:6:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book1.ditamap'.
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book2.ditamap:7:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book3.ditamap'.
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book3.ditamap:6:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book1.ditamap'.
   [mapref] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/book3.ditamap:7:101: [DOTX053E][ERROR]: A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to 'book2.ditamap'.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookA.ditamap:6:101: [DOTX020E][ERROR]: Missing navtitle attribute or element for peer topic "book1.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookA.ditamap:6:101: [DOTX024E][ERROR]: Missing linktext and navtitle for peer topic "book1.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookB.ditamap:7:101: [DOTX020E][ERROR]: Missing navtitle attribute or element for peer topic "book2.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookB.ditamap:7:101: [DOTX024E][ERROR]: Missing linktext and navtitle for peer topic "book2.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookA.ditamap:8:101: [DOTX020E][ERROR]: Missing navtitle attribute or element for peer topic "book3.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
[move-meta] file:/mnt/c/nobackup/experiments/olh_peerbooks_simple/bookA.ditamap:8:101: [DOTX024E][ERROR]: Missing linktext and navtitle for peer topic "book3.ditamap". References must provide a local navigation title when the target is not a local DITA resource.
```

A peer map reference in a lower level (the declaration of _existence_ of a resource) should not prohibit the actual _inclusion_ of that resource at a higher level. Just as in software, lower levels should be free to declare dependencies and higher levels should be free to satisfy them (or not, and allow the default to apply). Thus, the expectation is to be able to publish individual books or the entire collection cleanly, without errors.

## How Has This Been Tested?
The fixes have been tested with the following simple testcase:

[peer_map_fixes.tar.gz](https://github.com/dita-ot/dita-ot/files/6988904/peer_map_fixes.tar.gz)

To run it, extract it into a directory, then run the following commands in that directory:

```
dita -i bookA.ditamap -f html5
dita -i olh.ditamap -f html5
```

This testcase exhibits the errors above when the current DITA-OT code is used. It publishes cleanly without errors when the proposed DITA-OT code updates are used.

The fixes have also been tested on more complex examples within my company, involving several hundred topic files.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
- No documentation updates are needed for this change.
- No template interfaces have been altered, so other users' template overrides should be unaffected.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
