### PR TITLE
Add missing location to log messages

### DIFF
--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -269,7 +269,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
                 final String fragment = target.getFragment();
                 if (fragment == null) {
                     //if there is no '#' in target string, report error
-                    logger.error(MessageUtils.getMessage("DOTJ041E", target.toString()).toString());
+                    logger.error(MessageUtils.getMessage("DOTJ041E", target.toString()).setLocation(atts).toString());
                 } else {
                     String id;
                     //has element id

--- a/src/main/java/org/dita/dost/reader/CopyToReader.java
+++ b/src/main/java/org/dita/dost/reader/CopyToReader.java
@@ -162,7 +162,8 @@ public final class CopyToReader extends AbstractXMLFilter {
                     final URI copyToSourceAbs = copyToMap.get(targetAbs);
                     if (copyToSourceAbs != null) {
                         if (!sourceAbs.equals(copyToSourceAbs)) {
-                            logger.warn(MessageUtils.getMessage("DOTX065W", source.toString(), targetAbs.toString()).toString());
+                            logger.warn(MessageUtils.getMessage("DOTX065W", source.toString(), targetAbs.toString())
+                                    .setLocation(atts).toString());
                         }
                     } else if (atts.getValue(ATTRIBUTE_NAME_CHUNK) != null &&
                             atts.getValue(ATTRIBUTE_NAME_CHUNK).contains(CHUNK_TO_CONTENT)) {

--- a/src/main/java/org/dita/dost/reader/DitaValReader.java
+++ b/src/main/java/org/dita/dost/reader/DitaValReader.java
@@ -179,7 +179,7 @@ public final class DitaValReader implements AbstractReader {
                 action = readFlag(elem);
                 break;
             default:
-                throw new IllegalArgumentException(MessageUtils.getMessage("DOTJ077F", attAction).toString());
+                throw new IllegalArgumentException(MessageUtils.getMessage("DOTJ077F", attAction).setLocation(elem).toString());
         }
         if (action != null) {
             final QName attName;
@@ -205,7 +205,7 @@ public final class DitaValReader implements AbstractReader {
                 }
                 if (attName != null && attName.equals(REV)
                         && !filterAttributes.isEmpty() && !filterAttributes.contains(REV)) {
-                    logger.warn(MessageUtils.getMessage("DOTJ074W").toString());
+                    logger.warn(MessageUtils.getMessage("DOTJ074W").setLocation((elem)).toString());
                     return;
                 }
             }

--- a/src/main/java/org/dita/dost/reader/KeydefFilter.java
+++ b/src/main/java/org/dita/dost/reader/KeydefFilter.java
@@ -144,7 +144,7 @@ public final class KeydefFilter extends AbstractXMLFilter {
                         keysDefMap.put(key, new KeyDef(key, null, null, null, null, null));
                     }
                 } else {
-                    logger.info(MessageUtils.getMessage("DOTJ045I", key).toString());
+                    logger.info(MessageUtils.getMessage("DOTJ045I", key).setLocation(atts).toString());
                 }
             }
         }

--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -227,7 +227,9 @@ public final class MergeMapParser extends XMLFilterImpl {
                             XMLUtils.addOrSetAttribute(atts, ATTRIBUTE_NAME_FIRST_TOPIC_ID, firstTopicId.toString());
                         } else {
                             final URI fileName = URLUtils.toDirURI(dirPath).resolve(attValue);
-                            logger.error(MessageUtils.getMessage("DOTX008E", fileName.toString()).toString());
+                            logger.error(MessageUtils.getMessage("DOTX008E", fileName.toString())
+                                    .setLocation(attributes)
+                                    .toString());
                         }
                     }
                     }

--- a/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
+++ b/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
@@ -75,10 +75,10 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
                     }
                     XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_CONREF, target.toString());
                 } else {
-                    logger.warn(MessageUtils.getMessage("DOTJ060W", key, conkeyref).toString());
+                    logger.warn(MessageUtils.getMessage("DOTJ060W", key, conkeyref).setLocation(atts).toString());
                 }
             } else {
-                logger.error(MessageUtils.getMessage("DOTJ046E", conkeyref).toString());
+                logger.error(MessageUtils.getMessage("DOTJ046E", conkeyref).setLocation(atts).toString());
             }
         }
         getContentHandler().startElement(uri, localName, name, resAtts != null ? resAtts : atts);

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -304,7 +304,9 @@ public final class ValidationFilter extends AbstractXMLFilter {
                     for (final String s : keylist) {
                         if (!StringUtils.isEmptyString(s) && !valueSet.contains(s)) {
                             logger.warn(MessageUtils.getMessage("DOTJ049W",
-                                    attrName.toString(), qName, attrValue, StringUtils.join(valueSet, COMMA)).toString());
+                                            attrName.toString(), qName, attrValue, StringUtils.join(valueSet, COMMA))
+                                    .setLocation(atts)
+                                    .toString());
                         }
                     }
                 }

--- a/src/main/java/org/dita/dost/writer/include/IncludeText.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeText.java
@@ -42,7 +42,7 @@ final class IncludeText {
 
     boolean include(final Attributes atts) {
         final URI hrefValue = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
-        final Charset charset = getCharset(atts.getValue(ATTRIBUTE_NAME_FORMAT), atts.getValue(ATTRIBUTE_NAME_ENCODING));
+        final Charset charset = getCharset(atts);
         final Range range = getRange(hrefValue);
         final File codeFile = getFile(hrefValue);
         if (codeFile != null) {
@@ -125,11 +125,12 @@ final class IncludeText {
     /**
      * Get code file charset.
      *
-     * @param format   format attribute value, may be {@code null}
-     * @param encoding encoding attribute balue, may be {@code null}
      * @return charset if set, otherwise default charset
      */
-    private Charset getCharset(final String format, final String encoding) {
+
+    private Charset getCharset(Attributes atts) {
+        final String format = atts.getValue(ATTRIBUTE_NAME_FORMAT);
+        final String encoding = atts.getValue(ATTRIBUTE_NAME_ENCODING);
         Charset c = null;
         try {
             if (encoding != null) {
@@ -141,7 +142,7 @@ final class IncludeText {
                 }
             }
         } catch (final RuntimeException e) {
-            logger.error(MessageUtils.getMessage("DOTJ052E", encoding).toString());
+            logger.error(MessageUtils.getMessage("DOTJ052E", encoding).setLocation(atts).toString());
         }
         if (c == null) {
             final String defaultCharset = Configuration.configuration.get("default.coderef-charset");


### PR DESCRIPTION
## Description
Add location information to log messages.

## Motivation and Context
Fixes #3877

## How Has This Been Tested?
Manual test that messages include location information.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Note in release notes that the following log messages now contain location information when available:

* `DOTJ041E`
* `DOTJ045I`
* `DOTJ046E`
* `DOTJ052E`
* `DOTJ060W`
* `DOTJ074W`
* `DOTJ077F`
* `DOTX008E`
* `DOTX065W`
