### PR TITLE
Update PDF2 RenderX to 3.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ def bundled = [
         "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
         "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",
         "axf": "https://github.com/dita-ot/org.dita.pdf2.axf/releases/download/3.6.1/org.dita.pdf2.axf-3.6.1.zip",
-        "xep": "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.2/org.dita.pdf2.xep-3.6.2.zip",
+        "xep": "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.3/org.dita.pdf2.xep-3.6.3.zip",
 ]
 
 apply from: 'gradle/dist.gradle'


### PR DESCRIPTION
## Description
Update PDF2 RenderX to 3.6.3.

## Motivation and Context
Update to latest plug-in version.
## How Has This Been Tested?
Deployment passes.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Adds plug-in parameter configuration for old property `xep.dir`. 

