### PR TITLE
Refactor attribute generation in XSLT

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -113,7 +113,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <!--@type|@importance|@linking|@toc|@print|@search|@format|@scope-->
           <!--need to create type variable regardless, for passing as a parameter to getstuff template-->
           <xsl:if test="(:not(@type) and :)$type!='#none#'">
-            <xsl:attribute name="type"><xsl:value-of select="$type"/></xsl:attribute>
+            <xsl:attribute name="type" select="$type"/>
           </xsl:if>
           <!-- FIXME: importance is not inheretable per http://docs.oasis-open.org/dita/v1.2/os/spec/archSpec/cascading-in-a-ditamap.html -->
           <!--xsl:if test="not(@importance)"-->
@@ -140,16 +140,16 @@ Other modes can be found within the code, and may or may not prove useful for ov
             <xsl:apply-templates select="." mode="mappull:inherit-and-set-attribute"><xsl:with-param name="attrib">processing-role</xsl:with-param></xsl:apply-templates>
           </xsl:if>
           <xsl:if test="(:not(@print) and :)$print!='#none#'">
-            <xsl:attribute name="print"><xsl:value-of select="$print"/></xsl:attribute>
+            <xsl:attribute name="print" select="$print"/>
           </xsl:if>
           <!--xsl:if test="not(@search)"-->
             <xsl:apply-templates select="." mode="mappull:inherit-and-set-attribute"><xsl:with-param name="attrib">search</xsl:with-param></xsl:apply-templates>
           <!--/xsl:if-->
           <xsl:if test="(:not(@format) and :)$format!='#none#'">
-            <xsl:attribute name="format"><xsl:value-of select="$format"/></xsl:attribute>
+            <xsl:attribute name="format" select="$format"/>
           </xsl:if>
           <xsl:if test="(:not(@scope) and :)$scope!='#none#'">
-            <xsl:attribute name="scope"><xsl:value-of select="$scope"/></xsl:attribute>
+            <xsl:attribute name="scope" select="$scope"/>
           </xsl:if>
           <!--xsl:if test="not(@audience)"-->
             <xsl:apply-templates select="." mode="mappull:inherit-and-set-attribute"><xsl:with-param name="attrib">audience</xsl:with-param></xsl:apply-templates>
@@ -232,7 +232,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       </xsl:apply-templates>
     </xsl:variable>
     <xsl:if test="$inherited-value!='#none#'">
-      <xsl:attribute name="{$attrib}"><xsl:value-of select="$inherited-value"/></xsl:attribute>
+      <xsl:attribute name="{$attrib}" select="$inherited-value"/>
     </xsl:if>
   </xsl:template>
 
@@ -502,9 +502,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
             <xsl:variable name="target" select="if (exists($doc)) then (key('topic-by-id', $topicid, $doc)[1]) else ()" as="element()?"/>
             <xsl:choose>
               <xsl:when test="$target[contains(@class, $classval)]">
-                <xsl:attribute name="type">
-                  <xsl:value-of select="local-name($target[contains(@class, $classval)])"/>
-                </xsl:attribute>
+                <xsl:attribute name="type" select="local-name($target[contains(@class, $classval)])"/>
               </xsl:when>
               <xsl:when test="$topicid!='#none#' and not($target[contains(@class, ' topic/topic ')])">
                 <!-- topicid does not point to a valid topic -->
@@ -521,9 +519,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="$topicpos='firstinfile'">
             <xsl:choose>
               <xsl:when test="($doc//*[contains(@class, ' topic/topic ')])[1]">
-                <xsl:attribute name="type">
-                  <xsl:value-of select="local-name(($doc//*[contains(@class, $classval)])[1])"/>
-                </xsl:attribute>
+                <xsl:attribute name="type" select="local-name(($doc//*[contains(@class, $classval)])[1])"/>
               </xsl:when>
               <xsl:otherwise><!-- do nothing - omit attribute--></xsl:otherwise>
             </xsl:choose>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -198,14 +198,12 @@ See the accompanying LICENSE file for applicable license.
                 <xsl:value-of select="$href"/>
               </xsl:attribute>
               <xsl:if test="@keyscope | $target[@keyscope and contains(@class, ' map/map ')]">
-                <xsl:attribute name="keyscope">
-                  <xsl:variable name="keyscope">
-                    <xsl:value-of select="@keyscope"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="$target[contains(@class, ' map/map ')]/@keyscope"/>
-                  </xsl:variable>
-                  <xsl:value-of select="string-join(distinct-values(tokenize(normalize-space($keyscope), '\s+')), ' ')"/>
-                </xsl:attribute>
+                <xsl:variable name="keyscope">
+                  <xsl:value-of select="@keyscope"/>
+                  <xsl:text> </xsl:text>
+                  <xsl:value-of select="$target[contains(@class, ' map/map ')]/@keyscope"/>
+                </xsl:variable>
+                <xsl:attribute name="keyscope" select="string-join(distinct-values(tokenize(normalize-space($keyscope), '\s+')), ' ')"/>
               </xsl:if>
               <xsl:apply-templates select="$target/@chunk"/>
               <xsl:apply-templates select="@* except (@class, @href, @dita-ot:orig-href, @format, @dita-ot:orig-format, @keys, @keyscope, @type)"/>
@@ -272,14 +270,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:choose>
           <xsl:when test=". = ''"/>
           <xsl:when test="$relative-path = '#none#' or dita-ot:is-external(.)">
-            <xsl:attribute name="{name()}">
-              <xsl:value-of select="."/>
-            </xsl:attribute>
+            <xsl:attribute name="{name()}" select="."/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:attribute name="{name()}">
-              <xsl:value-of select="dita-ot:normalize-uri(concat($relative-path, .))"/>
-            </xsl:attribute>
+            <xsl:attribute name="{name()}" select="dita-ot:normalize-uri(concat($relative-path, .))"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:for-each>
@@ -536,9 +530,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:apply-templates>
     </xsl:variable>
     <xsl:if test="$inherited-value!='#none#'">
-      <xsl:attribute name="{$attrib}">
-        <xsl:value-of select="$inherited-value"/>
-      </xsl:attribute>
+      <xsl:attribute name="{$attrib}" select="$inherited-value"/>
     </xsl:if>
   </xsl:template>
 
@@ -550,9 +542,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:apply-templates>
     </xsl:variable>
     <xsl:if test="$inherited-value!='#none#'">
-      <xsl:attribute name="format">
-        <xsl:value-of select="$inherited-value"/>
-      </xsl:attribute>
+      <xsl:attribute name="format" select="$inherited-value"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -37,10 +37,7 @@ See the accompanying LICENSE file for applicable license.
       <span>
         <xsl:call-template name="commonattributes"/>
           <!-- Combine TT style with style from ditaval, if present -->
-          <xsl:attribute name="style">
-            <xsl:text>font-family: monospace; </xsl:text>
-            <xsl:value-of select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style"/>
-          </xsl:attribute>
+        <xsl:attribute name="style" select="('font-family: monospace', *[contains(@class,' ditaot-d/ditaval-startprop ')]/@style)" separator="; "/>
         <xsl:call-template name="setidaname"/>
         <xsl:apply-templates/>
       </span>

--- a/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
@@ -105,9 +105,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
   <xsl:template match="alt-text" mode="ditaval-outputflag">
-    <xsl:attribute name="alt">
-      <xsl:value-of select="."/>
-    </xsl:attribute>
+    <xsl:attribute name="alt" select="."/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
@@ -52,9 +52,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/var ')]" name="topic.pr-d.var">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'var'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -62,9 +60,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/synph ')]" name="topic.pr-d.synph">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'synph'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -72,9 +68,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/oper ')]" name="topic.pr-d.oper">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'oper'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -82,9 +76,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/delim ')]" name="topic.pr-d.delim">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'delim'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -92,9 +84,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/sep ')]" name="topic.pr-d.sep">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'sep'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -102,9 +92,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/repsep ')]" name="topic.pr-d.repsep">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'repsep'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -112,9 +100,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/option ')]" name="topic.pr-d.option">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'option'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -122,9 +108,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/parmname ')]" name="topic.pr-d.parmname">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'parmname'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -132,9 +116,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/apiname ')]" name="topic.pr-d.apiname">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'apiname'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -437,7 +437,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--basic child processing-->
   <xsl:template match="*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="2" name="topic.link_child">
-    <li class="ulchildlink">
+    <li>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'ulchildlink'"/>
       </xsl:call-template>
@@ -473,7 +473,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--ordered child processing-->
   <xsl:template match="*[@collection-type = 'sequence']/*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="3" name="topic.link_orderedchild">
-    <li class="olchildlink">
+    <li>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'olchildlink'"/>
       </xsl:call-template>

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -124,11 +124,7 @@ See the accompanying LICENSE file for applicable license.
       
       <!-- If there is a keycol header or an sthead header, create the attribute -->
       <xsl:if test="string-length($header) > 0 or string-length($keycolhead) > 0">
