### PR TITLE
Remove a Unicode quote character in the DOTJ085E message

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -424,7 +424,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ085E" type="ERROR">
-    <reason>The '%1' parameter can’t be set with 'param' in project files.</reason>
+    <reason>The '%1' parameter cannot be set with 'param' in project files.</reason>
     <response>Use '%2' instead.</response>
   </message>
 


### PR DESCRIPTION
## Description
This pull request changes a Unicode apostrophe (single-quote) character in the following message:

```
The '%1' parameter can’t be set with 'param' in project files.
                      ^
```

## Motivation and Context
This is the only message using "can't":

```
$ rg 'can’t' src/main/config/messages_template.xml
427:    <reason>The '%1' parameter can’t be set with 'param' in project files.</reason>
```

Other messages use "cannot":

```
$ rg 'cannot' src/main/config/messages_template.xml
23:    <reason>Input file '%1' cannot be located or read.</reason>
107:    <reason>At least one plug-in in '%1' is required by plug-in '%2'. Plug-in '%2' cannot be loaded.</reason>
377:    <reason>Rev attribute cannot be used with prop filter.</reason>
471:    <reason>File '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
477:    <reason>File '%1' does not exist or cannot be loaded.</reason>
718:    <reason>The link or cross reference target '%1' cannot be found, which may cause errors creating links or cross references in your output file.</reason>
738:    <reason>It appears that this document uses constraints, but the conref processor cannot validate that the target of a conref is valid.</reason>
813:    <reason>A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints "%1".</reason>
```

And, Oxygen does not show this Unicode character correctly in the transformation results window:

![image](https://user-images.githubusercontent.com/50950969/180625954-9294f04a-84ea-4515-890b-d7dac1fc1212.png)

## How Has This Been Tested?
I ran `.gradlew test`.

## Type of Changes
This is a single-word change in a relatively new message.

## Documentation and Compatibility
I don't think this change requires changes to documentation, user plugins, or anything else.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

No unit tests were affected.