### PR TITLE
Fix table/@frame="none" in PDF2

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl.bak
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl.bak
@@ -747,12 +747,8 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- DITA spec prose defines as either 0 or 1, but DTD as NMTOKENS. However, OASIS Table Exchange model uses 0 or anything else. -->
     <xsl:template name="getTableColsep" as="xs:string">
-        <xsl:param name="prmEntry" as="element()" required="no" select="."/>
         <xsl:variable name="colname" select="@colname"/>
         <xsl:choose>
-            <xsl:when test="dita-ot:isLastColumnEntry($prmEntry)">
-                <xsl:sequence select="'0'"/>
-            </xsl:when>
             <xsl:when test="@colsep">
                 <xsl:value-of select="@colsep"/>
             </xsl:when>
@@ -770,30 +766,10 @@ See the accompanying LICENSE file for applicable license.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
-    <!-- Judge that given entry ($prmEntry) is the last column cell -->
-    <xsl:function name="dita-ot:isLastColumnEntry" as="xs:boolean">
-        <xsl:param name="prmEntry" as="element()"/>
-        <xsl:variable name="tgroupCols" as="xs:integer" select="xs:integer(string($prmEntry/ancestor::*[contains(@class,' topic/tgroup ')][1]/@cols))"/>
-        <xsl:variable name="entryColNum" as="xs:integer" select="xs:integer(string($prmEntry/@dita-ot:x))"/>
-        <xsl:choose>
-            <xsl:when test="exists($prmEntry/@dita-ot:morecols)">
-                <xsl:variable name="endCol" as="xs:integer" select="$entryColNum + xs:integer($prmEntry/@dita-ot:morecols)"/>
-                <xsl:sequence select="$endCol eq $tgroupCols"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="$entryColNum eq $tgroupCols"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:function>
-    
+
     <xsl:template name="getTableRowsep" as="xs:string">
-        <xsl:param name="prmEntry" as="element()" required="no" select="."/>
         <xsl:variable name="colname" select="@colname"/>
         <xsl:choose>
-            <xsl:when test="dita-ot:isLastRowEntry($prmEntry)">
-                <xsl:sequence select="'0'"/>
-            </xsl:when>
             <xsl:when test="@rowsep">
                 <xsl:value-of select="@rowsep"/>
             </xsl:when>
@@ -815,22 +791,6 @@ See the accompanying LICENSE file for applicable license.
         </xsl:choose>
     </xsl:template>
 
-    <!-- Judge that given entry ($prmEntry) is the last row cell -->
-    <xsl:function name="dita-ot:isLastRowEntry" as="xs:boolean">
-        <xsl:param name="prmEntry" as="element()"/>
-        <xsl:variable name="tgroupRowCount" as="xs:integer" select="count($prmEntry/ancestor::*[contains(@class,' topic/tgroup ')][1]/descendant::*[contains(@class,' topic/row ')])"/>
-        <xsl:variable name="entryRowNum" as="xs:integer" select="xs:integer(string($prmEntry/@dita-ot:y))"/>
-        <xsl:choose>
-            <xsl:when test="exists($prmEntry/@morerows)">
-                <xsl:variable name="endRowNum" as="xs:integer" select="$entryRowNum + xs:integer($prmEntry/@morerows)"/>
-                <xsl:sequence select="$endRowNum eq $tgroupRowCount"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="$entryRowNum eq $tgroupRowCount"/>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:function>
-    
     <xsl:template name="displayAtts">
         <xsl:param name="element" as="element()"/>
         <xsl:variable name="frame" as="xs:string" select="($element/@frame, $table.frame-default)[1]"/>


### PR DESCRIPTION
Signed-off-by: Toshihiko Makita <tmakita@antenna.co.jp>

## Description
Update the @colsep/@rowsep processing that implements the DITA CALS table requirement.

## Motivation and Context
This pull request fixes the bug reported in #3303.

## How Has This Been Tested?
Using DITA-OT 3.7 release in Windows 11 environment.

The build result for reported example in #3303 

[Before this fix]
![pdf-table-cell-rule-before](https://user-images.githubusercontent.com/1801890/150566044-da409b78-6be1-4462-92c0-800e2f62e58f.png)

[After this fix]
![pdf-table-cell-rule-after](https://user-images.githubusercontent.com/1801890/150566138-c253cd40-2ded-4522-aeae-6eb60e22896f.png)

I have attached the test result:

[pdf2-test-result-2022-01-22.zip](https://github.com/dita-ot/dita-ot/files/7915307/pdf2-test-result-2022-01-22.zip)

The test data archive: 
[test-data-2022-01-21.zip](https://github.com/dita-ot/dita-ot/files/7915310/test-data-2022-01-21.zip)

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
None

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
