### PR TITLE
#3750 Updated force unique filter to work with references to separate topics inside the same file

### DIFF
--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 
 import static org.dita.dost.chunk.ChunkModule.isLocalScope;
@@ -39,12 +40,25 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     public final Map<FileInfo, FileInfo> copyToMap = new HashMap<>();
     private TempFileNameScheme tempFileNameScheme;
 
+    /**
+     * Stack used to detect the current element type. 
+     */
+    private final Deque<String> classElementStack = new LinkedList<>();
+    
+    /**
+     * Stack used to hold the current topicref parent.
+     */
+    private Deque<ParentTopicref> topicrefParentsStack = new ArrayDeque<>();
+    
     // ContentHandler methods
 
     @Override
     public void startElement(final String uri, final String localName, final String qName,
                              final Attributes atts) throws SAXException {
         ignoreStack.push(MAP_RELTABLE.matches(atts) ? false : ignoreStack.isEmpty() || ignoreStack.peek());
+
+        final String classValue = atts.getValue(ATTRIBUTE_NAME_CLASS);
+        classElementStack.addFirst(classValue);
 
         Attributes res = atts;
         if (ignoreStack.peek() && MAP_TOPICREF.matches(res)) {
@@ -55,20 +69,35 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
             final String format = res.getValue(ATTRIBUTE_NAME_FORMAT);
             // FIXME: handle cascading
             final String processingRole = res.getValue(ATTRIBUTE_NAME_PROCESSING_ROLE);
+            FileInfo dstFi = null;
             if (source != null &&
                     isLocalScope(scope) &&
                     (format == null || format.equals(ATTR_FORMAT_VALUE_DITA)) &&
                     (processingRole == null || processingRole.equals(ATTR_PROCESSING_ROLE_VALUE_NORMAL))) {
                 final URI file = stripFragment(source);
                 Integer count = topicrefCount.getOrDefault(file, 0);
-                count++;
-                topicrefCount.put(file, count);
+                
+                ParentTopicref parentTopicref = topicrefParentsStack.peek();
+                boolean parentTopicHasEmbededSubtopcis = false;
+                if(parentTopicref != null && parentTopicref.getHref() != null) {
+                  URI parentHref = parentTopicref.getHref();
+                  parentHref = stripFragment(parentHref);
+                  parentTopicHasEmbededSubtopcis = href != null && parentHref.equals(file) && href.getFragment() != null;
+                }
+                if(parentTopicHasEmbededSubtopcis) {
+                  dstFi = parentTopicref.getDstFi();
+                } else {
+                  count++;
+                  topicrefCount.put(file, count);
+                }
+                
                 if (count > 1) { // not only reference to this topic
                     final FileInfo srcFi = job.getFileInfo(currentFile.resolve(stripFragment(source)));
                     if (srcFi != null) {
-                        final FileInfo dstFi = generateCopyToTarget(srcFi, count);
+                        if(dstFi == null) {
+                          dstFi = generateCopyToTarget(srcFi, count);
+                        }
                         copyToMap.put(dstFi, srcFi);
-
                         final URI dstTempAbs = job.tempDirURI.resolve(dstFi.uri);
                         final URI targetRel = getRelativePath(currentFile, dstTempAbs);
                         final URI target = setFragment(targetRel, href.getFragment());
@@ -79,6 +108,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
                     }
                 }
             }
+            topicrefParentsStack.push(new ParentTopicref(href, dstFi));
         }
 
         getContentHandler().startElement(uri, localName, qName, res);
@@ -88,6 +118,10 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         getContentHandler().endElement(uri, localName, qName);
 
+        final String classValue = classElementStack.removeFirst();
+        if (classValue != null && ignoreStack.peek() && MAP_TOPICREF.matches(classValue)) {
+          topicrefParentsStack.pop();
+        }
         ignoreStack.pop();
     }
 
@@ -116,5 +150,47 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
 
     public void setTempFileNameScheme(TempFileNameScheme tempFileNameScheme) {
         this.tempFileNameScheme = tempFileNameScheme;
+    }
+    
+    /**
+     * Holds additional information about the parent for a topicref.
+     *
+     */
+    private static final class ParentTopicref {
+      /**
+       * The href value for the parent topic.
+       */
+      private URI href;
+      
+      /**
+       * Information about the destination file used in the output. 
+       */
+      private FileInfo dstFi;
+      
+      /**
+       * Constructor.
+       * 
+       * @param href The href value for the parent topic.
+       * @param dstFi Information about the destination file used in the output. 
+       */
+      public ParentTopicref(URI href, FileInfo dstFi) {
+        this.href = href;
+        this.dstFi = dstFi;
+      }
+      
+      /**
+       * @return The href value for the parent topic.
+       */
+      public URI getHref() {
+        return href;
+      }
+      
+      /**
+       * @return Information about the destination file used in the output. 
+       */
+      public FileInfo getDstFi() {
+        return dstFi;
+      }
+
     }
 }

