### PR TITLE
Fix Windows transformation slowdown for Java 12+ (#3932)

### DIFF
--- a/src/main/bin/ant.bat
+++ b/src/main/bin/ant.bat
@@ -128,14 +128,15 @@ if not "%JIKESPATH%"=="" goto runAntWithJikes
 :runAnt
 if "%_USE_CLASSPATH%"=="no" goto runAntNoClasspath
 :runAntWithClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %ANT_CMD_LINE_ARGS%
+rem sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
+"%_JAVACMD%" %ANT_OPTS% -Dsun.io.useCanonCaches=true -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %ANT_CMD_LINE_ARGS%
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%
 goto end
 
 :runAntNoClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% %ANT_CMD_LINE_ARGS%
+"%_JAVACMD%" %ANT_OPTS% -Dsun.io.useCanonCaches=true -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% %ANT_CMD_LINE_ARGS%
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%
@@ -152,14 +153,14 @@ goto runAntWithJikes
 if "%_USE_CLASSPATH%"=="no" goto runAntWithJikesNoClasspath
 
 :runAntWithJikesAndClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" "-Djikes.class.path=%JIKESPATH%" org.apache.tools.ant.launch.Launcher %ANT_ARGS%  -cp "%CLASSPATH%" %ANT_CMD_LINE_ARGS%
+"%_JAVACMD%" %ANT_OPTS% -Dsun.io.useCanonCaches=true -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" "-Djikes.class.path=%JIKESPATH%" org.apache.tools.ant.launch.Launcher %ANT_ARGS%  -cp "%CLASSPATH%" %ANT_CMD_LINE_ARGS%
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%
 goto end
 
 :runAntWithJikesNoClasspath
-"%_JAVACMD%" %ANT_OPTS% -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" "-Djikes.class.path=%JIKESPATH%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% %ANT_CMD_LINE_ARGS%
+"%_JAVACMD%" %ANT_OPTS% -Dsun.io.useCanonCaches=true -classpath "%ANT_HOME%\lib\ant-launcher.jar" "-Dant.home=%ANT_HOME%" "-Djikes.class.path=%JIKESPATH%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% %ANT_CMD_LINE_ARGS%
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%

--- a/src/main/bin/dita
+++ b/src/main/bin/dita
@@ -175,5 +175,6 @@ ant_sys_opts=
 if [ -n "$CYGHOME" ]; then
   ant_sys_opts="-Dcygwin.user.home=\"$CYGHOME\""
 fi
-ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
+# sun.io.useCanonCaches improves performance (see https://bugs.openjdk.java.net/browse/JDK-8207005)
+ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
 eval $ant_exec_command "$ant_exec_args"

--- a/src/main/bin/dita
+++ b/src/main/bin/dita
@@ -175,6 +175,5 @@ ant_sys_opts=
 if [ -n "$CYGHOME" ]; then
   ant_sys_opts="-Dcygwin.user.home=\"$CYGHOME\""
 fi
-# sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
-ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
+ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
 eval $ant_exec_command "$ant_exec_args"

--- a/src/main/bin/dita
+++ b/src/main/bin/dita
@@ -175,6 +175,6 @@ ant_sys_opts=
 if [ -n "$CYGHOME" ]; then
   ant_sys_opts="-Dcygwin.user.home=\"$CYGHOME\""
 fi
-# sun.io.useCanonCaches improves performance (see https://bugs.openjdk.java.net/browse/JDK-8207005)
+# sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
 ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
 eval $ant_exec_command "$ant_exec_args"

--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -57,7 +57,7 @@ if "%_JAVACMD%" == "" set _JAVACMD=%JAVA_HOME%\bin\java.exe
 if "%_JAVACMD%" == "" set _JAVACMD=java.exe
 
 :runAnt
-rem sun.io.useCanonCaches improves performance (see https://bugs.openjdk.java.net/browse/JDK-8207005)
+rem sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
 "%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError

--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -57,7 +57,8 @@ if "%_JAVACMD%" == "" set _JAVACMD=%JAVA_HOME%\bin\java.exe
 if "%_JAVACMD%" == "" set _JAVACMD=java.exe
 
 :runAnt
-"%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
+rem sun.io.useCanonCaches improves performance (see https://bugs.openjdk.java.net/browse/JDK-8207005)
+"%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%


### PR DESCRIPTION
## Description
Fixes Windows transformation slowdown for Java 12+ (#3932).

## Motivation and Context
This is a fix identified by @raducoravu. It improves a performance regression that occurred when Java versions 12+ disabled a canonical cache feature by default (see [JDK-8207005](https://bugs.openjdk.java.net/browse/JDK-8207005)). Windows is affected significantly (~2X) and linux is affected slightly (~5%).

## How Has This Been Tested?
Test results are posted in [#3932](https://github.com/dita-ot/dita-ot/issues/3932#issuecomment-1143569237).

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

`-Dsun.io.useCanonCaches=true` is added to the Java invocation command in the `dita.bat` and `dita` wrapper scripts.

## Documentation and Compatibility
No changes to plugins are needed; no documentation is needed.

For documentation, a release notes entry is sufficient.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I did not update any unit tests (I am not sure how to do this).