### PR TITLE
Fix mailto URI support in URI utils #3730

### DIFF
--- a/src/main/java/org/dita/dost/util/URLUtils.java
+++ b/src/main/java/org/dita/dost/util/URLUtils.java
@@ -572,7 +572,11 @@ public final class URLUtils {
      */
     public static URI setQuery(final URI path, final String query) {
         try {
-            return new URI(path.getScheme(), path.getUserInfo(), path.getHost(), path.getPort(), path.getPath(), query, path.getFragment());
+            if (path.getPath() != null) {
+                return new URI(path.getScheme(), path.getUserInfo(), path.getHost(), path.getPort(), path.getPath(), query, path.getFragment());
+            } else {
+                return new URI(path.getScheme(), path.getSchemeSpecificPart(), path.getFragment());
+            }
         } catch (final URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -197,9 +197,9 @@ public final class ValidationFilter extends AbstractXMLFilter {
         if (href != null) {
             try {
                 final URI uri = new URI(href);
-                final URI abs = URLUtils.setQuery(URLUtils.stripFragment(currentFile.resolve(uri)).normalize(), null);
-                if (abs.getScheme() != null && abs.getScheme().equals("file")) {
-                    final File p = new File(abs);
+                final URI abs = currentFile.resolve(uri).normalize();
+                if (Objects.equals(abs.getScheme(), "file")) {
+                    final File p = new File(URLUtils.setQuery(URLUtils.stripFragment(abs), null));
                     try {
                         final File canFile = p.getCanonicalFile();
                         final String absPath = p.getAbsolutePath();

--- a/src/test/java/org/dita/dost/util/URLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/URLUtilsTest.java
@@ -189,6 +189,11 @@ public class URLUtilsTest {
     }
 
     @Test
+    public void setFragment_mailto() {
+        assertEquals(URI.create("mailto:email@example.com?subject=Email"), URLUtils.setFragment(URI.create("mailto:email@example.com?subject=Email"), null));
+    }
+
+    @Test
     public void testRemoveFragment() throws URISyntaxException {
         assertEquals(new URI("foo"), URLUtils.removeFragment(new URI("foo#bar")));
         assertEquals(new URI("foo"), URLUtils.removeFragment(new URI("foo#")));
@@ -290,5 +295,10 @@ public class URLUtilsTest {
         assertEquals(URI.create("foo?baz"), URLUtils.setQuery(URI.create("foo"), "baz"));
         assertEquals(URI.create("foo"), URLUtils.setQuery(URI.create("foo?bar"), null));
         assertEquals(URI.create("foo?baz"), URLUtils.setQuery(URI.create("foo?bar"), "baz"));
+    }
+
+    @Test
+    public void setQuery_mailto() {
+        assertEquals(URI.create("mailto:email@example.com?subject=Email"), URLUtils.setQuery(URI.create("mailto:email@example.com?subject=Email"), null));
     }
 }


### PR DESCRIPTION
## Description
Support `mailto` URI scheme in URI utils to prevent exceptions.

## Motivation and Context
Fixes #3730

## How Has This Been Tested?
New unit tests
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Mention in release notes that `mailto` URIs will not cause exception anymore.