### PR TITLE
Feature/project reserved params 3913

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -423,6 +423,11 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <message id="DOTJ085E" type="ERROR">
+    <reason>Parameter '%1' cannot be set with param in project file. The param '%1' will be ignored.</reason>
+    <response>Use '%2' key instead.</response>
+  </message>
+
   <!-- End of Java Messages -->
     
   <!-- Start of XSL Messages -->  

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -28,6 +28,7 @@ package org.dita.dost.invoker;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import org.apache.tools.ant.*;
 import org.apache.tools.ant.input.DefaultInputHandler;
 import org.apache.tools.ant.input.InputHandler;
@@ -36,7 +37,6 @@ import org.apache.tools.ant.property.ResolvePropertyMap;
 import org.apache.tools.ant.util.ClasspathUtils;
 import org.apache.tools.ant.util.FileUtils;
 import org.apache.tools.ant.util.ProxySetup;
-import org.dita.dost.log.MessageUtils;
 import org.dita.dost.platform.Plugins;
 import org.dita.dost.project.Project.Context;
 import org.dita.dost.project.Project.Publication;
@@ -70,6 +70,12 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     private static final String ANT_TRANSTYPE = "transtype";
     private static final String ANT_PLUGIN_FILE = "plugin.file";
     private static final String ANT_PLUGIN_ID = "plugin.id";
+    private static final Map<String, String> RESERVED_PARAMS = ImmutableMap.of(
+            "output.dir", "output",
+            "transtype", "transtype",
+            "args.input", "input",
+            "args.filter", "profiles"
+    );
 
     /**
      * File that we are using for configuration.
@@ -482,10 +488,24 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         try {
             final ProjectFactory factory = ProjectFactory.getInstance();
             factory.setLax(true);
-            return factory.load(projectFile.toURI());
+            final org.dita.dost.project.Project res = factory.load(projectFile.toURI());
+            validateProject(res);
+            return res;
         } catch (Exception e) {
             printErrorMessage(e.getMessage());
             throw new BuildException("");
+        }
+    }
+
+    private void validateProject(org.dita.dost.project.Project project) throws IOException {
+        for (org.dita.dost.project.Project.Deliverable deliverable : project.deliverables) {
+            for (Publication.Param param : deliverable.publication.params) {
+                if (RESERVED_PARAMS.containsKey(param.name)) {
+                    final String msg = "Parameter " + param.name + " cannot be set with param, use "
+                            + RESERVED_PARAMS.get(param.name) + " key instead";
+                    printErrorMessage(msg);
+                }
+            }
         }
     }
 

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -37,6 +37,7 @@ import org.apache.tools.ant.property.ResolvePropertyMap;
 import org.apache.tools.ant.util.ClasspathUtils;
 import org.apache.tools.ant.util.FileUtils;
 import org.apache.tools.ant.util.ProxySetup;
+import org.dita.dost.log.MessageUtils;
 import org.dita.dost.platform.Plugins;
 import org.dita.dost.project.Project.Context;
 import org.dita.dost.project.Project.Publication;
@@ -501,9 +502,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         for (org.dita.dost.project.Project.Deliverable deliverable : project.deliverables) {
             for (Publication.Param param : deliverable.publication.params) {
                 if (RESERVED_PARAMS.containsKey(param.name)) {
-                    final String msg = "Parameter " + param.name + " cannot be set with param, use "
-                            + RESERVED_PARAMS.get(param.name) + " key instead";
-                    printErrorMessage(msg);
+                    printErrorMessage(MessageUtils.getMessage("DOTJ085E", param.name, RESERVED_PARAMS.get(param.name)).toString());
                 }
             }
         }


### PR DESCRIPTION
## Description
Log error message when `param` in project file defines a parameter that should be set with a dedicated key instead. 

## Motivation and Context
Fixes #3913.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Mention in release notes. More detailed description of error `DOTJ085E`.