-        <xsl:attribute name="headers">
-          <xsl:value-of select="$header"/>
-          <xsl:if test="string-length($header) > 0 and string-length($keycolhead) > 0"><xsl:text> </xsl:text></xsl:if>
-          <xsl:value-of select="$keycolhead"/>
-        </xsl:attribute>
+        <xsl:attribute name="headers" select="($header[normalize-space(.)], $keycolhead[normalize-space(.)])" separator=" "/>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
@@ -11,9 +11,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/filepath ')]" name="topic.sw-d.filepath">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'filepath'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -21,9 +19,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/msgph ')]" name="topic.sw-d.msgph">
    <samp>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'msgph'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </samp>
@@ -31,9 +27,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/userinput ')]" name="topic.sw-d.userinput">
    <kbd>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'userinput'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </kbd>
@@ -51,9 +45,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/cmdname ')]" name="topic.sw-d.cmdname">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'cmdname'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -61,9 +53,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/msgnum ')]" name="topic.sw-d.msgnum">
    <span>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'msgnum'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </span>
@@ -71,9 +61,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' sw-d/varname ')]" name="topic.sw-d.varname">
    <var>
-    <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'varname'"/>
-    </xsl:call-template>
+    <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
    </var>

--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -20,7 +20,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
     <div>
-    <a><xsl:attribute name="name"><xsl:value-of select="*[contains(@class,' topic/title ')]"/></xsl:attribute> </a>
+    <a><xsl:attribute name="name" select="*[contains(@class,' topic/title ')]"/> </a>
     <xsl:apply-templates mode="process-syntaxdiagram"/>
     </div>
   </xsl:template>
@@ -50,7 +50,7 @@ See the accompanying LICENSE file for applicable license.
   and if so, produce an associative link. -->
   <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="process-syntaxdiagram">
     <kbd>
-        <a><xsl:attribute name="href">#<xsl:value-of select="."/></xsl:attribute>
+        <a><xsl:attribute name="href" select="concat('#', .)"/>
     &lt;<xsl:value-of select="."/>&gt;</a>
     </kbd>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -20,7 +20,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
     <div>
-    <a><xsl:attribute name="name" select="*[contains(@class,' topic/title ')]"/> </a>
+    <a name="{*[contains(@class,' topic/title ')]}"> </a>
     <xsl:apply-templates mode="process-syntaxdiagram"/>
     </div>
   </xsl:template>
@@ -50,7 +50,7 @@ See the accompanying LICENSE file for applicable license.
   and if so, produce an associative link. -->
   <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="process-syntaxdiagram">
     <kbd>
-        <a><xsl:attribute name="href" select="concat('#', .)"/>
+        <a href="#{.}">
     &lt;<xsl:value-of select="."/>&gt;</a>
     </kbd>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
@@ -20,7 +20,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" priority="2">
     <div>
-     <a><xsl:attribute name="name" select="title"/> </a>
+     <a name="{title}"> </a>
      <xsl:apply-templates/>
     </div>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
@@ -20,7 +20,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" priority="2">
     <div>
-     <a><xsl:attribute name="name"><xsl:value-of select="title"/></xsl:attribute> </a>
+     <a><xsl:attribute name="name" select="title"/> </a>
      <xsl:apply-templates/>
     </div>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -405,8 +405,10 @@ See the accompanying LICENSE file for applicable license.
             </xsl:if>
           </span>
           <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-            <span class="tabledesc">
-              <xsl:call-template name="commonattributes"/>
+            <span>
+              <xsl:call-template name="commonattributes">
+                <xsl:with-param name="default-output-class" select="'tabledesc'"/>
+              </xsl:call-template>
               <xsl:apply-templates select="." mode="tabledesc"/>
             </span>
           </xsl:for-each>
@@ -415,8 +417,10 @@ See the accompanying LICENSE file for applicable license.
       <!-- desc -->
       <xsl:when test="*[contains(@class, ' topic/desc ')]">
         <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-          <span class="tabledesc">
-            <xsl:call-template name="commonattributes"/>
+          <span>
+            <xsl:call-template name="commonattributes">
+              <xsl:with-param name="default-output-class" select="'tabledesc'"/>
+            </xsl:call-template>
             <xsl:apply-templates select="." mode="tabledesc"/>
           </span>
         </xsl:for-each>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -147,9 +147,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:when>
     </xsl:choose>
     <xsl:if test="@morerows">
-      <xsl:attribute name="rowspan"> <!-- set the number of rows to span -->
-        <xsl:value-of select="@morerows + 1"/>
-      </xsl:attribute>
+      <!-- set the number of rows to span -->
+      <xsl:attribute name="rowspan" select="@morerows + 1"/>
     </xsl:if>
     <xsl:if test="@dita-ot:morecols"> <!-- get the number of columns to span from the specified named column values -->
       <xsl:attribute name="colspan" select="@dita-ot:morecols + 1"/>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -245,7 +245,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- only 1 step - output as a para -->
   <xsl:template match="*[contains(@class,' task/step ')]" mode="onestep">
     <xsl:param name="step_expand"/>
-    <div class="p">
+    <div>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'p'"/>
       </xsl:call-template>
@@ -380,8 +380,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' task/choicetable ')]" name="topic.task.choicetable">
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>
-    <table border="1" frame="hsides" rules="rows" cellpadding="4" cellspacing="0" summary="" class="choicetableborder">
-      <xsl:call-template name="commonattributes"/>
+    <table border="1" frame="hsides" rules="rows" cellpadding="4" cellspacing="0" summary="">
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class" select="'choicetableborder'"/>
+      </xsl:call-template>
       <xsl:apply-templates select="." mode="generate-table-summary-attribute"/>
       <xsl:call-template name="setid"/>
       <xsl:call-template name="dita2html:simpletable-cols"/>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -198,7 +198,7 @@ See the accompanying LICENSE file for applicable license.
                    It is possible (preferable) to keep stepsection within an <li> and use CSS to
                    fix numbering, but with testing in March of 2009, this does not work in IE. 
                    It is possible in Firefox 3. -->
-              <xsl:attribute name="start"><xsl:value-of select="count(preceding-sibling::*[contains(@class,' task/step ')])+1"/></xsl:attribute>
+              <xsl:attribute name="start" select="count(preceding-sibling::*[contains(@class,' task/step ')])+1"/>
             </xsl:if>
             <xsl:apply-templates select="." mode="steps">
               <xsl:with-param name="step_expand" select="$step_expand"/>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -264,7 +264,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
     </xsl:param>
     <xsl:element name="h{$headinglevel}">
-        <xsl:attribute name="class">topictitle<xsl:value-of select="$headinglevel"/></xsl:attribute>
+        <xsl:attribute name="class" select="concat('topictitle', $headinglevel)"/>
         <xsl:call-template name="commonattributes">
           <xsl:with-param name="default-output-class">topictitle<xsl:value-of select="$headinglevel"/></xsl:with-param>
         </xsl:call-template>
@@ -1446,14 +1446,14 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not($height-in-pixel = '100%')">
-      <xsl:attribute name="height">
+      <xsl:attribute name="height" select="number($height-in-pixel)">
         <!--xsl:choose>
           <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
             <xsl:value-of select="number($height-in-pixel) * number(../@scale)"/>
           </xsl:when>
-          <xsl:otherwise-->
+          <xsl:otherwise>
             <xsl:value-of select="number($height-in-pixel)"/>
-          <!--/xsl:otherwise>
+          </xsl:otherwise>
         </xsl:choose-->
       </xsl:attribute>
     </xsl:if>  
@@ -1466,14 +1466,14 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not($width-in-pixel = '100%')">
-      <xsl:attribute name="width">
+      <xsl:attribute name="width" select="number($width-in-pixel)">
         <!--xsl:choose>
           <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
             <xsl:value-of select="number($width-in-pixel) * number(../@scale)"/>
           </xsl:when>
-          <xsl:otherwise-->
+          <xsl:otherwise>
             <xsl:value-of select="number($width-in-pixel)"/>
-          <!--/xsl:otherwise>
+          <!/xsl:otherwise>
         </xsl:choose-->
       </xsl:attribute>
     </xsl:if>  
@@ -2802,9 +2802,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="*|text()" mode="text-only"/>
     </xsl:variable>
     <meta name="description">
-      <xsl:attribute name="content">
-        <xsl:value-of select="normalize-space($shortmeta)"/>
-      </xsl:attribute>
+      <xsl:attribute name="content" select="normalize-space($shortmeta)"/>
     </meta>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2179,9 +2179,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:choose>
         </xsl:when>
         <xsl:otherwise>
-          <a>
-            <xsl:attribute name="name" select="concat('fntarg_', $fnid)"/>
-            <xsl:attribute name="href" select="concat('#fnsrc_', $fnid)"/>
+          <a name="fntarg_{$fnid}" href="#fnsrc_{$fnid}">
             <sup>
               <xsl:value-of select="$convergedcallout"/>
             </sup>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -383,7 +383,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- section processor - div with no generated title -->
   <xsl:template match="*[contains(@class, ' topic/section ')]" name="topic.section">
