### PR TITLE
Replace attribute-set reflection in PDF2

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
@@ -50,268 +50,264 @@ checks a list of possible attribute-sets, and uses attribute-sets on the
 list just like regular named attribute sets.
 --> 
 
-    <xsl:template name="new-attr-set-reflection">
-        <xsl:param name="temp-element" />
-        <xsl:for-each select="$temp-element//@*">
-            <xsl:attribute name="{name()}">
-                <xsl:value-of select="."/>
-            </xsl:attribute>
-        </xsl:for-each>
+    <xsl:template name="get-attributes" as="attribute()*">
+        <xsl:param name="element" as="element()"/>
+        <xsl:sequence select="$element/@*"/>
     </xsl:template>
 
-
-    <xsl:template name="processAttrSetReflection">
+    <!-- Deprecated since 4.0 -->
+    <xsl:template name="processAttrSetReflection" as="attribute()*">
         <xsl:param name="attrSet"/>
         <xsl:param name="path"/>
         <xsl:choose>
             <xsl:when test="$attrSet = 'topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.topic.topic.title'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.topic.topic.title"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__tableframe__bottom'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__tableframe__bottom"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__tableframe__right'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__tableframe__right"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__tableframe__top'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__tableframe__top"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'lq'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="lq"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'lq_simple'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="lq_simple"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'table__tableframe__all'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="table__tableframe__all"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'table__tableframe__bottom'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="table__tableframe__bottom"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'table__tableframe__sides'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="table__tableframe__sides"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'table__tableframe__top'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="table__tableframe__top"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'table__tableframe__topbot'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="table__tableframe__topbot"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'thead__tableframe__bottom'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="thead__tableframe__bottom"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__align__left'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__align__left"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__align__right'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__align__right"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__align__center'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__align__center"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = '__align__justify'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="__align__justify"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'thead.row'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="thead.row"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'thead.row.entry'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="thead.row.entry"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'thead.row.entry__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="thead.row.entry__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tfoot.row'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tfoot.row"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tfoot.row.entry'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tfoot.row.entry"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tfoot.row.entry__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tfoot.row.entry__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tbody.row'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tbody.row"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tbody.row.entry'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tbody.row.entry"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'tbody.row.entry__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="tbody.row.entry__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
             <xsl:when test="$attrSet = 'topic.topic.topic.topic.topic.topic.title__content'">
-                <xsl:call-template name="new-attr-set-reflection">
-                    <xsl:with-param name="temp-element">
+                <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
                         <xsl:element name="placeholder" use-attribute-sets="topic.topic.topic.topic.topic.topic.title__content"/>
                     </xsl:with-param>
                 </xsl:call-template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -362,9 +362,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="frame" select="$frame"/>
       </xsl:call-template>
       <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top' or not($frame)">
-        <xsl:call-template name="processAttrSetReflection">
-          <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-          <xsl:with-param name="path" select="$tableAttrs"/>
+        <xsl:call-template name="get-attributes">
+          <xsl:with-param name="element" as="element()">
+            <placeholder xsl:use-attribute-sets="__tableframe__top"/>
+          </xsl:with-param>
         </xsl:call-template>
       </xsl:if>
       <xsl:if test="$hasVerticalBorder = 'yes'">
@@ -404,9 +405,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="frame" select="$frame"/>
       </xsl:call-template>
       <xsl:if test="$frame = 'all' or $frame = 'topbot' or $frame = 'top' or not($frame)">
-        <xsl:call-template name="processAttrSetReflection">
-          <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-          <xsl:with-param name="path" select="$tableAttrs"/>
+        <xsl:call-template name="get-attributes">
+          <xsl:with-param name="element" as="element()">
+            <placeholder xsl:use-attribute-sets="__tableframe__top"/>
+          </xsl:with-param>
         </xsl:call-template>
       </xsl:if>
       <xsl:if test="following-sibling::*[contains(@class, ' reference/proptypehd ') or contains(@class, ' reference/propvaluehd ') or contains(@class, ' reference/propdeschd ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -721,34 +721,39 @@ See the accompanying LICENSE file for applicable license.
             </xsl:choose>
         </xsl:variable>
         <xsl:if test="number($rowsep) = 1 and (../parent::node()[contains(@class, ' topic/thead ')])">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'thead__tableframe__bottom'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="thead__tableframe__bottom"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
         <xsl:if test="number($rowsep) = 1 and ((../following-sibling::*[contains(@class, ' topic/row ')]) or (../parent::node()[contains(@class, ' topic/tbody ')] and ancestor::*[contains(@class, ' topic/tgroup ')][1]/*[contains(@class, ' topic/tfoot ')]))">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__bottom'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__bottom"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
         <xsl:if test="$needTopBorderOnBreak">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__top"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
         <xsl:if test="number($colsep) = 1 and following-sibling::*[contains(@class, ' topic/entry ')]">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__right"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
         <xsl:if test="number($colsep) = 1 and not(following-sibling::*[contains(@class, ' topic/entry ')]) and ((count(preceding-sibling::*) + 1) &lt; ancestor::*[contains(@class, ' topic/tgroup ')][1]/@cols)">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__right"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
     </xsl:template>
 
@@ -810,34 +815,39 @@ See the accompanying LICENSE file for applicable license.
 
         <xsl:choose>
             <xsl:when test="$frame = 'all'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'table__tableframe__all'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="table__tableframe__all"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
             <xsl:when test="$frame = 'topbot'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'table__tableframe__topbot'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="table__tableframe__topbot"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
             <xsl:when test="$frame = 'top'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'table__tableframe__top'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="table__tableframe__top"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
             <xsl:when test="$frame = 'bottom'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'table__tableframe__bottom'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="table__tableframe__bottom"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
             <xsl:when test="$frame = 'sides'">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'table__tableframe__sides'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="table__tableframe__sides"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
@@ -1153,24 +1163,22 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
         <xsl:if test="$frame = ('all', 'topbot', 'top')">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__top'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__top"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
     </xsl:template>
     <xsl:template match="*" mode="simpletableSideBorders">
         <xsl:param name="frame" select="(ancestor-or-self::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"
             as="xs:string"/>
         <xsl:if test="$frame = ('all', 'topbot', 'sides')">
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__left'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
-                <xsl:with-param name="path" select="$tableAttrs"/>
-            </xsl:call-template>
+          <xsl:call-template name="get-attributes">
+            <xsl:with-param name="element" as="element()">
+              <placeholder xsl:use-attribute-sets="__tableframe__left __tableframe__right"/>
+            </xsl:with-param>
+          </xsl:call-template>
         </xsl:if>
     </xsl:template>
     <xsl:template match="*" mode="simpletableVerticalBorders">
@@ -1185,10 +1193,11 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
             <xsl:when test="$frame = ('all', 'topbot') or empty($frame)">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'__tableframe__bottom'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="__tableframe__bottom"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
@@ -1197,10 +1206,11 @@ See the accompanying LICENSE file for applicable license.
         <xsl:param name="frame" as="xs:string?"/>
         <xsl:choose>
             <xsl:when test="$frame = ('all', 'sides') or empty($frame)">
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="'__tableframe__right'"/>
-                    <xsl:with-param name="path" select="$tableAttrs"/>
-                </xsl:call-template>
+              <xsl:call-template name="get-attributes">
+                <xsl:with-param name="element" as="element()">
+                  <placeholder xsl:use-attribute-sets="__tableframe__right"/>
+                </xsl:with-param>
+              </xsl:call-template>
             </xsl:when>
         </xsl:choose>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -75,17 +75,62 @@ See the accompanying LICENSE file for applicable license.
                 <xsl:with-param name="theCounter" select="$level"/>
             </xsl:apply-templates>
         </xsl:variable>
-        <xsl:variable name="attrSet2" select="concat($attrSet1, '__content')"/>
         <fo:block>
             <xsl:call-template name="commonattributes"/>
-            <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="$attrSet1"/>
-                <xsl:with-param name="path" select="'../../cfg/fo/attrs/commons-attr.xsl'"/>
+            <xsl:call-template name="get-attributes">
+              <xsl:with-param name="element" as="element()">
+                <xsl:choose>
+                  <xsl:when test="$attrSet1 = 'topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.title"/>
+                  </xsl:when>
+                  <xsl:when test="$attrSet1 = 'topic.topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.topic.title"/>
+                  </xsl:when>
+                  <xsl:when test="$attrSet1 = 'topic.topic.topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.topic.topic.title"/>
+                  </xsl:when>
+                  <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.title"/>
+                  </xsl:when>
+                  <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.topic.title"/>
+                  </xsl:when>
+                  <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.topic.title'">
+                    <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.topic.topic.title"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <placeholder/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:with-param>
             </xsl:call-template>
             <fo:block>
-                <xsl:call-template name="processAttrSetReflection">
-                    <xsl:with-param name="attrSet" select="$attrSet2"/>
-                    <xsl:with-param name="path" select="'../../cfg/fo/attrs/commons-attr.xsl'"/>
+                <xsl:call-template name="get-attributes">
+                  <xsl:with-param name="element" as="element()">
+                    <xsl:choose>
+                      <xsl:when test="$attrSet1 = 'topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.title__content"/>
+                      </xsl:when>
+                      <xsl:when test="$attrSet1 = 'topic.topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.topic.title__content"/>
+                      </xsl:when>
+                      <xsl:when test="$attrSet1 = 'topic.topic.topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.topic.topic.title__content"/>
+                      </xsl:when>
+                      <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.title__content"/>
+                      </xsl:when>
+                      <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.topic.title__content"/>
+                      </xsl:when>
+                      <xsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.topic.title'">
+                        <placeholder xsl:use-attribute-sets="topic.topic.topic.topic.topic.topic.title__content"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <placeholder/>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </xsl:with-param>
                 </xsl:call-template>
                 <xsl:if test="$level = 1">
                     <xsl:apply-templates select="." mode="insertTopicHeaderMarker"/>
