### PR TITLE
Fix for #3967, cross-reference to footnote is double-wrapped in `<sup>`

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1147,9 +1147,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
-    <sup class="+ topic/ph hi-d/sup ">
-      <xsl:value-of select="$convergedcallout"/>
-    </sup>
+    <xsl:value-of select="$convergedcallout"/>
   </xsl:template>
 
   <!-- Getting text from a dlentry target: use the contents of the term -->


### PR DESCRIPTION
## Description
In `html5` and `xhtml` output, avoid double-wrapping an `<xref>` to a `<fn>` in `<sup>`.

## Motivation and Context
Fixes #3967.

## How Has This Been Tested?
Given the following cross-references:

```xml
<!-- computed target text -->
<xref href="#./fn" type="fn"/>
<xref href="#./fn" type="fn"><desc>mydesc</desc></xref>
```

the HTML output used to be (note the double `<sup>`):

```xml
<a class="xref topic/xref" href="#topic__fn"><sup><sup class="ph sup topic/ph hi-d/sup">1</sup></sup></a>
<a class="xref topic/xref" href="#topic__fn" title="mydesc"><sup><sup class="ph sup topic/ph hi-d/sup">1</sup></sup></a>
```

and with this fix, it is

```xml
<a class="xref topic/xref" href="#topic__fn"><sup>1</sup></a>
<a class="xref topic/xref" href="#topic__fn" title="mydesc"><sup>1</sup></a>
```

The testcase from #3967 yields the following results:

* `eclipsehelp`, `xhtml`, and `html5` reflect the fix in computed target text..
  * Explicitly specified target text remains unchanged.
* `markdown`, `markdown_gitbook`, `markdown_github`, `pdf`, and `pdf2` have no change in output.
  * `pdf` and `pdf2` do not use the target from preprocessing (computed or specified); they compute and use their own `<fn>` references.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

An extra `<xsl:when>` branch is added to detect the case of a single `<sup>`, which likely came from `topicpull`.

If there is a DITA-OT internal attribute that could be used to mark the `<sup>` from `topicpull`, that could be used too. But I didn't know if such a suitable attribute existed.

## Documentation and Compatibility
A release notes mention is sufficient. A potential draft description is:

> In earlier versions, when there was a cross-reference without target text to a `<fn>` element, XHTML and HTML5 processing rendered the link with two levels of `<sup>` (superscript) formatting. Now, these links are rendered with a single level of `<sup>` formatting.

This change should not adversely affect any existing plugins or flows.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