-    <section class="section">
+    <section>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="gen-toc-id"/>
       <xsl:call-template name="setidaname"/>
@@ -396,7 +396,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- example processor - div with no generated title -->
   <xsl:template match="*[contains(@class, ' topic/example ')]" name="topic.example">
-    <div class="example">
+    <div>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="gen-toc-id"/>
       <xsl:call-template name="setidaname"/>
@@ -425,8 +425,10 @@ See the accompanying LICENSE file for applicable license.
         If so, use div_class="p" instead of p -->
    <xsl:choose>
      <xsl:when test="descendant::*[dita-ot:is-block(.)]">
-       <div class="p">
-         <xsl:call-template name="commonattributes"/>
+       <div>
+         <xsl:call-template name="commonattributes">
+           <xsl:with-param name="default-output-class" select="'p'"/>
+         </xsl:call-template>
          <xsl:call-template name="setid"/>
          <xsl:apply-templates/>
        </div>
@@ -624,7 +626,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' topic/sl ')]" name="topic.sl">
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>
-    <ul class="simple">
+    <ul>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'simple'"/>
       </xsl:call-template>
@@ -893,8 +895,10 @@ See the accompanying LICENSE file for applicable license.
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <span class="keyword">
-          <xsl:call-template name="commonattributes"/>
+        <span>
+          <xsl:call-template name="commonattributes">
+            <xsl:with-param name="default-output-class" select="'keyword'"/>
+          </xsl:call-template>
           <xsl:call-template name="setidaname"/>   
           <xsl:apply-templates/>  
         </span>
@@ -1002,8 +1006,10 @@ See the accompanying LICENSE file for applicable license.
     <!-- Deprecated since 2.1 -->
     <xsl:param name="displaytext"/>
     
-    <dfn class="term">
-      <xsl:call-template name="commonattributes"/>
+    <dfn>
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class" select="'term'"/>
+      </xsl:call-template>
       <xsl:call-template name="setidaname"/>
       <xsl:choose>
         <xsl:when test="normalize-space($displaytext)">
@@ -1247,7 +1253,6 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="spec-title-nospace"/>
     <pre>
-      <xsl:attribute name="class" select="name()"/>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setscale"/>
       <xsl:call-template name="setidaname"/>
@@ -1446,16 +1451,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not($height-in-pixel = '100%')">
-      <xsl:attribute name="height" select="number($height-in-pixel)">
-        <!--xsl:choose>
-          <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
-            <xsl:value-of select="number($height-in-pixel) * number(../@scale)"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="number($height-in-pixel)"/>
-          </xsl:otherwise>
-        </xsl:choose-->
-      </xsl:attribute>
+      <xsl:attribute name="height" select="number($height-in-pixel)"/>
     </xsl:if>  
   </xsl:template>
   
@@ -1466,16 +1462,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not($width-in-pixel = '100%')">
-      <xsl:attribute name="width" select="number($width-in-pixel)">
-        <!--xsl:choose>
-          <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
-            <xsl:value-of select="number($width-in-pixel) * number(../@scale)"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="number($width-in-pixel)"/>
-          <!/xsl:otherwise>
-        </xsl:choose-->
-      </xsl:attribute>
+      <xsl:attribute name="width" select="number($width-in-pixel)"/>
     </xsl:if>  
   </xsl:template>
   
@@ -2150,7 +2137,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Catch footnotes that should appear at the end of the topic, and output them. -->
   <xsl:template match="*[contains(@class, ' topic/fn ')]" mode="genEndnote">
-    <div class="p">
+    <div>
       <xsl:variable name="fnid"><xsl:number from="/" level="any"/></xsl:variable>
       <xsl:variable name="callout" select="@callout"/>
       <xsl:variable name="convergedcallout" select="if (string-length($callout) > 0) then $callout else $fnid"/>
@@ -2881,8 +2868,10 @@ See the accompanying LICENSE file for applicable license.
             <xsl:text>. </xsl:text>
           </xsl:if>
           <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-            <span class="figdesc">
-              <xsl:call-template name="commonattributes"/>
+            <span>
+              <xsl:call-template name="commonattributes">
+                <xsl:with-param name="default-output-class" select="'figdesc'"/>
+              </xsl:call-template>
               <xsl:apply-templates select="." mode="figdesc"/>
             </span>
           </xsl:for-each>

--- a/src/main/plugins/org.dita.html5/xsl/ui-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ui-d.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' ui-d/screen ')]" name="topic.ui-d.screen">
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="spec-title-nospace"/>
-    <pre class="screen">
+    <pre>
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setscale"/>
       <xsl:call-template name="setidaname"/>
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
       </abbr>
     </xsl:if>
   </xsl:if>
-   <span class="uicontrol">
+   <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
@@ -49,7 +49,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' ui-d/wintitle ')]" name="topic.ui-d.wintitle">
-   <span class="wintitle">
+   <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' ui-d/menucascade ')]" name="topic.ui-d.menucascade">
-   <span class="menucascade">
+   <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>
@@ -67,7 +67,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' ui-d/menucascade ')]/text()"/>
   
   <xsl:template match="*[contains(@class,' ui-d/shortcut ')]" name="topic.ui-d.shortcut">
-   <span class="shortcut">
+   <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
     <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
@@ -47,8 +47,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:choose>
               <xsl:when test="*[contains(@class, ' topic/xref ')]">
                 <xsl:variable name="alttext"><xsl:apply-templates select="*[contains(@class, ' topic/xref ')]/node()[not(contains(@class, ' topic/desc '))]" mode="text-only"/></xsl:variable>
-                <xsl:attribute name="alt"><xsl:value-of select="normalize-space($alttext)"/></xsl:attribute>
-                <xsl:attribute name="title"><xsl:value-of select="normalize-space($alttext)"/></xsl:attribute>
+                <xsl:attribute name="alt" select="normalize-space($alttext)"/>
+                <xsl:attribute name="title" select="normalize-space($alttext)"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:apply-templates select="." mode="ditamsg:area-element-without-linktext"/>
@@ -57,9 +57,7 @@ See the accompanying LICENSE file for applicable license.
   
             <!-- if not valid shape (blank, rect, circle, poly); Warning, pass thru the value -->
             <xsl:variable name="shapeval"><xsl:value-of select="*[contains(@class,' ut-d/shape ')]"/></xsl:variable>
-            <xsl:attribute name="shape">
-              <xsl:value-of select="$shapeval"/>
-            </xsl:attribute>
+            <xsl:attribute name="shape" select="$shapeval"/>
             <xsl:variable name="shapetest" select="concat('-',$shapeval,'-')" as="xs:string"/>
             <xsl:choose>
               <xsl:when test="contains('--rect-circle-poly-default-',$shapetest)"/>
@@ -74,9 +72,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:variable name="coordval"><xsl:value-of select="*[contains(@class,' ut-d/coords ')]"/></xsl:variable>
             <xsl:choose>
               <xsl:when test="string-length($coordval)>0 and not($shapeval='default')">
-                <xsl:attribute name="coords">
-                  <xsl:value-of select="$coordval"/>
-                </xsl:attribute>
+                <xsl:attribute name="coords" select="$coordval"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:apply-templates select="." mode="ditamsg:area-element-missing-coords"/>
@@ -111,7 +107,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:attribute name="alt"><xsl:apply-templates select="*[contains(@class,' topic/alt ')]" mode="text-only"/></xsl:attribute>
       </xsl:when>
       <xsl:when test="@alt">
-        <xsl:attribute name="alt"><xsl:value-of select="@alt"/></xsl:attribute>
+        <xsl:attribute name="alt" select="@alt"/>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
@@ -292,10 +292,10 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:attribute>
               </xsl:when>
               <xsl:when test="contains(@href,'.htm') and @scope!='external'">
-                <xsl:attribute name="value"><xsl:value-of select="$pathFromMaplist"/><xsl:value-of select="@href"/></xsl:attribute>
+                <xsl:attribute name="value" select="$pathFromMaplist"/><xsl:value-of select="@href"/>
               </xsl:when>
               <xsl:otherwise> <!-- If non-DITA, keep the href as-is -->
-                <xsl:attribute name="value"><xsl:value-of select="@href"/></xsl:attribute>
+                <xsl:attribute name="value" select="@href"/>
               </xsl:otherwise>
             </xsl:choose>
           </xsl:element>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -65,7 +65,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:attribute-set name="common.border" use-attribute-sets="common.border__top common.border__right common.border__bottom common.border__left"/>
 
   <xsl:attribute-set name="base-font">
-    <xsl:attribute name="font-size"><xsl:value-of select="$default-font-size"/></xsl:attribute>
+    <xsl:attribute name="font-size" select="$default-font-size"/>
   </xsl:attribute-set>
 
   <!-- titles -->

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/index-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/index-attr.xsl
@@ -70,7 +70,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute-set name="index-indents">
         <xsl:attribute name="end-indent">5pt</xsl:attribute>
         <xsl:attribute name="last-line-end-indent">0pt</xsl:attribute>