@@ -949,16 +994,18 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="commonattributes"/>
             <xsl:choose>
                 <xsl:when test="@href or @reftitle">
-                    <xsl:call-template name="processAttrSetReflection">
-                        <xsl:with-param name="attrSet" select="'lq'"/>
-                        <xsl:with-param name="path" select="'../../cfg/fo/attrs/commons-attr.xsl'"/>
-                    </xsl:call-template>
+                  <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
+                      <placeholder xsl:use-attribute-sets="lq"/>
+                    </xsl:with-param>
+                  </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:call-template name="processAttrSetReflection">
-                        <xsl:with-param name="attrSet" select="'lq_simple'"/>
-                        <xsl:with-param name="path" select="'../../cfg/fo/attrs/commons-attr.xsl'"/>
-                    </xsl:call-template>
+                  <xsl:call-template name="get-attributes">
+                    <xsl:with-param name="element" as="element()">
+                      <placeholder xsl:use-attribute-sets="lq_simple"/>
+                    </xsl:with-param>
+                  </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
             <xsl:apply-templates/>
@@ -1285,10 +1332,27 @@ See the accompanying LICENSE file for applicable license.
             </xsl:choose>
         </xsl:param>
 <!--Using align attribute set according to image @align attribute-->
-        <xsl:call-template name="processAttrSetReflection">
-                <xsl:with-param name="attrSet" select="concat('__align__', $imageAlign)"/>
-                <xsl:with-param name="path" select="'../../cfg/fo/attrs/commons-attr.xsl'"/>
-            </xsl:call-template>
+        <xsl:call-template name="get-attributes">
+          <xsl:with-param name="element" as="element()">
+            <xsl:choose>
+              <xsl:when test="$imageAlign = 'left'">
+                <placeholder xsl:use-attribute-sets="__align__left"/>
+              </xsl:when>
+              <xsl:when test="$imageAlign = 'right'">
+                <placeholder xsl:use-attribute-sets="__align__right"/>
+              </xsl:when>
+              <xsl:when test="$imageAlign = 'center'">
+                <placeholder xsl:use-attribute-sets="__align__center"/>
+              </xsl:when>
+              <xsl:when test="$imageAlign = 'justify'">
+                <placeholder xsl:use-attribute-sets="__align__justify"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <placeholder/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:with-param>
+        </xsl:call-template>
         <fo:external-graphic src="url('{$href}')" xsl:use-attribute-sets="image">
             <!--Setting image height if defined-->
             <xsl:if test="$height">

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -175,7 +175,9 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testMetadataInheritance() throws Throwable {
-        test("MetadataInheritance");
+        builder()
+                .transtype(PREPROCESS)
+                .test("MetadataInheritance");
     }
 
     @Test

--- a/src/test/java/org/dita/dost/IntegrationTestPdf.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPdf.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2021 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import static org.dita.dost.AbstractIntegrationTest.Transtype.HTML5;
+import static org.dita.dost.AbstractIntegrationTest.Transtype.PDF;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IntegrationTestPdf extends AbstractIntegrationTest {
+
+    public AbstractIntegrationTest builder() {
+        return new IntegrationTestPdf();
+    }
+
+    @Override
+    Transtype getTranstype(Transtype transtype) {
+        return transtype;
+    }
+
+    @Test
+    public void pdf() throws Throwable {
+        builder().name("pdf")
+                .transtype(PDF)
+                .input(Paths.get("bookmap.ditamap"))
+                .warnCount(1)
+                .test();
+    }
+}

