### PR TITLE
Fix for #2704 Avoid renaming non-DITA resources on branches

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -596,31 +596,39 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
             final String scope = elem.getAttribute(ATTRIBUTE_NAME_SCOPE);
             if ((!href.isEmpty() || !copyTo.isEmpty()) && !scope.equals(ATTR_SCOPE_VALUE_EXTERNAL)) {
                 final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(href));
-                final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;
-                final URI dstSource;
-                dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result, filter);
-                final URI dstTemp = tempFileNameScheme.generateTempFileName(dstSource);
-                final String dstPathFromMap = !copyTo.isEmpty() ? FilenameUtils.getPath(copyTo) : FilenameUtils.getPath(href);
-                final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo)
-                        .result(dstSource)
-                        .uri(dstTemp);
-                if (dstBuilder.build().format == null) {
-                    dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
+                boolean isDITA = false;
+                if(hrefFileInfo != null) {
+                    isDITA = hrefFileInfo.format == null 
+                            || ATTR_FORMAT_VALUE_DITA.equals(hrefFileInfo.format) 
+                            || ATTR_FORMAT_VALUE_DITAMAP.equals(hrefFileInfo.format);
                 }
-                if (hrefFileInfo.src == null && href != null) {
-                    if (copyToFileInfo != null) {
-                        dstBuilder.src(copyToFileInfo.src);
+                if(isDITA) {
+                    final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;
+                    final URI dstSource;
+                    dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result, filter);
+                    final URI dstTemp = tempFileNameScheme.generateTempFileName(dstSource);
+                    final String dstPathFromMap = !copyTo.isEmpty() ? FilenameUtils.getPath(copyTo) : FilenameUtils.getPath(href);
+                    final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo)
+                            .result(dstSource)
+                            .uri(dstTemp);
+                    if (dstBuilder.build().format == null) {
+                        dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
                     }
-                }
-                final FileInfo dstFileInfo = dstBuilder
-                        .build();
+                    if (hrefFileInfo.src == null && href != null) {
+                        if (copyToFileInfo != null) {
+                            dstBuilder.src(copyToFileInfo.src);
+                        }
+                    }
+                    final FileInfo dstFileInfo = dstBuilder
+                            .build();
 
-                elem.setAttribute(BRANCH_COPY_TO, dstPathFromMap + FilenameUtils.getName(dstTemp.toString()));
-                if (!copyTo.isEmpty()) {
-                    elem.removeAttribute(ATTRIBUTE_NAME_COPY_TO);
-                }
+                    elem.setAttribute(BRANCH_COPY_TO, dstPathFromMap + FilenameUtils.getName(dstTemp.toString()));
+                    if (!copyTo.isEmpty()) {
+                        elem.removeAttribute(ATTRIBUTE_NAME_COPY_TO);
+                    }
 
-                job.add(dstFileInfo);
+                    job.add(dstFileInfo);
+                }
             }
         }
 

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -601,11 +601,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
             final String scope = elem.getAttribute(ATTRIBUTE_NAME_SCOPE);
             if ((!href.isEmpty() || !copyTo.isEmpty()) && !scope.equals(ATTR_SCOPE_VALUE_EXTERNAL)) {
                 final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(href));
