### PR TITLE
#3662 Output serialization of entire message.

### DIFF
--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -154,7 +154,8 @@ public final class XMLUtils {
                             .findAny()
                             .map(XdmItem::getStringValue)
                             .orElse("INFO");
-                final String msg = content.getStringValue();
+                //Output entire node set
+                final String msg = errorCode.isPresent() ? content.getStringValue() : content.toString();
                 switch (level) {
                     case "FATAL":
                         final TerminationException err = new TerminationException(msg);


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
When an xsl message is output and it contains serialized XML elements, output the complete serialized XML elements, not just their text contents.

## Motivation and Context
Fixes #3662

## How Has This Been Tested?
Manual tests, have been using this patch in the Oxygen's bundled DITA OT for a while.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc needed.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
