### PR TITLE
Fix link handling in conreffed content

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -547,7 +547,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="conref-topicid" as="xs:string">
       <xsl:choose>
         <xsl:when test="empty($topicid)">
-          <xsl:value-of select="//*[contains(@class, ' topic/topic ')][1]/@id"/>
+          <xsl:value-of select="/descendant-or-self::*[contains(@class, ' topic/topic ')][1]/@id"/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="$topicid"/>
@@ -559,10 +559,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="conref-gen-id" as="xs:string">
       <xsl:choose>
         <xsl:when test="empty($elemid) or $elemid = $href-elemid">
-          <xsl:value-of select="generate-id(key('id', $conref-topicid)[contains(@class, ' topic/topic ')]//*[@id = $href-elemid])"/>
+          <xsl:value-of select="generate-id((key('id', $conref-topicid)[contains(@class, ' topic/topic ')]//*[@id = $href-elemid])[1])"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="generate-id(key('id', $conref-topicid)[contains(@class, ' topic/topic ')]//*[@id = $elemid]//*[@id = $href-elemid])"/>
+          <xsl:value-of select="generate-id((key('id', $conref-topicid)[contains(@class, ' topic/topic ')]//*[@id = $elemid]//*[@id = $href-elemid])[1])"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>

--- a/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxref.dita
+++ b/src/test/resources/conrefbreaksxref/exp/preprocess/conrefbreaksxref.dita
@@ -3,20 +3,20 @@
 <shortdesc class="- topic/shortdesc ">This topic conrefs to another, which uses xref internally.</shortdesc>
 <body class="- topic/body ">
 <section class="- topic/section "><title class="- topic/title ">Section that is pulled to another topic.</title><p class="- topic/p ">Look
-as the figure in this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/fig" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
-at a figure in this topic, outside of this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/out" type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Now
+as the figure in this section: <xref class="- topic/xref " href="#conrefbreaksxref/d7e48" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
+at a figure in this topic, outside of this section: <xref class="- topic/xref " href="#conrefbreaksxref/d7e56"/></p><p class="- topic/p ">Now
 look at this topic: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target" type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p>
 <p class="- topic/p ">Now look at "current topic" with #. syntax: <xref class="- topic/xref " href="#conrefbreaksxref" type="topic"><?ditaot gentext?>conrefbreaksxref source<?ditaot genshortdesc?><desc class="- topic/desc ">This topic conrefs to another, which uses xref internally.</desc></xref></p>
 <p class="- topic/p ">Now look at "fig in current topic" with #./fig syntax: <xref
 class="- topic/xref " href="#conrefbreaksxref/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Now
 look at the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#sub" type="topic"><?ditaot gentext?>Sub-topic in the reusable file</xref>.</p><p class="- topic/p ">Now look at a figure
-in the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#sub/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><fig class="- topic/fig " id="d7e40"><title class="- topic/title ">Figure In My Section</title>
+in the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#sub/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><fig class="- topic/fig " id="d7e48"><title class="- topic/title ">Figure In My Section</title>
 <p class="- topic/p ">This is a figure here.</p>
 </fig></section>
 <section class="- topic/section "><title class="- topic/title ">Topic in the subdir</title><p class="- topic/p ">Look at the figure
-in this section: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir/subfig" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look at the figure
-in this topic, outside the section: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir/outfig" type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Look
-at this topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir" type="topic"><?ditaot gentext?>conrefbreaksxref: target in the subdir<?ditaot genshortdesc?><desc class="- topic/desc ">Pull in a section, from a topic in the subdir.</desc></xref></p><p class="- topic/p ">Look at a figure in a sub-topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig/nestfig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Look at the subtopic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig" type="topic"><?ditaot gentext?>Subdir Subfig</xref></p><fig class="- topic/fig " id="d8e39"><title class="- topic/title ">This iz me fig</title>
+in this section: <xref class="- topic/xref " href="#conrefbreaksxref/d8e39" type="fig"><?ditaot gentext?>Figure 2</xref>.</p><p class="- topic/p ">Look at the figure
+in this topic, outside the section: <xref class="- topic/xref " href="#conrefbreaksxref/d8e50"/></p><p class="- topic/p ">Look
+at this topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir" type="topic"><?ditaot gentext?>conrefbreaksxref: target in the subdir<?ditaot genshortdesc?><desc class="- topic/desc ">Pull in a section, from a topic in the subdir.</desc></xref></p><p class="- topic/p ">Look at a figure in a sub-topic: <xref class="- topic/xref " href="#conrefbreaksxref/d8e69"/></p><p class="- topic/p ">Look at the subtopic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig" type="topic"><?ditaot gentext?>Subdir Subfig</xref></p><fig class="- topic/fig " id="d8e39"><title class="- topic/title ">This iz me fig</title>
 <p class="- topic/p ">here's a figure. Go figure.</p>
 </fig></section>
 <fig class="- topic/fig " id="fig">

