### PR TITLE
Use separate temporary directory for each project deliverable

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -75,6 +75,7 @@ abstract class Arguments {
     boolean justPrintVersion;
     boolean justPrintDiagnostics;
     final Map<String, Object> definedProps = new HashMap<>();
+    int repeat = 1;
 
     Arguments() {
         useColor = getUseColor();

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -79,7 +79,6 @@ public class ConversionArguments extends Arguments {
      * Project file
      */
     File projectFile;
-    int repeat = 1;
 
     public final List<String> inputs = new ArrayList<>();
     private final List<String> resources = new ArrayList<>();

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -70,6 +70,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private static final String ANT_TRANSTYPE = "transtype";
     private static final String ANT_PLUGIN_FILE = "plugin.file";
     private static final String ANT_PLUGIN_ID = "plugin.id";
+    private static final String ANT_PROJECT_DELIVERABLE = "project.deliverable";
 
     /**
      * File that we are using for configuration.
@@ -407,13 +408,16 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     List<Map<String, Object>> collectProperties(final org.dita.dost.project.Project project,
                                                 final URI base,
                                                 final Map<String, Object> definedProps) {
-        final String runDeliverable = (String) definedProps.get("project.deliverable");
+        final String runDeliverable = (String) definedProps.get(ANT_PROJECT_DELIVERABLE);
 
         final List<Map<String, Object>> projectProps = project.deliverables.stream()
                 .filter(deliverable -> runDeliverable != null ? Objects.equals(deliverable.id, runDeliverable) : true)
                 .map(deliverable -> {
                     final Map<String, Object> props = new HashMap<>(definedProps);
 
+                    props.put(ANT_PROJECT_DELIVERABLE, deliverable.id != null
+                            ? deliverable.id
+                            : UUID.randomUUID().toString());
                     final Context context = deliverable.context;
                     final URI input = base.resolve(context.inputs.inputs.get(0).href);
                     props.put(ANT_ARGS_INPUT, input.toString());

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -348,6 +348,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             } else {
                 projectProps = collectProperties(conversionArgs.projectFile, definedProps);
             }
+            final String tempDirToken = "temp" + LocalDateTime.now().format(dateTimeFormatter);
             for (Map<String, Object> projectProp : projectProps) {
                 String err = null;
                 if (!projectProp.containsKey(ANT_TRANSTYPE) && !projectProp.containsKey(ANT_ARGS_INPUT)) {
@@ -371,14 +372,15 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 }
                 if (projectProp.containsKey(ANT_PROJECT_DELIVERABLE)) {
                     if (projectProp.containsKey(ANT_TEMP_DIR)) {
-                        projectProp.put(ANT_TEMP_DIR, Paths.get(projectProp.get(ANT_TEMP_DIR).toString(),
-                                        projectProp.get(ANT_PROJECT_DELIVERABLE).toString())
+                        final Path tempDir = Paths.get(projectProp.get(ANT_TEMP_DIR).toString(),
+                                projectProp.get(ANT_PROJECT_DELIVERABLE).toString());
+                        projectProp.put(ANT_TEMP_DIR, tempDir
                                 .toAbsolutePath().toString());
                     } else {
-                        final String tempDir = "temp" + projectProp.get(ANT_PROJECT_DELIVERABLE)
-                                + LocalDateTime.now().format(dateTimeFormatter);
-                        projectProp.put(ANT_TEMP_DIR, Paths.get(projectProp.get(ANT_BASE_TEMP_DIR).toString(), tempDir)
-                                .toAbsolutePath().toString());
+                        final Path tempDir =  Paths.get(projectProp.get(ANT_BASE_TEMP_DIR).toString(),
+                                tempDirToken,
+                                projectProp.get(ANT_PROJECT_DELIVERABLE).toString());
+                        projectProp.put(ANT_TEMP_DIR, tempDir.toAbsolutePath().toString());
                     }
                 }
             }

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -95,7 +95,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      * Set of properties that can be used by tasks.
      */
     private List<Map<String, Object>> projectProps;
-    private int repeat;
 
     /**
      * Whether or not this instance has successfully been constructed and is
@@ -196,8 +195,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         // expect the worst
         int exitCode = 1;
         try {
-            final long[] durations = new long[repeat];
-            for (int i = 0; i < repeat; i++) {
+            final long[] durations = new long[this.args.repeat];
+            for (int i = 0; i < this.args.repeat; i++) {
                 final long start = System.currentTimeMillis();
                 try {
                     for (Map<String, Object> props : projectProps) {
@@ -213,7 +212,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                 final long end = System.currentTimeMillis();
                 durations[i] = end - start;
             }
-            if (repeat > 1) {
+            if (this.args.repeat > 1) {
                 for (int i = 0; i < durations.length; i++) {
                     System.out.println(String.format(locale.getString("conversion.repeatDuration"),
                             i + 1, durations[i]));
@@ -284,7 +283,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         final Map<String, Object> definedProps = new HashMap<>(args.definedProps);
         projectProps = Collections.singletonList(definedProps);
         buildFile = args.buildFile;
-        repeat = 1;
 
         if (args.justPrintUsage) {
             args.printUsage(false);
@@ -358,7 +356,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             } else {
                 projectProps = collectProperties(conversionArgs.projectFile, definedProps);
             }
-            repeat = conversionArgs.repeat;
             // default values
             if (!definedProps.containsKey(ANT_OUTPUT_DIR)) {
                 definedProps.put(ANT_OUTPUT_DIR, new File(new File("."), "out").getAbsolutePath());

--- a/src/test/java/org/dita/dost/invoker/MainProjectTest.java
+++ b/src/test/java/org/dita/dost/invoker/MainProjectTest.java
@@ -51,6 +51,7 @@ public class MainProjectTest {
         final List<Map<String, Object>> act = main.collectProperties(project, projectFile, emptyMap());
 
         final Map<String, Object> exp = ImmutableMap.<String, Object>builder()
+                .put("project.deliverable", "site")
                 .put("output.dir", Paths.get("out", "site").toAbsolutePath().toString())
                 .put("args.input", baseDir.resolve("site.ditamap").toString())
                 .put("transtype", "html5")
@@ -73,6 +74,7 @@ public class MainProjectTest {
         final List<Map<String, Object>> act = main.collectProperties(project, projectFile, emptyMap());
 
         final Map<String, Object> exp = ImmutableMap.<String, Object>builder()
+                .put("project.deliverable", "site")
                 .put("output.dir", Paths.get("out", "site").toAbsolutePath().toString())
                 .put("args.input", baseDir.resolve("site.ditamap").toString())
                 .put("transtype", "html5")


### PR DESCRIPTION
## Description
Use separate temporary directory for each project deliverable.

Temporary directories with different argument combinations

| arguments | temporary directory |
| -----------| ---------------------|
| `dita -i root.ditamap` | `${java.io.tmpdir}/temp${timestamp}` |
| `dita -p project.xml` | `${java.io.tmpdir}/temp${timestamp}/${deliverable.id}` |
| `dita -i root.ditamap -t /tmp` | `/tmp` |
| `dita -p project.xml -t /tmp` | `/tmp/${deliverable.id}` |

Temporary directory for deliverables uses deliverable `@id` or a random UUID if not `@id` is set.

## Motivation and Context
Fixes #3757

## How Has This Been Tested?
Existing test pass.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This change is pretty deep in processing details and visible users only if they have strong expectations for temporary directory name. So in that sense this probably doesn't require long description in release notes. Docs currently don't have anything about the old temporary directory generation with project files.
