### PR TITLE
topic/media-track's href attribute should be transformed into a src attribute in HTML5.

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1581,6 +1581,10 @@ See the accompanying LICENSE file for applicable license.
     </track>
   </xsl:template>
   
+  <xsl:template match="*[contains(@class, ' topic/media-track ')]/@href">
+    <xsl:attribute name="src" select="."/>
+  </xsl:template>
+  
   <xsl:template match="*[contains(@class,' topic/audio ') or 
     contains(@class,' topic/video ') or 
     contains(@class,' topic/media-source ')]/@href">


### PR DESCRIPTION
@href under topic/media-track should be transformed into a src attribute in HTML5.

## Description
topic/media-track's @href was being emitted as a text node.  It should be a src attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track).  Another side-effect of this issue is it's emitting a text node first, and then its attributes, which causes the XSLT processor to crash.

## Motivation and Context
We're modelling our schema off of DITA 2.0's video/audio elements and would like to reuse the XSLT that was already written.

## Type of Changes
Added a template matching topic/media-track's href attribute that transforms it to a src attribute.
