### PR TITLE
Add dedicated class to ToC navigation

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -25,6 +25,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:variable>
 
   <xsl:attribute-set name="toc">
+    <xsl:attribute name="class">toc</xsl:attribute>
     <xsl:attribute name="role">navigation</xsl:attribute>
   </xsl:attribute-set>
 


### PR DESCRIPTION
## Description

#3800 changed the ARIA role for the table of contents `<nav>` element from the unique `toc` role to the `navigation` landmark role, which is also used for related links.

Prior to #3800, the ToC `<nav>` element could be targeted with the CSS selector `nav[role='toc']`, but after these changes, a role-based selector such as `nav[role='navigation']` would also affect the related links.

## Motivation and Context

This PR adds a dedicated `toc` class to the ToC `<nav>` element to simplify the process of styling the table of contents navigation without affecting related links.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  - _Add info to migration topic & Release Notes_
- Will this change affect backwards compatibility or other users' overrides?
  - _No_