--- a/src/test/resources/pdf/exp/pdf/topic.fo
+++ b/src/test/resources/pdf/exp/pdf/topic.fo
@@ -1,0 +1,1016 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fo:root xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="http://www.w3.org/1999/XSL/Format"
+  xmlns:opentopic-i18n="http://www.idiominc.com/opentopic/i18n" xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:x="adobe:ns:meta/"
+  xmlns:xmp="http://ns.adobe.com/xap/1.0/" font-size="10pt" writing-mode="lr" xml:lang="en"
+  line-height-shift-adjustment="disregard-shifts"
+  font-family="Times New Roman, Times, Arial Unicode MS, Tahoma, Batang, SimSun">
+  <fo:layout-master-set>
+    <fo:simple-page-master master-name="front-matter-first" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="front-matter-last" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="last-frontmatter-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="last-frontmatter-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="front-matter-odd" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-frontmatter-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-frontmatter-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="toc-odd" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-toc-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-toc-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="toc-last" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="even-toc-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="even-toc-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="toc-first" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-toc-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-toc-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="body-first" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="first-body-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="first-body-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="body-odd" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-body-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-body-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="body-last" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="last-body-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="last-body-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="index-first" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body column-count="2" margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-index-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-index-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="index-odd" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body column-count="2" margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-index-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-index-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="glossary-first" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-glossary-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-glossary-footer"/>
+    </fo:simple-page-master>
+    <fo:simple-page-master master-name="glossary-odd" page-height="279.4mm" page-width="215.9mm">
+      <fo:region-body margin-bottom="20mm" margin-left="20mm" margin-right="20mm" margin-top="20mm"/>
+      <fo:region-before display-align="before" extent="20mm" region-name="odd-glossary-header"/>
+      <fo:region-after display-align="after" extent="20mm" region-name="odd-glossary-footer"/>
+    </fo:simple-page-master>
+    <fo:page-sequence-master master-name="toc-sequence">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="toc-first" odd-or-even="odd" page-position="first"/>
+        <fo:conditional-page-master-reference master-reference="toc-last" odd-or-even="even" page-position="last"/>
+        <fo:conditional-page-master-reference master-reference="toc-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+    <fo:page-sequence-master master-name="body-sequence">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="body-first" odd-or-even="odd" page-position="first"/>
+        <fo:conditional-page-master-reference master-reference="body-last" odd-or-even="even" page-position="last"/>
+        <fo:conditional-page-master-reference master-reference="body-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+    <fo:page-sequence-master master-name="ditamap-body-sequence">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="body-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+    <fo:page-sequence-master master-name="index-sequence">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="index-first" odd-or-even="odd" page-position="first"/>
+        <fo:conditional-page-master-reference master-reference="index-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+    <fo:page-sequence-master master-name="front-matter">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="front-matter-first" odd-or-even="odd"
+          page-position="first"/>
+        <fo:conditional-page-master-reference master-reference="front-matter-last" odd-or-even="even"
+          page-position="last"/>
+        <fo:conditional-page-master-reference master-reference="front-matter-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+    <fo:page-sequence-master master-name="glossary-sequence">
+      <fo:repeatable-page-master-alternatives>
+        <fo:conditional-page-master-reference master-reference="glossary-first" odd-or-even="odd" page-position="first"/>
+        <fo:conditional-page-master-reference master-reference="glossary-odd"/>
+      </fo:repeatable-page-master-alternatives>
+    </fo:page-sequence-master>
+  </fo:layout-master-set>
+  <fo:declarations>
+    <x:xmpmeta>
+      <rdf:RDF>
+        <rdf:Description rdf:about="">
+          <dc:title>mainbooktitle</dc:title>
+          <xmp:CreatorTool>DITA Open Toolkit</xmp:CreatorTool>
+        </rdf:Description>
+      </rdf:RDF>
+    </x:xmpmeta>
+  </fo:declarations>
+  <fo:bookmark-tree>
+    <fo:bookmark internal-destination="_OPENTOPIC_TOC_PROCESSING_d160e65" starting-state="hide">
+      <fo:bookmark-title>title title/keyword</fo:bookmark-title>
+      <fo:bookmark internal-destination="_OPENTOPIC_TOC_PROCESSING_d160e384" starting-state="hide">
+        <fo:bookmark-title>Inline elements</fo:bookmark-title>
+      </fo:bookmark>
+    </fo:bookmark>
+    <fo:bookmark internal-destination="_OPENTOPIC_TOC_PROCESSING_d160e627" starting-state="hide">
+      <fo:bookmark-title>title title/keyword</fo:bookmark-title>
+    </fo:bookmark>
+    <fo:bookmark internal-destination="_OPENTOPIC_TOC_PROCESSING_d160e718" starting-state="hide">
+      <fo:bookmark-title>title title/keyword</fo:bookmark-title>
+    </fo:bookmark>
+    <fo:bookmark internal-destination="_OPENTOPIC_TOC_PROCESSING_d160e793" starting-state="hide">
+      <fo:bookmark-title>title title/keyword</fo:bookmark-title>
+    </fo:bookmark>
+  </fo:bookmark-tree>
+  <fo:page-sequence force-page-count="even" master-reference="front-matter">
+    <fo:static-content flow-name="xsl-footnote-separator">
+      <fo:block><fo:leader color="black" leader-length="25%" leader-pattern="rule" rule-style="solid"
+          rule-thickness="0.5pt"/></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-frontmatter-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-frontmatter-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"
+          > | Introduction | <fo:inline font-weight="bold"><fo:page-number/></fo:inline></fo:block>
+    </fo:static-content>
+    <fo:flow flow-name="xsl-region-body">
+      <fo:block-container text-align="center">
+        <fo:block font-size="22pt" font-weight="bold" line-height="140%" space-before="80mm"
+          space-before.conditionality="retain" line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"><fo:block/><fo:block><fo:inline
+              border-end-width="0pt" border-start-width="0pt">mainbooktitle</fo:inline></fo:block></fo:block>
+        <fo:block font-size="11pt" font-weight="bold" line-height="normal" space-before="36pt"
+          line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"/>
+      </fo:block-container>
+    </fo:flow>
+  </fo:page-sequence>
+  <fo:page-sequence force-page-count="even" master-reference="body-sequence">
+    <fo:static-content flow-name="xsl-footnote-separator">
+      <fo:block><fo:leader color="black" leader-length="25%" leader-pattern="rule" rule-style="solid"
+          rule-thickness="0.5pt"/></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"
+            > | <fo:inline><fo:retrieve-marker retrieve-class-name="current-header"/></fo:inline> | <fo:inline
+          font-weight="bold"><fo:page-number/></fo:inline></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-header">
+      <fo:block/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-footer">
+      <fo:block/>
+    </fo:static-content>
+    <fo:flow flow-name="xsl-region-body">
+      <fo:block font-size="10pt" id="unique_1"><fo:marker marker-class-name="current-topic-number"
+          >1</fo:marker><fo:marker marker-class-name="current-header">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:marker><fo:block
+          id="_OPENTOPIC_TOC_PROCESSING_d160e65"><fo:block border-after-style="solid" border-after-width="2pt"
+            border-before-style="solid" border-before-width="2pt" font-size="20pt" font-weight="bold" padding-top="10pt"
+            >Chapter <fo:block font-size="40pt" font-weight="bold">1</fo:block></fo:block></fo:block><fo:block
+          border-after-color="black" border-after-style="solid" border-after-width="3pt" font-size="18pt"
+          font-weight="bold" keep-with-next.within-column="always" padding-top="16.8pt" space-after="16.8pt"
+          space-before="0pt" line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:block><fo:table page-break-after="always"
+          table-layout="fixed" width="100%">
+          <fo:table-column column-number="1" column-width="35%"/>
+          <fo:table-column column-number="2" column-width="65%"/>
+          <fo:table-body>
+            <fo:table-row>
+              <fo:table-cell>
+                <fo:block end-indent="5pt" font-size="10.5pt" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"><fo:block end-indent="5pt"
+                    font-size="10.5pt" font-weight="bold" line-height-shift-adjustment="disregard-shifts"
+                    font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">Topics: </fo:block><fo:list-block
+                    provisional-distance-between-starts="18pt" provisional-label-separation="12pt" space-after="9pt"
+                    space-before="9pt">
+                    <fo:list-item relative-align="baseline" space-after="1.5pt" space-before="1.5pt">
+                      <fo:list-item-label end-indent="label-end()" keep-together.within-line="always">
+                        <fo:block text-align="start">•</fo:block>
+                      </fo:list-item-label>
+                      <fo:list-item-body start-indent="body-start()">
+                        <fo:block><fo:basic-link color="blue" internal-destination="unique_2">Inline
+                            elements</fo:basic-link></fo:block>
+                      </fo:list-item-body>
+                    </fo:list-item>
+                  </fo:list-block></fo:block>
+              </fo:table-cell>
+              <fo:table-cell border-start-color="black" border-start-style="solid" border-start-width="1pt"
+                padding-start="10pt">
+                <fo:block><fo:block>bodydiv <fo:inline border-end-width="0pt" border-start-width="0pt"
+                      >bodydiv/keyword</fo:inline>
+                    <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                    >bodydiv/p</fo:block></fo:block><fo:block space-after="0.6em" space-before="0.6em">div <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">div/keyword</fo:inline>
+                    <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                    >div/p</fo:block></fo:block><fo:table space-after="5pt" space-before="5pt" table-layout="fixed"
+                    width="100%">
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell relative-align="baseline">
+                          <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                            space-after.conditionality="retain" space-before="3pt" space-before.conditionality="retain"
+                            start-indent="3pt"><fo:inline>dt <fo:inline border-end-width="0pt" border-start-width="0pt"
+                                >dt/keyword</fo:inline></fo:inline></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                          <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                            space-before="3pt" space-before.conditionality="retain" start-indent="3pt">dd <fo:inline
+                              border-end-width="0pt" border-start-width="0pt">dd/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >dd/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:block space-before="0.6em"><fo:block>example <fo:inline border-end-width="0pt"
+                        border-start-width="0pt">example/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-after="5pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >example/title</fo:block><fo:block>example <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">example/p</fo:block></fo:block></fo:block><fo:block id="d160e146"
+                        ><fo:inline><fo:external-graphic src="url('file:/Users/xxx/image.svg')"/></fo:inline><fo:block
+                      font-size="10pt" font-weight="bold" keep-with-previous.within-page="always" space-after="10pt"
+                      space-before="5pt" line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">Figure 1:
+                    fig/title</fo:block></fo:block><fo:table border-after-color="black" border-after-style="solid"
+                    border-after-width="1pt" border-before-color="black" border-before-style="solid"
+                    border-before-width="1pt" border-color="black" border-end-color="black" border-end-style="solid"
+                    border-end-width="1pt" border-start-color="black" border-start-style="solid"
+                    border-start-width="1pt" border-style="solid" border-width="5pt" space-after="10pt"
+                    space-before="8pt" width="100%">
+                    <fo:table-column column-width="6em"/>
+                    <fo:table-column/>
+                    <fo:table-body>
+                      <fo:table-row keep-with-next="always">
+                        <fo:table-cell background-color="#FFD100" border-color="black" border-style="solid"
+                          border-width="2pt" font-size="1.5em" font-style="normal" font-weight="bold"
+                          keep-together="always" number-columns-spanned="2" padding="3pt" start-indent="0pt"
+                          text-align="center" text-transform="uppercase" line-height-shift-adjustment="disregard-shifts"
+                          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="1em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/><fo:inline>CAUTION</fo:inline></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                      <fo:table-row>
+                        <fo:table-cell border-color="black" border-style="solid" border-width="2pt"
+                          keep-together="always" padding="3pt" start-indent="0pt" text-align="center">
+                          <fo:block><fo:external-graphic content-width="4em"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              width="4em"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell border-color="black" border-style="solid" border-width="2pt"
+                          keep-together="always" padding="3pt" start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">typeofhazard <fo:inline
+                              border-end-width="0pt" border-start-width="0pt"
+                            >typeofhazard/keyword</fo:inline></fo:block>
+                          <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">howtoavoid <fo:inline
+                              border-end-width="0pt" border-start-width="0pt">howtoavoid/keyword</fo:inline></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:inline><fo:external-graphic xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
+                      fox:alt-text="image/alt" src="url('file:/Users/xxx/image.svg')"/></fo:inline><fo:block
+                    font-size="10pt" linefeed-treatment="preserve" space-after="0.8em" space-before="0.8em"
+                    white-space-collapse="true" wrap-option="wrap">lines <fo:inline border-end-width="0pt"
+                      border-start-width="0pt">lines/keyword</fo:inline></fo:block><fo:block
+                    end-indent="15pt + from-parent(end-indent)" space-after="0.6em" space-before="0.6em"
+                    start-indent="30pt + from-parent(start-indent)">lq <fo:inline border-end-width="0pt"
+                      border-start-width="0pt">lq/keyword</fo:inline>
+                    <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                    >lq/p</fo:block></fo:block><fo:block space-after="0.6em" space-before="0.6em"><fo:inline
+                      border-end-width="0pt" border-start-width="0pt" font-weight="bold"><fo:inline>Note</fo:inline>:
+                    </fo:inline> note <fo:inline border-end-width="0pt" border-start-width="0pt"
+                      >note/keyword</fo:inline>
+                    <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                    >note/p</fo:block></fo:block><fo:table space-after="0.6em" space-before="0.6em" table-layout="fixed"
+                    width="100%">
+                    <fo:table-column column-number="1" column-width="32pt"/>
+                    <fo:table-column column-number="2" column-width="100% - 32pt"/>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell padding-end="5pt" start-indent="0pt">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="2em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                              border-start-width="0pt" font-weight="bold"><fo:inline>Attention</fo:inline>: </fo:inline>
+                            note/attention</fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:table space-after="0.6em" space-before="0.6em" table-layout="fixed" width="100%">
+                    <fo:table-column column-number="1" column-width="32pt"/>
+                    <fo:table-column column-number="2" column-width="100% - 32pt"/>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell padding-end="5pt" start-indent="0pt">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="2em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                              border-start-width="0pt" font-weight="bold"><fo:inline>CAUTION</fo:inline>: </fo:inline>
+                            note/caution</fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:table space-after="0.6em" space-before="0.6em" table-layout="fixed" width="100%">
+                    <fo:table-column column-number="1" column-width="32pt"/>
+                    <fo:table-column column-number="2" column-width="100% - 32pt"/>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell padding-end="5pt" start-indent="0pt">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="2em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                              border-start-width="0pt" font-weight="bold"><fo:inline>DANGER</fo:inline>: </fo:inline>
+                            note/danger</fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                      border-start-width="0pt" font-weight="bold"><fo:inline>Fastpath</fo:inline>: </fo:inline>
+                    note/fastpath</fo:block><fo:block space-after="0.6em" space-before="0.6em"><fo:inline
+                      border-end-width="0pt" border-start-width="0pt" font-weight="bold"
+                        ><fo:inline>Important</fo:inline>: </fo:inline> note/important</fo:block><fo:block
+                    space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt" border-start-width="0pt"
+                      font-weight="bold"><fo:inline>Note</fo:inline>: </fo:inline> note/note</fo:block><fo:block
+                    space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt" border-start-width="0pt"
+                      font-weight="bold"><fo:inline>Notice</fo:inline>: </fo:inline> note/notice</fo:block><fo:block
+                    space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt" border-start-width="0pt"
+                      font-weight="bold"><fo:inline>Remember</fo:inline>: </fo:inline> note/remember</fo:block><fo:block
+                    space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt" border-start-width="0pt"
+                      font-weight="bold"><fo:inline>Restriction</fo:inline>: </fo:inline>
+                    note/restriction</fo:block><fo:block space-after="0.6em" space-before="0.6em"><fo:inline
+                      border-end-width="0pt" border-start-width="0pt" font-weight="bold"><fo:inline>Tip</fo:inline>:
+                    </fo:inline> note/tip</fo:block><fo:table space-after="0.6em" space-before="0.6em"
+                    table-layout="fixed" width="100%">
+                    <fo:table-column column-number="1" column-width="32pt"/>
+                    <fo:table-column column-number="2" column-width="100% - 32pt"/>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell padding-end="5pt" start-indent="0pt">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="2em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                              border-start-width="0pt" font-weight="bold"><fo:inline>Trouble</fo:inline>: </fo:inline>
+                            note/trouble</fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:table space-after="0.6em" space-before="0.6em" table-layout="fixed" width="100%">
+                    <fo:table-column column-number="1" column-width="32pt"/>
+                    <fo:table-column column-number="2" column-width="100% - 32pt"/>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell padding-end="5pt" start-indent="0pt">
+                          <fo:block><fo:external-graphic baseline-shift="baseline" content-height="2em"
+                              padding-right="3pt"
+                              src="url('file:/Users/jelovirt/Work/dita-ot/build/tmp/integrationTest/pdf/temp/pdf/Configuration/OpenTopic/cfg/common/artwork/ISO_7010_W001.svg')"
+                              vertical-align="middle"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell start-indent="0pt">
+                          <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                              border-start-width="0pt" font-weight="bold"><fo:inline>Warning</fo:inline>: </fo:inline>
+                            note/warning</fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:list-block provisional-distance-between-starts="5mm" provisional-label-separation="1mm"
+                    space-after="0.6em" space-before="0.6em">
+                    <fo:list-item relative-align="baseline" space-after="1.5pt" space-before="1.5pt">
+                      <fo:list-item-label end-indent="label-end()" keep-together.within-line="always">
+                        <fo:block font-weight="bold" text-align="start">1. </fo:block>
+                      </fo:list-item-label>
+                      <fo:list-item-body start-indent="body-start()">
+                        <fo:block>li <fo:inline border-end-width="0pt" border-start-width="0pt">li/keyword</fo:inline>
+                          <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                          >li/p</fo:block></fo:block>
+                      </fo:list-item-body>
+                    </fo:list-item>
+                  </fo:list-block><fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">p <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">p/keyword</fo:inline></fo:block><fo:block
+                    font-size="10pt" line-height="106%" linefeed-treatment="preserve" space-after="0.6em"
+                    space-before="0.6em" white-space-collapse="false" white-space-treatment="preserve"
+                    wrap-option="wrap" line-height-shift-adjustment="disregard-shifts"
+                    font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">pre <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">pre/keyword</fo:inline></fo:block><fo:block
+                    space-before="0.6em"><fo:block>section <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >section/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >section/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-before="15pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >section/title</fo:block><fo:block>section <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">section/p</fo:block></fo:block></fo:block><fo:table border-after-color="black"
+                    border-after-style="solid" border-after-width="1pt" border-before-color="black"
+                    border-before-style="solid" border-before-width="1pt" border-end-color="black"
+                    border-end-style="solid" border-end-width="1pt" border-start-color="black"
+                    border-start-style="solid" border-start-width="1pt" font-size="10pt" space-after="10pt"
+                    space-before="8pt" table-layout="fixed" width="100%">
+                    <fo:table-header>
+                      <fo:table-row>
+                        <fo:table-cell border-after-color="black" border-after-style="solid" border-after-width="1pt"
+                          border-after-width.conditionality="retain" border-before-color="black"
+                          border-before-style="solid" border-before-width="1pt">
+                          <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                            space-after.conditionality="retain" space-before="3pt" space-before.conditionality="retain"
+                            start-indent="3pt">stentry <fo:inline border-end-width="0pt" border-start-width="0pt"
+                              >stentry/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >stentry/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-header>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell>
+                          <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                            space-before="3pt" space-before.conditionality="retain" start-indent="3pt">stentry
+                              <fo:inline border-end-width="0pt" border-start-width="0pt">stentry/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >stentry/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:list-block provisional-distance-between-starts="5mm" provisional-label-separation="1mm"
+                    space-after="0.6em" space-before="0.6em">
+                    <fo:list-item space-after="1.5pt" space-before="1.5pt">
+                      <fo:list-item-label end-indent="label-end()" keep-together.within-line="always">
+                        <fo:block text-align="start"/>
+                      </fo:list-item-label>
+                      <fo:list-item-body start-indent="body-start()">
+                        <fo:block>sli <fo:inline border-end-width="0pt" border-start-width="0pt"
+                          >sli/keyword</fo:inline></fo:block>
+                      </fo:list-item-body>
+                    </fo:list-item>
+                  </fo:list-block><fo:block-container reference-orientation="0" start-indent="from-parent(start-indent)">
+                    <fo:block font-size="10pt" id="d160e328" space-after="10pt" start-indent="0pt">
+                      <fo:table border-after-color="black" border-after-style="solid" border-after-width="1pt"
+                        border-before-color="black" border-before-style="solid" border-before-width="1pt"
+                        border-end-color="black" border-end-style="solid" border-end-width="1pt"
+                        border-start-color="black" border-start-style="solid" border-start-width="1pt" space-after="5pt"
+                        space-before="5pt" table-layout="fixed" width="100%">
+                        <fo:table-column column-number="1" column-width="proportional-column-width(1)"/>
+                        <fo:table-header>
+                          <fo:table-row>
+                            <fo:table-cell border-before-color="black" border-before-style="solid"
+                              border-before-width="1pt" text-align="from-table-column()">
+                              <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                                space-after.conditionality="retain" space-before="3pt"
+                                space-before.conditionality="retain" start-indent="3pt">entry <fo:inline
+                                  border-end-width="0pt" border-start-width="0pt">entry/keyword</fo:inline>
+                                <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                                >entry/p</fo:block></fo:block>
+                            </fo:table-cell>
+                          </fo:table-row>
+                        </fo:table-header>
+                        <fo:table-body>
+                          <fo:table-row keep-together.within-page="always">
+                            <fo:table-cell border-before-color="black" border-before-style="solid"
+                              border-before-width="1pt" text-align="from-table-column()">
+                              <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                                space-before="3pt" space-before.conditionality="retain" start-indent="3pt">entry
+                                  <fo:inline border-end-width="0pt" border-start-width="0pt">entry/keyword</fo:inline>
+                                <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                                >entry/p</fo:block></fo:block>
+                            </fo:table-cell>
+                          </fo:table-row>
+                        </fo:table-body>
+                      </fo:table>
+                    </fo:block>
+                  </fo:block-container><fo:list-block provisional-distance-between-starts="5mm"
+                    provisional-label-separation="1mm" space-after="0.6em" space-before="0.6em">
+                    <fo:list-item relative-align="baseline" space-after="1.5pt" space-before="1.5pt">
+                      <fo:list-item-label end-indent="label-end()" keep-together.within-line="always">
+                        <fo:block text-align="start">•</fo:block>
+                      </fo:list-item-label>
+                      <fo:list-item-body start-indent="body-start()">
+                        <fo:block>li <fo:inline border-end-width="0pt" border-start-width="0pt">li/keyword</fo:inline>
+                          <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                          >li/p</fo:block></fo:block>
+                      </fo:list-item-body>
+                    </fo:list-item>
+                  </fo:list-block></fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+          </fo:table-body>
+        </fo:table><fo:block font-size="10pt"><fo:block><fo:block border-after-color="black" border-after-style="solid"
+              border-after-width="1pt" font-size="14pt" font-weight="bold" keep-with-next.within-column="always"
+              padding-top="12pt" space-after="5pt" space-before="12pt" line-height-shift-adjustment="disregard-shifts"
+              font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"><fo:block border-end-width="0pt"
+                border-start-width="0pt"><fo:marker marker-class-name="current-h2">Inline
+                  elements</fo:marker><fo:wrapper id="unique_2"/><fo:wrapper id="_OPENTOPIC_TOC_PROCESSING_d160e384"
+                />Inline elements</fo:block></fo:block><fo:block font-size="10pt" start-indent="25pt">
+              <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"> abbreviated-form <fo:inline
+                  line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">apiname</fo:inline>
+                <fo:inline font-weight="bold">b</fo:inline> boolean <fo:inline border-end-width="0pt"
+                  border-start-width="0pt" color="green">boolean: yes</fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt" color="green">boolean: no</fo:inline>
+                <fo:inline font-style="italic">cite</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">cmdname</fo:inline>
+                <fo:block background-color="#f0f0f0" end-indent="6pt + from-parent(end-indent)" font-size="10pt"
+                  hyphenation-character="►" keep-with-previous.within-page="always" line-height="106%"
+                  linefeed-treatment="preserve" padding="6pt" space-after="0.6em" space-before="0.6em"
+                  start-indent="6pt + from-parent(start-indent)" white-space-collapse="false"
+                  white-space-treatment="preserve" wrap-option="wrap" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">codeblock</fo:block>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">codeph</fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">equation-inline</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">filepath</fo:inline>
+                <fo:footnote>
+                  <fo:inline baseline-shift="super" font-size="75%" keep-with-previous.within-line="always"
+                      ><fo:basic-link internal-destination="fnd160e435">1</fo:basic-link></fo:inline>
+                  <fo:footnote-body>
+                    <fo:list-block font-size="10pt" font-style="normal" font-weight="normal" line-height="1.2"
+                      provisional-distance-between-starts="8mm" provisional-label-separation="2mm" start-indent="0pt"
+                      text-decoration="no-underline no-overline">
+                      <fo:list-item>
+                        <fo:list-item-label end-indent="label-end()">
+                          <fo:block id="fnd160e435" text-align="right"><fo:inline baseline-shift="super" font-size="75%"
+                              keep-with-previous.within-line="always">1</fo:inline></fo:block>
+                        </fo:list-item-label>
+                        <fo:list-item-body start-indent="body-start()" text-align="start">
+                          <fo:block>fn</fo:block>
+                        </fo:list-item-body>
+                      </fo:list-item>
+                    </fo:list-block>
+                  </fo:footnote-body>
+                </fo:footnote>
+                <fo:inline font-style="italic">i</fo:inline>
+                <fo:inline><fo:external-graphic xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
+                    fox:alt-text="image/alt" src="url('file:/Users/xxx/image.svg')"/></fo:inline> indexterm <fo:inline
+                  border-end-width="0pt" border-start-width="0pt">keyword</fo:inline>
+                <fo:inline text-decoration="line-through">line-through</fo:inline>
+                <fo:block font-size="10pt" linefeed-treatment="preserve" space-after="0.8em" space-before="0.8em"
+                  white-space-collapse="true" wrap-option="wrap">lines</fo:block>
+                <fo:block end-indent="15pt + from-parent(end-indent)" space-after="0.6em" space-before="0.6em"
+                  start-indent="30pt + from-parent(start-indent)">lq</fo:block>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">markupname</fo:inline>
+                <fo:inline line-height="100%"><fo:inline font-weight="bold" line-height="100%">menucascade</fo:inline>
+                  &gt; <fo:inline font-weight="bold" line-height="100%">uicontrol</fo:inline></fo:inline>
+                <fo:block font-size="10pt" line-height="106%" linefeed-treatment="preserve" space-after="0.6em"
+                  space-before="0.6em" white-space-collapse="false" white-space-treatment="preserve" wrap-option="wrap"
+                  line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">msgblock</fo:block>
+                <fo:inline>msgnum</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">msgph</fo:inline>
+                <fo:block space-after="0.6em" space-before="0.6em"><fo:inline border-end-width="0pt"
+                    border-start-width="0pt" font-weight="bold"><fo:inline>Note</fo:inline>: </fo:inline>
+                  note</fo:block>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                  >&amp;#numcharref;</fo:inline>
+                <fo:inline>option</fo:inline>
+                <fo:inline text-decoration="overline">overline</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                  >%parameterentity;</fo:inline>
+                <fo:inline>parmname</fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">ph</fo:inline>
+                <fo:block font-size="10pt" line-height="106%" linefeed-treatment="preserve" space-after="0.6em"
+                  space-before="0.6em" white-space-collapse="false" white-space-treatment="preserve" wrap-option="wrap"
+                  line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">pre</fo:block>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">“q”</fo:inline>
+                <fo:block background-color="#f0f0f0" font-size="10pt" line-height="106%" linefeed-treatment="preserve"
+                  space-after="0.8em" space-before="1.2em" white-space-collapse="false" white-space-treatment="preserve"
+                  wrap-option="wrap" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">screen</fo:block>
+                <fo:inline border-end-width="0pt" border-start-width="0pt" color="red">state: state=value</fo:inline>
+                <fo:inline baseline-shift="sub" font-size="75%">sub</fo:inline>
+                <fo:inline baseline-shift="super" font-size="75%">sup</fo:inline>
+                <fo:instream-foreign-object xmlns:svg="http://www.w3.org/2000/svg">
+                  <svg:svg xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+                    xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+                    xmlns:xlink="http://www.w3.org/1999/xlink" contentScriptType="application/ecmascript"
+                    contentStyleType="text/css" height="12pt" preserveAspectRatio="xMidYMid meet" version="1.1"
+                    viewBox="0 0 1 1" width="12pt" zoomAndPan="magnify">
+                    <svg:rect fill="red" height="1" width="1" x="0" y="0"/>
+                  </svg:svg>
+                </fo:instream-foreign-object>
+                <fo:inline>synph</fo:inline>
+                <fo:block><fo:block>
+                    <fo:inline line-height-shift-adjustment="disregard-shifts"
+                      font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >syntaxdiagram</fo:inline><fo:inline line-height-shift-adjustment="disregard-shifts"
+                      font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >/</fo:inline><fo:inline line-height-shift-adjustment="disregard-shifts"
+                      font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >groupseq</fo:inline><fo:inline line-height-shift-adjustment="disregard-shifts"
+                      font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >/</fo:inline><fo:inline line-height-shift-adjustment="disregard-shifts"
+                      font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">kwd</fo:inline>
+                  </fo:block></fo:block>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">systemoutput</fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt" font-style="italic">term</fo:inline>
+                <fo:inline>text</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                  >&amp;textentity;</fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">reg<fo:inline baseline-shift="20%"
+                    font-size="75%" line-height-shift-adjustment="disregard-shifts"><fo:inline line-height="100%"
+                      font-family="Times New Roman, Times, Arial Unicode MS, Tahoma, Batang" baseline-shift="20%"
+                      font-size="smaller">®</fo:inline></fo:inline></fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">service<fo:inline baseline-shift="50%"
+                    font-size="40%" line-height-shift-adjustment="disregard-shifts"><fo:inline line-height="100%"
+                      font-family="Times New Roman, Times, Arial Unicode MS, Tahoma, Batang" baseline-shift="20%"
+                      font-size="smaller">℠</fo:inline></fo:inline></fo:inline>
+                <fo:inline border-end-width="0pt" border-start-width="0pt">tm<fo:inline baseline-shift="20%"
+                    font-size="75%" line-height-shift-adjustment="disregard-shifts"><fo:inline line-height="100%"
+                      font-family="Times New Roman, Times, Arial Unicode MS, Tahoma, Batang" baseline-shift="20%"
+                      font-size="smaller">™</fo:inline></fo:inline></fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">tt</fo:inline>
+                <fo:inline text-decoration="underline">u</fo:inline>
+                <fo:inline font-weight="bold" line-height="100%">uicontrol</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">userinput</fo:inline>
+                <fo:inline font-style="italic">varname</fo:inline>
+                <fo:inline font-weight="bold">wintitle</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">@xmlatt</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                  >&lt;xmlelement&gt;</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun">xmlnsname</fo:inline>
+                <fo:inline line-height-shift-adjustment="disregard-shifts"
+                  font-family="Courier New, Courier, Arial Unicode MS, Tahoma, Batang, SimSun"
+                  >&lt;?xmlpi?&gt;</fo:inline>
+                <fo:basic-link color="blue" internal-destination="unique_1">xref</fo:basic-link>
+                <fo:basic-link color="blue" internal-destination="unique_1">title
+                  title/keyword</fo:basic-link><fo:inline> on page <fo:inline><fo:page-number-citation ref-id="unique_1"
+                    /></fo:inline></fo:inline>
+              </fo:block>
+            </fo:block></fo:block></fo:block></fo:block>
+    </fo:flow>
+  </fo:page-sequence>
+  <fo:page-sequence force-page-count="even" master-reference="body-sequence">
+    <fo:static-content flow-name="xsl-footnote-separator">
+      <fo:block><fo:leader color="black" leader-length="25%" leader-pattern="rule" rule-style="solid"
+          rule-thickness="0.5pt"/></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"
+            > | <fo:inline><fo:retrieve-marker retrieve-class-name="current-header"/></fo:inline> | <fo:inline
+          font-weight="bold"><fo:page-number/></fo:inline></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-header">
+      <fo:block/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-footer">
+      <fo:block/>
+    </fo:static-content>
+    <fo:flow flow-name="xsl-region-body">
+      <fo:block font-size="10pt" id="unique_3"><fo:marker marker-class-name="current-topic-number"
+          >2</fo:marker><fo:marker marker-class-name="current-header">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:marker><fo:block
+          id="_OPENTOPIC_TOC_PROCESSING_d160e627"><fo:block border-after-style="solid" border-after-width="2pt"
+            border-before-style="solid" border-before-width="2pt" font-size="20pt" font-weight="bold" padding-top="10pt"
+            >Chapter <fo:block font-size="40pt" font-weight="bold">2</fo:block></fo:block></fo:block><fo:block
+          border-after-color="black" border-after-style="solid" border-after-width="3pt" font-size="18pt"
+          font-weight="bold" keep-with-next.within-column="always" padding-top="16.8pt" space-after="16.8pt"
+          space-before="0pt" line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:block><fo:table page-break-after="always"
+          table-layout="fixed" width="100%">
+          <fo:table-column column-number="1" column-width="35%"/>
+          <fo:table-column column-number="2" column-width="65%"/>
+          <fo:table-body>
+            <fo:table-row>
+              <fo:table-cell>
+                <fo:block end-indent="5pt" font-size="10.5pt" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"/>
+              </fo:table-cell>
+              <fo:table-cell border-start-color="black" border-start-style="solid" border-start-width="1pt"
+                padding-start="10pt">
+                <fo:block><fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">shortdesc <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">shortdesc/keyword</fo:inline></fo:block><fo:block
+                    space-after="0.6em" space-before="0.6em">div <fo:inline border-end-width="0pt"
+                      border-start-width="0pt">div/keyword</fo:inline></fo:block><fo:table space-after="5pt"
+                    space-before="5pt" table-layout="fixed" width="100%">
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell relative-align="baseline">
+                          <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                            space-after.conditionality="retain" space-before="3pt" space-before.conditionality="retain"
+                            start-indent="3pt"><fo:inline>dt <fo:inline border-end-width="0pt" border-start-width="0pt"
+                                >dt/keyword</fo:inline></fo:inline></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell>
+                          <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                            space-before="3pt" space-before.conditionality="retain" start-indent="3pt">dd <fo:inline
+                              border-end-width="0pt" border-start-width="0pt">dd/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >dd/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:block space-before="0.6em"><fo:block>example <fo:inline border-end-width="0pt"
+                        border-start-width="0pt">example/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-after="5pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >example/title</fo:block><fo:block>example <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"
+                      ><fo:block>section <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >section/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >section/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-before="15pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >section/title</fo:block><fo:block>section <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">section/p</fo:block></fo:block></fo:block></fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+          </fo:table-body>
+        </fo:table></fo:block>
+    </fo:flow>
+  </fo:page-sequence>
+  <fo:page-sequence force-page-count="even" master-reference="body-sequence">
+    <fo:static-content flow-name="xsl-footnote-separator">
+      <fo:block><fo:leader color="black" leader-length="25%" leader-pattern="rule" rule-style="solid"
+          rule-thickness="0.5pt"/></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"
+            > | <fo:inline><fo:retrieve-marker retrieve-class-name="current-header"/></fo:inline> | <fo:inline
+          font-weight="bold"><fo:page-number/></fo:inline></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-header">
+      <fo:block/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-footer">
+      <fo:block/>
+    </fo:static-content>
+    <fo:flow flow-name="xsl-region-body">
+      <fo:block font-size="10pt" id="unique_4"><fo:marker marker-class-name="current-topic-number"
+          >3</fo:marker><fo:marker marker-class-name="current-header">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:marker><fo:block
+          id="_OPENTOPIC_TOC_PROCESSING_d160e718"><fo:block border-after-style="solid" border-after-width="2pt"
+            border-before-style="solid" border-before-width="2pt" font-size="20pt" font-weight="bold" padding-top="10pt"
+            >Chapter <fo:block font-size="40pt" font-weight="bold">3</fo:block></fo:block></fo:block><fo:block
+          border-after-color="black" border-after-style="solid" border-after-width="3pt" font-size="18pt"
+          font-weight="bold" keep-with-next.within-column="always" padding-top="16.8pt" space-after="16.8pt"
+          space-before="0pt" line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:block><fo:table page-break-after="always"
+          table-layout="fixed" width="100%">
+          <fo:table-column column-number="1" column-width="35%"/>
+          <fo:table-column column-number="2" column-width="65%"/>
+          <fo:table-body>
+            <fo:table-row>
+              <fo:table-cell>
+                <fo:block end-indent="5pt" font-size="10.5pt" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"/>
+              </fo:table-cell>
+              <fo:table-cell border-start-color="black" border-start-style="solid" border-start-width="1pt"
+                padding-start="10pt">
+                <fo:block><fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">shortdesc <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">shortdesc/keyword</fo:inline></fo:block><fo:block
+                    space-before="0.6em"><fo:block>prereq <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >prereq/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >prereq/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block>context
+                        <fo:inline border-end-width="0pt" border-start-width="0pt">context/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >context/p</fo:block></fo:block></fo:block><fo:block><fo:block space-after="0.6em"
+                      space-before="0.6em">
+                      <fo:block>cmd <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >cmd/keyword</fo:inline></fo:block>
+                    </fo:block></fo:block><fo:block space-before="0.6em"><fo:block>result <fo:inline
+                        border-end-width="0pt" border-start-width="0pt">result/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >result/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"
+                      ><fo:block>tasktroubleshooting <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >tasktroubleshooting/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                        >tasktroubleshooting/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"
+                      ><fo:block>example <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >example/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block>postreq
+                        <fo:inline border-end-width="0pt" border-start-width="0pt">postreq/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >postreq/p</fo:block></fo:block></fo:block></fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+          </fo:table-body>
+        </fo:table></fo:block>
+    </fo:flow>
+  </fo:page-sequence>
+  <fo:page-sequence force-page-count="even" master-reference="body-sequence">
+    <fo:static-content flow-name="xsl-footnote-separator">
+      <fo:block><fo:leader color="black" leader-length="25%" leader-pattern="rule" rule-style="solid"
+          rule-thickness="0.5pt"/></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="odd-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"
+            > | <fo:inline><fo:retrieve-marker retrieve-class-name="current-header"/></fo:inline> | <fo:inline
+          font-weight="bold"><fo:page-number/></fo:inline></fo:block>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-header">
+      <fo:block end-indent="10pt" space-before="10pt" space-before.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="first-body-footer">
+      <fo:block end-indent="10pt" space-after="10pt" space-after.conditionality="retain" text-align="end"/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-header">
+      <fo:block/>
+    </fo:static-content>
+    <fo:static-content flow-name="last-body-footer">
+      <fo:block/>
+    </fo:static-content>
+    <fo:flow flow-name="xsl-region-body">
+      <fo:block font-size="10pt" id="unique_5"><fo:marker marker-class-name="current-topic-number"
+          >4</fo:marker><fo:marker marker-class-name="current-header">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:marker><fo:block
+          id="_OPENTOPIC_TOC_PROCESSING_d160e793"><fo:block border-after-style="solid" border-after-width="2pt"
+            border-before-style="solid" border-before-width="2pt" font-size="20pt" font-weight="bold" padding-top="10pt"
+            >Chapter <fo:block font-size="40pt" font-weight="bold">4</fo:block></fo:block></fo:block><fo:block
+          border-after-color="black" border-after-style="solid" border-after-width="3pt" font-size="18pt"
+          font-weight="bold" keep-with-next.within-column="always" padding-top="16.8pt" space-after="16.8pt"
+          space-before="0pt" line-height-shift-adjustment="disregard-shifts"
+          font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun">title <fo:inline border-end-width="0pt"
+            border-start-width="0pt">title/keyword</fo:inline></fo:block><fo:table page-break-after="always"
+          table-layout="fixed" width="100%">
+          <fo:table-column column-number="1" column-width="35%"/>
+          <fo:table-column column-number="2" column-width="65%"/>
+          <fo:table-body>
+            <fo:table-row>
+              <fo:table-cell>
+                <fo:block end-indent="5pt" font-size="10.5pt" line-height-shift-adjustment="disregard-shifts"
+                  font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"/>
+              </fo:table-cell>
+              <fo:table-cell border-start-color="black" border-start-style="solid" border-start-width="1pt"
+                padding-start="10pt">
+                <fo:block><fo:block space-after="0.6em" space-before="0.6em" text-indent="0em">shortdesc <fo:inline
+                      border-end-width="0pt" border-start-width="0pt">shortdesc/keyword</fo:inline></fo:block><fo:block
+                    space-before="0.6em"><fo:block>example <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >example/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-after="5pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >example/title</fo:block><fo:block>example <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">example/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"
+                      ><fo:block>section <fo:inline border-end-width="0pt" border-start-width="0pt"
+                        >section/keyword</fo:inline>
+                      <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                      >section/p</fo:block></fo:block></fo:block><fo:block space-before="0.6em"><fo:block
+                      font-weight="bold" keep-with-next.within-column="always" space-before="15pt"
+                      line-height-shift-adjustment="disregard-shifts"
+                      font-family="Helvetica, Arial Unicode MS, Tahoma, Batang, SimSun"
+                      >section/title</fo:block><fo:block>section <fo:block space-after="0.6em" space-before="0.6em"
+                        text-indent="0em">section/p</fo:block></fo:block></fo:block><fo:table border-after-color="black"
+                    border-after-style="solid" border-after-width="1pt" border-before-color="black"
+                    border-before-style="solid" border-before-width="1pt" border-end-color="black"
+                    border-end-style="solid" border-end-width="1pt" border-start-color="black"
+                    border-start-style="solid" border-start-width="1pt" font-size="10pt" space-after="10pt"
+                    space-before="8pt" table-layout="fixed" width="100%">
+                    <fo:table-header>
+                      <fo:table-row>
+                        <fo:table-cell border-after-color="black" border-after-style="solid" border-after-width="1pt"
+                          border-after-width.conditionality="retain" border-before-color="black"
+                          border-before-style="solid" border-before-width="1pt">
+                          <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                            space-after.conditionality="retain" space-before="3pt" space-before.conditionality="retain"
+                            start-indent="3pt">stentry <fo:inline border-end-width="0pt" border-start-width="0pt"
+                              >stentry/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >stentry/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-header>
+                    <fo:table-body>
+                      <fo:table-row>
+                        <fo:table-cell>
+                          <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                            space-before="3pt" space-before.conditionality="retain" start-indent="3pt">stentry
+                              <fo:inline border-end-width="0pt" border-start-width="0pt">stentry/keyword</fo:inline>
+                            <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                            >stentry/p</fo:block></fo:block>
+                        </fo:table-cell>
+                      </fo:table-row>
+                    </fo:table-body>
+                  </fo:table><fo:block-container reference-orientation="0" start-indent="from-parent(start-indent)">
+                    <fo:block font-size="10pt" id="d160e889" space-after="10pt" start-indent="0pt">
+                      <fo:table border-after-color="black" border-after-style="solid" border-after-width="1pt"
+                        border-before-color="black" border-before-style="solid" border-before-width="1pt"
+                        border-end-color="black" border-end-style="solid" border-end-width="1pt"
+                        border-start-color="black" border-start-style="solid" border-start-width="1pt" space-after="5pt"
+                        space-before="5pt" table-layout="fixed" width="100%">
+                        <fo:table-column column-number="1"/>
+                        <fo:table-header>
+                          <fo:table-row>
+                            <fo:table-cell border-before-color="black" border-before-style="solid"
+                              border-before-width="1pt" text-align="from-table-column()">
+                              <fo:block end-indent="3pt" font-weight="bold" space-after="3pt"
+                                space-after.conditionality="retain" space-before="3pt"
+                                space-before.conditionality="retain" start-indent="3pt">entry <fo:inline
+                                  border-end-width="0pt" border-start-width="0pt">entry/keyword</fo:inline>
+                                <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                                >entry/p</fo:block></fo:block>
+                            </fo:table-cell>
+                          </fo:table-row>
+                        </fo:table-header>
+                        <fo:table-body>
+                          <fo:table-row keep-together.within-page="always">
+                            <fo:table-cell border-before-color="black" border-before-style="solid"
+                              border-before-width="1pt" text-align="from-table-column()">
+                              <fo:block end-indent="3pt" space-after="3pt" space-after.conditionality="retain"
+                                space-before="3pt" space-before.conditionality="retain" start-indent="3pt">entry
+                                  <fo:inline border-end-width="0pt" border-start-width="0pt">entry/keyword</fo:inline>
+                                <fo:block space-after="0.6em" space-before="0.6em" text-indent="0em"
+                                >entry/p</fo:block></fo:block>
+                            </fo:table-cell>
+                          </fo:table-row>
+                        </fo:table-body>
+                      </fo:table>
+                    </fo:block>
+                  </fo:block-container></fo:block>
+              </fo:table-cell>
+            </fo:table-row>
+          </fo:table-body>
+        </fo:table></fo:block>
+    </fo:flow>
+  </fo:page-sequence>
+</fo:root>

