### PR TITLE
Fix for #3727 Allow Saxon to decide configuration class

### DIFF
--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -81,7 +81,7 @@ public final class XMLUtils {
 
     public XMLUtils() {
         catalogResolver = CatalogUtils.getCatalogResolver();
-        final net.sf.saxon.Configuration config = new net.sf.saxon.Configuration();
+        final net.sf.saxon.Configuration config = net.sf.saxon.Configuration.newConfiguration();
         config.setURIResolver(catalogResolver);
         configureSaxonExtensions(config);
         configureSaxonCollationResolvers(config);


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
When there are a Saxon Enterprise Edition license and Saxon EE libraries present, allow Saxon XSLT engine to decide its own configuration implementation. 

## Motivation and Context
Allow running DITA OT with Saxon compatible EE libraries.

## How Has This Been Tested?
I tested this change manually some time ago. No auto test.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No doc in my opinion

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
