### PR TITLE
Fix for #3724, properly compute absolute references to files.

### DIFF
--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -59,7 +59,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
             res = new ArrayList<>();
             for (final FileInfo f : job.getFileInfo(this::filter)) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
-                final File tempFile = new File(job.tempDir, f.file.getPath());
+                final File tempFile = FileUtils.getFilePath(job.tempDir, f.file);
                 if (job.getStore().exists(tempFile.toURI())) {
                     log("Found temporary directory file " + tempFile, Project.MSG_VERBOSE);
                     res.add(new StoreResource(job, job.tempDirURI.relativize(f.uri)));

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -7,10 +7,6 @@
  */
 package org.dita.dost.ant.types;
 
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.supportedImageExtensions;
-import static org.dita.dost.util.URLUtils.*;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.apache.tools.ant.Project;
@@ -31,6 +27,11 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
+
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
+import static org.dita.dost.util.FileUtils.supportedImageExtensions;
+import static org.dita.dost.util.URLUtils.toFile;
 
 /**
  * Resource collection that finds matching resources from job configuration.
@@ -59,7 +60,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
             res = new ArrayList<>();
             for (final FileInfo f : job.getFileInfo(this::filter)) {
                 log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
-                final File tempFile = FileUtils.getFilePath(job.tempDir, f.file);
+                final File tempFile = new File(job.tempDirURI.resolve(f.uri));
                 if (job.getStore().exists(tempFile.toURI())) {
                     log("Found temporary directory file " + tempFile, Project.MSG_VERBOSE);
                     res.add(new StoreResource(job, job.tempDirURI.relativize(f.uri)));

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -15,7 +15,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.ChunkMapReader;
 import org.dita.dost.util.Configuration;
 import org.dita.dost.util.DitaClass;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.TopicRefWriter;
@@ -74,7 +73,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
             if (transtype.equals(INDEX_TYPE_ECLIPSEHELP) && isEclipseMap(mapFile.toURI())) {
                 for (final FileInfo f : job.getFileInfo()) {
                     if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
-                        mapReader.read(FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile());
+                        mapReader.read(new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile());
                     }
                 }
             } else {

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.ChunkMapReader;
 import org.dita.dost.util.Configuration;
 import org.dita.dost.util.DitaClass;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.TopicRefWriter;
@@ -73,7 +74,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
             if (transtype.equals(INDEX_TYPE_ECLIPSEHELP) && isEclipseMap(mapFile.toURI())) {
                 for (final FileInfo f : job.getFileInfo()) {
                     if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
-                        mapReader.read(new File(job.tempDir, f.file.getPath()).getAbsoluteFile());
+                        mapReader.read(FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile());
                     }
                 }
             } else {

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -19,6 +19,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.ConrefPushReader;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.ConrefPushParser;
 import org.w3c.dom.DocumentFragment;
@@ -38,7 +39,7 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
             reader.setLogger(logger);
             reader.setJob(job);
             for (final FileInfo f: fis) {
-                final File file = new File(job.tempDir, f.file.getPath());
+                final File file = FileUtils.getFilePath(job.tempDir, f.file);
                 logger.info("Reading " + file.toURI());
                 //FIXME: this reader calculate parent directory
                 reader.read(file.getAbsoluteFile());

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -8,21 +8,20 @@
  */
 package org.dita.dost.module;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.ConrefPushReader;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.ConrefPushParser;
 import org.w3c.dom.DocumentFragment;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Conref push module.
@@ -39,7 +38,7 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
             reader.setLogger(logger);
             reader.setJob(job);
             for (final FileInfo f: fis) {
-                final File file = FileUtils.getFilePath(job.tempDir, f.file);
+                final File file = new File(job.tempDirURI.resolve(f.uri));
                 logger.info("Reading " + file.toURI());
                 //FIXME: this reader calculate parent directory
                 reader.read(file.getAbsoluteFile());

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -119,7 +119,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             logger.warn("Ignoring a copy-to file " + f.result);
             return;
         }
-        outputFile = FileUtils.getFilePath(job.tempDir, f.file);
+        outputFile = new File(job.tempDirURI.resolve(f.uri));
         logger.info("Processing " + f.src + " to " + outputFile.toURI());
 
         final Set<URI> schemaSet = dic.get(f.uri);

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -119,7 +119,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             logger.warn("Ignoring a copy-to file " + f.result);
             return;
         }