--- a/src/test/resources/pdf/src/bookmap.ditamap
+++ b/src/test/resources/pdf/src/bookmap.ditamap
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA BookMap//EN" "bookmap.dtd">
+<bookmap>
+  <booktitle>
+    <mainbooktitle>mainbooktitle</mainbooktitle>
+  </booktitle>
+  <chapter href="topic.dita"/>
+  <chapter href="concept.dita"/>
+  <chapter href="task.dita"/>
+  <chapter href="reference.dita"/>
+</bookmap>

--- a/src/test/resources/pdf/src/concept.dita
+++ b/src/test/resources/pdf/src/concept.dita
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="concept_yh1_zrb_qrb">
+    <title>title <keyword>title/keyword</keyword></title>
+    <shortdesc>shortdesc <keyword>shortdesc/keyword</keyword></shortdesc>
+    <conbody>
+        <data>data <keyword>data/keyword</keyword></data>
+        <data-about>
+            <data>data <keyword>data/keyword</keyword></data>
+        </data-about>
+        <div>div <keyword>div/keyword</keyword></div>
+        <dl>
+            <dlentry>
+                <dt>dt <keyword>dt/keyword</keyword></dt>
+                <dd>dd <keyword>dd/keyword</keyword>
+                    <p>dd/p</p></dd>
+            </dlentry>
+        </dl>
+        <draft-comment>draft-comment <keyword>draft-comment/keyword</keyword>
+            <p>draft-comment/p</p></draft-comment>
+        <example>example <keyword>example/keyword</keyword>
+            <p>example/p</p></example>
+        <example><title>example/title</title>example
+            <p>example/p</p></example>
+        <section>section <keyword>section/keyword</keyword>
+            <p>section/p</p></section>
+        <section><title>section/title</title>section
+            <p>section/p</p></section>
+    </conbody>
+</concept>

