### PR TITLE
Add param to publication ref element

### DIFF
--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.List;
 
+/**
+ * Project file AST builder.
+ */
 public class ProjectBuilder {
 
     @JsonProperty("deliverables")

--- a/src/main/resources/project.rnc
+++ b/src/main/resources/project.rnc
@@ -70,7 +70,8 @@ publication =
 publication-ref =
   ## Publication reference
   element publication {
-    attribute idref { xsd:NCName }
+    attribute idref { xsd:NCName },
+    param*
   }
 
 param =

--- a/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
@@ -18,7 +18,9 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertTrue;
@@ -64,6 +66,50 @@ public class ProjectFactoryTest {
                 null
         );
         ProjectFactory.resolveReferences(src);
+    }
+
+    @Test
+    public void resolveReferences_publicationRefWithParam() {
+        final Project src = new Project(
+                singletonList(
+                        new Deliverable(
+                                null,
+                                null,
+                                null,
+                                null,
+                                new Publication(
+                                        null,
+                                        null,
+                                        "id",
+                                        null,
+                                        Arrays.asList(new Publication.Param("different", "override", null, null)),
+                                        null)
+                        )
+                ),
+                null,
+                singletonList(
+                        new Publication(
+                                null,
+                                "id",
+                                null,
+                                null,
+                                Arrays.asList(
+                                        new Publication.Param("different", "base", null, null),
+                                        new Publication.Param("same", "base", null, null)
+                                ),
+                                null)
+                ),
+                null
+        );
+        final Project act = ProjectFactory.resolveReferences(src);
+
+        final List<Publication.Param> params = new ArrayList<>(act.deliverables.get(0).publication.params);
+        params.sort(Comparator.comparing(p -> p.name));
+        assertEquals(2, params.size());
+        assertEquals("different", params.get(0).name);
+        assertEquals("override", params.get(0).value);
+        assertEquals("same", params.get(1).name);
+        assertEquals("base", params.get(1).value);
     }
 
     @Test
@@ -123,7 +169,6 @@ public class ProjectFactoryTest {
         assertEquals("id", act.deliverables.get(0).publication.id);
     }
 
-
     @Test
     public void read() throws IOException, URISyntaxException, SAXException {
         final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/simple.json").toURI();
@@ -134,6 +179,21 @@ public class ProjectFactoryTest {
     }
 
     @Test
+    public void read_product() throws IOException, URISyntaxException {
+        for (String extension : new String[]{"xml", "yaml", "json"}) {
+            final String path = String.format("org/dita/dost/project/product.%s", extension);
+            final URI file = getClass().getClassLoader().getResource(path).toURI();
+            final Project project = factory.load(file);
+            assertEquals(1, project.deliverables.size());
+            assertTrue(project.deliverables.get(0).context.inputs.inputs.get(0).href.isAbsolute());
+            assertEquals(3, project.deliverables.get(0).publication.params.size());
+            final Map<String, Project.Publication.Param> params = project.deliverables.get(0).publication.params.stream()
+                    .collect(Collectors.toMap(p -> p.name, Function.identity()));
+            assertEquals("NO", params.get("args.gen.task.lbl").value);
+        }
+    }
+
+    @Test
     public void readMultiple() throws IOException, URISyntaxException, SAXException {
         final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/multiple.json").toURI();
         final Project project = factory.load(file);
@@ -141,7 +201,6 @@ public class ProjectFactoryTest {
         assertTrue(project.deliverables.get(0).context.inputs.inputs.get(0).href.isAbsolute());
         assertTrue(project.includes.isEmpty());
     }
-
 
     @Test
     public void deserializeJsonRoot() throws IOException, URISyntaxException, SAXException {

--- a/src/test/resources/org/dita/dost/project/product.json
+++ b/src/test/resources/org/dita/dost/project/product.json
@@ -10,7 +10,10 @@
       },
       "output": "./site",
       "publication": {
-        "idref": "common-sitePub2"
+        "idref": "common-sitePub2",
+        "params": [
+          { "name": "args.gen.task.lbl", "value": "NO" }
+        ]
       }
     }
   ]

--- a/src/test/resources/org/dita/dost/project/product.xml
+++ b/src/test/resources/org/dita/dost/project/product.xml
@@ -5,6 +5,8 @@
   <deliverable name="name">
     <context idref="site"/>
     <output href="./site"/>
-    <publication idref="common-sitePub2"/>
+    <publication idref="common-sitePub2">
+      <param name="args.gen.task.lbl" value="NO"/>
+    </publication>
   </deliverable>
 </project>

--- a/src/test/resources/org/dita/dost/project/product.yaml
+++ b/src/test/resources/org/dita/dost/project/product.yaml
@@ -6,5 +6,7 @@ deliverables:
   output: "./site"
   publication:
     idref: "common-sitePub2"
+    params:
+    - { name: "args.gen.task.lbl", value: "NO" }
 includes:
 - "common.json"


### PR DESCRIPTION
## Description
Add support for overriding `param` in `publication` reference.

```xml
<project xmlns="https://www.dita-ot.org/project">
  <publication transtype="html5" id="common-html5">
    <param name="nav-toc" value="partial"/>
  </publication>
  <deliverable>
    <context>
      <input href="root.ditamap"/>
    </context>
    <output href="./out"/>
    <publication idref="common-html5">
      <param name="nav-toc" value="full"/> <!-- override common HTML publication -->
    </publication>
  </deliverable>
</project>
```

## Motivation and Context
Enables referencing a reusable publication and override parameters for it.

Fixes #3682

## How Has This Been Tested?
New tests.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
The docs currently don't have a reference for project syntax, so this param override should go into the examples.