--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -18,7 +18,6 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
 
 import static org.dita.dost.chunk.ChunkModule.isLocalScope;
@@ -43,7 +42,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     /**
      * Stack used to detect the current element type. 
      */
-    private final Deque<String> classElementStack = new LinkedList<>();
+    private final Deque<String> classElementStack = new ArrayDeque<>();
     
     /**
      * Stack used to hold the current topicref parent.
@@ -79,23 +78,23 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
                 
                 ParentTopicref parentTopicref = topicrefParentsStack.peek();
                 boolean parentTopicHasEmbededSubtopcis = false;
-                if(parentTopicref != null && parentTopicref.getHref() != null) {
-                  URI parentHref = parentTopicref.getHref();
-                  parentHref = stripFragment(parentHref);
-                  parentTopicHasEmbededSubtopcis = href != null && parentHref.equals(file) && href.getFragment() != null;
+                if (parentTopicref != null && parentTopicref.href != null) {
+                    URI parentHref = parentTopicref.href;
+                    parentHref = stripFragment(parentHref);
+                    parentTopicHasEmbededSubtopcis = href != null && parentHref.equals(file) && href.getFragment() != null;
                 }
-                if(parentTopicHasEmbededSubtopcis) {
-                  dstFi = parentTopicref.getDstFi();
+                if (parentTopicHasEmbededSubtopcis) {
+                    dstFi = parentTopicref.dstFi;
                 } else {
-                  count++;
-                  topicrefCount.put(file, count);
+                    count++;
+                    topicrefCount.put(file, count);
                 }
                 
                 if (count > 1) { // not only reference to this topic
                     final FileInfo srcFi = job.getFileInfo(currentFile.resolve(stripFragment(source)));
                     if (srcFi != null) {
-                        if(dstFi == null) {
-                          dstFi = generateCopyToTarget(srcFi, count);
+                        if (dstFi == null) {
+                            dstFi = generateCopyToTarget(srcFi, count);
                         }
                         copyToMap.put(dstFi, srcFi);
                         final URI dstTempAbs = job.tempDirURI.resolve(dstFi.uri);
@@ -120,7 +119,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
 
         final String classValue = classElementStack.removeFirst();
         if (classValue != null && ignoreStack.peek() && MAP_TOPICREF.matches(classValue)) {
-          topicrefParentsStack.pop();
+            topicrefParentsStack.pop();
         }
         ignoreStack.pop();
     }
@@ -157,40 +156,26 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
      *
      */
     private static final class ParentTopicref {
-      /**
-       * The href value for the parent topic.
-       */
-      private URI href;
+        /**
+         * The href value for the parent topic.
+         */
+        public final URI href;
       
-      /**
-       * Information about the destination file used in the output. 
-       */
-      private FileInfo dstFi;
+        /**
+         * Information about the destination file used in the output. 
+         */
+        public final FileInfo dstFi;
       
-      /**
-       * Constructor.
-       * 
-       * @param href The href value for the parent topic.
-       * @param dstFi Information about the destination file used in the output. 
-       */
-      public ParentTopicref(URI href, FileInfo dstFi) {
-        this.href = href;
-        this.dstFi = dstFi;
-      }
+        /**
+         * Constructor.
+         * 
+         * @param href The href value for the parent topic.
+         * @param dstFi Information about the destination file used in the output. 
+         */
+        public ParentTopicref(URI href, FileInfo dstFi) {
+            this.href = href;
+            this.dstFi = dstFi;
+        }
       
-      /**
-       * @return The href value for the parent topic.
-       */
-      public URI getHref() {
-        return href;
-      }
-      
-      /**
-       * @return Information about the destination file used in the output. 
-       */
-      public FileInfo getDstFi() {
-        return dstFi;
-      }
-
     }
 }

--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -47,7 +47,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     /**
      * Stack used to hold the current topicref parent.
      */
-    private Deque<ParentTopicref> topicrefParentsStack = new ArrayDeque<>();
+    private final Deque<ParentTopicref> topicrefParentsStack = new ArrayDeque<>();
     
     // ContentHandler methods
 