--- a/src/test/resources/pdf/src/image.svg
+++ b/src/test/resources/pdf/src/image.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" height="12pt" width="12pt" viewBox="0 0 1 1">
+    <rect width="1" height="1" x="0" y="0" fill="blue"/>
+</svg>

--- a/src/test/resources/pdf/src/reference.dita
+++ b/src/test/resources/pdf/src/reference.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
+<reference id="reference_rky_2sb_qrb">
+    <title>title <keyword>title/keyword</keyword></title>
+    <shortdesc>shortdesc <keyword>shortdesc/keyword</keyword></shortdesc>
+    <refbody>
+        <data>data <keyword>data/keyword</keyword></data>
+        <data-about>
+            <data>data <keyword>data/keyword</keyword></data>
+        </data-about>
+        <example>example <keyword>example/keyword</keyword>
+            <p>example/p</p></example>
+        <example><title>example/title</title>example
+            <p>example/p</p></example>
+        <foreign>foreign <keyword>foreign/keyword</keyword>
+            <p>foreign/p</p></foreign>
+        <section>section <keyword>section/keyword</keyword>
+            <p>section/p</p></section>
+        <section><title>section/title</title>section
+            <p>section/p</p></section>
+        <simpletable>
+            <sthead>
+                <stentry>stentry <keyword>stentry/keyword</keyword>
+                    <p>stentry/p</p></stentry>
+            </sthead>
+            <strow>
+                <stentry>stentry <keyword>stentry/keyword</keyword>
+                    <p>stentry/p</p></stentry>
+            </strow>
+        </simpletable>
+        <sort-as>sort-as <keyword>sort-as/keyword</keyword></sort-as>
+        <table>
+            <tgroup cols="1">
+                <colspec/>
+                <thead>
+                    <row>
+                        <entry>entry <keyword>entry/keyword</keyword>
+                            <p>entry/p</p></entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry>entry <keyword>entry/keyword</keyword>
+                            <p>entry/p</p></entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <unknown>unknown <keyword>unknown/keyword</keyword>
+            <p>unknown/p</p></unknown>
+    </refbody>
+</reference>