--- a/src/test/resources/conrefbreaksxref/exp/preprocess2/conrefbreaksxref.dita
+++ b/src/test/resources/conrefbreaksxref/exp/preprocess2/conrefbreaksxref.dita
@@ -3,8 +3,8 @@
 <shortdesc class="- topic/shortdesc ">This topic conrefs to another, which uses xref internally.</shortdesc>
 <body class="- topic/body ">
 <section class="- topic/section "><title class="- topic/title ">Section that is pulled to another topic.</title><p class="- topic/p ">Look
-as the figure in this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/fig" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
-at a figure in this topic, outside of this section: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target/out" type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Now
+as the figure in this section: <xref class="- topic/xref " href="#conrefbreaksxref/d7e48" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look
+at a figure in this topic, outside of this section: <xref class="- topic/xref " href="#conrefbreaksxref/d7e56"/></p><p class="- topic/p ">Now
 look at this topic: <xref class="- topic/xref " href="conrefbreaksxreftarget.dita#this-target" type="topic"><?ditaot gentext?>conrefbreaksxref target<?ditaot genshortdesc?><desc class="- topic/desc ">This topic is referenced by another, and has some internal linking.</desc></xref></p>
 <p class="- topic/p ">Now look at "current topic" with #. syntax: <xref class="- topic/xref " href="#conrefbreaksxref" type="topic"><?ditaot gentext?>conrefbreaksxref source<?ditaot genshortdesc?><desc class="- topic/desc ">This topic conrefs to another, which uses xref internally.</desc></xref></p>
 <p class="- topic/p ">Now look at "fig in current topic" with #./fig syntax: <xref class="- topic/xref " href="#conrefbreaksxref/fig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Now
@@ -13,9 +13,9 @@ in the topic below: <xref class="- topic/xref " href="conrefbreaksxreftarget.dit
 <p class="- topic/p ">This is a figure here.</p>
 </fig></section>
 <section class="- topic/section "><title class="- topic/title ">Topic in the subdir</title><p class="- topic/p ">Look at the figure
-in this section: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir/subfig" type="fig"><?ditaot gentext?>Figure 1</xref>.</p><p class="- topic/p ">Look at the figure
-in this topic, outside the section: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir/outfig" type="fig"><?ditaot gentext?>Figure 2</xref></p><p class="- topic/p ">Look
-at this topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir" type="topic"><?ditaot gentext?>conrefbreaksxref: target in the subdir<?ditaot genshortdesc?><desc class="- topic/desc ">Pull in a section, from a topic in the subdir.</desc></xref></p><p class="- topic/p ">Look at a figure in a sub-topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig/nestfig" type="fig"><?ditaot gentext?>Figure 3</xref></p><p class="- topic/p ">Look at the subtopic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig" type="topic"><?ditaot gentext?>Subdir Subfig</xref></p><fig class="- topic/fig " id="d8e39"><title class="- topic/title ">This iz me fig</title>
+in this section: <xref class="- topic/xref " href="#conrefbreaksxref/d8e39" type="fig"><?ditaot gentext?>Figure 2</xref>.</p><p class="- topic/p ">Look at the figure
+in this topic, outside the section: <xref class="- topic/xref " href="#conrefbreaksxref/d8e50"/></p><p class="- topic/p ">Look
+at this topic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdir" type="topic"><?ditaot gentext?>conrefbreaksxref: target in the subdir<?ditaot genshortdesc?><desc class="- topic/desc ">Pull in a section, from a topic in the subdir.</desc></xref></p><p class="- topic/p ">Look at a figure in a sub-topic: <xref class="- topic/xref " href="#conrefbreaksxref/d8e69"/></p><p class="- topic/p ">Look at the subtopic: <xref class="- topic/xref " href="subdir/conrefbreaksxrefsubdir.dita#subdirsubfig" type="topic"><?ditaot gentext?>Subdir Subfig</xref></p><fig class="- topic/fig " id="d8e39"><title class="- topic/title ">This iz me fig</title>
 <p class="- topic/p ">here's a figure. Go figure.</p>
 </fig></section>
 <fig class="- topic/fig " id="fig">


### PR DESCRIPTION
## Description
Link handling in conreffed content has bugs in how target elements are selected. This PR fixes the conref stylesheet query issues.

## Motivation and Context
The `conrefImpl.xsl` was originally written some 17 years ago with XSLT 1.0. When the conref code was moved to XSLT 2.0, the relavant code was not adjusted for the differences between XSLT 1.0 and 2.0. The code also contains a bug in selection of the first topic in a document.

## How Has This Been Tested?
Existing tests pass or have been fixed to expect correct output.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Mention in release notes. Fixes a bug that's been in the codebase for 17 year. Seventeen years.


