### PR TITLE
In PDF2: Select correct abbrev href target.

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
@@ -25,7 +25,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' abbrev-d/abbreviated-form ')]" name="topic.abbreviated-form">
     <xsl:variable name="keys" select="@keyref"/>
-    <xsl:variable name="target" select="key('id', substring(@href, 2))[1]" as="element()?"/>
+    <xsl:variable name="target" select="key('id', substring(@href, 2))[2]" as="element()?"/>
     <xsl:choose>
       <xsl:when test="$keys and $target/self::*[contains(@class,' glossentry/glossentry ')]">
         <xsl:call-template name="topic.term">


### PR DESCRIPTION
## Description
Select glossref instead of topicref as target when evaluating abbreviated-form gloss entries in pdf transformation.

## Motivation and Context
Currently abbreviated-form gloss entriy references raises error DOTX060W as reported in #2773 and #3431. This issue seems to have been introduced in #3210. This PR does not revert the changes from #3210, but rather fixes the indexing so the correct href'd element is selected. 

A more thorough fix discussed in #2773 and #3431 would be to update the pipeline to decorate the elements with separate ids so they can be correctly selected in the xsl transform.

## How Has This Been Tested?
- Tested on internal code base that manifested the issue. 
- Also tested on reproducer examples provided in the issue tickets.
-- The initial example from #2773, abbreviation-test.zip did need to add print="yes" to the glossref in glossary.ditamap
-- Otherwise, all examples built successfully with the patch, and failed with DOTX060W without it.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->
None needed

## Checklist
