### PR TITLE
Update to latest DITA 1.3 hotfix

### DIFF
--- a/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/dtd/tblDecl.mod
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/dtd/base/dtd/tblDecl.mod
@@ -222,9 +222,14 @@
                           NMTOKENS
                                     #IMPLIED"
 >
+<!-- Include colspec/@outputclass fix for DITA 1.3:
+     https://lists.oasis-open.org/archives/dita-comment/202112/msg00000.html -->
 <!ENTITY % dita.colspec.attributes
               "%id-atts;
-               %localization-atts;"
+               %localization-atts;
+               outputclass
+                          CDATA
+                                    #IMPLIED"
 >
 <!--                    LONG NAME: Table                           -->
 <!ENTITY % table.content

--- a/src/main/plugins/org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/releaseManagementDomain.mod
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/releaseManagementDomain.mod
@@ -59,7 +59,10 @@
                        "(%change-item;)*"
 >
 <!ENTITY % change-historylist.attributes
-              "%changehistory.data.atts;"
+              "%univ-atts;
+               mapkeyref
+                          CDATA
+                                    #IMPLIED"
 >
 <!ELEMENT  change-historylist %change-historylist.content;>
 <!ATTLIST  change-historylist %change-historylist.attributes;>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/rng/base/rng/tblDeclMod.rng
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/rng/base/rng/tblDeclMod.rng
@@ -300,6 +300,11 @@ For <entry>, add:
   <define name="dita.colspec.attributes">
     <ref name="id-atts"/>
     <ref name="localization-atts"/>
+    <!-- Include colspec/@outputclass fix for DITA 1.3:
+      https://lists.oasis-open.org/archives/dita-comment/202112/msg00000.html -->
+    <optional>
+      <attribute name="outputclass"/>
+    </optional>
   </define>
   
   <!--  -->

--- a/src/main/plugins/org.oasis-open.dita.v1_3/rng/technicalContent/rng/releaseManagementDomain.rng
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/rng/technicalContent/rng/releaseManagementDomain.rng
@@ -109,7 +109,10 @@ PUBLIC "-//OASIS//ENTITIES DITA Release Management Domain//EN"
         </zeroOrMore>
       </define>
       <define name="change-historylist.attributes">
-        <ref name="changehistory.data.atts"/>
+        <ref name="univ-atts"/>
+        <optional>
+          <attribute name="mapkeyref"/>
+        </optional>
       </define>
       <define name="change-historylist.element">
         <element name="change-historylist" dita:longName="Change History List"

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclMod.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclMod.xsd
@@ -218,6 +218,9 @@
    <xs:attributeGroup name="dita.colspec.attributes">
       <xs:attributeGroup ref="id-atts"/>
       <xs:attributeGroup ref="localization-atts"/>
+      <!-- Include colspec/@outputclass fix for DITA 1.3:
+           https://lists.oasis-open.org/archives/dita-comment/202112/msg00000.html -->
+      <xs:attribute name="outputclass" type="xs:string"/>
    </xs:attributeGroup>
    <xs:element name="table">
       <xs:annotation>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/releaseManagementDomain.xsd
@@ -133,7 +133,8 @@
       </xs:sequence>
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
-      <xs:attributeGroup ref="changehistory.data.atts"/>
+      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>
    <xs:element name="change-item">

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema/base/xsd/tblDeclMod.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema/base/xsd/tblDeclMod.xsd
@@ -218,6 +218,9 @@
    <xs:attributeGroup name="dita.colspec.attributes">
       <xs:attributeGroup ref="id-atts"/>
       <xs:attributeGroup ref="localization-atts"/>
+      <!-- Include colspec/@outputclass fix for DITA 1.3:
+           https://lists.oasis-open.org/archives/dita-comment/202112/msg00000.html -->
+      <xs:attribute name="outputclass" type="xs:string"/>
    </xs:attributeGroup>
    <xs:element name="table">
       <xs:annotation>

--- a/src/main/plugins/org.oasis-open.dita.v1_3/schema/technicalContent/xsd/releaseManagementDomain.xsd
+++ b/src/main/plugins/org.oasis-open.dita.v1_3/schema/technicalContent/xsd/releaseManagementDomain.xsd
@@ -133,7 +133,8 @@
       </xs:sequence>
    </xs:group>
    <xs:attributeGroup name="change-historylist.attributes">
-      <xs:attributeGroup ref="changehistory.data.atts"/>
+      <xs:attributeGroup ref="univ-atts"/>
+      <xs:attribute name="mapkeyref" type="xs:string"/>
       <xs:attributeGroup ref="global-atts"/>
    </xs:attributeGroup>
    <xs:element name="change-item">


### PR DESCRIPTION
## Description

DITA 1.3 doesn't have a new errata but has had a couple of fixes to the released grammar, maintained in a hotfix/errata3 branch at OASIS. We should update to use those fixes. Includes:

2019 fix to release management domain attribute list: https://github.com/oasis-tcs/dita/commit/38893d11c6e7676cbb68fecfbfec34dde65add1c

Fix from this month for missing attribute on colspec: https://github.com/oasis-tcs/dita/commit/0d868b22617bebd31e32110f0c35e12ccd926f70

Fix today, noticed a syntax error in that 2019 PR: https://github.com/oasis-tcs/dita/pull/578/commits/6c3f6081bfd0680d4e151f2fc8ff39339471dada

## Motivation and Context

Keep up to date with latest 1.3 grammar fixes

## How Has This Been Tested?

Unit / integration tests pass

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

n/a

