### PR TITLE
Fix reading empty param value in XML project file

### DIFF
--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -215,7 +215,7 @@ public class XmlReader {
                 getChildren(publication, ELEM_PARAM)
                         .map(param -> new ProjectBuilder.Publication.Param(
                                 getValue(param, ATTR_NAME),
-                                getValue(param, ATTR_VALUE),
+                                param.getAttributeNode(ATTR_VALUE) != null ? param.getAttribute(ATTR_VALUE) : null,
                                 getHref(param).orElse(null),
                                 getFile(param).orElse(null)
                         ))

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -48,10 +48,11 @@ public class XmlReaderTest {
             assertEquals("sitePub", publication.id);
             assertEquals(null, publication.idref);
             assertEquals("html5", publication.transtype);
-            assertEquals(4, publication.params.size());
+            assertEquals(5, publication.params.size());
             assertEquals("args.gen.task.lbl", publication.params.get(0).name);
             assertEquals("YES", publication.params.get(0).value);
             assertEquals(null, publication.params.get(0).href);
+            assertEquals("", publication.params.get(4).value);
             assertTrue(project.includes.isEmpty());
             assertTrue(project.publications.isEmpty());
             assertTrue(project.contexts.isEmpty());

--- a/src/test/resources/org/dita/dost/project/simple.json
+++ b/src/test/resources/org/dita/dost/project/simple.json
@@ -34,6 +34,10 @@
           {
             "name": "args.rellinks",
             "path": "baz+qux"
+          },
+          {
+            "name": "args.empty",
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/org/dita/dost/project/simple.xml
+++ b/src/test/resources/org/dita/dost/project/simple.xml
@@ -14,6 +14,7 @@
       <param name="args.rellinks" value="noparent"/>
       <param name="args.uri" href="foo%20bar"/>
       <param name="args.path" path="baz+qux"/>
+      <param name="args.empty" value=""/>
     </publication>
   </deliverable>
 </project>

--- a/src/test/resources/org/dita/dost/project/simple.yaml
+++ b/src/test/resources/org/dita/dost/project/simple.yaml
@@ -22,3 +22,5 @@ deliverables:
       href: "foo%20bar"
     - name: "args.path"
       path: "baz+qux"
+    - name: "args.empty"
+      value: ""


### PR DESCRIPTION

## Description
Fix parsing bug for empty `<param>` `@value` in XML project file.

## Motivation and Context
Fixes #3761

## How Has This Been Tested?
Added unit test for empty param value.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None needed.

