### PR TITLE
Bump OASIS 2.0 grammars to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ def bundled = [
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
         "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
-        "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20211007/org.oasis-open.dita.v2_0.zip",
+        "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20211202/org.oasis-open.dita.v2_0.zip",
         "dita20-techcomm": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20211007/org.oasis-open.dita.techcomm.v2_0.zip",
         "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
         "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",


### PR DESCRIPTION
## Description

Bumps beta DITA 2.0 grammars to latest, picking up changes from the last month.

Minor update in base grammar, no changes to tech-comm package since last bump.