--- a/src/test/resources/pdf/src/task.dita
+++ b/src/test/resources/pdf/src/task.dita
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
+<task id="task_gnt_nrb_qrb">
+    <title>title <keyword>title/keyword</keyword></title>
+    <shortdesc>shortdesc <keyword>shortdesc/keyword</keyword></shortdesc>
+    <taskbody>
+        <prereq>prereq <keyword>prereq/keyword</keyword>
+            <p>prereq/p</p></prereq>
+        <context>context <keyword>context/keyword</keyword>
+            <p>context/p</p></context>
+        <steps>
+            <step>
+                <cmd>cmd <keyword>cmd/keyword</keyword></cmd>
+            </step>
+        </steps>
+        <result>result <keyword>result/keyword</keyword>
+            <p>result/p</p></result>
+        <tasktroubleshooting>tasktroubleshooting <keyword>tasktroubleshooting/keyword</keyword>
+            <p>tasktroubleshooting/p</p></tasktroubleshooting>
+        <example>example <keyword>example/keyword</keyword>
+            <p>example/p</p></example>
+        <postreq>postreq <keyword>postreq/keyword</keyword>
+            <p>postreq/p</p></postreq>
+    </taskbody>
+</task>

--- a/src/test/resources/pdf/src/topic.dita
+++ b/src/test/resources/pdf/src/topic.dita
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic_z3z_1qb_qrb">
+    <title>title <keyword>title/keyword</keyword></title>
+    <body>
+        <bodydiv>bodydiv <keyword>bodydiv/keyword</keyword>
+            <p>bodydiv/p</p></bodydiv>
+        <data>data <keyword>data/keyword</keyword></data>
+        <data-about>
+            <data>data <keyword>data/keyword</keyword></data>
+        </data-about>
+        <div>div <keyword>div/keyword</keyword>
+            <p>div/p</p></div>
+        <dl>
+            <dlentry>
+                <dt>dt <keyword>dt/keyword</keyword></dt>
+                <dd>dd <keyword>dd/keyword</keyword>
+                    <p>dd/p</p></dd>
+            </dlentry>
+        </dl>
+        <draft-comment>draft-comment <keyword>draft-comment/keyword</keyword>
+            <p>draft-comment/p</p></draft-comment>
+        <example>example <keyword>example/keyword</keyword>
+            <p>example/p</p></example>
+        <example><title>example/title</title>example
+            <p>example/p</p></example>
+        <fig>
+            <title>fig/title</title>
+            <image href="image.svg"/>
+        </fig>
+        <foreign>foreign <keyword>foreign/keyword</keyword>
+            <p>foreign/p</p></foreign>
+        <hazardstatement>
+            <messagepanel>
+                <typeofhazard>typeofhazard <keyword>typeofhazard/keyword</keyword></typeofhazard>
+                <howtoavoid>howtoavoid <keyword>howtoavoid/keyword</keyword></howtoavoid>
+            </messagepanel>
+        </hazardstatement>
+        <image href="image.svg">
+            <alt>image/alt</alt>
+        </image>
+        <!--
+    <imagemap>
+      <image></image>
+      <area>
+        <shape>rect</shape>
+        <coords></coords>
+        <xref></xref>
+      </area>
+    </imagemap>
+    -->
+        <lines>lines <keyword>lines/keyword</keyword></lines>
+        <lq>lq <keyword>lq/keyword</keyword>
+            <p>lq/p</p></lq>
+        <note>note <keyword>note/keyword</keyword>
+            <p>note/p</p></note>
+        <note type="attention">note/attention</note>
+        <note type="caution">note/caution</note>
+        <note type="danger">note/danger</note>
+        <note type="fastpath">note/fastpath</note>
+        <note type="important">note/important</note>
+        <note type="note">note/note</note>
+        <note type="notice">note/notice</note>
+        <note type="remember">note/remember</note>
+        <note type="restriction">note/restriction</note>
+        <note type="tip">note/tip</note>
+        <note type="trouble">note/trouble</note>
+        <note type="warning">note/warning</note>
+        <ol>
+            <li>li <keyword>li/keyword</keyword>
+                <p>li/p</p></li>
+        </ol>
+        <p>p <keyword>p/keyword</keyword></p>
+        <pre>pre <keyword>pre/keyword</keyword></pre>
+        <required-cleanup>required-cleanup <keyword>required-cleanup/keyword</keyword>
+            <p>required-cleanup/p</p></required-cleanup>
+        <section>section <keyword>section/keyword</keyword>
+            <p>section/p</p></section>
+        <section><title>section/title</title>section
+            <p>section/p</p></section>
+        <simpletable>
+            <sthead>
+                <stentry>stentry <keyword>stentry/keyword</keyword>
+                    <p>stentry/p</p></stentry>
+            </sthead>
+            <strow>
+                <stentry>stentry <keyword>stentry/keyword</keyword>
+                    <p>stentry/p</p></stentry>
+            </strow>
+        </simpletable>
+        <sl>
+            <sli>sli <keyword>sli/keyword</keyword></sli>
+        </sl>
+        <sort-as>sort-as <keyword>sort-as/keyword</keyword></sort-as>
+        <table>
+            <tgroup cols="1">
+                <colspec colwidth="1*"/>
+                <thead>
+                    <row>
+                        <entry>entry <keyword>entry/keyword</keyword>
+                            <p>entry/p</p></entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry>entry <keyword>entry/keyword</keyword>
+                            <p>entry/p</p></entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <ul>
+            <li>li <keyword>li/keyword</keyword>
+                <p>li/p</p></li>
+        </ul>
+        <unknown>unknown <keyword>unknown/keyword</keyword>
+            <p>unknown/p</p></unknown>
+    </body>
+    <topic id="idw_p4d_qrb">
+        <title>Inline elements</title>
+        <body>
+            <p>
+                abbreviated-form <abbreviated-form keyref="abbreviated-form"/>
+                <apiname>apiname</apiname>
+                <b>b</b>
+                boolean <boolean state="yes"/> <boolean state="no"/>
+                <cite>cite</cite>
+                <cmdname>cmdname</cmdname>
+                <codeblock>codeblock</codeblock>
+                <codeph>codeph</codeph>
+                <data>data</data>
+                <data-about><data>data/data-about</data></data-about>
+                <draft-comment>draft-comment</draft-comment>
+                <equation-inline>equation-inline</equation-inline>
+                <filepath>filepath</filepath>
+                <fn>fn</fn>
+                <foreign>foreign</foreign>
+                <i>i</i>
+                <image href="image.svg"><alt>image/alt</alt></image>
+                <indexterm>indexterm</indexterm>
+                <keyword>keyword</keyword>
+                <line-through>line-through</line-through>
+                <lines>lines</lines>
+                <lq>lq</lq>
+                <markupname>markupname</markupname>
+                <mathml><m:math><m:mn>1</m:mn></m:math></mathml>
+                <menucascade><uicontrol>menucascade</uicontrol><uicontrol>uicontrol</uicontrol></menucascade>
+                <msgblock>msgblock</msgblock>
+                <msgnum>msgnum</msgnum>
+                <msgph>msgph</msgph>
+                <note>note</note>
+                <numcharref>numcharref</numcharref>
+                <option>option</option>
+                <overline>overline</overline>
+                <parameterentity>parameterentity</parameterentity>
+                <parmname>parmname</parmname>
+                <ph>ph</ph>
+                <pre>pre</pre>
+                <q>q</q>
+                <required-cleanup>required-cleanup</required-cleanup>
+                <screen>screen</screen>
+                <sort-as>sort-as</sort-as>
+                <state name="state" value="value"/>
+                <sub>sub</sub>
+                <sup>sup</sup>
+                <svg-container>
+                    <svg:svg height="12pt" width="12pt" viewBox="0 0 1 1">
+                        <svg:rect width="1" height="1" x="0" y="0" fill="red"/>
+                    </svg:svg>
+                </svg-container>
+                <synph>synph</synph>
+                <syntaxdiagram><groupseq><kwd>syntaxdiagram</kwd><delim>/</delim><kwd>groupseq</kwd><delim>/</delim><kwd>kwd</kwd></groupseq></syntaxdiagram>
+                <systemoutput>systemoutput</systemoutput>
+                <term>term</term>
+                <text>text</text>
+                <textentity>textentity</textentity>
+                <tm tmtype="reg">reg</tm>
+                <tm tmtype="service">service</tm>
+                <tm tmtype="tm">tm</tm>
+                <tt>tt</tt>
+                <u>u</u>
+                <uicontrol>uicontrol</uicontrol>
+                <unknown>unknown</unknown>
+                <userinput>userinput</userinput>
+                <varname>varname</varname>
+                <wintitle>wintitle</wintitle>
+                <xmlatt>xmlatt</xmlatt>
+                <xmlelement>xmlelement</xmlelement>
+                <xmlnsname>xmlnsname</xmlnsname>
+                <xmlpi>xmlpi</xmlpi>
+                <xref href="#topic_z3z_1qb_qrb">xref</xref>
+                <xref href="#topic_z3z_1qb_qrb"/>
+             </p>
+        </body>
+    </topic>
+</topic>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
@@ -59,6 +59,21 @@
   <xsl:attribute-set name="thead.row.entry__content"/>
   <xsl:attribute-set name="thead.row.entry"/>
   <xsl:attribute-set name="thead.row"/>
