### PR TITLE
merge duplicate @keyscope values between <mapref> and <map>

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -204,7 +204,7 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:text> </xsl:text>
                     <xsl:value-of select="$target[contains(@class, ' map/map ')]/@keyscope"/>
                   </xsl:variable>
-                  <xsl:value-of select="string-join(distinct-values(tokenize($keyscope, '\s+')), ' ')"/>
+                  <xsl:value-of select="string-join(distinct-values(tokenize(normalize-space($keyscope), '\s+')), ' ')"/>
                 </xsl:attribute>
               </xsl:if>
               <xsl:apply-templates select="$target/@chunk"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -204,7 +204,7 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:text> </xsl:text>
                     <xsl:value-of select="$target[contains(@class, ' map/map ')]/@keyscope"/>
                   </xsl:variable>
-                  <xsl:value-of select="normalize-space($keyscope)"/>
+                  <xsl:value-of select="string-join(distinct-values(tokenize($keyscope, '\s+')), ' ')"/>
                 </xsl:attribute>
               </xsl:if>
               <xsl:apply-templates select="$target/@chunk"/>


### PR DESCRIPTION
## Description
Per ["2.3.4.2 Key scopes"](http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/archSpec/base/keyScopes.html), when a `<mapref>` element and its target `<map>` element both define `@keyscope` values, the resulting `@keyscope` value is a union of the original values.

In `mapref` preprocessing, this is currently implemented with simple string concatenation, which results in duplicate values when the `<mapref>` and `<map>` scopes are the same:

```
<submap keyscope="bookA bookA">
                  ^^^^^^^^^^^
```

This duplication can be avoided by combining the values using the `distinct-values()` XSLT function instead:

```
<submap keyscope="bookA">
                  ^^^^^
```

## Motivation and Context
I noticed this behavior while debugging another issue (#3795). We are adding local keyscopes to all our books, and thus this duplication will occur in all of our collection maps.

The motivation is (1) the desirability of keeping unique keyscope values through downstream processing, (2) the simplicity of the change, and (3) the low risk of the proposed change.

In addition, (4) this elegantly works around #3795 for our case.

The runtime improvement is perhaps negligible for Java-based processing of keyscopes, but perhaps more significant for XSLT-based processing of keyscopes.

## How Has This Been Tested?
I ran the `gradlew` tests and observed no new errors.

I published multiple book collections in our environment to HTML5 with and without the change, then compared the results.

## Type of Changes
- Coding style _(non-breaking change to code structure)_

## Documentation and Compatibility
- No documentation updates are needed for this change.
- No template interfaces have been altered, so other users' template overrides should be unaffected.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
