### PR TITLE
DITA 2.0 support for nested steps oasis-tcs/dita#106

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -86,6 +86,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="*/*[contains(@class,' task/stepxmp ')]">yes</xsl:when>
       <xsl:when test="*/*[contains(@class,' task/tutorialinfo ')]">yes</xsl:when>
       <xsl:when test="*/*[contains(@class,' task/stepresult ')]">yes</xsl:when>
+      <xsl:when test="*/*[contains(@class,' task/steps ')]">yes</xsl:when>
+      <xsl:when test="*/*[contains(@class,' task/steps-unordered ')]">yes</xsl:when>
       <xsl:otherwise>no</xsl:otherwise>
     </xsl:choose>
   </xsl:template>
@@ -103,15 +105,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
   </xsl:template>
   
-  <xsl:template match="*[contains(@class,' task/steps ') or contains(@class,' task/steps-unordered ')]"
+  <xsl:template match="*[not(contains(@class,' task/step '))]
+                /*[contains(@class,' task/steps ') or contains(@class,' task/steps-unordered ')]"
                 mode="common-processing-within-steps">
     <xsl:param name="step_expand"/>
-    <xsl:param name="list-type">
-      <xsl:choose>
-        <xsl:when test="contains(@class,' task/steps ')">ol</xsl:when>
-        <xsl:otherwise>ul</xsl:otherwise>
-      </xsl:choose>
-    </xsl:param>
+    <xsl:param name="list-type" select="if (contains(@class,' task/steps ')) then 'ol' else 'ul'"/>
     <section>
       <xsl:call-template name="gen-toc-id"/>
       <xsl:call-template name="setidaname"/>
@@ -164,6 +162,52 @@ See the accompanying LICENSE file for applicable license.
     </section>
   </xsl:template>
   
+  <!-- Nested steps: no section container, no label, no special format for single step -->
+  <xsl:template match="*[contains(@class,' task/step ')]
+    /*[contains(@class,' task/steps ') or contains(@class,' task/steps-unordered ')]"
+    mode="common-processing-within-steps">
+    <xsl:param name="step_expand"/>
+    <xsl:param name="list-type" select="if (contains(@class,' task/steps ')) then 'ol' else 'ul'"/>
+    <div>
+      <xsl:call-template name="gen-toc-id"/>
+      <xsl:call-template name="setidaname"/>
+      <xsl:choose>
+        <xsl:when test="not(*[contains(@class,' task/stepsection ')])">
+          <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:when test="*[1][contains(@class,' task/stepsection ')] and not(*[contains(@class,' task/stepsection ')][2])">
+          <!-- Stepsection is first, no other appearances -->
+          <xsl:apply-templates select="*[contains(@class,' task/stepsection ')]"/>
+          <xsl:apply-templates select="." mode="step-elements-with-no-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Stepsection elements mixed in with steps -->
+          <xsl:apply-templates select="." mode="step-elements-with-stepsection">
+            <xsl:with-param name="step_expand" select="$step_expand"/>
+            <xsl:with-param name="list-type" select="$list-type"/>
+          </xsl:apply-templates>
+        </xsl:otherwise>
+      </xsl:choose>
+    </div>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="set-step-list-style" as="attribute()?">
+    <xsl:if test="contains(@class,' task/steps ')">
+      <xsl:variable name="stepscount" select="count(ancestor-or-self::*[contains(@class, ' task/steps ')])"/>
+      <xsl:choose>
+        <xsl:when test="$stepscount mod 3 = 1"/>
+        <xsl:when test="$stepscount mod 3 = 2"><xsl:attribute name="type">a</xsl:attribute></xsl:when>
+        <xsl:otherwise><xsl:attribute name="type">i</xsl:attribute></xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+  
   <xsl:template match="*" mode="step-elements-with-no-stepsection">
     <xsl:param name="step_expand"/>
     <xsl:param name="list-type"/>
@@ -171,6 +215,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:element name="{$list-type}">
       <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="setid"/>
+      <xsl:apply-templates select="." mode="set-step-list-style"/>
       <xsl:apply-templates select="*[contains(@class,' task/step ')]" mode="steps">
         <xsl:with-param name="step_expand" select="$step_expand"/>
       </xsl:apply-templates>
@@ -191,7 +236,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:otherwise>
           <!-- First step in a series of steps -->
           <xsl:element name="{$list-type}">
-            <xsl:for-each select=".."><xsl:call-template name="commonattributes"/></xsl:for-each>
+            <xsl:for-each select="..">
+              <xsl:call-template name="commonattributes"/>
+              <xsl:apply-templates select="." mode="set-step-list-style"/>
+            </xsl:for-each>
             <xsl:if test="$list-type='ol' and preceding-sibling::*[contains(@class,' task/step ')]">
               <!-- Restart numbering for ordered steps that were interrupted by stepsection.
                    The start attribute is valid in XHTML 1.0 Transitional, but not for XHTML 1.0 Strict.

--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml
@@ -140,11 +140,20 @@ See the accompanying LICENSE file for applicable license.
   <!-- Image path to use for a note of "other" type. -->
   <variable id="other Note Image Path"/>
 
-  <!--Numbering and format for task steps-->
+  <!--Deprecated since 4.0: "Step Number", "Step Format", "Substep Number", and "Substep Format"-->
   <variable id="Step Number"><param ref-name="number"/>. </variable>
   <variable id="Step Format">1</variable>
   <variable id="Substep Number"><param ref-name="number"/>) </variable>
   <variable id="Substep Format">a</variable>
+  <!--Numbering and format for task steps-->
+  <variable id="Step Number 1"><param ref-name="number"/>. </variable>
+  <variable id="Step Format 1">1</variable>
+  <variable id="Step Number 2"><param ref-name="number"/>) </variable>
+  <variable id="Step Format 2">a</variable>
+  <variable id="Step Number 3"><param ref-name="number"/>. </variable>
+  <variable id="Step Format 3">1</variable>
+  <variable id="Step Number 4"><param ref-name="number"/>) </variable>
+  <variable id="Step Format 4">a</variable>
 
   <variable id="#quote-start"><variableref refid="OpenQuote"/></variable>
   <variable id="#quote-end"><variableref refid="CloseQuote"/></variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -216,7 +216,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:with-param>
       </xsl:apply-templates>
       <xsl:choose>
-        <xsl:when test="count(*[contains(@class, ' task/step ')]) eq 1">
+        <xsl:when test="count(*[contains(@class, ' task/step ')]) eq 1 and
+                        not(contains(parent::*/@class, ' task/step '))">
           <fo:block>
             <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates mode="onestep"/>