@@ -76,14 +76,13 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
                 final URI file = stripFragment(source);
                 Integer count = topicrefCount.getOrDefault(file, 0);
                 
-                ParentTopicref parentTopicref = topicrefParentsStack.peek();
-                boolean parentTopicHasEmbededSubtopcis = false;
+                final ParentTopicref parentTopicref = topicrefParentsStack.peek();
+                boolean parentTopicHasEmbededSubtopics = false;
                 if (parentTopicref != null && parentTopicref.href != null) {
-                    URI parentHref = parentTopicref.href;
-                    parentHref = stripFragment(parentHref);
-                    parentTopicHasEmbededSubtopcis = href != null && parentHref.equals(file) && href.getFragment() != null;
+                    final URI parentHref = stripFragment(parentTopicref.href);
+                    parentTopicHasEmbededSubtopics = href != null && parentHref.equals(file) && href.getFragment() != null;
                 }
-                if (parentTopicHasEmbededSubtopcis) {
+                if (parentTopicHasEmbededSubtopics) {
                     dstFi = parentTopicref.dstFi;
                 } else {
                     count++;

--- a/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
@@ -73,6 +73,11 @@ public class ForceUniqueFilterTest {
                 .uri(URI.create("test2.dita"))
                 .result(srcDir.toURI().resolve("test2.dita"))
                 .build());
+        job.add(new Builder()
+                .src(srcDir.toURI().resolve("topic.dita"))
+                .uri(URI.create("topic.dita"))
+                .result(srcDir.toURI().resolve("topic.dita"))
+                .build());
         tempFileNameScheme = new DefaultTempFileScheme();
         tempFileNameScheme.setBaseDir(srcDir.toURI());
     }
@@ -100,12 +105,14 @@ public class ForceUniqueFilterTest {
         assertFalse(d.hasDifferences());
 
         assertEquals(new HashMap<FileInfo, FileInfo>(ImmutableMap.of(
-                createFileInfo("test.dita", "test_3.dita"),
-                createFileInfo("test.dita", "test.dita"),
+                createFileInfo(null, "copy-to_2.dita"),
+                createFileInfo(null, "copy-to.dita"),
                 createFileInfo("test.dita", "test_2.dita"),
                 createFileInfo("test.dita", "test.dita"),
-                createFileInfo(null, "copy-to_2.dita"),
-                createFileInfo(null, "copy-to.dita")
+                createFileInfo("topic.dita", "topic_2.dita"),
+                createFileInfo("topic.dita", "topic.dita"),
+                createFileInfo("test.dita", "test_3.dita"),
+                createFileInfo("test.dita", "test.dita")
         )), f.copyToMap);
     }
 

--- a/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
@@ -15,4 +15,14 @@
   </reltable>
   <topicref class="- map/topicref " href="test2.dita" copy-to="copy-to.dita"/>
   <topicref class="- map/topicref " href="test3.dita" copy-to="copy-to_2.dita"/>
+  <topicref class="- map/topicref " href="topic.dita">
+    <topicref class="- map/topicref " href="topic.dita#configuration">
+      <topicref class="- map/topicref " href="topic.dita#option"></topicref>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " href="topic.dita" copy-to="topic_2.dita">
+    <topicref class="- map/topicref " href="topic.dita#configuration" copy-to="topic_2.dita#configuration">
+      <topicref class="- map/topicref " href="topic.dita#option" copy-to="topic_2.dita#option"></topicref>
+    </topicref>
+  </topicref>
 </map>

--- a/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
@@ -15,4 +15,14 @@
   </reltable>
   <topicref class="- map/topicref " href="test2.dita" copy-to="copy-to.dita"/>
   <topicref class="- map/topicref " href="test3.dita" copy-to="copy-to.dita"/>
+  <topicref class="- map/topicref " href="topic.dita">
+    <topicref class="- map/topicref " href="topic.dita#configuration">
+      <topicref class="- map/topicref " href="topic.dita#option"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " href="topic.dita">
+    <topicref class="- map/topicref " href="topic.dita#configuration">
+      <topicref class="- map/topicref " href="topic.dita#option"/>
+    </topicref>
+  </topicref>
 </map>


### PR DESCRIPTION
Fix for #3750. Updated force unique filter to work with references to separate topics inside the same file.

Signed-off-by: Beniamin Savu <beniamin_savu@sync.ro>

## Description
Updated force unique filter to work with references to separate topics inside the same file.

## Motivation and Context
Fixes #3750

## How Has This Been Tested?
Manual testing using the samples from #3750 and with an automated test.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No docs update necessary.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
