### PR TITLE
Add utility methods

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -20,6 +20,8 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.dita.dost.util.LangUtils.pair;
+
 /**
  * Command line arguments.
  *
@@ -145,7 +147,7 @@ abstract class Arguments {
         } else {
             value = args.pop();
         }
-        return new AbstractMap.SimpleEntry<>(name, value);
+        return pair(name, value);
     }
 
     /**

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -51,12 +51,13 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.dita.dost.invoker.Arguments.*;
 import static org.dita.dost.util.Configuration.transtypes;
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
+import static org.dita.dost.util.LangUtils.pair;
+import static org.dita.dost.util.LangUtils.zipWithIndex;
 
 /**
  * Command line entry point into DITA-OT. This class is entered via the canonical
@@ -425,12 +426,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         return collectProperties(project, base, definedProps);
     }
 
-    private <T> Stream<Map.Entry<T, Integer>> zipWithIndex(List<T> src) {
-        return IntStream
-                .range(0, src.size())
-                .mapToObj(i -> new AbstractMap.SimpleImmutableEntry(src.get(i), i));
-    }
-
     @VisibleForTesting
     List<Map<String, Object>> collectProperties(final org.dita.dost.project.Project project,
                                                 final URI base,
@@ -556,7 +551,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private void printDeliverables(final File projectFile) {
         final List<Map.Entry<String, String>> pairs = readProjectFile(projectFile).deliverables.stream()
                 .filter(deliverable -> deliverable.id != null)
-                .map(deliverable -> new AbstractMap.SimpleEntry<>(deliverable.id, deliverable.name))
+                .map(deliverable -> pair(deliverable.id, deliverable.name))
                 .collect(Collectors.toList());
         final int length = pairs.stream()
                 .map(Map.Entry::getKey)

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -27,13 +27,13 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
 import static org.dita.dost.util.FileUtils.replaceExtension;
+import static org.dita.dost.util.LangUtils.pair;
 import static org.dita.dost.util.XMLUtils.toErrorReporter;
 import static org.dita.dost.util.XMLUtils.toMessageListener;
 
@@ -123,7 +123,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                                 if (in.equals(out)) {
                                     final File tmp = new File(out.getAbsolutePath() + FILE_EXTENSION_TEMP);
                                     transform(in, tmp, transformer);
-                                    return new SimpleEntry<>(tmp, out);
+                                    return pair(tmp, out);
                                 } else {
                                     transform(in, out, transformer);
                                     return null;

--- a/src/main/java/org/dita/dost/util/LangUtils.java
+++ b/src/main/java/org/dita/dost/util/LangUtils.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2022 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class LangUtils {
+    public static <T, S> Map.Entry<T, S> pair(T left, S right) {
+        return new AbstractMap.SimpleImmutableEntry(left, right);
+    }
+
+    /**
+     * Zip list with 0-based index.
+     *
+     * @return stream of value-index pairs
+     */
+    public static <T> Stream<Map.Entry<T, Integer>> zipWithIndex(List<T> src) {
+        return IntStream
+                .range(0, src.size())
+                .mapToObj(i -> pair(src.get(i), i));
+    }
+}

--- a/src/test/java/org/dita/dost/util/LangUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/LangUtilsTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2022 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.util;
+
+import org.junit.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.*;
+
+public class LangUtilsTest {
+
+    @Test
+    public void pair() {
+        final Map.Entry<String, String> act = LangUtils.pair("left", "right");
+        assertEquals("left", act.getKey());
+        assertEquals("right", act.getValue());
+    }
+
+    @Test
+    public void pair_null() {
+        final Map.Entry<String, String> act = LangUtils.pair(null, null);
+        assertEquals(null, act.getKey());
+        assertEquals(null, act.getValue());
+    }
+
+    @Test
+    public void zipWithIndex() {
+        final List<String> src = asList("first", "second");
+        final List<Map.Entry<String, Integer>> act = LangUtils.zipWithIndex(src).collect(toList());
+        assertEquals("first", act.get(0).getKey());
+        assertEquals(0, act.get(0).getValue().intValue());
+        assertEquals("second", act.get(1).getKey());
+        assertEquals(1, act.get(1).getValue().intValue());
+    }
+
+    @Test
+    public void zipWithIndex_null() {
+        final List<String> src = new ArrayList<>();
+        src.add(null);
+        final List<Map.Entry<String, Integer>> act = LangUtils.zipWithIndex(src).collect(toList());
+        assertEquals(null, act.get(0).getKey());
+        assertEquals(0, act.get(0).getValue().intValue());
+    }
+
+    @Test
+    public void zipWithIndex_empty() {
+        final List<String> src = Collections.emptyList();
+        final List<Map.Entry<String, Integer>> act = LangUtils.zipWithIndex(src).collect(toList());
+        assertTrue(act.isEmpty());
+    }
+}


### PR DESCRIPTION
## Description
Add utility functions missing from Java 8.
## Motivation and Context
Make it easier to write compact code with Java 8.
## How Has This Been Tested?
New unit tests.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Not visible to end-users.
