### PR TITLE
Log invalid character in file include

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -423,6 +423,11 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <message id="DOTJ084E" type="ERROR">
+    <reason>Included file %1 contained invalid byte sequence for charset %2</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -424,8 +424,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ084E" type="ERROR">
-    <reason>Included file %1 contained invalid byte sequence for charset %2</reason>
-    <response></response>
+    <reason>Couldn’t read '%1' with the %2 character set.</reason>
+    <response>Save the file with %2 encoding.</response>
   </message>
 
   <!-- End of Java Messages -->

--- a/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
@@ -9,6 +9,7 @@
 package org.dita.dost.writer.include;
 
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.Configuration;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -58,6 +59,7 @@ public class IncludeResolver extends AbstractXMLFilter {
 
     private Deque<Boolean> ignoreDepth = new ArrayDeque<>();
     private Deque<Deque<StackItem>> includeStack = new ArrayDeque<>();
+    private Configuration.Mode processingMode;
 
     private static class StackItem {
         public final String cls;
@@ -88,8 +90,11 @@ public class IncludeResolver extends AbstractXMLFilter {
 
     // XMLFilter methods -------------------------------------------------------
 
+    @Override
     public void startDocument()
             throws SAXException {
+        final String mode = params.get(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
+        processingMode = mode != null ? Configuration.Mode.valueOf(mode.toUpperCase()) : Configuration.Mode.LAX;
         final ArrayDeque<StackItem> elementStack = new ArrayDeque<>();
         elementStack.push(new StackItem(null, true));
         includeStack.push(elementStack);
@@ -135,7 +140,7 @@ public class IncludeResolver extends AbstractXMLFilter {
                         final String parse = getParse(atts.getValue(ATTRIBUTE_NAME_PARSE));
                         switch (parse) {
                             case "text":
-                                include = new IncludeText(job, currentFile, getContentHandler(), logger).include(atts);
+                                include = new IncludeText(job, currentFile, getContentHandler(), logger, processingMode).include(atts);
                                 break;
                             case "xml":
                                 include = new IncludeXml(job, currentFile, getContentHandler(), logger).include(atts);

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -351,7 +351,9 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.NormalizeSimpleTableFilter"/>
-        <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
+        <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip">
+          <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        </filter>
         <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>
     </pipeline>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -265,7 +265,9 @@ See the accompanying LICENSE file for applicable license.
           <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         </filter>
         <filter class="org.dita.dost.writer.NormalizeSimpleTableFilter"/>
-        <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip"/>
+        <filter class="org.dita.dost.writer.CoderefResolver" unless:set="preprocess.coderef.skip">
+          <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        </filter>
         <filter class="org.dita.dost.writer.NormalizeCodeblock" unless:set="preprocess.normalize-codeblock.skip"/>
       </sax>
     </pipeline>

--- a/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
+++ b/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
@@ -7,7 +7,6 @@
  */
 package org.dita.dost.writer.include;
 
-import com.google.common.io.Files;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.store.StreamStore;
@@ -25,18 +24,17 @@ import org.xml.sax.InputSource;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.net.URI.create;
-import static org.apache.commons.io.FileUtils.copyFile;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
 import static org.dita.dost.util.Constants.PR_D_CODEREF;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class IncludeResolverTest {
@@ -66,10 +64,10 @@ public class IncludeResolverTest {
     public void setup() throws IOException {
         tempDir = TestUtils.createTempDir(IncludeResolverTest.class);
 
-        copyFile(new File(srcDir, test), new File(tempDir, test));
-        Files.write("dummy", new File(tempDir, "topic.dita"), Charset.forName("UTF-8"));
+        Files.copy(new File(srcDir, test).toPath(), new File(tempDir, test).toPath());
+        Files.write(new File(tempDir, "topic.dita").toPath(),"dummy".getBytes(StandardCharsets.UTF_8));
         for (final String file : new String[]{"code.xml", "utf-8.xml", "plain.txt", "range.txt", "schema.xml"}) {
-            copyFile(new File(srcDir, file), new File(tempDir, file));
+            Files.copy(new File(srcDir, file).toPath(), new File(tempDir, file).toPath());
         }
 
         filter = new CoderefResolver();

--- a/src/test/java/org/dita/dost/writer/include/IncludeTextTest.java
+++ b/src/test/java/org/dita/dost/writer/include/IncludeTextTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2022 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.writer.include;
+
+import org.dita.dost.TestUtils;
+import org.dita.dost.exception.UncheckedDITAOTException;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Configuration;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertEquals;
+
+public class IncludeTextTest {
+
+    private static final String DATA;
+
+    static {
+        final byte[] buf = new byte[256];
+        for (int i = 0; i < 256; i++) {
+            buf[i] = (byte) i;
+        }
+        DATA = new String(buf, ISO_8859_1);
+    }
+
+    private File tempDir;
+    private Job job;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = TestUtils.createTempDir(IncludeResolverTest.class);
+        job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+        job.add(new Job.FileInfo.Builder()
+                .uri(URI.create("include.txt"))
+                .src(tempDir.toURI().resolve("include.txt"))
+                .format(PR_D_CODEREF.localName)
+                .build());
+
+    }
+
+    @After
+    public void cleanUp() throws IOException {
+        TestUtils.forceDelete(tempDir);
+    }
+
+    @Test
+    public void include_validEncoding() throws IOException {
+        final CharacterBufferContentHandler characterBuffer = new CharacterBufferContentHandler();
+        final IncludeText includeText = new IncludeText(
+                job,
+                tempDir.toURI().resolve("topic.dita"),
+                characterBuffer,
+                new TestUtils.TestLogger(),
+                Configuration.Mode.STRICT);
+        createIncludeFile(UTF_8);
+
+        includeText.include(createAttributes(UTF_8));
+
+        // AllRange will normalize line feeds to '\n', so we cannot compare String directly
+        try (BufferedReader act = new BufferedReader(new StringReader(characterBuffer.characters.toString()));
+             BufferedReader exp = new BufferedReader(new StringReader(DATA))) {
+            String line;
+            while ((line = exp.readLine()) != null) {
+                assertEquals(line, act.readLine());
+            }
+        }
+    }
+
+    @Test(expected = UncheckedDITAOTException.class)
+    public void include_invalidEncoding() throws IOException {
+        final IncludeText includeText = new IncludeText(
+                job,
+                tempDir.toURI().resolve("topic.dita"),
+                new DefaultHandler(),
+                new TestUtils.TestLogger(),
+                Configuration.Mode.STRICT);
+        createIncludeFile(ISO_8859_1);
+
+        includeText.include(createAttributes(UTF_8));
+    }
+
+    private Attributes createAttributes(Charset charset) {
+        return new XMLUtils.AttributesBuilder()
+                .add(ATTRIBUTE_NAME_HREF, "include.txt")
+                .add(ATTRIBUTE_NAME_ENCODING, charset.toString())
+                .build();
+    }
+
+    private Path createIncludeFile(Charset charset) throws IOException {
+        return Files.write(new File(tempDir, "include.txt").toPath(), DATA.getBytes(charset));
+    }
+
+    private static class CharacterBufferContentHandler extends DefaultHandler {
+        StringBuilder characters = new StringBuilder();
+        @Override
+        public void characters(char[] ch, int start, int length) throws SAXException {
+            characters.append(ch, start, length);
+        }
+    }
+}

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -183,3 +183,4 @@ DOTJ044W=There is a redundant conref action "pushbefore". Please make sure that 
 DOTA014W=Attribute @{0} is deprecated. Use attribute @{1} instead.
 DOTJ080W=Integrator configuration ''{0}'' has been deprecated. Use plugin configuration ''{0}'' instead.
 DOTJ082E=Resource {0} is referenced with incorrect path capitalization
+DOTJ084E=Included file {0} contained invalid byte sequence for charset {1}


### PR DESCRIPTION
## Description
Log a `DOTJ084E` message when file include process fails due to charset mismatch.

## Motivation and Context
When file include is in charset that is neither the system default or matches the explicit charset definition in the include, reading the file may fail. A dedicated error message for this makes debugging source issues easier.

## How Has This Been Tested?
New unit tests added for success and failure cases.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Describe the `DOTJ084E` message in more detail. This error is thrown e.g. when

* Included file is UTF-8 encoded but default encoding is used to read it (no `@format` or `@encoding`)
* Included file is Windows-1252 encoded (Windows default) but `<include>` element has `@encoding` with value UTF-8.