### PR TITLE
Remove gen-user-sidetoc deprecation

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2296,7 +2296,6 @@ See the accompanying LICENSE file for applicable license.
   <!-- it will be placed in the running footing section of the XHTML. -->
 </xsl:template>
 
-<!-- Deprecated since 3.7, use "args.xhtml.toc.xsl" or "args.html5.toc.xsl" instead -->
 <xsl:template name="gen-user-sidetoc">
   <xsl:apply-templates select="." mode="gen-user-sidetoc"/>
 </xsl:template>


### PR DESCRIPTION
## Description
Remove gen-user-sidetoc deprecation.

## Motivation and Context
This extension-point has no alternative.
## How Has This Been Tested?
Deprecation comment removal doesn't affect output.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Release notes and migration guide should remove this deprecation.
