### PR TITLE
HTML5: Use valid ARIA role for ToC <nav>

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:variable>
 
   <xsl:attribute-set name="toc">
-    <xsl:attribute name="role">toc</xsl:attribute>
+    <xsl:attribute name="role">navigation</xsl:attribute>
   </xsl:attribute-set>
 
   <xsl:template match="*" mode="gen-user-sidetoc">


### PR DESCRIPTION
## Description

Microsoft Edge DevTools flags our use of `<nav role="toc">` as an accessibility issue.

This PR replaces the invalid `toc` role with the `navigation` landmark role.

## Motivation and Context

Per https://dequeuniversity.com/rules/axe/4.1/aria-roles

> ARIA roles used must conform to valid values:
> Role must be one of the of the valid ARIA roles: `toc`
>
> Available roles by type are:
> * **Landmark**: article, banner, complementary, main, navigation, region, search, contentinfo

## Type of Changes

Not entirely sure which of these applies:

- Bug fix _(non-breaking change which fixes an issue)_ ?
- Breaking change _(fix or feature that changes existing functionality)_ ?

## Documentation and Compatibility

- What documentation changes are needed for this feature?
  - _Add info to migration topic_
- Will this change affect backwards compatibility or other users' overrides?
  - _Existing plug-ins or stylesheets that expect the ToC `<nav>` element to have the `toc` role would need to be updated_

