### PR TITLE
Port fix for #3867 from #3874 to 3.7.3

### DIFF
--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -329,11 +329,11 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                     AttributeMap atts = ni.attributes();
                     final QName rewriteAttrName = getReferenceAttribute(node);
                     if (rewriteAttrName != null) {
-                        String referenceValue = node.getAttributeValue(rewriteAttrName);
+                        URI referenceValue = toURI(node.getAttributeValue(rewriteAttrName));
                         if (referenceValue != null) {
                             for (final KeyScope s : ss) {
-                                URI resolved = map.uri.resolve(referenceValue);
-                                String frag = resolved.getFragment();
+                                final URI resolved = map.uri.resolve(referenceValue);
+                                final String fragment = resolved.getFragment();
                                 final URI href = stripFragment(resolved);
                                 final FileInfo fi = job.getFileInfo(href);
                                 if (fi != null && fi.hasKeyref) {
@@ -344,10 +344,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                                     if (count != 0 && existing.isPresent()) {
                                         final ResolveTask resolveTask = existing.get();
                                         if (resolveTask.out != null) {
-                                            final URI value = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
-                                            referenceValue = value.toString();
-                                            if(frag != null && ! referenceValue.contains("#")) {
-                                                referenceValue += "#" + frag;
+                                            referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
+                                            if (fragment != null && referenceValue.getFragment() == null) {
+                                                referenceValue = setFragment(referenceValue, fragment);
                                             }
                                         }
                                     } else {
@@ -355,11 +354,10 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                                         res.add(resolveTask);
                                         final Integer used = usage.get(fi.uri);
                                         if (used > 1) {
-                                            final URI value = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
-                                            fixKeyDefRefs(s, fi.uri, value);
-                                            referenceValue = value.toString();
-                                            if(frag != null && ! referenceValue.contains("#")) {
-                                                referenceValue += "#" + frag;
+                                            referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
+                                            fixKeyDefRefs(s, fi.uri, referenceValue);
+                                            if (fragment != null && referenceValue.getFragment() == null) {
+                                                referenceValue = setFragment(referenceValue, fragment);
                                             }
                                         }
                                     }
@@ -368,7 +366,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                             atts = atts.put(new AttributeInfo(
                                     toNodeName(rewriteAttrName),
                                     STRING,
-                                    referenceValue,
+                                    referenceValue.toString(),
                                     Loc.NONE,
                                     ReceiverOption.NONE));
                         }

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -332,7 +332,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                         String referenceValue = node.getAttributeValue(rewriteAttrName);
                         if (referenceValue != null) {
                             for (final KeyScope s : ss) {
-                                final URI href = stripFragment(map.uri.resolve(referenceValue));
+                                URI resolved = map.uri.resolve(referenceValue);
+                                String frag = resolved.getFragment();
+                                final URI href = stripFragment(resolved);
                                 final FileInfo fi = job.getFileInfo(href);
                                 if (fi != null && fi.hasKeyref) {
                                     final int count = usage.getOrDefault(fi.uri, 0);
@@ -344,6 +346,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                                         if (resolveTask.out != null) {
                                             final URI value = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
                                             referenceValue = value.toString();
+                                            if(frag != null && ! referenceValue.contains("#")) {
+                                                referenceValue += "#" + frag;
+                                            }
                                         }
                                     } else {
                                         final ResolveTask resolveTask = processTopic(fi, s, isResourceOnly(node));
@@ -353,6 +358,9 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                                             final URI value = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
                                             fixKeyDefRefs(s, fi.uri, value);
                                             referenceValue = value.toString();
+                                            if(frag != null && ! referenceValue.contains("#")) {
+                                                referenceValue += "#" + frag;
+                                            }
                                         }
                                     }
                                 }

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -14,6 +14,8 @@ import net.sf.saxon.s9api.DOMDestination;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmDestination;
 import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.streams.Predicates;
+import net.sf.saxon.s9api.streams.Steps;
 import net.sf.saxon.serialize.SerializationProperties;
 import net.sf.saxon.trans.XPathException;
 import org.dita.dost.TestUtils;
@@ -46,7 +48,10 @@ import static java.net.URI.create;
 import static java.util.Collections.*;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.TestUtils.createTempDir;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
+import static org.dita.dost.util.Constants.MAP_TOPICREF;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class KeyrefModuleTest {
 
@@ -310,7 +315,7 @@ public class KeyrefModuleTest {
     }
 
 	@Test
-	public void testWalkMapAndRewriteKeydefHrefKeepAnchor() throws ParserConfigurationException, IOException, SAXException, URISyntaxException, XPathException {
+	public void testWalkMapAndRewriteKeydefHrefKeepAnchor() throws URISyntaxException, XPathException {
 	    inputMapFileInfo = new Builder()
 	            .uri(create("test3.ditamap"))
 	            .src(new File(baseDir, "src" + File.separator + "test3.ditamap").toURI())
@@ -348,19 +353,14 @@ public class KeyrefModuleTest {
 	    receiver.close();
 	    
 	    XdmNode node = destination.getXdmNode();
-	    assertEquals("<map xmlns:dita-ot=\"http://dita-ot.sourceforge.net/ns/201007/dita-ot\"\n" + 
-	    		"     xmlns:ditaarch=\"http://dita.oasis-open.org/architecture/2005/\"\n" + 
-	    		"     cascade=\"merge\"\n" + 
-	    		"     class=\"- map/map \"\n" + 
-	    		"     ditaarch:DITAArchVersion=\"1.3\"\n" + 
-	    		"     domains=\"(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)\">\n" + 
-	    		"   <topicref class=\"- map/topicref \" href=\"topic.dita#abc\"/>\n" + 
-	    		"   <topicgroup class=\"+ map/topicref mapgroup-d/topicgroup \" keyscope=\"A\">\n" + 
-	    		"      <topicref class=\"- map/topicref \" href=\"topic-1.dita#abc\"/>\n" + 
-	    		"   </topicgroup>\n" + 
-	    		"   <topicgroup class=\"+ map/topicref mapgroup-d/topicgroup \" keyscope=\"B\">\n" + 
-	    		"      <topicref class=\"- map/topicref \" href=\"topic-2.dita#abc\"/>\n" + 
-	    		"   </topicgroup>\n" + 
-	    		"</map>", node.toString());
+
+		assertTrue(node
+				.select(Steps.descendant(MAP_TOPICREF.matcher())
+						.where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-1.dita#abc")))
+				.exists());
+		assertTrue(node
+				.select(Steps.descendant(MAP_TOPICREF.matcher())
+						.where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-2.dita#abc")))
+				.exists());
 	}
 }

--- a/src/test/resources/KeyrefModuleTest/src/test3.ditamap
+++ b/src/test/resources/KeyrefModuleTest/src/test3.ditamap
@@ -1,0 +1,10 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" cascade="merge" class="- map/map " ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)">
+  <topicref class="- map/topicref " href="topic.dita#abc"/>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="A">
+    <topicref class="- map/topicref " href="topic.dita#abc"/>
+  </topicgroup>
+  
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup " keyscope="B">
+    <topicref class="- map/topicref " href="topic.dita#abc"/>
+  </topicgroup>
+</map>


### PR DESCRIPTION
This PR ports the fix for #3867 that @chrispy-snps provided in #3874 to 3.7.3 (previously merged to `develop` in 0ca967d).

Per @jlacour31’s suggestion in https://github.com/dita-ot/dita-ot/issues/3867#issuecomment-1156104320:

> @jelovirt and @infotexture it seems that the pull request was merged into develop branch and not in hotfixes/3.7.1. So the fix is not available neither in DOT 3.7.1 nor 3.7.2. You should consider cherry picking this fix for a 3.7.3 and updating the release notes to remove the reference to this fix.