-        outputFile = new File(job.tempDir, f.file.getPath());
+        outputFile = FileUtils.getFilePath(job.tempDir, f.file);
         logger.info("Processing " + f.src + " to " + outputFile.toURI());
 
         final Set<URI> schemaSet = dic.get(f.uri);

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -1035,7 +1035,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
+        final File list = job.tempDir.toPath().resolve(prop.getProperty(fileKey)).toFile();
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             final Iterator<URI> it = newSet.iterator();
             while (it.hasNext()) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -1035,7 +1035,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = new File(job.tempDir, prop.getProperty(fileKey));
+        final File list = FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             final Iterator<URI> it = newSet.iterator();
             while (it.hasNext()) {

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -7,7 +7,13 @@
  */
 package org.dita.dost.module;
 
-import static org.dita.dost.util.Constants.*;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.Pool;
+import org.dita.dost.writer.ImageMetadataFilter;
+import org.xml.sax.Attributes;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,16 +22,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.pipeline.AbstractPipelineInput;
-import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.FileUtils;
-import org.dita.dost.util.Pool;
-import org.dita.dost.writer.ImageMetadataFilter;
-import org.xml.sax.Attributes;
+import static org.dita.dost.util.Constants.*;
 
 /**
  * Image metadata module.
@@ -69,7 +67,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
                 });
                 job.getFileInfo(filter).stream()
                         .parallel()
-                        .map(f -> FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile())
+                        .map(f -> new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile())
                         .forEach(filename -> {
                             final ImageMetadataFilter writer = pool.borrowObject();
                             try {
@@ -83,7 +81,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
                 writer.setLogger(logger);
                 writer.setJob(job);
                 for (final FileInfo f : job.getFileInfo(filter)) {
-                    writer.write(FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile());
+                    writer.write(new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile());
                 }
             }
 

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -22,6 +22,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Pool;
 import org.dita.dost.writer.ImageMetadataFilter;
 import org.xml.sax.Attributes;
@@ -68,7 +69,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
                 });
                 job.getFileInfo(filter).stream()
                         .parallel()
-                        .map(f -> new File(job.tempDir, f.file.getPath()).getAbsoluteFile())
+                        .map(f -> FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile())
                         .forEach(filename -> {
                             final ImageMetadataFilter writer = pool.borrowObject();
                             try {
@@ -82,7 +83,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
                 writer.setLogger(logger);
                 writer.setJob(job);
                 for (final FileInfo f : job.getFileInfo(filter)) {
-                    writer.write(new File(job.tempDir, f.file.getPath()).getAbsoluteFile());
+                    writer.write(FileUtils.getFilePath(job.tempDir, f.file).getAbsoluteFile());
                 }
             }
 

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -24,7 +24,6 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.KeyrefReader;
 import org.dita.dost.util.DelayConrefUtils;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
@@ -33,7 +32,6 @@ import org.dita.dost.writer.KeyrefPaser;
 import org.dita.dost.writer.TopicFragmentFilter;
 import org.xml.sax.XMLFilter;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
@@ -500,12 +498,12 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             if (r.out != null) {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri) +
                         " to " + job.tempDirURI.resolve(r.out.uri));
-                job.getStore().transform(FileUtils.getFilePath(job.tempDir, r.in.file).toURI(),
-                        FileUtils.getFilePath(job.tempDir, r.out.file).toURI(),
+                job.getStore().transform(job.tempDirURI.resolve(r.in.uri),
+                        job.tempDirURI.resolve(r.out.uri),
                         filters);
             } else {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri));
-                job.getStore().transform(FileUtils.getFilePath(job.tempDir, r.in.file).toURI(),
+                job.getStore().transform(job.tempDirURI.resolve(r.in.uri),
                         filters);
             }
             // validate resource-only list

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -24,6 +24,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.KeyrefReader;
 import org.dita.dost.util.DelayConrefUtils;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.KeyScope;
@@ -499,12 +500,12 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             if (r.out != null) {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri) +
                         " to " + job.tempDirURI.resolve(r.out.uri));
-                job.getStore().transform(new File(job.tempDir, r.in.file.getPath()).toURI(),
-                        new File(job.tempDir, r.out.file.getPath()).toURI(),
+                job.getStore().transform(FileUtils.getFilePath(job.tempDir, r.in.file).toURI(),
+                        FileUtils.getFilePath(job.tempDir, r.out.file).toURI(),
                         filters);
             } else {
                 logger.info("Processing " + job.tempDirURI.resolve(r.in.uri));
-                job.getStore().transform(new File(job.tempDir, r.in.file.getPath()).toURI(),
+                job.getStore().transform(FileUtils.getFilePath(job.tempDir, r.in.file).toURI(),
                         filters);
             }
             // validate resource-only list

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -15,6 +15,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
@@ -87,7 +88,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     }
 
     private void processMap(final FileInfo input) throws DITAOTException {
-        final File inputFile = new File(job.tempDir, input.file.getPath());
+        final File inputFile = FileUtils.getFilePath(job.tempDir, input.file);
         final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
 
         logger.info("Processing " + inputFile.toURI());
@@ -160,8 +161,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     }
 
     private void replace(final FileInfo input) throws DITAOTException {
-        final File inputFile = new File(job.tempDir, input.file.getPath() + FILE_EXTENSION_TEMP);
-        final File outputFile = new File(job.tempDir, input.file.getPath());
+        final File inputFile = FileUtils.getFilePath(job.tempDir, input.file.getPath() + FILE_EXTENSION_TEMP);
+        final File outputFile = FileUtils.getFilePath(job.tempDir, input.file);
         try {
             job.getStore().move(inputFile.toURI(), outputFile.toURI());
         } catch (final IOException e) {

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -15,7 +15,6 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
@@ -88,7 +87,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     }
 
     private void processMap(final FileInfo input) throws DITAOTException {
-        final File inputFile = FileUtils.getFilePath(job.tempDir, input.file);
+        final File inputFile = new File(job.tempDirURI.resolve(input.uri));
         final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
 
         logger.info("Processing " + inputFile.toURI());
@@ -161,8 +160,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     }
 
     private void replace(final FileInfo input) throws DITAOTException {
-        final File inputFile = FileUtils.getFilePath(job.tempDir, input.file.getPath() + FILE_EXTENSION_TEMP);
-        final File outputFile = FileUtils.getFilePath(job.tempDir, input.file);
+        final File inputFile = new File(job.tempDirURI.resolve(input.uri + FILE_EXTENSION_TEMP));
+        final File outputFile = new File(job.tempDirURI.resolve(input.uri));
         try {
             job.getStore().move(inputFile.toURI(), outputFile.toURI());
         } catch (final IOException e) {

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -16,6 +16,7 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MapMetaReader;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.DitaMapMetaWriter;
 import org.dita.dost.writer.DitaMetaWriter;
@@ -80,7 +81,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         }
 
         for (final FileInfo f : fis) {
-            final File inputFile = new File(job.tempDir, f.file.getPath());
+            final File inputFile = FileUtils.getFilePath(job.tempDir, f.file);
             final File tmp = new File(inputFile.getAbsolutePath() + ".tmp" + Long.toString(System.currentTimeMillis()));
             logger.info("Processing " + inputFile.toURI());
             logger.debug("Processing " + inputFile.toURI() + " to " + tmp.toURI());
@@ -133,7 +134,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
-                    logger.error("File " + new File(job.tempDir, key.getPath()) + " was not found.");
+                    logger.error("File " + FileUtils.getFilePath(job.tempDir, key) + " was not found.");
                     continue;
                 }
                 final URI targetFileName = job.tempDirURI.resolve(fi.uri);
@@ -159,7 +160,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
-                    logger.error("File " + new File(job.tempDir, key.getPath()) + " was not found.");
+                    logger.error("File " + FileUtils.getFilePath(job.tempDir, key) + " was not found.");
                     continue;
                 }
                 final URI targetFileName = job.tempDirURI.resolve(fi.uri);
@@ -186,7 +187,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         metaReader.setLogger(logger);
         metaReader.setJob(job);
         for (final FileInfo f : fis) {
-            final File mapFile = new File(job.tempDir, f.file.getPath());
+            final File mapFile = FileUtils.getFilePath(job.tempDir, f.file);
             //FIXME: this reader gets the parent path of input file
             try {
                 metaReader.read(mapFile);

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -16,7 +16,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MapMetaReader;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.DitaMapMetaWriter;
 import org.dita.dost.writer.DitaMetaWriter;
@@ -81,7 +80,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         }
 
         for (final FileInfo f : fis) {
-            final File inputFile = FileUtils.getFilePath(job.tempDir, f.file);
+            final File inputFile = new File(job.tempDirURI.resolve(f.uri));
             final File tmp = new File(inputFile.getAbsolutePath() + ".tmp" + Long.toString(System.currentTimeMillis()));
             logger.info("Processing " + inputFile.toURI());
             logger.debug("Processing " + inputFile.toURI() + " to " + tmp.toURI());
@@ -134,7 +133,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
-                    logger.error("File " + FileUtils.getFilePath(job.tempDir, key) + " was not found.");
+                    logger.error("File " + job.tempDirURI.resolve(key) + " was not found.");
                     continue;
                 }
                 final URI targetFileName = job.tempDirURI.resolve(fi.uri);
@@ -160,7 +159,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 final URI key = stripFragment(entry.getKey());
                 final FileInfo fi = job.getFileInfo(key);
                 if (fi == null) {
-                    logger.error("File " + FileUtils.getFilePath(job.tempDir, key) + " was not found.");
+                    logger.error("File " + job.tempDirURI.resolve(key) + " was not found.");
                     continue;
                 }
                 final URI targetFileName = job.tempDirURI.resolve(fi.uri);
@@ -187,7 +186,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         metaReader.setLogger(logger);
         metaReader.setJob(job);
         for (final FileInfo f : fis) {
-            final File mapFile = FileUtils.getFilePath(job.tempDir, f.file);
+            final File mapFile = job.tempDir.toPath().resolve(f.file.toPath()).toFile();
             //FIXME: this reader gets the parent path of input file
             try {
                 metaReader.read(mapFile);

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -19,6 +19,7 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 
 import javax.xml.transform.Source;
@@ -114,7 +115,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                 final List<Entry<File, File>> tmps = includes.stream().parallel()
                         .map(include -> {
                             try {
-                                final File in = new File(baseDir, include.getPath());
+                                final File in = FileUtils.getFilePath(baseDir, include);
                                 final File out = getOutput(include.getPath());
                                 if (out == null) {
                                     return null;
@@ -159,7 +160,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
     }
 
     private File getOutput(final String path) {
-        File out = new File(destDir, path);
+        File out = FileUtils.getFilePath(destDir, path);
         if (mapper != null) {
             final String[] outs = mapper.mapFileName(path);
             if (outs == null) {
@@ -168,7 +169,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
             if (outs.length > 1) {
                 throw new RuntimeException("XSLT module only support one to one output mapping");
             }
-            out = new File(destDir, outs[0]);
+            out = FileUtils.getFilePath(destDir, outs[0]);
         } else if (extension != null) {
             out = new File(replaceExtension(out.getAbsolutePath(), extension));
         }

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -19,7 +19,6 @@ import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.DelegatingURIResolver;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 
 import javax.xml.transform.Source;
@@ -115,7 +114,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                 final List<Entry<File, File>> tmps = includes.stream().parallel()
                         .map(include -> {
                             try {
-                                final File in = FileUtils.getFilePath(baseDir, include);
+                                final File in = baseDir.toPath().resolve(include.toPath()).toFile();
                                 final File out = getOutput(include.getPath());
                                 if (out == null) {
                                     return null;
@@ -160,7 +159,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
     }
 
     private File getOutput(final String path) {
-        File out = FileUtils.getFilePath(destDir, path);
+        File out = destDir.toPath().resolve(path).toFile();
         if (mapper != null) {
             final String[] outs = mapper.mapFileName(path);
             if (outs == null) {
@@ -169,7 +168,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
             if (outs.length > 1) {
                 throw new RuntimeException("XSLT module only support one to one output mapping");
             }
-            out = FileUtils.getFilePath(destDir, outs[0]);
+            out = destDir.toPath().resolve(outs[0]).toFile();
         } else if (extension != null) {
             out = new File(replaceExtension(out.getAbsolutePath(), extension));
         }

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -154,7 +154,7 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
+        final File list = job.tempDir.toPath().resolve(prop.getProperty(fileKey)).toFile();
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -154,7 +154,7 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = new File(job.tempDir, prop.getProperty(fileKey));
+        final File list = FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -33,7 +33,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -915,7 +914,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = org.dita.dost.util.FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
+        final File list = job.tempDir.toPath().resolve(prop.getProperty(fileKey)).toFile();
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -915,7 +915,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         // write list attribute to file
         final String fileKey = REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + "file";
         prop.setProperty(fileKey, REL_FLAGIMAGE_LIST.substring(0, REL_FLAGIMAGE_LIST.lastIndexOf("list")) + ".list");
-        final File list = new File(job.tempDir, prop.getProperty(fileKey));
+        final File list = org.dita.dost.util.FileUtils.getFilePath(job.tempDir, prop.getProperty(fileKey));
         try (Writer bufferedWriter = new BufferedWriter(new OutputStreamWriter(job.getStore().getOutputStream(list.toURI())))) {
             for (URI aNewSet : newSet) {
                 bufferedWriter.write(aNewSet.getPath());

--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -8,36 +8,29 @@
  */
 package org.dita.dost.reader;
 
-import static javax.xml.transform.OutputKeys.*;
-import static org.dita.dost.chunk.ChunkModule.isLocalScope;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.*;
+import org.dita.dost.util.Job.FileInfo;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.XMLFilterImpl;
 
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Stack;
 
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
-import javax.xml.transform.stream.StreamResult;
-
-import org.xml.sax.helpers.XMLFilterImpl;
-import org.xml.sax.helpers.AttributesImpl;
-
-import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.FileUtils;
-import org.dita.dost.util.Job;
-import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.MergeUtils;
-import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLUtils;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+import static org.dita.dost.chunk.ChunkModule.isLocalScope;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
 
 /**
  * MergeMapParser reads the ditamap file after preprocessing and merges
@@ -250,14 +243,14 @@ public final class MergeMapParser extends XMLFilterImpl {
                     String element = f.file.getPath();
                     if (!dirPath.equals(tempdir)) {
                         element = FileUtils.getRelativeUnixPath(new File(dirPath,"a.ditamap").getAbsolutePath(),
-                                                                   FileUtils.getFilePath(tempdir, element).getAbsolutePath());
+                                                                   tempdir.toPath().resolve(element).toAbsolutePath().toString());
                     }
                     final URI abs = job.tempDirURI.resolve(f.uri);
                     if (!util.isVisited(abs)) {
                         util.visit(abs);
                         if (!f.isResourceOnly) {
                             //ensure the file exists
-                            final File file = FileUtils.getFilePath(dirPath, element);
+                            final File file = dirPath.toPath().resolve(element).toFile();
                             if (job.getStore().exists(file.toURI())) {
                                 topicParser.parse(element, dirPath);
                             } else {

--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -250,14 +250,14 @@ public final class MergeMapParser extends XMLFilterImpl {
                     String element = f.file.getPath();
                     if (!dirPath.equals(tempdir)) {
                         element = FileUtils.getRelativeUnixPath(new File(dirPath,"a.ditamap").getAbsolutePath(),
-                                                                   new File(tempdir, element).getAbsolutePath());
+                                                                   FileUtils.getFilePath(tempdir, element).getAbsolutePath());
                     }
                     final URI abs = job.tempDirURI.resolve(f.uri);
                     if (!util.isVisited(abs)) {
                         util.visit(abs);
                         if (!f.isResourceOnly) {
                             //ensure the file exists
-                            final File file = new File(dirPath, element);
+                            final File file = FileUtils.getFilePath(dirPath, element);
                             if (job.getStore().exists(file.toURI())) {
                                 topicParser.parse(element, dirPath);
                             } else {

--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.URI;
 
 import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.MergeUtils;
 import org.dita.dost.util.URLUtils;
@@ -174,7 +175,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
         filePath = stripFragment(filename);
         dirPath = dir;
         try {
-            final URI f = new File(dir, filePath).getAbsoluteFile().toURI();
+            final URI f = FileUtils.getFilePath(dir, filePath).getAbsoluteFile().toURI();
             logger.info("Processing " + f);
             job.getStore().transform(f, this);
         } catch (final RuntimeException e) {
@@ -251,7 +252,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
      * @return rewritten href value
      */
     private URI handleLocalHref(final URI attValue) {
-        final URI current = new File(dirPath, filePath).toURI().normalize();
+        final URI current = FileUtils.getFilePath(dirPath, filePath).toURI().normalize();
         final URI reference = current.resolve(attValue);
         final URI merge = output.toURI();
         return getRelativePath(merge, reference);

--- a/src/main/java/org/dita/dost/reader/MergeTopicParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeTopicParser.java
@@ -8,19 +8,7 @@
  */
 package org.dita.dost.reader;
 
-import static javax.xml.XMLConstants.*;
-import static org.dita.dost.chunk.ChunkModule.isLocalScope;
-import static org.dita.dost.reader.MergeMapParser.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.URLUtils.setFragment;
-
-import java.io.File;
-import java.net.URI;
-
 import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.MergeUtils;
 import org.dita.dost.util.URLUtils;
@@ -29,6 +17,17 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.XMLFilterImpl;
+
+import java.io.File;
+import java.net.URI;
+
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.chunk.ChunkModule.isLocalScope;
+import static org.dita.dost.reader.MergeMapParser.ATTRIBUTE_NAME_OHREF;
+import static org.dita.dost.reader.MergeMapParser.ATTRIBUTE_NAME_OID;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.*;
 
 /**
  * MergeTopicParser reads topic file and transform the references to other dita
@@ -175,7 +174,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
         filePath = stripFragment(filename);
         dirPath = dir;
         try {
-            final URI f = FileUtils.getFilePath(dir, filePath).getAbsoluteFile().toURI();
+            final URI f = dir.toPath().resolve(filePath).toAbsolutePath().toFile().toURI();
             logger.info("Processing " + f);
             job.getStore().transform(f, this);
         } catch (final RuntimeException e) {
@@ -252,7 +251,7 @@ public final class MergeTopicParser extends XMLFilterImpl {
      * @return rewritten href value
      */
     private URI handleLocalHref(final URI attValue) {
-        final URI current = FileUtils.getFilePath(dirPath, filePath).toURI().normalize();
+        final URI current = dirPath.toPath().resolve(filePath).toUri().normalize();
         final URI reference = current.resolve(attValue);
         final URI merge = output.toURI();
         return getRelativePath(merge, reference);

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -8,12 +8,12 @@
  */
 package org.dita.dost.util;
 
-import static org.apache.commons.io.FilenameUtils.*;
-import static org.dita.dost.util.Constants.*;
-
 import java.io.File;
 import java.net.URI;
 import java.util.*;
+
+import static org.apache.commons.io.FilenameUtils.normalize;
+import static org.dita.dost.util.Constants.*;
 
 /**
  * Static file utilities.
@@ -623,7 +623,7 @@ public final class FileUtils {
      * @return The file path, never <code>null</code>
      */
     public static File getFilePath(File parent, URI path) {
-        return getFilePath(parent, path.getPath());
+        return parent.toPath().resolve(path.getPath()).toFile();
     }
     
     /**
@@ -633,7 +633,7 @@ public final class FileUtils {
      * @return The file path, never <code>null</code>
      */
     public static File getFilePath(File parent, File path) {
-        return getFilePath(parent, path.getPath());
+        return parent.toPath().resolve(path.toPath()).toFile();
     }
 
     /**
@@ -643,10 +643,6 @@ public final class FileUtils {
      * @return The file path, never <code>null</code>
      */
     public static File getFilePath(File parent, String path) {
-        File filePath = new File(path);
-        if(!filePath.isAbsolute()) {
-            filePath = new File(parent, path);
-        }
-        return filePath;
+        return parent.toPath().resolve(path).toFile();
     }
 }

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -615,34 +615,5 @@ public final class FileUtils {
             return c.getPath().startsWith(d.getPath());
         }
     }
-    
-    /**
-     * Get a file path.
-     * @param parent The parent file.
-     * @param path An URI containing a path which can be either absolute or relative. 
-     * @return The file path, never <code>null</code>
-     */
-    public static File getFilePath(File parent, URI path) {
-        return parent.toPath().resolve(path.getPath()).toFile();
-    }
-    
-    /**
-     * Get a file path.
-     * @param parent The parent file.
-     * @param path A file containing a path which can be either absolute or relative. 
-     * @return The file path, never <code>null</code>
-     */
-    public static File getFilePath(File parent, File path) {
-        return parent.toPath().resolve(path.toPath()).toFile();
-    }
 
-    /**
-     * Get a file path.
-     * @param parent The parent file.
-     * @param path A file path which can be either absolute or relative. 
-     * @return The file path, never <code>null</code>
-     */
-    public static File getFilePath(File parent, String path) {
-        return parent.toPath().resolve(path).toFile();
-    }
 }

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -615,5 +615,38 @@ public final class FileUtils {
             return c.getPath().startsWith(d.getPath());
         }
     }
