### PR TITLE
Retain same file links in copy-to

### DIFF
--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -240,11 +240,13 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
                 throws SAXException {
             Attributes resAtts = atts;
             if ((TOPIC_XREF.matches(atts) || TOPIC_LINK.matches(atts) || TOPIC_IMAGE.matches(atts))
-                    && !Objects.equals(ATTR_SCOPE_VALUE_EXTERNAL, atts.getValue(ATTRIBUTE_NAME_SCOPE))
-                    && atts.getValue(ATTRIBUTE_NAME_HREF) != null) {
-                resAtts = new XMLUtils.AttributesBuilder(atts)
-                        .add(ATTRIBUTE_NAME_HREF, updateHref(atts.getValue(ATTRIBUTE_NAME_HREF)))
-                        .build();
+                    && !Objects.equals(ATTR_SCOPE_VALUE_EXTERNAL, atts.getValue(ATTRIBUTE_NAME_SCOPE))) {
+                final String value = atts.getValue(ATTRIBUTE_NAME_HREF);
+                if (value != null && !value.startsWith("#")) {
+                    resAtts = new XMLUtils.AttributesBuilder(atts)
+                            .add(ATTRIBUTE_NAME_HREF, updateHref(value))
+                            .build();
+                }
             }
             getContentHandler().startElement(uri, localName, qName, resAtts);
         }

--- a/src/test/resources/copyto/exp/preprocess/newtest2.dita
+++ b/src/test/resources/copyto/exp/preprocess/newtest2.dita
@@ -19,7 +19,7 @@
         <linktext class="- topic/linktext "><?ditaot gentext?>test 2</linktext>
       </link>
     </linkpool>
-    <link href="test2.dita#test2/content2" class="- topic/link " type="p">
+    <link href="#test2/content2" class="- topic/link " type="p">
       <?ditaot gentext?>
       <linktext class="- topic/linktext "/>
     </link>

--- a/src/test/resources/copyto/exp/preprocess/newtest2.dita
+++ b/src/test/resources/copyto/exp/preprocess/newtest2.dita
@@ -19,5 +19,9 @@
         <linktext class="- topic/linktext "><?ditaot gentext?>test 2</linktext>
       </link>
     </linkpool>
+    <link href="test2.dita#test2/content2" class="- topic/link " type="p">
+      <?ditaot gentext?>
+      <linktext class="- topic/linktext "/>
+    </link>
   </related-links>
 </topic>

--- a/src/test/resources/copyto/exp/preprocess/test2.dita
+++ b/src/test/resources/copyto/exp/preprocess/test2.dita
@@ -6,4 +6,10 @@
   <body class="- topic/body ">
     <p id="content2" class="- topic/p "> content of test2 </p>
   </body>
+  <related-links class="- topic/related-links ">
+    <link href="#test2/content2" class="- topic/link " type="p">
+      <?ditaot gentext?>
+      <linktext class="- topic/linktext "/>
+    </link>
+  </related-links>
 </topic>

--- a/src/test/resources/copyto/src/test2.dita
+++ b/src/test/resources/copyto/src/test2.dita
@@ -7,4 +7,7 @@
 <body>
 	<p id="content2"> content of test2 </p>
 </body>
+<related-links>
+  <link href="#./content2"/>
+</related-links>
 </topic>


### PR DESCRIPTION
## Description
Change links to same file in copy-to to not generate the file name, but rather keep the fragment-only links.

## Motivation and Context
Fixes #3811

## How Has This Been Tested?
New test for link to same file added.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Change not really visible to end users, but it does change output to use fragment-only links where possible.