+  <xsl:attribute-set name="thead__tableframe__bottom"/>
+  <xsl:attribute-set name="__tableframe__bottom"/>
+  <xsl:attribute-set name="__tableframe__top"/>
+  <xsl:attribute-set name="__tableframe__right"/>
+  <xsl:attribute-set name="__tableframe__right"/>
+  <xsl:attribute-set name="table__tableframe__all"/>
+  <xsl:attribute-set name="table__tableframe__topbot"/>
+  <xsl:attribute-set name="table__tableframe__top"/>
+  <xsl:attribute-set name="table__tableframe__bottom"/>
+  <xsl:attribute-set name="table__tableframe__sides"/>
+  <xsl:attribute-set name="__tableframe__top"/>
+  <xsl:attribute-set name="__tableframe__left"/>
+  <xsl:attribute-set name="__tableframe__right"/>
+  <xsl:attribute-set name="__tableframe__bottom"/>
+  <xsl:attribute-set name="__tableframe__right"/>
   
   <xsl:template name="get-id"/>
   
@@ -91,10 +106,9 @@
   </xsl:template>
   
   <xsl:template name="commonattributes"/>
-  
-  <xsl:template name="processAttrSetReflection">
-    <xsl:param name="attrSet"/>
-    <xsl:param name="path"/>
+
+  <xsl:template name="get-attributes" as="attribute()*">
+    <xsl:param name="element" as="element()"/>
   </xsl:template>
   
   <xsl:template name="setExpanse"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -39,6 +39,23 @@
   <xsl:attribute-set name="image__block"/>
   <xsl:attribute-set name="image__inline"/>
   <xsl:attribute-set name="topic"/>
