### PR TITLE
In preprocess2 fail on missing image in strict mode

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -12,12 +12,14 @@ import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
+import org.dita.dost.exception.UncheckedDITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
 import org.dita.dost.reader.SubjectSchemeReader;
+import org.dita.dost.util.Configuration;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.NormalizeFilter;
@@ -296,7 +298,11 @@ public final class TopicReaderModule extends AbstractReaderModule {
             } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
                 formatSet.add(file);
                 if (!exists(file.filename)) {
-                    logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
+                    if (processingMode == Configuration.Mode.STRICT) {
+                        throw new UncheckedDITAOTException(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toException());
+                    } else {
+                        logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
+                    }
                 }
             } else {
                 htmlSet.put(file.format, file.filename);


### PR DESCRIPTION
## Description
In preprocess2 fail on missing image in strict mode

## Motivation and Context
Fixes #3858

## How Has This Been Tested?
Tests pass.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Note in release notes.