-        <xsl:attribute name="start-indent"><xsl:value-of select="$index.indent"/> * 2</xsl:attribute>
+        <xsl:attribute name="start-indent" select="concat($index.indent, ' * 2')"/>
         <xsl:attribute name="text-indent">-<xsl:value-of select="$index.indent"/> * 2</xsl:attribute>
         <xsl:attribute name="font-size">9pt</xsl:attribute>
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
@@ -11,45 +11,25 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0">
     
   <xsl:attribute-set name="simple-page-master">
-    <xsl:attribute name="page-width">
-      <xsl:value-of select="$page-width"/>
-    </xsl:attribute>
-    <xsl:attribute name="page-height">
-      <xsl:value-of select="$page-height"/>
-    </xsl:attribute>
+    <xsl:attribute name="page-width" select="$page-width"/>
+    <xsl:attribute name="page-height" select="$page-height"/>
   </xsl:attribute-set>
   
   <!-- legacy attribute set -->
   <xsl:attribute-set name="region-body" use-attribute-sets="region-body.odd"/>
   
   <xsl:attribute-set name="region-body.odd">
-    <xsl:attribute name="margin-top">
-      <xsl:value-of select="$page-margin-top"/>
-    </xsl:attribute>
-    <xsl:attribute name="margin-bottom">
-      <xsl:value-of select="$page-margin-bottom"/>
-    </xsl:attribute>
-    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-left' else 'margin-right'}">
-      <xsl:value-of select="$page-margin-inside"/>
-    </xsl:attribute>
-    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-right' else 'margin-left'}">
-      <xsl:value-of select="$page-margin-outside"/>
-    </xsl:attribute>
+    <xsl:attribute name="margin-top" select="$page-margin-top"/>
+    <xsl:attribute name="margin-bottom" select="$page-margin-bottom"/>
+    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-left' else 'margin-right'}" select="$page-margin-inside"/>
+    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-right' else 'margin-left'}" select="$page-margin-outside"/>
   </xsl:attribute-set>
 
   <xsl:attribute-set name="region-body.even">
-    <xsl:attribute name="margin-top">
-      <xsl:value-of select="$page-margin-top"/>
-    </xsl:attribute>
-    <xsl:attribute name="margin-bottom">
-      <xsl:value-of select="$page-margin-bottom"/>
-    </xsl:attribute>
-    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-left' else 'margin-right'}">
-      <xsl:value-of select="$page-margin-outside"/>
-    </xsl:attribute>
-    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-right' else 'margin-left'}">
-      <xsl:value-of select="$page-margin-inside"/>
-    </xsl:attribute>
+    <xsl:attribute name="margin-top" select="$page-margin-top"/>
+    <xsl:attribute name="margin-bottom" select="$page-margin-bottom"/>
+    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-left' else 'margin-right'}" select="$page-margin-outside"/>
+    <xsl:attribute name="{if ($writing-mode = 'lr') then 'margin-right' else 'margin-left'}" select="$page-margin-inside"/>
   </xsl:attribute-set>
   
   <xsl:attribute-set name="region-body__frontmatter.odd" use-attribute-sets="region-body.odd">
@@ -74,16 +54,12 @@ See the accompanying LICENSE file for applicable license.
   </xsl:attribute-set>
 
   <xsl:attribute-set name="region-before">
-    <xsl:attribute name="extent">
-      <xsl:value-of select="$page-margin-top"/>
-    </xsl:attribute>
+    <xsl:attribute name="extent" select="$page-margin-top"/>
     <xsl:attribute name="display-align">before</xsl:attribute>
   </xsl:attribute-set>
   
   <xsl:attribute-set name="region-after">
-    <xsl:attribute name="extent">
-      <xsl:value-of select="$page-margin-bottom"/>
-    </xsl:attribute>
+    <xsl:attribute name="extent" select="$page-margin-bottom"/>
     <xsl:attribute name="display-align">after</xsl:attribute>
   </xsl:attribute-set>
     

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
@@ -56,11 +56,11 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="related-links__content">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="related-links.ul" use-attribute-sets="ul">
-    <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+    <xsl:attribute name="start-indent" select="$side-col-width"/>
   </xsl:attribute-set>
 
     <xsl:attribute-set name="related-links.ul.li" use-attribute-sets="ul.li">
@@ -79,7 +79,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:attribute-set>
 
   <xsl:attribute-set name="related-links.ol" use-attribute-sets="ol">
-    <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+    <xsl:attribute name="start-indent" select="$side-col-width"/>
   </xsl:attribute-set>
 
     <xsl:attribute-set name="related-links.ol.li" use-attribute-sets="ol.li">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute-set name="__toc__topic__content">
         <xsl:attribute name="last-line-end-indent">-22pt</xsl:attribute>
         <xsl:attribute name="end-indent">22pt</xsl:attribute>
-        <xsl:attribute name="text-indent">-<xsl:value-of select="$toc.text-indent"/></xsl:attribute>
+        <xsl:attribute name="text-indent" select="concat('-', $toc.text-indent)"/>
         <xsl:attribute name="text-align">start</xsl:attribute>
         <xsl:attribute name="text-align-last">justify</xsl:attribute>
         <xsl:attribute name="font-size">
@@ -111,11 +111,11 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__toc__title">
-      <xsl:attribute name="end-indent"><xsl:value-of select="$toc.text-indent"/></xsl:attribute>
+      <xsl:attribute name="end-indent" select="$toc.text-indent"/>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="__toc__page-number">
-      <xsl:attribute name="start-indent">-<xsl:value-of select="$toc.text-indent"/></xsl:attribute>
+      <xsl:attribute name="start-indent" select="concat('-', $toc.text-indent)"/>
       <xsl:attribute name="keep-together.within-line">always</xsl:attribute>
     </xsl:attribute-set>
 
@@ -188,7 +188,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
     
     <xsl:attribute-set name="__toc__indent__booklist" use-attribute-sets="__toc__indent">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/> + <xsl:value-of select="$toc.text-indent"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="concat($side-col-width, ' + ', $toc.text-indent)"/>
         <xsl:attribute name="space-before">10pt</xsl:attribute>
         <xsl:attribute name="space-after">10pt</xsl:attribute>
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -102,7 +102,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:attribute-set name="topic.topic.topic.topic.title" use-attribute-sets="base-font common.title">
         <xsl:attribute name="space-before">10pt</xsl:attribute>
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
     </xsl:attribute-set>
@@ -111,7 +111,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="topic.topic.topic.topic.topic.title" use-attribute-sets="base-font common.title">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
     </xsl:attribute-set>
@@ -120,7 +120,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="topic.topic.topic.topic.topic.topic.title" use-attribute-sets="base-font common.title">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
         <xsl:attribute name="font-style">italic</xsl:attribute>
         <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
     </xsl:attribute-set>
@@ -172,15 +172,15 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="body__toplevel" use-attribute-sets="base-font">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="body__secondLevel" use-attribute-sets="base-font">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="body" use-attribute-sets="base-font">
-        <xsl:attribute name="start-indent"><xsl:value-of select="$side-col-width"/></xsl:attribute>
+        <xsl:attribute name="start-indent" select="$side-col-width"/>
     </xsl:attribute-set>
 
     <xsl:attribute-set name="abstract" use-attribute-sets="body">

--- a/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
@@ -330,9 +330,7 @@ list just like regular named attribute sets.
         </xsl:if>
 
         <xsl:for-each select="xsl:attribute">
-            <xsl:attribute name="{@name}">
-                <xsl:value-of select="."/>
-            </xsl:attribute>
+            <xsl:attribute name="{@name}" select="."/>
             <xsl:for-each select="xsl:*">
               <xsl:call-template name="output-message">
                 <xsl:with-param name="id" select="'PDFX009E'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -266,9 +266,7 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:variable>
-            <xsl:attribute name="id">
-              <xsl:value-of select="$new_id"/>
-            </xsl:attribute>
+            <xsl:attribute name="id" select="$new_id"/>
             <xsl:apply-templates>
                 <xsl:with-param name="newid" select="$new_id"/>
             </xsl:apply-templates>
@@ -280,9 +278,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' map/topicref ')][not(@href)]" priority="5">
     <xsl:param name="newid"/>
     <xsl:copy>
-      <xsl:attribute name="id">
-        <xsl:value-of select="generate-id()"/>
-      </xsl:attribute>
+      <xsl:attribute name="id" select="generate-id()"/>
       <xsl:apply-templates select="@*">
         <xsl:with-param name="newid" select="$newid"/>
       </xsl:apply-templates>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging.xsl
@@ -117,29 +117,19 @@ See the accompanying LICENSE file for applicable license.
 
             <xsl:choose>
                <xsl:when test="$attr='color'">
-                  <xsl:attribute name="change-bar-color">
-                     <xsl:value-of select="$val"/>
-                  </xsl:attribute>
+                  <xsl:attribute name="change-bar-color" select="$val"/>
                </xsl:when>
                <xsl:when test="$attr='offset'">
