### PR TITLE
#3846 Do not append two anchors to target chunked reference.

### DIFF
--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -301,13 +301,9 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
                 // update @href to point back to current file
                 // if the location is moved to chunk, @href will
                 // be update again to the new location.
-            	if(relative.toString().contains(SHARP)) {
-            		//If the relative reference already has an anchor, we need to replace that with the current anchor.
-            		final URI res = URLUtils.setFragment(relative, href.substring(1)); 
-            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, res.toString());
-            	} else {
-            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative + href);
-            	}
+                final URI hrefUri = URI.create(href);
+                final URI res = URLUtils.setFragment(relative.resolve(hrefUri), hrefUri.getFragment());
+                XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, res.toString());
             } else if (relative.toString().contains(SLASH)) {
                 // if new file is not under the same directory with current file
                 // add path information to the @href value

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -14,6 +14,7 @@ import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.TopicIdParser;
+import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -300,9 +301,10 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
                 // update @href to point back to current file
                 // if the location is moved to chunk, @href will
                 // be update again to the new location.
-            	if(relative.toString().contains("#")) {
+            	if(relative.toString().contains(SHARP)) {
             		//If the relative reference already has an anchor, we need to replace that with the current anchor.
-            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative.resolve(href).toString());
+            		final URI res = URLUtils.setFragment(relative, href.substring(1)); 
+            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, res.toString());
             	} else {
             		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative + href);
             	}

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -300,7 +300,12 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
                 // update @href to point back to current file
                 // if the location is moved to chunk, @href will
                 // be update again to the new location.
-                XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative + href);
+            	if(relative.toString().contains("#")) {
+            		//If the relative reference already has an anchor, we need to replace that with the current anchor.
+            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative.resolve(href).toString());
+            	} else {
+            		XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative + href);
+            	}
             } else if (relative.toString().contains(SLASH)) {
                 // if new file is not under the same directory with current file
                 // add path information to the @href value

--- a/src/test/java/org/dita/dost/TestUtils.java
+++ b/src/test/java/org/dita/dost/TestUtils.java
@@ -7,6 +7,10 @@
  */
 package org.dita.dost;
 
+import net.sf.saxon.Configuration;
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
 import nu.validator.htmlparser.dom.HtmlDocumentBuilder;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.CatalogUtils;
@@ -55,6 +59,7 @@ public class TestUtils {
     public static final File testStub = new File("src" + File.separator + "test" + File.separator + "resources");
 
     private static final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+    private static Processor processor = new Processor(new Configuration());
 
     static {
         builderFactory.setNamespaceAware(true);
@@ -786,4 +791,7 @@ public class TestUtils {
 
     }
 
+    public static XdmNode parse(File input) throws SaxonApiException {
+        return processor.newDocumentBuilder().build(input);
+    }
 }

--- a/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/ChunkMapReaderTest.java
@@ -22,16 +22,13 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
-import static org.dita.dost.util.Constants.INPUT_DITAMAP_URI;
 import static org.dita.dost.util.URLUtils.toURI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/resources/ChunkMapReaderTest/src/chunkedMap.ditamap
+++ b/src/test/resources/ChunkMapReaderTest/src/chunkedMap.ditamap
@@ -2,4 +2,5 @@
     <title class="- topic/title ">My map</title>
     <topicref href="chunkedTopic.dita#subtopic2" chunk="to-content select-topic" class="- map/topicref "/>
     <topicref href="chunkedTopic.dita#subtopic3" chunk="to-content select-topic" class="- map/topicref "/>
+    <topicref href="chunkedTopic.dita" chunk="to-content select-topic" class="- map/topicref "/>
 </map>

--- a/src/test/resources/ChunkMapReaderTest/src/chunkedMap.ditamap
+++ b/src/test/resources/ChunkMapReaderTest/src/chunkedMap.ditamap
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " class="- map/map ">
+    <title class="- topic/title ">My map</title>
+    <topicref href="chunkedTopic.dita#subtopic2" chunk="to-content select-topic" class="- map/topicref "/>
+    <topicref href="chunkedTopic.dita#subtopic3" chunk="to-content select-topic" class="- map/topicref "/>
+</map>

--- a/src/test/resources/ChunkMapReaderTest/src/chunkedTopic.dita
+++ b/src/test/resources/ChunkMapReaderTest/src/chunkedTopic.dita
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?><topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="parentTopic" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " class="- topic/topic ">
+    <title class="- topic/title ">Parent topic</title>
+    <body class="- topic/body ">
+        <p class="- topic/p ">Para in parent</p>
+    </body>
+    <topic id="subtopic2" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " class="- topic/topic ">
+        <title class="- topic/title ">Topic 2</title>
+        <body class="- topic/body ">
+            <p class="- topic/p ">link to topic3: <xref href="#subtopic3" class="- topic/xref "/></p>
+        </body>
+    </topic>
+    <topic id="subtopic3" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " class="- topic/topic ">
+        <title class="- topic/title ">Topic 3</title>
+        <body class="- topic/body ">
+            <p class="- topic/p ">Para 3</p>
+        </body>
+    </topic>
+</topic>


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Avoid appending anchor twice to target reference when referencing a chunked topic.

## Motivation and Context
Fixes #3846

## How Has This Been Tested?
Using samples from #3846 and with an automated test in the ChunkMapReaderTest class.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Not needed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