+    
+    /**
+     * Get a file path.
+     * @param parent The parent file.
+     * @param path An URI containing a path which can be either absolute or relative. 
+     * @return The file path, never <code>null</code>
+     */
+    public static File getFilePath(File parent, URI path) {
+        return getFilePath(parent, path.getPath());
+    }
+    
+    /**
+     * Get a file path.
+     * @param parent The parent file.
+     * @param path A file containing a path which can be either absolute or relative. 
+     * @return The file path, never <code>null</code>
+     */
+    public static File getFilePath(File parent, File path) {
+        return getFilePath(parent, path.getPath());
+    }
 
+    /**
+     * Get a file path.
+     * @param parent The parent file.
+     * @param path A file path which can be either absolute or relative. 
+     * @return The file path, never <code>null</code>
+     */
+    public static File getFilePath(File parent, String path) {
+        File filePath = new File(path);
+        if(!filePath.isAbsolute()) {
+            filePath = new File(parent, path);
+        }
+        return filePath;
+    }
 }

--- a/src/test/java/org/dita/dost/util/TestFileUtils.java
+++ b/src/test/java/org/dita/dost/util/TestFileUtils.java
@@ -274,6 +274,16 @@ public class TestFileUtils {
         assertFalse(FileUtils.directoryContains(new File(srcDir, "test"), srcDir));
         assertFalse(FileUtils.directoryContains(srcDir, new File(srcDir, ".." + File.separator + "test.txt")));
     }