-                  <xsl:attribute name="change-bar-offset">
-                     <xsl:value-of select="$val"/>
-                  </xsl:attribute>
+                  <xsl:attribute name="change-bar-offset" select="$val"/>
                </xsl:when>
                <xsl:when test="$attr='placement'">
-                  <xsl:attribute name="change-bar-placement">
-                     <xsl:value-of select="$val"/>
-                  </xsl:attribute>
+                  <xsl:attribute name="change-bar-placement" select="$val"/>
                </xsl:when>
                <xsl:when test="$attr='style'">
-                  <xsl:attribute name="change-bar-style">
-                     <xsl:value-of select="$val"/>
-                  </xsl:attribute>
+                  <xsl:attribute name="change-bar-style" select="$val"/>
                </xsl:when>
                <xsl:when test="$attr='width'">
-                  <xsl:attribute name="change-bar-width">
-                     <xsl:value-of select="$val"/>
-                  </xsl:attribute>
+                  <xsl:attribute name="change-bar-width" select="$val"/>
                </xsl:when>
             </xsl:choose>
          </xsl:when>
@@ -195,9 +185,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:variable name="attr" select="substring-before($value,':')"/>
             <xsl:variable name="val" select="substring-after($value,':')"/>
             
-            <xsl:attribute name="{$attr}">
-               <xsl:value-of select="$val"/>
-            </xsl:attribute>
+            <xsl:attribute name="{$attr}" select="$val"/>
             
          </xsl:when>
          <xsl:otherwise>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
@@ -109,7 +109,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:copy>
             <xsl:copy-of select="@*[not(name() = 'font-family')]"/>
             <xsl:attribute name="line-height-shift-adjustment">disregard-shifts</xsl:attribute>
-            <xsl:attribute name="font-family"><xsl:value-of select="normalize-space($physical-font-family)"/></xsl:attribute>
+            <xsl:attribute name="font-family" select="normalize-space($physical-font-family)"/>
             <xsl:apply-templates/>
         </xsl:copy>
     </xsl:template>
@@ -195,18 +195,18 @@ See the accompanying LICENSE file for applicable license.
         </xsl:comment>
         </xsl:if>
         <fo:inline line-height="100%">
-            <xsl:attribute name="font-family"><xsl:value-of select="normalize-space($physical-font-family)"/></xsl:attribute>
+            <xsl:attribute name="font-family" select="normalize-space($physical-font-family)"/>
 
             <xsl:if test="$font-style">
-                <xsl:attribute name="font-style"><xsl:value-of select="normalize-space($font-style)"/></xsl:attribute>
+                <xsl:attribute name="font-style" select="normalize-space($font-style)"/>
             </xsl:if>
 
             <xsl:if test="$baseline-shift">
-                <xsl:attribute name="baseline-shift"><xsl:value-of select="normalize-space($baseline-shift)"/></xsl:attribute>
+                <xsl:attribute name="baseline-shift" select="normalize-space($baseline-shift)"/>
             </xsl:if>
 
             <xsl:if test="$override-size">
-                <xsl:attribute name="font-size"><xsl:value-of select="normalize-space($override-size)"/></xsl:attribute>
+                <xsl:attribute name="font-size" select="normalize-space($override-size)"/>
             </xsl:if>
 
             <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -586,21 +586,15 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:attribute>
             </xsl:when>
           <xsl:when test="$scope = 'peer'">
-            <xsl:attribute name="internal-destination">
-              <xsl:value-of select="$href"/>
-            </xsl:attribute>
+            <xsl:attribute name="internal-destination" select="$href"/>
           </xsl:when>
           <xsl:when test="contains($href, '#')">
-            <xsl:attribute name="internal-destination">
-              <xsl:value-of select="opentopic-func:getDestinationId($href)"/>
-            </xsl:attribute>
+            <xsl:attribute name="internal-destination" select="opentopic-func:getDestinationId($href)"/>
           </xsl:when>         
             <xsl:otherwise>
               <!-- Appears that topicmerge updates links so that this section will never be triggered; 
                    keeping $href as backup value in case something goes wrong. -->
-              <xsl:attribute name="internal-destination">
-                <xsl:value-of select="$href"/>
-              </xsl:attribute>
+              <xsl:attribute name="internal-destination" select="$href"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -607,14 +607,10 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template name="applySpansAttrs">
         <xsl:if test="exists(@morerows) and xs:integer(@morerows) gt 0">
-            <xsl:attribute name="number-rows-spanned">
-              <xsl:value-of select="xs:integer(@morerows) + 1"/>
-            </xsl:attribute>
+            <xsl:attribute name="number-rows-spanned" select="xs:integer(@morerows) + 1"/>
         </xsl:if>
       <xsl:if test="exists(@dita-ot:morecols) and xs:integer(@dita-ot:morecols) gt 0">
-        <xsl:attribute name="number-columns-spanned">
-        <xsl:value-of select="xs:integer(@dita-ot:morecols) + 1"/>
-        </xsl:attribute>
+        <xsl:attribute name="number-columns-spanned" select="xs:integer(@dita-ot:morecols) + 1"/>
       </xsl:if>
     </xsl:template>
 
@@ -648,9 +644,7 @@ See the accompanying LICENSE file for applicable license.
 
         <xsl:choose>
             <xsl:when test="not(normalize-space($align) = '')">
-                <xsl:attribute name="text-align">
-                    <xsl:value-of select="$align"/>
-                </xsl:attribute>
+                <xsl:attribute name="text-align" select="$align"/>
             </xsl:when>
             <xsl:when test="(normalize-space($align) = '') and contains(@class, ' topic/colspec ')"/>
             <xsl:otherwise>
@@ -659,19 +653,13 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
         <xsl:choose>
             <xsl:when test="$valign='top'">
-                <xsl:attribute name="display-align">
-                    <xsl:value-of select="'before'"/>
-                </xsl:attribute>
+                <xsl:attribute name="display-align" select="'before'"/>
             </xsl:when>
             <xsl:when test="$valign='middle'">
-                <xsl:attribute name="display-align">
-                    <xsl:value-of select="'center'"/>
-                </xsl:attribute>
+                <xsl:attribute name="display-align" select="'center'"/>
             </xsl:when>
             <xsl:when test="$valign='bottom'">
-                <xsl:attribute name="display-align">
-                    <xsl:value-of select="'after'"/>
-                </xsl:attribute>
+                <xsl:attribute name="display-align" select="'after'"/>
             </xsl:when>
         </xsl:choose>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -1103,9 +1103,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template name="setScale">
         <xsl:if test="@scale">
             <!-- For applications that do not yet take percentages. need to divide by 10 and use "pt" -->
-            <xsl:attribute name="font-size">
-                <xsl:value-of select="concat(@scale, '%')"/>
-            </xsl:attribute>
+            <xsl:attribute name="font-size" select="concat(@scale, '%')"/>
         </xsl:if>
     </xsl:template>
 
@@ -1391,9 +1389,7 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:attribute>
             </xsl:if>
             <xsl:if test="not($width) and not($height) and $scale">
-                <xsl:attribute name="content-width">
-                    <xsl:value-of select="concat($scale,'%')"/>
-                </xsl:attribute>
+                <xsl:attribute name="content-width" select="concat($scale,'%')"/>
             </xsl:if>
           <xsl:if test="@scalefit = 'yes' and not($width) and not($height) and not($scale)">            
             <xsl:attribute name="width">100%</xsl:attribute>
@@ -1554,9 +1550,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- Template to copy original IDs -->
 
     <xsl:template match="@id">
-        <xsl:attribute name="id">
-            <xsl:value-of select="."/>
-        </xsl:attribute>
+        <xsl:attribute name="id" select="."/>
     </xsl:template>
     
     <!-- Templates to reprocess reused content while dropping IDs from reuse context -->

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
@@ -22,12 +22,8 @@ See the accompanying LICENSE file for applicable license.
   <!-- Add both lang and xml:lang attributes -->
   <xsl:template match="@xml:lang" name="generate-lang">
     <xsl:param name="lang" select="."/>
-    <xsl:attribute name="xml:lang">
-      <xsl:value-of select="$lang"/>
-    </xsl:attribute>
-    <xsl:attribute name="lang">
-      <xsl:value-of select="$lang"/>
-    </xsl:attribute>
+    <xsl:attribute name="xml:lang" select="$lang"/>
+    <xsl:attribute name="lang" select="$lang"/>
   </xsl:template>
 
 

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
@@ -57,9 +57,7 @@ See the accompanying LICENSE file for applicable license.
 
   <body>
      <xsl:if test="string-length($OUTPUTCLASS) &gt; 0">
-       <xsl:attribute name="class">
-         <xsl:value-of select="$OUTPUTCLASS"/>
-       </xsl:attribute>
+       <xsl:attribute name="class" select="$OUTPUTCLASS"/>
      </xsl:if>
      <xsl:value-of select="$newline"/>
     <xsl:apply-templates mode="toc"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -2312,9 +2312,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <a>
