### PR TITLE
Use UTF-8 encoding when writing job

### DIFF
--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -27,6 +27,8 @@ import javax.xml.transform.dom.DOMResult;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
@@ -310,7 +312,7 @@ public final class Job {
      * @throws IOException if writing configuration files failed
      */
     public void write() throws IOException {
-        try (Writer outStream = new BufferedWriter(new OutputStreamWriter(getStore().getOutputStream(jobFile.toURI())))) {
+        try (Writer outStream = new BufferedWriter(new OutputStreamWriter(getStore().getOutputStream(jobFile.toURI()), StandardCharsets.UTF_8))) {
             XMLStreamWriter out = null;
             try {
                 out = XMLOutputFactory.newInstance().createXMLStreamWriter(outStream);


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Force using UTF-8 encoding when writing the .job.xml file as on Windows the default encoding might be some other encoding.
This fixes serialization problems when file paths may contain non-ASCII characters (for example Asian, Arabic).

## Motivation and Context
Fixes #3934

## How Has This Been Tested?
Automatic test, I do not have Windows with Asian locale to be able to work fluently with Asian characters in file paths.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
