### PR TITLE
Fix mkdir issue when parallel=true

### DIFF
--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -235,7 +235,7 @@ public class StreamStore extends AbstractStore implements Store {
     }
 
     @VisibleForTesting
-    Serializer getSerializer(final URI dst) throws IOException {
+    synchronized Serializer getSerializer(final URI dst) throws IOException {
         final File outputFile = new File(dst);
         final File dir = outputFile.getParentFile();
         if (!dir.exists() && !dir.mkdirs()) {


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
This fixes the following error that could occur when `--parallel=yes` was used:

```
     [xslt] Failed to transform document: Failed to transform document: Failed to
            create directory /chrispy/dita/out/826_to_858
```

@raducoravu describes the root cause [here](https://github.com/dita-ot/dita-ot/issues/3917#issuecomment-1118201374).

## Motivation and Context
This is a fix for #3917 (if parallel=true, some files are not rendered).

## How Has This Been Tested?
I created a testcase to specifically reproduce the issue, then tested on two machines (12-core and 24-core) to reproduce the original problem and validate the fix.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Only release notes needed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I did not update any unit tests, but I don't think we have unit tests for parallel-processing transformations.