-          <xsl:attribute name="name" select="concat('fntarg_', $fnid)"/>
-          <xsl:attribute name="href" select="concat('#fnsrc_', $fnid)"/>
+        <a name="fntarg_{$fnid}" href="#fnsrc_{$fnid}">
           <sup>
             <xsl:value-of select="$convergedcallout"/>
           </sup>
@@ -2340,8 +2338,7 @@ See the accompanying LICENSE file for applicable license.
      <li>
 <!-- this directive provides a "depth" indicator without doing recursive nesting -->
 <xsl:value-of select="substring('------', 1, count(ancestor::*))"/>
-     <a>
-       <xsl:attribute name="href" select="concat('#', generate-id())"/>
+     <a href="#{generate-id()}">
        <xsl:value-of select="."/>
      </a>
      <!--recursive call for subtopics here"/-->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -326,7 +326,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
   </xsl:param>
   <xsl:element name="h{$headinglevel}">
-      <xsl:attribute name="class">topictitle<xsl:value-of select="$headinglevel"/></xsl:attribute>
+      <xsl:attribute name="class" select="concat('topictitle', $headinglevel)"/>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class">topictitle<xsl:value-of select="$headinglevel"/></xsl:with-param>
       </xsl:call-template>
@@ -1603,14 +1603,14 @@ See the accompanying LICENSE file for applicable license.
     </xsl:call-template>
   </xsl:variable>
   <xsl:if test="not($height-in-pixel = '100%')">
-    <xsl:attribute name="height">
+    <xsl:attribute name="height" select="number($height-in-pixel)">
       <!--xsl:choose>
         <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
           <xsl:value-of select="number($height-in-pixel) * number(../@scale)"/>
         </xsl:when>
-        <xsl:otherwise-->
+        <xsl:otherwise>
           <xsl:value-of select="number($height-in-pixel)"/>
-        <!--/xsl:otherwise>
+        </xsl:otherwise>
       </xsl:choose-->
     </xsl:attribute>
   </xsl:if>  
@@ -1623,14 +1623,14 @@ See the accompanying LICENSE file for applicable license.
     </xsl:call-template>
   </xsl:variable>
   <xsl:if test="not($width-in-pixel = '100%')">
-    <xsl:attribute name="width">
+    <xsl:attribute name="width" select="number($width-in-pixel)">
       <!--xsl:choose>
         <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
           <xsl:value-of select="number($width-in-pixel) * number(../@scale)"/>
         </xsl:when>
-        <xsl:otherwise-->
+        <xsl:otherwise>
           <xsl:value-of select="number($width-in-pixel)"/>
-        <!--/xsl:otherwise>
+        </xsl:otherwise>
       </xsl:choose-->
     </xsl:attribute>
   </xsl:if>  
@@ -2341,7 +2341,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- this directive provides a "depth" indicator without doing recursive nesting -->
 <xsl:value-of select="substring('------', 1, count(ancestor::*))"/>
      <a>
-       <xsl:attribute name="href">#<xsl:value-of select="generate-id()"/></xsl:attribute>
+       <xsl:attribute name="href" select="concat('#', generate-id())"/>
        <xsl:value-of select="."/>
      </a>
      <!--recursive call for subtopics here"/-->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -447,7 +447,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- section processor - div with no generated title -->
 <xsl:template match="*[contains(@class, ' topic/section ')]" name="topic.section">
-  <section class="section">
+  <section>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="gen-toc-id"/>
     <xsl:call-template name="setidaname"/>
@@ -460,7 +460,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- example processor - div with no generated title -->
 <xsl:template match="*[contains(@class, ' topic/example ')]" name="topic.example">
-  <div class="example">
+  <div>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="gen-toc-id"/>
     <xsl:call-template name="setidaname"/>
@@ -489,8 +489,10 @@ See the accompanying LICENSE file for applicable license.
       If so, use div_class="p" instead of p -->
  <xsl:choose>
    <xsl:when test="descendant::*[dita-ot:is-block(.)]">
-     <div class="p">
-       <xsl:call-template name="commonattributes"/>
+     <div>
+       <xsl:call-template name="commonattributes">
+         <xsl:with-param name="default-output-class" select="'p'"/>
+       </xsl:call-template>
        <xsl:call-template name="setid"/>
        <xsl:apply-templates/>
      </div>
@@ -658,8 +660,10 @@ See the accompanying LICENSE file for applicable license.
 <!-- Caution and Danger both use a div for the title, so they do not
      use the common note processing template. -->
 <xsl:template match="*" mode="process.note.caution">
-  <div class="cautiontitle">
-    <xsl:call-template name="commonattributes"/>
+  <div>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class" select="'cautiontitle'"/>
+    </xsl:call-template>
     <xsl:attribute name="class">cautiontitle</xsl:attribute>
     <xsl:call-template name="setidaname"/>
     <!-- Normal flags go before the generated title; revision flags only go on the content. -->
@@ -671,7 +675,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:with-param name="id" select="'ColonSymbol'"/>
     </xsl:call-template>
   </div>
-  <div class="caution">
+  <div>
     <xsl:call-template name="commonattributes">
       <xsl:with-param name="default-output-class" select="'caution'"/>
     </xsl:call-template>
@@ -682,8 +686,10 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*" mode="process.note.danger">
-  <div class="dangertitle">
-    <xsl:call-template name="commonattributes"/>
+  <div>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class" select="'dangertitle'"/>
+    </xsl:call-template>
     <xsl:attribute name="class">dangertitle</xsl:attribute>
     <xsl:call-template name="setidaname"/>
     <!-- Normal flags go before the generated title; revision flags only go on the content. -->
@@ -692,7 +698,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:with-param name="id" select="'Danger'"/>
     </xsl:call-template>
   </div>
-  <div class="danger">
+  <div>
     <xsl:call-template name="commonattributes">
       <xsl:with-param name="default-output-class" select="'danger'"/>
     </xsl:call-template>
@@ -765,7 +771,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class, ' topic/sl ')]" name="topic.sl">
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="setaname"/>
-  <ul class="simple">
+  <ul>
     <xsl:call-template name="commonattributes">
       <xsl:with-param name="default-output-class" select="'simple'"/>
     </xsl:call-template>
@@ -1045,8 +1051,10 @@ See the accompanying LICENSE file for applicable license.
       </xsl:apply-templates>
     </xsl:when>
     <xsl:otherwise>
-      <span class="keyword">
-        <xsl:call-template name="commonattributes"/>
+      <span>
+        <xsl:call-template name="commonattributes">
+          <xsl:with-param name="default-output-class" select="'keyword'"/>
+        </xsl:call-template>
         <xsl:call-template name="setidaname"/>   
         <xsl:apply-templates/>  
       </span>
@@ -1157,8 +1165,10 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 2.1 -->
   <xsl:param name="displaytext"/>
   
-  <dfn class="term">
-    <xsl:call-template name="commonattributes"/>
+  <dfn>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class" select="'term'"/>
+    </xsl:call-template>
     <xsl:call-template name="setidaname"/>
     <xsl:choose>
       <xsl:when test="normalize-space($displaytext)">
@@ -1403,7 +1413,6 @@ See the accompanying LICENSE file for applicable license.
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="spec-title-nospace"/>
   <pre>
-    <xsl:attribute name="class" select="name()"/>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setscale"/>
     <xsl:call-template name="setidaname"/>
@@ -1603,16 +1612,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:call-template>
   </xsl:variable>
   <xsl:if test="not($height-in-pixel = '100%')">
-    <xsl:attribute name="height" select="number($height-in-pixel)">
-      <!--xsl:choose>
-        <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
-          <xsl:value-of select="number($height-in-pixel) * number(../@scale)"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="number($height-in-pixel)"/>
-        </xsl:otherwise>
-      </xsl:choose-->
-    </xsl:attribute>
+    <xsl:attribute name="height" select="number($height-in-pixel)"/>
   </xsl:if>  
 </xsl:template>
 
@@ -1623,16 +1623,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:call-template>
   </xsl:variable>
   <xsl:if test="not($width-in-pixel = '100%')">
-    <xsl:attribute name="width" select="number($width-in-pixel)">
-      <!--xsl:choose>
-        <xsl:when test="../@scale and string(number(../@scale))!='NaN'">          
-          <xsl:value-of select="number($width-in-pixel) * number(../@scale)"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="number($width-in-pixel)"/>
-        </xsl:otherwise>
-      </xsl:choose-->
-    </xsl:attribute>
+    <xsl:attribute name="width" select="number($width-in-pixel)"/>
   </xsl:if>  
 </xsl:template>
 
@@ -2283,7 +2274,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Catch footnotes that should appear at the end of the topic, and output them. -->
 <xsl:template match="*[contains(@class, ' topic/fn ')]" mode="genEndnote">
-  <div class="p">
+  <div>
     <xsl:variable name="fnid"><xsl:number from="/" level="any"/></xsl:variable>
     <xsl:variable name="callout" select="@callout"/>
     <xsl:variable name="convergedcallout" select="if (string-length($callout) > 0) then $callout else $fnid"/>