@@ -247,18 +248,20 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/steps ')]/*[contains(@class, ' task/step ')]">
+        <xsl:variable name="depth" select="count(ancestor::*[contains(@class, ' task/steps ')])"/>
         <xsl:variable name="format">
           <xsl:call-template name="getVariable">
-            <xsl:with-param name="id" select="'Step Format'"/>
+            <xsl:with-param name="id" select="concat('Step Format ', $depth)"/>
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="steps.step">
             <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps.step__label">
                 <fo:block xsl:use-attribute-sets="steps.step__label__content">
-                    <xsl:if test="preceding-sibling::*[contains(@class, ' task/step ')] | following-sibling::*[contains(@class, ' task/step ')]">
+                    <xsl:if test="$depth > 1 or 
+                                  (preceding-sibling::*[contains(@class, ' task/step ')] | following-sibling::*[contains(@class, ' task/step ')])">
                         <xsl:call-template name="getVariable">
-                            <xsl:with-param name="id" select="'Step Number'"/>
+                            <xsl:with-param name="id" select="concat('Step Number ', $depth)"/>
                             <xsl:with-param name="params" as="element()*">
                                 <number>
                                     <xsl:number format="{$format}" count="*[contains(@class, ' task/step ')]"/>
@@ -336,7 +339,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' task/substeps ')]/*[contains(@class, ' task/substep ')]">
         <xsl:variable name="format">
           <xsl:call-template name="getVariable">
-            <xsl:with-param name="id" select="'Substep Format'"/>
+            <xsl:with-param name="id" select="'Step Format 2'"/>
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="substeps.substep">
@@ -344,7 +347,7 @@ See the accompanying LICENSE file for applicable license.
             <fo:list-item-label xsl:use-attribute-sets="substeps.substep__label">
                 <fo:block xsl:use-attribute-sets="substeps.substep__label__content">
                     <xsl:call-template name="getVariable">
-                      <xsl:with-param name="id" select="'Substep Number'"/>
+                      <xsl:with-param name="id" select="'Step Number 2'"/>
                       <xsl:with-param name="params" as="element()*">
                         <number>
                           <xsl:number format="{$format}"/>
@@ -562,6 +565,10 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
 
+    <xsl:template match="*[contains(@class,' task/step ')]/*" mode="dita2xslfo:task-heading">
+      <!-- No heading for DITA 2.0 nested steps -->
+    </xsl:template>
+      
     <xsl:template match="*" mode="dita2xslfo:task-heading">
         <xsl:param name="use-label"/>
         <xsl:if test="$GENERATE-TASK-LABELS='YES'">


### PR DESCRIPTION
Signed-off-by: Robert D. Anderson <robert.dan.anderson@oracle.com>

## Description

Updates to PDF and HTML5 styling to support https://github.com/oasis-tcs/dita/issues/106

## Motivation and Context

Need to support upcoming ability to nest steps, without disabling any of the current `<substep>` processing that DITA 1.x content relies on.

* Process `taskbody/steps` the same as today
* For nested steps:
** Ignore the style rule that "single step is formatted as a paragraph" -- single nested step is a single nested list item
** Add explicit list styles (using variables for PDF, or using `@type` for HTML5) -- this matches current list/nested list styling, and matches what is produced for cross references. Any style change to use different list numbers already requires digging into code to change cross references.
** Disable the "Steps" task heading when using nested steps
** Not enabled for XHTML, which is not maintained for the purposes of new DITA 2.0 features

## How Has This Been Tested?

DITA 2.0 test task with each combination of steps/steps-unordered nesting steps/steps-unordered, with single-step `<steps>` and multi-step `<steps>` (file attached renamed to `.txt` to allow attaching)
[nestedsteps.dita.txt](https://github.com/dita-ot/dita-ot/files/8352711/nestedsteps.dita.txt)


## Type of Changes

New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

No changes outside of release notes, possible list of what DITA 2.0 features are supported

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