+    @Test
+    public void testFilePath() {
+        File f1 = new File(".").getAbsoluteFile();
+        File f2 = new File(srcDir, "test2.xml").getAbsoluteFile();
+        File f3 = new File("abc/test3.xml");
+        assertEquals(f2, FileUtils.getFilePath(f1, f2));
+        assertEquals(f2, FileUtils.getFilePath(f1, f2.toURI()));
+        assertEquals(f2, FileUtils.getFilePath(f1, f2.getPath()));
+        assertEquals(new File(f1, f3.getPath()), FileUtils.getFilePath(f1, f3));
+    }
     
     @AfterClass
     public static void tearDown() throws IOException {

--- a/src/test/java/org/dita/dost/util/TestFileUtils.java
+++ b/src/test/java/org/dita/dost/util/TestFileUtils.java
@@ -7,16 +7,15 @@
  */
 package org.dita.dost.util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-
-import java.io.*;
-
+import org.dita.dost.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.dita.dost.TestUtils;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 public class TestFileUtils {
 
@@ -273,16 +272,6 @@ public class TestFileUtils {
         assertFalse(FileUtils.directoryContains(srcDir, srcDir));
         assertFalse(FileUtils.directoryContains(new File(srcDir, "test"), srcDir));
         assertFalse(FileUtils.directoryContains(srcDir, new File(srcDir, ".." + File.separator + "test.txt")));
-    }
-    @Test
-    public void testFilePath() {
-        File f1 = new File(".").getAbsoluteFile();
-        File f2 = new File(srcDir, "test2.xml").getAbsoluteFile();
-        File f3 = new File("abc/test3.xml");
-        assertEquals(f2, FileUtils.getFilePath(f1, f2));
-        assertEquals(f2, FileUtils.getFilePath(f1, f2.toURI()));
-        assertEquals(f2, FileUtils.getFilePath(f1, f2.getPath()));
-        assertEquals(new File(f1, f3.getPath()), FileUtils.getFilePath(f1, f3));
     }
     
     @AfterClass


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Properly compute file path from parent and child path when the child path may be absolute.

## Motivation and Context
Fixes #3724

## How Has This Been Tested?
Automatic test.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