-                boolean isDITA = false;
-                if(hrefFileInfo != null) {
-                    isDITA = isDitaFormat(hrefFileInfo.format);
-                }
-                if(isDITA) {
+                if (isDitaFormat(hrefFileInfo.format)) {
                     final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;
                     final URI dstSource;
                     dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result, filter);

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -267,8 +267,13 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
     private boolean isDitaFormat(final Attr formatAttr) {
         return formatAttr == null ||
-                ATTR_FORMAT_VALUE_DITA.equals(formatAttr.getNodeValue()) ||
-                ATTR_FORMAT_VALUE_DITAMAP.equals(formatAttr.getNodeValue());
+                isDitaFormat(formatAttr.getNodeValue());
+    }
+    
+    private boolean isDitaFormat(final String formatAttr) {
+        return formatAttr == null ||
+                ATTR_FORMAT_VALUE_DITA.equals(formatAttr) ||
+                ATTR_FORMAT_VALUE_DITAMAP.equals(formatAttr);
     }
 
     /** Filter map and remove excluded content. */
@@ -598,9 +603,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
                 final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(href));
                 boolean isDITA = false;
                 if(hrefFileInfo != null) {
-                    isDITA = hrefFileInfo.format == null 
-                            || ATTR_FORMAT_VALUE_DITA.equals(hrefFileInfo.format) 
-                            || ATTR_FORMAT_VALUE_DITAMAP.equals(hrefFileInfo.format);
+                    isDITA = isDitaFormat(hrefFileInfo.format);
                 }
                 if(isDITA) {
                     final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -7,6 +7,7 @@
  */
 package org.dita.dost.module;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
@@ -359,5 +360,27 @@ public class BranchFilterModuleTest extends BranchFilterModule {
 	    assertXMLEqual(new InputSource(new File(expDir, "topicAnchors.ditamap").toURI().toURL().toString()), 
 	    		new InputSource(new File(tempDir, "topicAnchors.ditamap").toURI().toURL().toString()));
 	}
+
+        @Test
+        public void testNoRenameNonDITAResources() throws IOException, SAXException {
+            final BranchFilterModule m = new BranchFilterModule();
+            final Job job = getJob();
+            for (final String uri: Arrays.asList("test.pdf")) {
+                job.add(new Job.FileInfo.Builder()
+                        .src(new File(tempDir, uri).toURI())
+                        .result(new File(tempDir, uri).toURI())
+                        .uri(URI.create(uri))
+                        .format(ATTR_FORMAT_VALUE_NONDITA)
+                        .build());
+            }
+            m.setJob(job);
+            final CachingLogger logger = new CachingLogger();
+            m.setLogger(logger);
+            m.setXmlUtils(new XMLUtils());
+            
+            m.processMap(URI.create("inputNonDitaRes.ditamap"));
+            assertXMLEqual(new InputSource(new File(expDir, "inputNonDitaRes.ditamap").toURI().toString()),
+                    new InputSource(new File(tempDir, "inputNonDitaRes.ditamap").toURI().toString()));
+        }
 
 }

--- a/src/test/resources/BranchFilterModuleTest/exp/inputNonDitaRes.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/exp/inputNonDitaRes.ditamap
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="1.3" domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   ">
+  <title class="- topic/title ">DITA Topic Map</title>
+  <topicref class="- map/topicref " href="install-mac.dita" keyscope="mac-">
+    
+      <topicref class="- map/topicref " format="pdf" href="test.pdf" navtitle="THIS IS MY PDF"/>
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref></topicref>
+</map>

--- a/src/test/resources/BranchFilterModuleTest/src/inputNonDitaRes.ditamap
+++ b/src/test/resources/BranchFilterModuleTest/src/inputNonDitaRes.ditamap
@@ -1,0 +1,14 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">DITA Topic Map</title>
+  <topicref href="install.dita" class="- map/topicref ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="mac.ditaval" processing-role="resource-only">
+      <ditavalmeta class="+ map/topicmeta ditavalref-d/ditavalmeta ">
+        <dvrResourceSuffix class="+ topic/data ditavalref-d/dvrResourceSuffix " name="dvrResourceSuffix">-mac</dvrResourceSuffix>
+        <dvrKeyscopePrefix class="+ topic/data ditavalref-d/dvrKeyscopePrefix " name="dvrKeyscopePrefix">mac-</dvrKeyscopePrefix>
+      </ditavalmeta>
+    </ditavalref>
+      <topicref href="test.pdf" format="pdf" navtitle="THIS IS MY PDF" class="- map/topicref "/>
+    </topicref>
+</map>


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Avoid renaming non-DITA resources in DITA Maps when using ditaval filters.

## Motivation and Context
Fixes #2704

## How Has This Been Tested?
Automatic test.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Avoid renaming non-DITA resources in DITA Maps when using ditaval filters.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
