### PR TITLE
Integrator should fail more often

### DIFF
--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -170,9 +170,10 @@ final class FileGenerator extends XMLFilterImpl {
                 }
                 getContentHandler().startElement(uri, localName, qName, atts.build());
             }
+        } catch (SAXException | RuntimeException e) {
+            throw e;
         } catch (final Exception e) {
-            e.printStackTrace();
-            logger.error(e.getMessage(), e) ;
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/dita/dost/platform/InsertAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertAction.java
@@ -8,6 +8,9 @@
  */
 package org.dita.dost.platform;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -72,12 +75,16 @@ class InsertAction extends XMLFilterImpl implements IAction {
     public void getResult(final ContentHandler retBuf) throws SAXException {
         setContentHandler(retBuf);
         try {
-            for (final Value fileName: fileNameSet) {
+            for (final Value fileName : fileNameSet) {
                 currentFile = fileName.value;
                 reader.parse(currentFile);
             }
-        } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+        } catch (SAXException | RuntimeException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/org/dita/dost/platform/IntegratorTest.java
+++ b/src/test/java/org/dita/dost/platform/IntegratorTest.java
@@ -111,7 +111,7 @@ public class IntegratorTest {
                 new InputSource(new File(tempDir, "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator + "shell.xsl").toURI().toString()));
     }
 
-    @Test
+    @Test(expected = UncheckedIOException.class)
     public void testExecute_missingFile() throws Exception {
         Files.delete(tempDir.toPath().resolve(Paths.get("plugins", "dummy", "build.xml")));
 

--- a/src/test/java/org/dita/dost/platform/IntegratorTest.java
+++ b/src/test/java/org/dita/dost/platform/IntegratorTest.java
@@ -11,10 +11,9 @@ import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.util.Constants.CONF_SUPPORTED_IMAGE_EXTENSIONS;
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
@@ -110,7 +109,25 @@ public class IntegratorTest {
                 new InputSource(new File(tempDir, "xsl" + File.separator + "shell.xsl").toURI().toString()));
         assertXMLEqual(new InputSource(new File(expDir, "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator + "shell.xsl").toURI().toString()),
                 new InputSource(new File(tempDir, "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator + "shell.xsl").toURI().toString()));
+    }
 
+    @Test
+    public void testExecute_missingFile() throws Exception {
+        Files.delete(tempDir.toPath().resolve(Paths.get("plugins", "dummy", "build.xml")));
+
+        final File libDir = new File(tempDir, "lib");
+        if (!libDir.exists() && !libDir.mkdirs()) {
+            throw new IOException("Failed to create directory " + libDir);
+        }
+        final File resourcesDir = new File(tempDir, "resources");
+        if (!resourcesDir.exists() && !resourcesDir.mkdirs()) {
+            throw new IOException("Failed to create directory " + resourcesDir);
+        }
+
+        final Integrator i = new Integrator(tempDir);
+        i.setProperties(new File(tempDir, "integrator.properties"));
+        i.setLogger(new TestUtils.TestLogger(false));
+        i.execute();
     }
 
     private Properties getProperties(final File f) throws IOException {


### PR DESCRIPTION
## Description
When the integration process encounters an exception, let the process fail instead of logging an error message.

## Motivation and Context
Fixes #2641

## How Has This Been Tested?
New tests added.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Release notes can mention that the integration process will now fail on fatal errors instead of logging the error. The old behaviour resulted in non-working configuration state, so this is treated as a bug fix.