+  <xsl:attribute-set name="topic.title"/>
+  <xsl:attribute-set name="topic.topic.title"/>
+  <xsl:attribute-set name="topic.topic.topic.title"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.title"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.topic.title"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.topic.topic.title"/>
+  <xsl:attribute-set name="topic.title__content"/>
+  <xsl:attribute-set name="topic.topic.title__content"/>
+  <xsl:attribute-set name="topic.topic.topic.title__content"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.title__content"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.topic.title__content"/>
+  <xsl:attribute-set name="topic.topic.topic.topic.topic.topic.title__content"/>
+  <xsl:attribute-set name="lq_simple"/>
+  <xsl:attribute-set name="__align__left"/>
+  <xsl:attribute-set name="__align__right"/>
+  <xsl:attribute-set name="__align__center"/>
+  <xsl:attribute-set name="__align__justify"/>
   <xsl:attribute-set name="section.title"/>
   <xsl:attribute-set name="example.title"/>
   <xsl:attribute-set name="tm__content__service"/>
@@ -118,9 +135,8 @@
   </xsl:template>
   <xsl:template name="get-id"/>
   <xsl:template name="determineTopicType"/>
-  <xsl:template name="processAttrSetReflection">
-  <xsl:param name="attrSet"/>
-  <xsl:param name="path"/>
+  <xsl:template name="get-attributes" as="attribute()*">
+  <xsl:param name="element" as="element()"/>
   </xsl:template>
   <xsl:template name="topic-title-mock" match="*[contains(@class,' topic/title ')]"><topic-title/></xsl:template>
   <xsl:template name="topic-desc-mock" match="*[contains(@class,' topic/desc ')]"><topic-desc/></xsl:template>


### PR DESCRIPTION
## Description
Replace PDF2 attribute-set reflection with direct attribute-set use.

## Motivation and Context
Fixes #3827

## How Has This Been Tested?
Added integration test for PDF that compares `topic.fo` with expected output.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Backwards compatible as code for the old attribute-set reflection is retained but PDF2 now uses new attribute-set generation everywhere reflection used to be uses.