@@ -2410,8 +2401,10 @@ See the accompanying LICENSE file for applicable license.
        </xsl:if>
       </span>
       <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-       <span class="figdesc">
-         <xsl:call-template name="commonattributes"/>
+       <span>
+         <xsl:call-template name="commonattributes">
+           <xsl:with-param name="default-output-class" select="'figdesc'"/>
+         </xsl:call-template>
          <xsl:apply-templates select="." mode="figdesc"/>
        </span>
       </xsl:for-each>
@@ -2419,8 +2412,10 @@ See the accompanying LICENSE file for applicable license.
     <!-- desc -->
     <xsl:when test="*[contains(@class, ' topic/desc ')]">
       <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-       <span class="figdesc">
-         <xsl:call-template name="commonattributes"/>
+       <span>
+         <xsl:call-template name="commonattributes">
+           <xsl:with-param name="default-output-class" select="'figdesc'"/>
+         </xsl:call-template>
          <xsl:apply-templates select="." mode="figdesc"/>
        </span>
       </xsl:for-each>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
@@ -172,7 +172,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="DC.title">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($titlemeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($titlemeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -183,11 +183,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="abstract">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($shortmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($shortmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
   <meta name="description">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($shortmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($shortmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -201,11 +201,11 @@ See the accompanying LICENSE file for applicable license.
   </xsl:variable>
   <xsl:if test="normalize-space($shortmeta)!=''">
     <meta name="abstract">
-      <xsl:attribute name="content"><xsl:value-of select="normalize-space($shortmeta)"/></xsl:attribute>
+      <xsl:attribute name="content" select="normalize-space($shortmeta)"/>
     </meta>
     <xsl:value-of select="$newline"/>
     <meta name="description">
-      <xsl:attribute name="content"><xsl:value-of select="normalize-space($shortmeta)"/></xsl:attribute>
+      <xsl:attribute name="content" select="normalize-space($shortmeta)"/>
     </meta>
     <xsl:value-of select="$newline"/>
   </xsl:if>
@@ -264,7 +264,7 @@ See the accompanying LICENSE file for applicable license.
      </xsl:choose>
     </xsl:variable>
     <meta name="DC.relation" scheme="URI">
-      <xsl:attribute name="content"><xsl:value-of select="$linkmeta_ext"/></xsl:attribute>
+      <xsl:attribute name="content" select="$linkmeta_ext"/>
     </meta>
     <xsl:value-of select="$newline"/>
   </xsl:otherwise>
@@ -403,7 +403,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="prodname">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($prodnamemeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($prodnamemeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -426,7 +426,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="brand">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($brandmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($brandmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -436,7 +436,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="component">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($componentmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($componentmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -446,7 +446,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="featnum">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($featnummeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($featnummeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -456,7 +456,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="prognum">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($prognummeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($prognummeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -466,7 +466,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="platform">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($platformmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($platformmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>
@@ -476,7 +476,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*|text()" mode="text-only"/>
   </xsl:variable>
   <meta name="series">
-    <xsl:attribute name="content"><xsl:value-of select="normalize-space($seriesmeta)"/></xsl:attribute>
+    <xsl:attribute name="content" select="normalize-space($seriesmeta)"/>
   </meta>
   <xsl:value-of select="$newline"/>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
@@ -18,7 +18,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->
-    <xsl:attribute name="style"><xsl:value-of select="."/></xsl:attribute>
+    <xsl:attribute name="style" select="."/>
   </xsl:template>
 
   <!-- By default, process flags where encountered: at the start and end of the element content. -->
@@ -105,9 +105,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:choose>
   </xsl:template>
   <xsl:template match="alt-text" mode="ditaval-outputflag">
-    <xsl:attribute name="alt">
-      <xsl:value-of select="."/>
-    </xsl:attribute>
+    <xsl:attribute name="alt" select="."/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
@@ -41,18 +41,17 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/kwd ')]" name="topic.pr-d.kwd">
- <span class="kwd">
-  <xsl:if test="(@importance='default')">
-   <xsl:attribute name="class">defkwd</xsl:attribute>
-  </xsl:if>
-  <xsl:call-template name="commonattributes"/>
+ <span>
+  <xsl:call-template name="commonattributes">
+   <xsl:with-param name="default-output-class" select="if (@importance = 'default') then 'defkwd' else 'kwd'"/>
+  </xsl:call-template>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
  </span>
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/var ')]" name="topic.pr-d.var">
- <span class="var">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -60,7 +59,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/synph ')]" name="topic.pr-d.synph">
- <span class="synph">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -68,7 +67,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/oper ')]" name="topic.pr-d.oper">
- <span class="oper">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -76,7 +75,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/delim ')]" name="topic.pr-d.delim">
- <span class="delim">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -84,7 +83,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/sep ')]" name="topic.pr-d.sep">
- <span class="sep">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -92,7 +91,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/repsep ')]" name="topic.pr-d.repsep">
- <span class="repsep">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -100,7 +99,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/option ')]" name="topic.pr-d.option">
- <span class="option">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -108,7 +107,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/parmname ')]" name="topic.pr-d.parmname">
- <span class="parmname">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -116,7 +115,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/apiname ')]" name="topic.pr-d.apiname">
- <span class="apiname">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
@@ -141,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
                <xsl:call-template name="th-align"/>
              </xsl:with-param>
            </xsl:call-template>           
-           <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-type</xsl:attribute>
+           <xsl:attribute name="id" select="concat(generate-id(parent::*), '-type')"/>
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Type'"/>
            </xsl:call-template>
@@ -160,7 +160,7 @@ See the accompanying LICENSE file for applicable license.
                <xsl:call-template name="th-align"/>
              </xsl:with-param>
            </xsl:call-template>
-           <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-value</xsl:attribute>
+           <xsl:attribute name="id" select="concat(generate-id(parent::*), '-value')"/>
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Value'"/>
            </xsl:call-template>
@@ -182,7 +182,7 @@ See the accompanying LICENSE file for applicable license.
                <xsl:call-template name="th-align"/>
              </xsl:with-param>
            </xsl:call-template>           
-           <xsl:attribute name="id"><xsl:value-of select="generate-id(parent::*)"/>-desc</xsl:attribute>
+           <xsl:attribute name="id" select="concat(generate-id(parent::*), '-desc')"/>
            <xsl:call-template name="getVariable">
              <xsl:with-param name="id" select="'Description'"/>
            </xsl:call-template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -448,7 +448,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--basic child processing-->
   <xsl:template match="*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="2" name="topic.link_child">
-    <li class="ulchildlink">
+    <li>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'ulchildlink'"/>
       </xsl:call-template>
@@ -486,7 +486,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
 
   <!--ordered child processing-->
   <xsl:template match="*[@collection-type = 'sequence']/*[contains(@class, ' topic/link ')][@role = ('child', 'descendant')]" priority="3" name="topic.link_orderedchild">
-    <li class="olchildlink">
+    <li>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class" select="'olchildlink'"/>
       </xsl:call-template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- software-domain.ent domain: filepath | msgph | userinput | systemoutput | cmdname | msgnum | varname -->
 
 <xsl:template match="*[contains(@class,' sw-d/filepath ')]" name="topic.sw-d.filepath">
- <span class="filepath">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/msgph ')]" name="topic.sw-d.msgph">
- <samp class="msgph">
+ <samp>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -29,7 +29,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/userinput ')]" name="topic.sw-d.userinput">
- <kbd class="userinput">
+ <kbd>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -37,15 +37,17 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/systemoutput ')]" name="topic.sw-d.systemoutput">
- <samp class="sysout">
-  <xsl:call-template name="commonattributes"/>
+ <samp>
+  <xsl:call-template name="commonattributes">
+   <xsl:with-param name="default-output-class" select="'sysout'"/>
+  </xsl:call-template>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
  </samp>
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/cmdname ')]" name="topic.sw-d.cmdname">
- <span class="cmdname">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -53,7 +55,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/msgnum ')]" name="topic.sw-d.msgnum">
- <span class="msgnum">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -61,7 +63,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/varname ')]" name="topic.sw-d.varname">
- <var class="varname">
+ <var>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
   <div>
-  <a><xsl:attribute name="name"><xsl:value-of select="*[contains(@class,' topic/title ')]"/></xsl:attribute> </a>
+  <a><xsl:attribute name="name" select="*[contains(@class,' topic/title ')]"/> </a>
   <xsl:apply-templates mode="process-syntaxdiagram"/>
   </div>
 </xsl:template>
@@ -56,7 +56,7 @@ See the accompanying LICENSE file for applicable license.
 and if so, produce an associative link. -->
 <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="process-syntaxdiagram">
   <kbd>
-      <a><xsl:attribute name="href">#<xsl:value-of select="."/></xsl:attribute>
+      <a><xsl:attribute name="href" select="concat('#', .)"/>
   &lt;<xsl:value-of select="."/>&gt;</a>
   </kbd>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
   <div>
-  <a><xsl:attribute name="name" select="*[contains(@class,' topic/title ')]"/> </a>
+  <a name="{*[contains(@class,' topic/title ')]}"> </a>
   <xsl:apply-templates mode="process-syntaxdiagram"/>
   </div>
 </xsl:template>
@@ -56,7 +56,7 @@ See the accompanying LICENSE file for applicable license.
 and if so, produce an associative link. -->
 <xsl:template match="*[contains(@class,' pr-d/fragref ')]" mode="process-syntaxdiagram">
   <kbd>
-      <a><xsl:attribute name="href" select="concat('#', .)"/>
+      <a href="#{.}">
   &lt;<xsl:value-of select="."/>&gt;</a>
   </kbd>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]" priority="2">
   <div>
-  <a><xsl:attribute name="name" select="title"/> </a>
+  <a name="{title}"> </a>
   <xsl:apply-templates/>
   </div>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]" priority="2">
   <div>
-  <a><xsl:attribute name="name"><xsl:value-of select="title"/></xsl:attribute> </a>
+  <a><xsl:attribute name="name" select="title"/> </a>
   <xsl:apply-templates/>
   </div>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -833,11 +833,7 @@ See the accompanying LICENSE file for applicable license.
 
       <!-- If there is a keycol header or an sthead header, create the attribute -->
       <xsl:if test="string-length($header) > 0 or string-length($keycolhead) > 0">
-          <xsl:attribute name="headers">
-              <xsl:value-of select="$header"/>
-              <xsl:if test="string-length($header) > 0 and string-length($keycolhead) > 0"><xsl:text> </xsl:text></xsl:if>
-              <xsl:value-of select="$keycolhead"/>
-          </xsl:attribute>
+        <xsl:attribute name="headers" select="($header[normalize-space(.)], $keycolhead[normalize-space(.)])" separator=" "/>
       </xsl:if>
   </xsl:if>
 </xsl:template>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -997,8 +997,10 @@ See the accompanying LICENSE file for applicable license.
           </xsl:if>
         </span>
         <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-          <span class="tabledesc">
-            <xsl:call-template name="commonattributes"/>
+          <span>
+            <xsl:call-template name="commonattributes">
+              <xsl:with-param name="default-output-class" select="'tabledesc'"/>
+            </xsl:call-template>
             <xsl:apply-templates select="." mode="tabledesc"/>
           </span>
         </xsl:for-each>
@@ -1007,8 +1009,10 @@ See the accompanying LICENSE file for applicable license.
     <!-- desc -->
     <xsl:when test="*[contains(@class, ' topic/desc ')]">
       <xsl:for-each select="*[contains(@class, ' topic/desc ')]">
-        <span class="tabledesc">
-          <xsl:call-template name="commonattributes"/>
+        <span>
+          <xsl:call-template name="commonattributes">
+            <xsl:with-param name="default-output-class" select="'tabledesc'"/>
+          </xsl:call-template>
           <xsl:apply-templates select="." mode="tabledesc"/>
         </span>
       </xsl:for-each>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -49,8 +49,10 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class,' task/prereq ')]" mode="get-output-class">p</xsl:template>
 <xsl:template match="*[contains(@class,' task/prereq ')]" name="topic.task.prereq">
-<div class="p">
-  <xsl:call-template name="commonattributes"/>
+<div>
+  <xsl:call-template name="commonattributes">
+    <xsl:with-param name="default-output-class" select="'p'"/>
+  </xsl:call-template>
   <xsl:call-template name="gen-toc-id"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
@@ -239,7 +241,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- only 1 step - output as a para -->
 <xsl:template match="*[contains(@class,' task/step ')]" mode="onestep">
   <xsl:param name="step_expand"/>
-  <div class="p">
+  <div>
     <xsl:call-template name="commonattributes">
       <xsl:with-param name="default-output-class" select="'p'"/>
     </xsl:call-template>
@@ -375,8 +377,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>
     <xsl:value-of select="$newline"/>
-    <table border="1" frame="hsides" rules="rows" cellpadding="4" cellspacing="0" summary="" class="choicetableborder">
-      <xsl:call-template name="commonattributes"/>
+    <table border="1" frame="hsides" rules="rows" cellpadding="4" cellspacing="0" summary="">
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class" select="'choicetableborder'"/>
+      </xsl:call-template>
       <xsl:apply-templates select="." mode="generate-table-summary-attribute"/>
       <xsl:call-template name="setid"/>
       <xsl:value-of select="$newline"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -192,7 +192,7 @@ See the accompanying LICENSE file for applicable license.
                  It is possible (preferable) to keep stepsection within an <li> and use CSS to
                  fix numbering, but with testing in March of 2009, this does not work in IE. 
                  It is possible in Firefox 3. -->
-            <xsl:attribute name="start"><xsl:value-of select="count(preceding-sibling::*[contains(@class,' task/step ')])+1"/></xsl:attribute>
+            <xsl:attribute name="start" select="count(preceding-sibling::*[contains(@class,' task/step ')])+1"/>
           </xsl:if>
           <xsl:apply-templates select="." mode="steps">
             <xsl:with-param name="step_expand" select="$step_expand"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ui-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ui-d.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class,' ui-d/screen ')]" name="topic.ui-d.screen">
   <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="spec-title-nospace"/>
-  <pre class="screen">
+  <pre>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setscale"/>
     <xsl:call-template name="setidaname"/>
@@ -45,7 +45,7 @@ See the accompanying LICENSE file for applicable license.
     </abbr>
   </xsl:if>
 </xsl:if>
- <span class="uicontrol">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -53,7 +53,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' ui-d/wintitle ')]" name="topic.ui-d.wintitle">
- <span class="wintitle">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -61,7 +61,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' ui-d/menucascade ')]" name="topic.ui-d.menucascade">
- <span class="menucascade">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>
@@ -71,7 +71,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class,' ui-d/menucascade ')]/text()"/>
 
 <xsl:template match="*[contains(@class,' ui-d/shortcut ')]" name="topic.ui-d.shortcut">
- <span class="shortcut">
+ <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
   <xsl:apply-templates/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
@@ -53,8 +53,8 @@ See the accompanying LICENSE file for applicable license.
           <xsl:choose>
             <xsl:when test="*[contains(@class, ' topic/xref ')]">
               <xsl:variable name="alttext"><xsl:apply-templates select="*[contains(@class, ' topic/xref ')]/node()[not(contains(@class, ' topic/desc '))]" mode="text-only"/></xsl:variable>
-              <xsl:attribute name="alt"><xsl:value-of select="normalize-space($alttext)"/></xsl:attribute>
-              <xsl:attribute name="title"><xsl:value-of select="normalize-space($alttext)"/></xsl:attribute>
+              <xsl:attribute name="alt" select="normalize-space($alttext)"/>
+              <xsl:attribute name="title" select="normalize-space($alttext)"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="." mode="ditamsg:area-element-without-linktext"/>
@@ -63,9 +63,7 @@ See the accompanying LICENSE file for applicable license.
 
           <!-- if not valid shape (blank, rect, circle, poly); Warning, pass thru the value -->
           <xsl:variable name="shapeval"><xsl:value-of select="*[contains(@class,' ut-d/shape ')]"/></xsl:variable>
-          <xsl:attribute name="shape">
-            <xsl:value-of select="$shapeval"/>
-          </xsl:attribute>
+          <xsl:attribute name="shape" select="$shapeval"/>
           <xsl:variable name="shapetest" select="concat('-',$shapeval,'-')" as="xs:string"/>
           <xsl:choose>
             <xsl:when test="contains('--rect-circle-poly-default-',$shapetest)"/>
@@ -80,9 +78,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:variable name="coordval"><xsl:value-of select="*[contains(@class,' ut-d/coords ')]"/></xsl:variable>
           <xsl:choose>
             <xsl:when test="string-length($coordval)>0 and not($shapeval='default')">
-              <xsl:attribute name="coords">
-                <xsl:value-of select="$coordval"/>
-              </xsl:attribute>
+              <xsl:attribute name="coords" select="$coordval"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="." mode="ditamsg:area-element-missing-coords"/>
@@ -121,7 +117,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:attribute name="alt"><xsl:apply-templates select="*[contains(@class,' topic/alt ')]" mode="text-only"/></xsl:attribute>
     </xsl:when>
     <xsl:when test="@alt">
-      <xsl:attribute name="alt"><xsl:value-of select="@alt"/></xsl:attribute>
+      <xsl:attribute name="alt" select="@alt"/>
     </xsl:when>
   </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
## Description
In XSLT stylesheets, refactor `<xsl:value-of select="…">` inside `<xsl:attribute>` into `<xsl:attribute select="…"/>`. Use `commonattributes` to generate `@class` attributes in HTML5 and XHTML output.

## Motivation and Context
The `<xsl:value-of>` inside `<xsl:attribute>` is XSLT 1.0 style. We now have XSLT 2.0 and moving to XSLT 3.0, the coding conventions should also evolve.

## How Has This Been Tested?
Existing tests pass.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
None needed.
## Checklist

