### PR TITLE
Add commonattributes mode in HTML5 to allow for easier extension

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1794,11 +1794,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- Process standard attributes that may appear anywhere. Previously this was "setclass" -->
   <xsl:template name="commonattributes">
     <xsl:param name="default-output-class"/>
+    <xsl:apply-templates select="." mode="commonattributes">
+      <xsl:with-param name="default-output-class" select="tokenize(normalize-space($default-output-class), '\s+')"/>
+    </xsl:apply-templates>
+  </xsl:template>
+  
+  <xsl:template match="@* | node()" mode="commonattributes">
+    <xsl:param name="default-output-class" as="xs:string*"/>
     <xsl:apply-templates select="@xml:lang"/>
     <xsl:apply-templates select="@dir"/>
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
     <xsl:apply-templates select="." mode="set-output-class">
-      <xsl:with-param name="default" select="$default-output-class"/>
+      <xsl:with-param name="default" select="string-join($default-output-class, ' ')"/>
     </xsl:apply-templates>
     <xsl:choose>
       <xsl:when test="exists($passthrough-attrs[empty(@att) and empty(@value)])">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -1505,6 +1505,9 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Process common attributes -->
     <xsl:template name="commonattributes">
+      <xsl:apply-templates select="." mode="commonattributes"/>
+    </xsl:template>
+    <xsl:template match="@* | node()" mode="commonattributes">
       <xsl:apply-templates select="@id"/>
       <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')] |
                                    *[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="flag-attributes"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1910,11 +1910,18 @@ See the accompanying LICENSE file for applicable license.
 <!-- Process standard attributes that may appear anywhere. Previously this was "setclass" -->
 <xsl:template name="commonattributes">
   <xsl:param name="default-output-class"/>
+  <xsl:apply-templates select="." mode="commonattributes">
+    <xsl:with-param name="default-output-class" select="tokenize(normalize-space($default-output-class), '\s+')"/>
+  </xsl:apply-templates>
+</xsl:template>
+
+<xsl:template match="@* | node()" mode="commonattributes">
+  <xsl:param name="default-output-class" as="xs:string*"/>
   <xsl:apply-templates select="@xml:lang"/>
   <xsl:apply-templates select="@dir"/>
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
   <xsl:apply-templates select="." mode="set-output-class">
-    <xsl:with-param name="default" select="$default-output-class"/>
+    <xsl:with-param name="default" select="string-join($default-output-class, ' ')"/>
   </xsl:apply-templates>
   <xsl:if test="exists($passthrough-attrs)">
     <xsl:for-each select="@*">


### PR DESCRIPTION
## Description
Retrofit `commonattributes` named template to be backed up by `commonattributes` mode in HTML5 plug-in.

## Motivation and Context
Modes allow for easier extension combined with `<xsl:next-match>` than named templates.

## How Has This Been Tested?
Existing tests pass.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Existing plug-ins continue to work without migration.

Recommended change is to replace

```xml
<xsl:template name="commonattributes">
  <!-- whole copy of commonattributes named template with customizations -->
</xsl:template>
```
with
```xml
<xsl:template match="@* | node()" mode="commonattributes">
  <xsl:param name="default-output-class" as="xs:string*"/>
  <xsl:next-match>
    <xsl:with-param name="default-output-class" select="$default-output-class"/>
  </xsl:next-match>
  <!-- customizations -->
</xsl:template>
```