### PR TITLE
do not call dita-ot:matches-linktext-class() for <prop> or <revprop>

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -587,8 +587,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]">
             <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/navtitle ')]/node()"/>
           </xsl:when>
-          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
-            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
+          <xsl:when test="*/*[@class][dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[@class][dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of select="@href"/>
@@ -604,8 +604,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="@navtitle">
             <xsl:value-of select="@navtitle"/>
           </xsl:when>
-          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
-            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
+          <xsl:when test="*/*[@class][dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[@class][dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:otherwise>#none#</xsl:otherwise>
         </xsl:choose>
@@ -618,8 +618,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="@navtitle">
             <xsl:value-of select="@navtitle"/>
           </xsl:when>
-          <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
-            <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
+          <xsl:when test="*/*[@class][dita-ot:matches-linktext-class(@class)]">
+            <xsl:value-of select="*/*[@class][dita-ot:matches-linktext-class(@class)]"/>
           </xsl:when>
           <xsl:when test="$format = 'ditamap'">
             <!-- don't complain - peer maps don't need a navtitle -->
@@ -810,8 +810,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
   <xsl:template match="*" mode="mappull:navtitle-fallback" as="xs:string?">
     <xsl:choose>
       <xsl:when test="@navtitle"><xsl:value-of select="@navtitle"/></xsl:when>
-      <xsl:when test="*/*[dita-ot:matches-linktext-class(@class)]">
-        <xsl:value-of select="*/*[dita-ot:matches-linktext-class(@class)]"/>
+      <xsl:when test="*/*[@class][dita-ot:matches-linktext-class(@class)]">
+        <xsl:value-of select="*/*[@class][dita-ot:matches-linktext-class(@class)]"/>
         <xsl:apply-templates select="." mode="ditamsg:using-linktext-for-navtitle"/>
       </xsl:when>
       <xsl:otherwise>


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
This change ensures that `dita-ot:matches-linktext-class()` is not called with an empty sequence, which causes the function to fail with an exception because it requires a `@class` attribute as input.

`<prop>` and `<revprop>` elements do not have a `@class` attribute. The current code can inadvertently try to evaluate their `@class` attribute with this function, causing the issue.

## Motivation and Context
This fixes #3814.

## How Has This Been Tested?
This fix resolves the following four code paths that previously failed:

```
<topicref href="NOTFOUND.dita" rev="1.0"/>
<topicref href="topic.pdf" rev="1.0" scope="external" format="pdf"/>
<topicref href="topic.dita" rev="1.0" scope="peer"/>
<topicref href="topic.dita" rev="1.0" scope="external"/>
```

It was also tested by running `./gradlew test`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

The code paths related to the four cases above were updated to avoid calling the function with an empty sequence. Other approaches are described in #3814, but this change seemed the most precise.

## Documentation and Compatibility
This change introduces no compatibility issues. For documentation, a release notes mention is sufficient.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I do not know Java; can someone update unit tests to include this condition? Any map including the four constructs above is sufficient, along with a DITAVAL file that highlights `@rev`:

```
<val>
   <!-- highlight @rev revisions -->
   <revprop action="flag" backcolor="#FEFEE1"/>
</val>
```
