### PR TITLE
Use #current in mode where possible

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/dita-utilities.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/dita-utilities.xsl
@@ -286,18 +286,18 @@ See the accompanying LICENSE file for applicable license.
       <xsl:text>.</xsl:text>
       <xsl:value-of select="substring-before($afterDot,'/')"/>
       <xsl:text>/</xsl:text>
-      <xsl:apply-templates select="." mode="parseHrefUptoExtension"><xsl:with-param name="href" select="substring-after($afterDot,'/')"/></xsl:apply-templates>
+      <xsl:apply-templates select="." mode="#current"><xsl:with-param name="href" select="substring-after($afterDot,'/')"/></xsl:apply-templates>
     </xsl:when>
     <!-- Multiple periods, no slashes, no topic or element ID, so the file name contains more periods -->
     <xsl:when test="not(contains($afterDot,'#'))">
       <xsl:text>.</xsl:text>
-      <xsl:apply-templates select="." mode="parseHrefUptoExtension"><xsl:with-param name="href" select="$afterDot"/></xsl:apply-templates>
+      <xsl:apply-templates select="." mode="#current"><xsl:with-param name="href" select="$afterDot"/></xsl:apply-templates>
     </xsl:when>
     <!-- Multiple periods, no slashes, with #. Move to next period. Needs additional work to support
          IDs containing periods. -->
     <xsl:otherwise>
       <xsl:text>.</xsl:text>
-      <xsl:apply-templates select="." mode="parseHrefUptoExtension"><xsl:with-param name="href" select="$afterDot"/></xsl:apply-templates>
+      <xsl:apply-templates select="." mode="#current"><xsl:with-param name="href" select="$afterDot"/></xsl:apply-templates>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>

--- a/src/main/plugins/org.dita.base/xsl/common/topic2textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/topic2textonly.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- DEFAULT RULE: FOR EVERY ELEMENT, ONLY PROCESS TEXT CONTENT -->
   <xsl:template match="*" mode="dita-ot:text-only">
-    <xsl:apply-templates select="text()|*|processing-instruction()" mode="dita-ot:text-only"/>
+    <xsl:apply-templates select="text()|*|processing-instruction()" mode="#current"/>
   </xsl:template>
 
   <xsl:template match="text()" mode="dita-ot:text-only">
@@ -26,7 +26,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="getVariable">
       <xsl:with-param name="id" select="'OpenQuote'"/>
     </xsl:call-template>
-    <xsl:apply-templates mode="dita-ot:text-only"/>
+    <xsl:apply-templates mode="#current"/>
     <xsl:call-template name="getVariable">
       <xsl:with-param name="id" select="'CloseQuote'"/>
     </xsl:call-template>
@@ -47,7 +47,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- EXCEPTIONS -->
   <xsl:template match="*[contains(@class,' topic/image ')]" mode="dita-ot:text-only">
     <xsl:choose>
-      <xsl:when test="*[contains(@class,' topic/alt ')]"><xsl:apply-templates mode="dita-ot:text-only"/></xsl:when>
+      <xsl:when test="*[contains(@class,' topic/alt ')]"><xsl:apply-templates mode="#current"/></xsl:when>
       <xsl:when test="@alt"><xsl:value-of select="@alt"/></xsl:when>
     </xsl:choose>
   </xsl:template>
@@ -62,7 +62,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' topic/xref ')]" mode="dita-ot:text-only">
-    <xsl:apply-templates select="node()[not(contains(@class,' topic/desc '))]" mode="dita-ot:text-only"/>
+    <xsl:apply-templates select="node()[not(contains(@class,' topic/desc '))]" mode="#current"/>
   </xsl:template>
 
 

--- a/src/main/plugins/org.dita.base/xsl/common/ui-d2textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/ui-d2textonly.xsl
@@ -18,7 +18,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="id" select="'#menucascade-separator'"/>
       </xsl:call-template>
     </xsl:if>
-    <xsl:apply-templates select="*|text()" mode="dita-ot:text-only"/>
+    <xsl:apply-templates select="*|text()" mode="#current"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -454,7 +454,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Processing a copy of the original element, that used @conref: apply-templates on
      all of the attributes, though some may be filtered out. -->
   <xsl:template match="*" mode="original-attributes">
-    <xsl:apply-templates select="@*" mode="original-attributes"/>
+    <xsl:apply-templates select="@*" mode="#current"/>
   </xsl:template>
 
   <xsl:template match="@*" mode="original-attributes">

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -53,11 +53,11 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="node() | @*" mode="strip">
     <xsl:copy>
-      <xsl:apply-templates select="node() | @*" mode="strip"/>
+      <xsl:apply-templates select="node() | @*" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' ditaot-d/submap ')]" mode="strip">
-    <xsl:apply-templates select="node()" mode="strip"/>
+    <xsl:apply-templates select="node()" mode="#current"/>
   </xsl:template>
 
   <!-- Start by creating the collection element for the map being processed. -->
@@ -142,7 +142,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:if test="*/*">
       <xsl:copy>
         <xsl:copy-of select="@*"/>
-        <xsl:apply-templates mode="add-links-to-temp-file"/>
+        <xsl:apply-templates mode="#current"/>
       </xsl:copy>
     </xsl:if>
   </xsl:template>
@@ -329,7 +329,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:apply-templates>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]" mode="recusive">
-    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="recusive"/>
+    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current"/>
   </xsl:template>
   <xsl:template match="*" mode="recusive" priority="-10">
     <xsl:apply-templates select="self::*[@href and not(@href = '')]
@@ -436,7 +436,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:value-of select="*[contains(@class, ' topic/title ')]"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:apply-templates mode="grab-group-title" select="*[contains(@class, ' map/topicref ')][1]"/>
+        <xsl:apply-templates mode="#current" select="*[contains(@class, ' map/topicref ')][1]"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>  
@@ -612,7 +612,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="@*|node()" mode="add-props-to-link">
     <xsl:copy>
-      <xsl:apply-templates select="@*|node()" mode="add-props-to-link"/>
+      <xsl:apply-templates select="@*|node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   <xsl:template match="@imageref" mode="add-props-to-link">

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -288,7 +288,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       <xsl:value-of select="@*[local-name() = $attrib]"/>
       <xsl:text> </xsl:text>
       <xsl:if test="ancestor-or-self::*[@cascade][1]/@cascade = 'merge'">
-        <xsl:apply-templates select="parent::*" mode="mappull:merge-inherit-attribute">
+        <xsl:apply-templates select="parent::*" mode="#current">
           <xsl:with-param name="attrib" select="$attrib"/>
         </xsl:apply-templates>
       </xsl:if>
@@ -300,12 +300,12 @@ Other modes can be found within the code, and may or may not prove useful for ov
     <xsl:value-of>
       <xsl:value-of select="@*[local-name() = $attrib]"/>
       <xsl:text> </xsl:text>
-      <xsl:apply-templates select="parent::*" mode="mappull:merge-inherit-attribute">
+      <xsl:apply-templates select="parent::*" mode="#current">
         <xsl:with-param name="attrib" select="$attrib"/>
       </xsl:apply-templates>
       <xsl:text> </xsl:text>
       <xsl:variable name="position" select="1 + count(preceding-sibling::*)" as="xs:integer"/>
-      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][$position ]" mode="mappull:merge-inherit-attribute">
+      <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]/*[contains(@class, ' map/relheader ')]/*[contains(@class, ' map/relcolspec ')][$position ]" mode="#current">
         <xsl:with-param name="attrib" select="$attrib"/>
       </xsl:apply-templates>
     </xsl:value-of>
@@ -320,7 +320,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
     <!--@importance|@linking|@toc|@print|@search|@format|@scope-->
     <xsl:param name="attrib" as="xs:string"/>
     <xsl:variable name="attrib-here" as="xs:string?">
-      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="mappull:inherit-attribute"/>
+      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="#current"/>
     </xsl:variable>
     <xsl:choose>
       <!-- Any time the attribute is specified on this element, use it -->
@@ -346,7 +346,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
           <xsl:when test="$row!=''"><xsl:value-of select="$row"/></xsl:when>
           <xsl:when test="$colspec!=''"><xsl:value-of select="$colspec"/></xsl:when>
           <xsl:otherwise>
-            <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]" mode="mappull:inherit-attribute">
+            <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]" mode="#current">
               <xsl:with-param name="attrib" select="$attrib"/>
             </xsl:apply-templates>
           </xsl:otherwise>
@@ -358,7 +358,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
         </xsl:apply-templates>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:apply-templates select="parent::*" mode="mappull:inherit-attribute">
+        <xsl:apply-templates select="parent::*" mode="#current">
           <xsl:with-param name="attrib" select="$attrib"/>
         </xsl:apply-templates>
       </xsl:otherwise>
@@ -1160,7 +1160,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
       <!-- In an abstract, and this is not the first -->
       <xsl:text> </xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="node()" mode="copy-shortdesc"/>
+    <xsl:apply-templates select="node()" mode="#current"/>
   </xsl:template>
   
   <xsl:template match="@id" mode="copy-shortdesc"/>
@@ -1176,7 +1176,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
   
   <xsl:template match="@* | node()" mode="copy-shortdesc" name="copy-shortdesc" priority="-10">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="copy-shortdesc"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -406,7 +406,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="not($linking='none') and @href and not(contains(@href,'#')) and not(@scope = 'peer')">
         <xsl:variable name="update-id-path" select="($mapref-id-path, generate-id(.))"/>
         <xsl:variable name="href" select="@href" as="xs:string?"/>
-        <xsl:apply-templates select="document($href, /)/*[contains(@class,' map/map ')]" mode="mapref">
+        <xsl:apply-templates select="document($href, /)/*[contains(@class,' map/map ')]" mode="#current">
           <xsl:with-param name="parentMaprefKeyscope" select="@keyscope" tunnel="yes"/>
           <xsl:with-param name="relative-path">
             <xsl:choose>
@@ -470,13 +470,13 @@ See the accompanying LICENSE file for applicable license.
       <xsl:if test="$keyscope">
         <xsl:attribute name="keyscope" select="$keyscope"/>
       </xsl:if>
-      <xsl:apply-templates select="@* | node()" mode="reltable-copy"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 
   <xsl:template match="@* | node()" mode="reltable-copy">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="reltable-copy"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 
@@ -590,7 +590,7 @@ See the accompanying LICENSE file for applicable license.
     <!--@importance|@linking|@toc|@print|@search|@format|@scope-->
     <xsl:param name="attrib"/>
     <xsl:variable name="attrib-here">
-      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="mappull:inherit-attribute"/>
+      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="#current"/>
     </xsl:variable>
     <xsl:choose>
       <!-- Any time the attribute is specified on this element, use it -->
@@ -625,14 +625,14 @@ See the accompanying LICENSE file for applicable license.
             <xsl:value-of select="$colspec"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]" mode="mappull:inherit-attribute">
+            <xsl:apply-templates select="ancestor::*[contains(@class, ' map/reltable ')]" mode="#current">
               <xsl:with-param name="attrib" select="$attrib"/>
             </xsl:apply-templates>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:apply-templates select="parent::*" mode="mappull:inherit-attribute">
+        <xsl:apply-templates select="parent::*" mode="#current">
           <xsl:with-param name="attrib" select="$attrib"/>
         </xsl:apply-templates>
       </xsl:otherwise>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -446,7 +446,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="*" mode="topicpull:inherit-attribute">
     <xsl:param name="attrib"/>
     <xsl:variable name="attrib-here" as="xs:string?">
-      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="topicpull:inherit-attribute"/>
+      <xsl:apply-templates select="@*[local-name()=$attrib]" mode="#current"/>
     </xsl:variable>
     <xsl:choose>
       <!-- Any time the attribute is specified on this element, use it -->
@@ -831,7 +831,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   
   <!-- If a link is to a title, assume the parent is the real target, process accordingly -->
   <xsl:template match="*[contains(@class,' topic/title ')]" mode="topicpull:resolvelinktext">
-    <xsl:apply-templates select=".." mode="topicpull:resolvelinktext"/>
+    <xsl:apply-templates select=".." mode="#current"/>
   </xsl:template>
   
   <!-- Get the link text from a specific topic. -->
@@ -1231,21 +1231,21 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:choose>
       <xsl:when test="empty(@href) or @scope='peer' or @scope='external'">
         <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="copy-shortdesc" />
+          <xsl:apply-templates select="@*|text()|*" mode="#current" />
         </xsl:copy>
       </xsl:when>
       <xsl:when test="@format and not(@format='dita')">
         <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="copy-shortdesc" />
+          <xsl:apply-templates select="@*|text()|*" mode="#current" />
         </xsl:copy>
       </xsl:when>
       <xsl:when test="not(contains(@href,'/'))"><!-- May be DITA, but in the same directory -->
         <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="copy-shortdesc" />
+          <xsl:apply-templates select="@*|text()|*" mode="#current" />
         </xsl:copy>
       </xsl:when>
       <xsl:when test="text()|*[not(contains(@class,' topic/desc '))]">
-        <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))]|text()|comment()|processing-instruction()" mode="copy-shortdesc" />
+        <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))]|text()|comment()|processing-instruction()" mode="#current" />
       </xsl:when>
       <xsl:otherwise>
         <xsl:text>***</xsl:text><!-- go get the target text -->
@@ -1267,7 +1267,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       <!-- In an abstract, and this is not the first -->
       <xsl:text> </xsl:text>
     </xsl:if>
-    <xsl:apply-templates select="*|text()|comment()|processing-instruction()" mode="copy-shortdesc" />
+    <xsl:apply-templates select="*|text()|comment()|processing-instruction()" mode="#current" />
   </xsl:template>
   
   <xsl:template match="@id" mode="copy-shortdesc" />
@@ -1277,7 +1277,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   
   <xsl:template match="*|@*|processing-instruction()" mode="copy-shortdesc">
     <xsl:copy>
-      <xsl:apply-templates select="@*|text()|*|processing-instruction()" mode="copy-shortdesc" />
+      <xsl:apply-templates select="@*|text()|*|processing-instruction()" mode="#current" />
     </xsl:copy>
   </xsl:template>
 
@@ -1386,7 +1386,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   
   <xsl:template match="*|@*|text()|comment()|processing-instruction()" mode="specialize-foreign-unknown">
     <xsl:copy>
-      <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="specialize-foreign-unknown"/>
+      <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
       <nav>
         <ul>
           <xsl:call-template name="commonattributes"/>
-          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
             <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
           </xsl:apply-templates>
         </ul>
@@ -92,7 +92,7 @@ See the accompanying LICENSE file for applicable license.
             [not(@toc = 'no')]
             [not(@processing-role = 'resource-only')]">
             <ul>
-              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
                 <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
               </xsl:apply-templates>
             </ul>
@@ -100,7 +100,7 @@ See the accompanying LICENSE file for applicable license.
         </li>
       </xsl:when>
       <xsl:otherwise><!-- if it is an empty topicref -->
-        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
           <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
         </xsl:apply-templates>
       </xsl:otherwise>
@@ -113,7 +113,7 @@ See the accompanying LICENSE file for applicable license.
     [not(@processing-role = 'resource-only')]"
     mode="toc">
     <xsl:param name="pathFromMaplist"/>
-    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
     </xsl:apply-templates>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -161,7 +161,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- CONTENT: Type -->
   <xsl:template match="dita" mode="gen-type-metadata">
-    <xsl:apply-templates select="*[1]" mode="gen-type-metadata"/>
+    <xsl:apply-templates select="*[1]" mode="#current"/>
   </xsl:template>
 
   <xsl:template match="*" mode="gen-type-metadata">
@@ -205,7 +205,7 @@ See the accompanying LICENSE file for applicable license.
     <meta name="rights">
       <xsl:attribute name="content">
         <xsl:text>&#xA9; </xsl:text>
-        <xsl:apply-templates select="*[contains(@class,' topic/copyryear ')][1]" mode="gen-metadata"/>
+        <xsl:apply-templates select="*[contains(@class,' topic/copyryear ')][1]" mode="#current"/>
         <xsl:text> </xsl:text>
         <xsl:if test="*[contains(@class,' topic/copyrholder ')]">
           <xsl:value-of select="*[contains(@class,' topic/copyrholder ')]"/>
@@ -234,7 +234,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:value-of select="@year"/>
       </xsl:otherwise>
     </xsl:choose>
-    <xsl:apply-templates select="$next" mode="gen-metadata">
+    <xsl:apply-templates select="$next" mode="#current">
       <xsl:with-param name="previous" select="."/>
       <xsl:with-param name="open-sequence" select="$begin-sequence"/>
     </xsl:apply-templates>

--- a/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
@@ -96,7 +96,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:choose>
       <xsl:when test="@imageref">
         <img src="{@imageref}">
-          <xsl:apply-templates select="alt-text" mode="ditaval-outputflag"/>
+          <xsl:apply-templates select="alt-text" mode="#current"/>
         </img>
       </xsl:when>
       <xsl:otherwise>

--- a/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
@@ -24,7 +24,7 @@ See the accompanying LICENSE file for applicable license.
       <nav>
         <ul>
           <xsl:call-template name="commonattributes"/>
-          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
             <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
           </xsl:apply-templates>
         </ul>
@@ -95,7 +95,7 @@ See the accompanying LICENSE file for applicable license.
                                      [not(@toc = 'no')]
                                      [not(@processing-role = 'resource-only')]">
             <ul>
-              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
                 <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
               </xsl:apply-templates>
             </ul>
@@ -103,7 +103,7 @@ See the accompanying LICENSE file for applicable license.
         </li>
       </xsl:when>
       <xsl:otherwise><!-- if it is an empty topicref -->
-        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
           <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
         </xsl:apply-templates>
       </xsl:otherwise>
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
                         [not(@processing-role = 'resource-only')]"
                 mode="toc">
     <xsl:param name="pathFromMaplist"/>
-    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
     </xsl:apply-templates>
   </xsl:template>
@@ -165,12 +165,12 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="/ | @* | node()" mode="normalize-map">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="normalize-map"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]" mode="normalize-map">
-    <xsl:apply-templates select="* except *[contains(@class, ' map/topicmeta ')]" mode="normalize-map"/>
+    <xsl:apply-templates select="* except *[contains(@class, ' map/topicmeta ')]" mode="#current"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -70,7 +70,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="pathFromMaplist" as="xs:string"/>
     <xsl:param name="children" select="()" as="element()*"/>
     <xsl:param name="parent" select="parent::*" as="element()?"/>
-    <xsl:apply-templates select="$parent" mode="toc-pull">
+    <xsl:apply-templates select="$parent" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
       <xsl:with-param name="children" select="$children"/>
     </xsl:apply-templates>
@@ -86,7 +86,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="title">
       <xsl:apply-templates select="." mode="get-navtitle"/>
     </xsl:variable>
-    <xsl:apply-templates select="$parent" mode="toc-pull">
+    <xsl:apply-templates select="$parent" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
       <xsl:with-param name="children" as="element()*">
         <xsl:apply-templates select="preceding-sibling::*[contains(@class, ' map/topicref ')]" mode="toc">
@@ -159,7 +159,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*" mode="toc" priority="-10">
     <xsl:param name="pathFromMaplist" as="xs:string"/>
-    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
     </xsl:apply-templates>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -104,7 +104,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="$include.roles = 'previous'">
           <!--output previous link first, if it exists-->
           <xsl:if test="*[@href][@role = 'previous']">
-            <xsl:apply-templates select="*[@href][@role = 'previous'][1]" mode="breadcrumb"/>
+            <xsl:apply-templates select="*[@href][@role = 'previous'][1]" mode="#current"/>
           </xsl:if>
         </xsl:if>
         <!--if both previous and next links exist, output a separator bar-->
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="$include.roles = 'next'">
           <!--output next link, if it exists-->
           <xsl:if test="*[@href][@role = 'next']">
-            <xsl:apply-templates select="*[@href][@role = 'next'][1]" mode="breadcrumb"/>
+            <xsl:apply-templates select="*[@href][@role = 'next'][1]" mode="#current"/>
           </xsl:if>
         </xsl:if>
         <xsl:if test="$include.roles = 'previous' and $include.roles = 'next' and $include.roles = 'ancestor'">
@@ -152,7 +152,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:with-param name="id" select="'Prerequisites'"/>
           </xsl:call-template>
         </dt>
-        <xsl:apply-templates select="$prereqs" mode="prereqs"/>
+        <xsl:apply-templates select="$prereqs" mode="#current"/>
       </dl>
     </xsl:if>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/svg-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/svg-d.xsl
@@ -39,13 +39,13 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="svg:*" mode="dita-ot:svg-prefix" priority="10">
     <xsl:element name="{local-name()}" namespace="http://www.w3.org/2000/svg">
-      <xsl:apply-templates select="@* | node()" mode="dita-ot:svg-prefix"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:element>
   </xsl:template>
   
   <xsl:template match="@* | node()" mode="dita-ot:svg-prefix">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="dita-ot:svg-prefix"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
     <div>
     <a name="{*[contains(@class,' topic/title ')]}"> </a>
-    <xsl:apply-templates mode="process-syntaxdiagram"/>
+    <xsl:apply-templates mode="#current"/>
     </div>
   </xsl:template>
   
@@ -42,7 +42,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]/*[contains(@class,' topic/title ')]" mode="process-syntaxdiagram">
-    <h4><xsl:apply-templates mode="process-syntaxdiagram"/></h4>
+    <h4><xsl:apply-templates mode="#current"/></h4>
   </xsl:template>
   
   
@@ -247,7 +247,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:otherwise>
           <a href="#">
             <xsl:attribute name="onMouseOver">
-              <xsl:text>alert('</xsl:text><xsl:apply-templates mode="process-syntaxdiagram"/><xsl:text>')</xsl:text>
+              <xsl:text>alert('</xsl:text><xsl:apply-templates mode="#current"/><xsl:text>')</xsl:text>
             </xsl:attribute>
             <xsl:text>*</xsl:text>
           </a>

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -316,7 +316,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="number($endCurrentRow) &lt; number($startMatchRow)">
         <!-- Call this template again with the next entry in column one -->
         <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">
-          <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
+          <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="#current">
             <xsl:with-param name="startMatchRow" select="$startMatchRow"/>
             <xsl:with-param name="endMatchRow" select="$endMatchRow"/>
             <xsl:with-param name="startCurrentRow" select="number($endCurrentRow)+1"/>
@@ -332,7 +332,7 @@ See the accompanying LICENSE file for applicable license.
         <!-- If we are not at the end of the tbody cell, and more rows exist, continue testing column 1 -->
         <xsl:if test="number($endCurrentRow) &lt; number($endMatchRow) and
                       parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">
-          <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
+          <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="#current">
             <xsl:with-param name="startMatchRow" select="$startMatchRow"/>
             <xsl:with-param name="endMatchRow" select="$endMatchRow"/>
             <xsl:with-param name="startCurrentRow" select="number($endCurrentRow)+1"/>

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -264,7 +264,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="." mode="steps">
       <xsl:with-param name="step_expand" select="$step_expand"/>
     </xsl:apply-templates>
-    <xsl:apply-templates select="following-sibling::*[1][contains(@class,' task/step ')]" mode="sequence-of-steps">
+    <xsl:apply-templates select="following-sibling::*[1][contains(@class,' task/step ')]" mode="#current">
       <xsl:with-param name="step_expand" select="$step_expand"/>
     </xsl:apply-templates>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1900,7 +1900,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:variable>
       <!-- If there are any module/element pairs before the last one, process them and add a space -->
       <xsl:if test="contains(substring-before($checkclass, $lastpair), '/')">
-        <xsl:apply-templates select="." mode="get-element-ancestry">
+        <xsl:apply-templates select="." mode="#current">
           <xsl:with-param name="checkclass" select="substring-before($checkclass, $lastpair)"/>
         </xsl:apply-templates>
         <xsl:text> </xsl:text>
@@ -2113,12 +2113,12 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- For header file processing, pull out the wrapping DIV if one is there -->
   <xsl:template match="/div" mode="add-HDF">
-    <xsl:apply-templates select="*|comment()|processing-instruction()|text()" mode="add-HDF"/>
+    <xsl:apply-templates select="*|comment()|processing-instruction()|text()" mode="#current"/>
   </xsl:template>
   
   <xsl:template match="*|@*|comment()|processing-instruction()|text()" mode="add-HDF">
     <xsl:copy>
-      <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="add-HDF"/>
+      <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -101,7 +101,7 @@ See the accompanying LICENSE file for applicable license.
                 <xsl:attribute name="href" select="$updateTopicTarget"/>
                 <xsl:choose>
                   <xsl:when test="$lastTopic">
-                    <xsl:apply-templates select="*|comment()|processing-instruction()" mode="resolve-root-dita">
+                    <xsl:apply-templates select="*|comment()|processing-instruction()" mode="#current">
                       <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
                     </xsl:apply-templates>
                   </xsl:when>
@@ -115,7 +115,7 @@ See the accompanying LICENSE file for applicable license.
         </xsl:when>
         <xsl:otherwise>
           <xsl:copy>
-            <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+            <xsl:apply-templates select="@*|node()" mode="#current">
               <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
             </xsl:apply-templates>
           </xsl:copy>
@@ -139,7 +139,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="dita/*[contains(@class,' topic/topic ')]" mode="resolve-root-dita">
       <xsl:param name="ditaDocs" as="element()+"/>
       <xsl:copy>
-        <xsl:apply-templates select="parent::dita/@*,@*|node()" mode="resolve-root-dita">
+        <xsl:apply-templates select="parent::dita/@*,@*|node()" mode="#current">
           <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
         </xsl:apply-templates>
       </xsl:copy>
@@ -148,7 +148,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="@*|node()" mode="resolve-root-dita">
       <xsl:param name="ditaDocs" as="element()+"/>
       <xsl:copy>
-        <xsl:apply-templates select="@*|node()" mode="resolve-root-dita">
+        <xsl:apply-templates select="@*|node()" mode="#current">
           <xsl:with-param name="ditaDocs" select="$ditaDocs" as="element()+"/>
         </xsl:apply-templates>
       </xsl:copy>
@@ -158,7 +158,7 @@ See the accompanying LICENSE file for applicable license.
         <opentopic:map xmlns:opentopic="http://www.idiominc.com/opentopic">
             <xsl:apply-templates/>
         </opentopic:map>
-        <xsl:apply-templates mode="build-tree"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' map/topicref ')]" mode="build-tree">
@@ -196,12 +196,12 @@ See the accompanying LICENSE file for applicable license.
                       </xsl:choose>
                   </title>
                   <!--body class=" topic/body "/-->
-                  <xsl:apply-templates mode="build-tree"/>
+                  <xsl:apply-templates mode="#current"/>
               </topic>
           </xsl:if>
       </xsl:when>
       <xsl:otherwise>
-          <xsl:apply-templates mode="build-tree"/>
+          <xsl:apply-templates mode="#current"/>
       </xsl:otherwise>
     </xsl:choose>
     </xsl:template>
@@ -211,36 +211,36 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' bookmap/backmatter ')] |
                          *[contains(@class,' bookmap/booklists ')] |
                          *[contains(@class,' bookmap/frontmatter ')]" priority="2" mode="build-tree">
-        <xsl:apply-templates mode="build-tree"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' bookmap/toc ')][not(@href)]" priority="2" mode="build-tree">
         <ot-placeholder:toc id="{generate-id()}">
-            <xsl:apply-templates mode="build-tree"/>
+            <xsl:apply-templates mode="#current"/>
         </ot-placeholder:toc>
     </xsl:template>
   
     <xsl:template match="*[contains(@class,' bookmap/indexlist ')][not(@href)]" priority="2" mode="build-tree">
         <ot-placeholder:indexlist id="{generate-id()}">
-            <xsl:apply-templates mode="build-tree"/>
+            <xsl:apply-templates mode="#current"/>
         </ot-placeholder:indexlist>
     </xsl:template>
   
     <xsl:template match="*[contains(@class,' bookmap/glossarylist ')][not(@href)]" priority="2" mode="build-tree">
         <ot-placeholder:glossarylist id="{generate-id()}">
-            <xsl:apply-templates mode="build-tree"/>
+            <xsl:apply-templates mode="#current"/>
         </ot-placeholder:glossarylist>
     </xsl:template>
   
     <xsl:template match="*[contains(@class,' bookmap/tablelist ')][not(@href)]" priority="2" mode="build-tree">
         <ot-placeholder:tablelist id="{generate-id()}">
-            <xsl:apply-templates mode="build-tree"/>
+            <xsl:apply-templates mode="#current"/>
         </ot-placeholder:tablelist>
     </xsl:template>
   
     <xsl:template match="*[contains(@class,' bookmap/figurelist ')][not(@href)]" priority="2" mode="build-tree">
         <ot-placeholder:figurelist id="{generate-id()}">
-            <xsl:apply-templates mode="build-tree"/>
+            <xsl:apply-templates mode="#current"/>
         </ot-placeholder:figurelist>
     </xsl:template>
 
@@ -329,7 +329,7 @@ See the accompanying LICENSE file for applicable license.
 
 
     <xsl:template match="*" mode="build-tree" priority="-1">
-        <xsl:apply-templates mode="build-tree"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="text()" mode="build-tree" priority="-1"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
@@ -68,17 +68,17 @@ See the accompanying LICENSE file for applicable license.
                 <fo:bookmark-title>
                     <xsl:value-of select="normalize-space($topicTitle)"/>
                 </fo:bookmark-title>
-                <xsl:apply-templates mode="bookmark"/>
+                <xsl:apply-templates mode="#current"/>
             </fo:bookmark>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:apply-templates mode="bookmark"/>
+            <xsl:apply-templates mode="#current"/>
           </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
     <xsl:template match="*" mode="bookmark">
-        <xsl:apply-templates mode="bookmark"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="text()" mode="bookmark"/>
@@ -172,7 +172,7 @@ See the accompanying LICENSE file for applicable license.
                 </xsl:call-template>
             </fo:bookmark-title>
             
-            <xsl:apply-templates mode="bookmark"/>
+            <xsl:apply-templates mode="#current"/>
         </fo:bookmark>
     </xsl:template>
     
@@ -188,7 +188,7 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:call-template>
                 </fo:bookmark-title>
                 
-                <xsl:apply-templates mode="bookmark"/>
+                <xsl:apply-templates mode="#current"/>
             </fo:bookmark>
         </xsl:if>
     </xsl:template>
@@ -205,7 +205,7 @@ See the accompanying LICENSE file for applicable license.
                     </xsl:call-template>
                 </fo:bookmark-title>
                 
-                <xsl:apply-templates mode="bookmark"/>
+                <xsl:apply-templates mode="#current"/>
             </fo:bookmark>
         </xsl:if>
     </xsl:template>
@@ -224,7 +224,7 @@ See the accompanying LICENSE file for applicable license.
                       </fo:bookmark-title>
                       <xsl:if test="$bookmarks.index-group-size !=0 and 
                                     count(//opentopic-index:index.groups//opentopic-index:index.entry) &gt; $bookmarks.index-group-size">
-                        <xsl:apply-templates select="//opentopic-index:index.groups" mode="bookmark-index"/>
+                        <xsl:apply-templates select="//opentopic-index:index.groups" mode="#current"/>
                       </xsl:if>
                   </fo:bookmark>
               </xsl:when>
@@ -233,10 +233,10 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="opentopic-index:index.groups" mode="bookmark-index">
-      <xsl:apply-templates select="opentopic-index:index.group" mode="bookmark-index"/>
+      <xsl:apply-templates select="opentopic-index:index.group" mode="#current"/>
     </xsl:template>
     <xsl:template match="opentopic-index:index.group" mode="bookmark-index">
-      <xsl:apply-templates select="opentopic-index:label" mode="bookmark-index"/>
+      <xsl:apply-templates select="opentopic-index:label" mode="#current"/>
     </xsl:template>
     <xsl:template match="opentopic-index:label" mode="bookmark-index">
       <!-- Letter headings in index are always collapsed, regardless of bookmarkStyle. -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flag-rules.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flag-rules.xsl
@@ -571,7 +571,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:param name="flagrules"/>
   <xsl:choose>
    <xsl:when test="$flagrules/*">
-    <xsl:apply-templates select="$flagrules/*[1]" mode="conflict-check"/>
+    <xsl:apply-templates select="$flagrules/*[1]" mode="#current"/>
    </xsl:when>
    <xsl:otherwise>
     <xsl:value-of select="'false'"/>
@@ -588,7 +588,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:value-of select="'true'"/>
    </xsl:when>
    <xsl:when test="following-sibling::*">
-    <xsl:apply-templates select="following-sibling::*[1]" mode="conflict-check">
+    <xsl:apply-templates select="following-sibling::*[1]" mode="#current">
      <xsl:with-param name="color" select="@color"/>
      <xsl:with-param name="backcolor" select="@backcolor"/>
     </xsl:apply-templates>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -102,7 +102,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="flag-attributes">
       <xsl:apply-templates select=".//prop/@backcolor | .//prop/@color | .//prop/@style |
-                                   .//revprop/@backcolor | .//revprop/@color | .//revprop/@style" mode="flag-attributes"/>
+                                   .//revprop/@backcolor | .//revprop/@color | .//revprop/@style" mode="#current"/>
     </xsl:template>
     <xsl:template match="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="flag-attributes">
       <!-- No flagging at end -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -78,7 +78,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:variable name="id" select="ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id"/>
         <xsl:variable name="mapTopicref" select="key('map-id', $id)[1]" as="element()?"/>
         <xsl:if test="not(contains($mapTopicref/@otherprops, 'noindex'))">
-            <xsl:apply-templates mode="index-entries"/>
+            <xsl:apply-templates mode="#current"/>
         </xsl:if>
     </xsl:template>
 
@@ -93,7 +93,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="opentopic-index:index.entry" mode="index-entries">
         <xsl:choose>
             <xsl:when test="opentopic-index:index.entry">
-                <xsl:apply-templates mode="index-entries"/>
+                <xsl:apply-templates mode="#current"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:copy-of select="."/>
@@ -104,7 +104,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="opentopic-index:index.groups" mode="index-entries"/>
 
     <xsl:template match="*" priority="-1" mode="index-entries">
-        <xsl:apply-templates mode="index-entries"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/indexterm ')]">
@@ -210,20 +210,20 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="id" select="'Index'"/>
       </xsl:call-template>
     </fo:block>
-    <xsl:apply-templates select="//opentopic-index:index.groups" mode="index-postprocess"/>
+    <xsl:apply-templates select="//opentopic-index:index.groups" mode="#current"/>
   </xsl:template>
 
     <xsl:template match="*" mode="index-postprocess" priority="-1">
-    <xsl:apply-templates mode="index-postprocess"/>
+    <xsl:apply-templates mode="#current"/>
   </xsl:template>
 
   <xsl:template match="opentopic-index:index.groups" mode="index-postprocess">
-    <xsl:apply-templates mode="index-postprocess"/>
+    <xsl:apply-templates mode="#current"/>
   </xsl:template>
 
   <xsl:template match="opentopic-index:index.group[opentopic-index:index.entry]" mode="index-postprocess">
     <fo:block xsl:use-attribute-sets="index.entry" >
-      <xsl:apply-templates mode="index-postprocess"/>
+      <xsl:apply-templates mode="#current"/>
     </fo:block>
   </xsl:template>
 
@@ -322,7 +322,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="opentopic-index:index.entry" mode="get-see-destination-id">
       <xsl:value-of select="concat(@value,':')"/>
-      <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-destination-id"/>
+      <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="#current"/>
     </xsl:template>
 
     <xsl:template match="opentopic-index:index.entry" mode="get-see-value">
@@ -330,7 +330,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="opentopic-index:formatted-value/node()"/>
             <xsl:if test="exists(opentopic-index:index.entry)">
               <xsl:text> </xsl:text>
-              <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="get-see-value"/>
+              <xsl:apply-templates select="opentopic-index:index.entry[1]" mode="#current"/>
             </xsl:if>
         </fo:inline>
     </xsl:template>
@@ -444,7 +444,7 @@ See the accompanying LICENSE file for applicable license.
             <fo:table-row>
               <fo:table-cell>
                 <fo:block xsl:use-attribute-sets="index.entry__content">
-                  <xsl:apply-templates mode="index-postprocess"/>
+                  <xsl:apply-templates mode="#current"/>
                 </fo:block>
               </fo:table-cell>
             </fo:table-row>
@@ -468,7 +468,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:if>
         </fo:block>
         <fo:block xsl:use-attribute-sets="index.entry__content">
-          <xsl:apply-templates mode="index-postprocess"/>
+          <xsl:apply-templates mode="#current"/>
         </fo:block>
       </xsl:otherwise>
     </xsl:choose>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -235,14 +235,14 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/dlentry ')]" mode="retrieveReferenceTitle">
-      <xsl:apply-templates select="*[contains(@class,' topic/dt ')][1]" mode="retrieveReferenceTitle"/>
+      <xsl:apply-templates select="*[contains(@class,' topic/dt ')][1]" mode="#current"/>
     </xsl:template>
     <xsl:template match="*[contains(@class, ' topic/dt ')]" mode="retrieveReferenceTitle">
       <xsl:apply-templates select="." mode="text-only"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/title ')]" mode="retrieveReferenceTitle">
-      <xsl:apply-templates select=".." mode="retrieveReferenceTitle"/>
+      <xsl:apply-templates select=".." mode="#current"/>
     </xsl:template>
 
     <!-- Default rule: if element has a title, use that, otherwise return '#none#' -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -120,7 +120,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="node() | @*" mode="codeblock.line-number">
     <xsl:copy>
-      <xsl:apply-templates select="node() | @*" mode="codeblock.line-number"/>
+      <xsl:apply-templates select="node() | @*" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   
@@ -142,7 +142,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="@* | node()" mode="codeblock">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="codeblock"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -96,7 +96,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="opentopic:map" mode="topicref-validation">
-        <xsl:apply-templates mode="topicref-validation"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="topicref-validation">
@@ -113,7 +113,7 @@ See the accompanying LICENSE file for applicable license.
               </xsl:call-template>
             </xsl:if>
         </xsl:if>
-        <xsl:apply-templates mode="topicref-validation"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*" mode="topicref-validation"/>
@@ -246,7 +246,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="generatePageSequenceFromTopicref"/>
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="$referencedTopic">
@@ -260,7 +260,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="createFrontMatter"/>
     <xsl:choose>
       <xsl:when test="$map-based-page-sequence-generation">
-        <xsl:apply-templates select="opentopic:map/*[contains(@class, ' map/topicref ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="opentopic:map/*[contains(@class, ' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <!-- legacy topic based page-sequence generation -->
       <xsl:otherwise>
@@ -278,13 +278,13 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*" mode="generatePageSequences" priority="-1">
-    <xsl:apply-templates select="*" mode="generatePageSequences"/>
+    <xsl:apply-templates select="*" mode="#current"/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' map/topicref ')]" mode="generatePageSequences" priority="0">
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <xsl:when test="ancestor::*[contains(@class,' bookmap/frontmatter ')]">
         <!-- TODO: To fit the pattern, this should be in its own match template. But a general match for frontmatter/*
@@ -304,13 +304,13 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' bookmap/frontmatter ') or
                          contains(@class, ' bookmap/backmatter ') or
                          contains(@class, ' bookmap/booklists ')]" mode="generatePageSequences">
-    <xsl:apply-templates select="*" mode="generatePageSequences"/>
+    <xsl:apply-templates select="*" mode="#current"/>
   </xsl:template>
   <xsl:template match="*[contains(@class, ' bookmap/chapter ')]" mode="generatePageSequences">
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="$referencedTopic">
@@ -323,7 +323,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="$referencedTopic">
@@ -336,7 +336,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="*[contains(@class,' map/topicref ')]" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="$referencedTopic">
@@ -349,7 +349,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="referencedTopic" select="key('topic-id', @id)" as="element()*"/>
     <xsl:choose>
       <xsl:when test="empty($referencedTopic)">
-        <xsl:apply-templates select="*[contains(@class, ' bookmap/appendix ')]" mode="generatePageSequences"/>
+        <xsl:apply-templates select="*[contains(@class, ' bookmap/appendix ')]" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:for-each select="$referencedTopic">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -188,7 +188,7 @@ See the accompanying LICENSE file for applicable license.
           <xsl:sequence select="$newmaxcount"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:apply-templates select="following-sibling::*[contains(@class, ' topic/strow ')][1]" mode="count-max-simpletable-cells">
+          <xsl:apply-templates select="following-sibling::*[contains(@class, ' topic/strow ')][1]" mode="#current">
             <xsl:with-param name="maxcount" select="$newmaxcount"/>
           </xsl:apply-templates>
         </xsl:otherwise>
@@ -260,7 +260,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:function>
 
     <xsl:template match="*" mode="insert-text">
-        <xsl:apply-templates mode="insert-text"/>
+        <xsl:apply-templates mode="#current"/>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/indexterm ')]" mode="insert-text"/>
@@ -896,7 +896,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="node() | text()" mode="setTableEntriesScale">
         <xsl:copy>
-            <xsl:apply-templates select="node() | @* | text()" mode="setTableEntriesScale"/>
+            <xsl:apply-templates select="node() | @* | text()" mode="#current"/>
         </xsl:copy>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -54,7 +54,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     
     <xsl:template match="/" mode="toc">
-        <xsl:apply-templates mode="toc">
+        <xsl:apply-templates mode="#current">
             <xsl:with-param name="include" select="'true'"/>
         </xsl:apply-templates>
     </xsl:template>
@@ -115,12 +115,12 @@ See the accompanying LICENSE file for applicable license.
                           </xsl:otherwise>
                         </xsl:choose>
                     </fo:block>
-                    <xsl:apply-templates mode="toc">
+                    <xsl:apply-templates mode="#current">
                         <xsl:with-param name="include" select="'true'"/>
                     </xsl:apply-templates>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:apply-templates mode="toc">
+                <xsl:apply-templates mode="#current">
                         <xsl:with-param name="include" select="'true'"/>
                 </xsl:apply-templates>
               </xsl:otherwise>
@@ -241,7 +241,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="node()" mode="toc">
         <xsl:param name="include"/>
-        <xsl:apply-templates mode="toc">
+        <xsl:apply-templates mode="#current">
             <xsl:with-param name="include" select="$include"/>
         </xsl:apply-templates>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -179,7 +179,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:param name="theName" select="''" as="xs:string"/>
         <xsl:choose>
             <xsl:when test="$theCounter > 0">
-                <xsl:apply-templates select="." mode="createTopicAttrsName">
+                <xsl:apply-templates select="." mode="#current">
                     <xsl:with-param name="theCounter" select="$theCounter - 1"/>
                     <xsl:with-param name="theName" select="concat($theName, 'topic.')"/>
                 </xsl:apply-templates>
@@ -1557,7 +1557,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="@id" mode="dropCopiedIds"/>
     <xsl:template match="*|@*|text()" mode="dropCopiedIds">
         <xsl:copy>
-            <xsl:apply-templates select="@*|*|text()" mode="dropCopiedIds"/>
+            <xsl:apply-templates select="@*|*|text()" mode="#current"/>
         </xsl:copy>
     </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml-util.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml-util.xsl
@@ -22,23 +22,23 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[namespace-uri() eq '']" mode="add-xhtml-ns" priority="10">
     <xsl:element name="{name()}" namespace="http://www.w3.org/1999/xhtml">
-      <xsl:apply-templates select="@* | node()" mode="add-xhtml-ns"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:element>
   </xsl:template>
   
   <xsl:template match="nav | section | figure | article" mode="add-xhtml-ns" priority="20">
     <xsl:element name="div" namespace="http://www.w3.org/1999/xhtml">
-      <xsl:apply-templates select="@* except @role | node()" mode="add-xhtml-ns"/>
+      <xsl:apply-templates select="@* except @role | node()" mode="#current"/>
     </xsl:element>
   </xsl:template>
 
   <!-- Group for root document node does not need extra XHTML div -->
   <xsl:template match="main/article" mode="add-xhtml-ns" priority="30">
-    <xsl:apply-templates select="node()" mode="add-xhtml-ns"/>
+    <xsl:apply-templates select="node()" mode="#current"/>
   </xsl:template>
 
   <xsl:template match="header | footer | main" mode="add-xhtml-ns" priority="20">
-    <xsl:apply-templates select="node()" mode="add-xhtml-ns"/>
+    <xsl:apply-templates select="node()" mode="#current"/>
   </xsl:template>
   
   <xsl:template match="div/@role" mode="add-xhtml-ns" priority="10"/>
@@ -47,7 +47,7 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="@* | node()" mode="add-xhtml-ns">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="add-xhtml-ns"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
@@ -24,7 +24,7 @@ See the accompanying LICENSE file for applicable license.
       <nav>
         <ul>
           <xsl:call-template name="commonattributes"/>
-          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+          <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
             <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
           </xsl:apply-templates>
         </ul>
@@ -95,7 +95,7 @@ See the accompanying LICENSE file for applicable license.
                                      [not(@toc = 'no')]
                                      [not(@processing-role = 'resource-only')]">
             <ul>
-              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+              <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
                 <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
               </xsl:apply-templates>
             </ul>
@@ -103,7 +103,7 @@ See the accompanying LICENSE file for applicable license.
         </li>
       </xsl:when>
       <xsl:otherwise><!-- if it is an empty topicref -->
-        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+        <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
           <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
         </xsl:apply-templates>
       </xsl:otherwise>
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
                         [not(@processing-role = 'resource-only')]"
                 mode="toc">
     <xsl:param name="pathFromMaplist"/>
-    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="toc">
+    <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="#current">
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
     </xsl:apply-templates>
   </xsl:template>
@@ -172,12 +172,12 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="/ | @* | node()" mode="normalize-map">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="normalize-map"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]" mode="normalize-map">
-    <xsl:apply-templates select="* except *[contains(@class, ' map/topicmeta ')]" mode="normalize-map"/>
+    <xsl:apply-templates select="* except *[contains(@class, ' map/topicmeta ')]" mode="#current"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1996,7 +1996,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
     <!-- If there are any module/element pairs before the last one, process them and add a space -->
     <xsl:if test="contains(substring-before($checkclass, $lastpair), '/')">
-      <xsl:apply-templates select="." mode="get-element-ancestry">
+      <xsl:apply-templates select="." mode="#current">
         <xsl:with-param name="checkclass" select="substring-before($checkclass, $lastpair)"/>
       </xsl:apply-templates>
       <xsl:text> </xsl:text>
@@ -2254,12 +2254,12 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- For header file processing, pull out the wrapping DIV if one is there -->
 <xsl:template match="/div" mode="add-HDF">
-  <xsl:apply-templates select="*|comment()|processing-instruction()|text()" mode="add-HDF"/>
+  <xsl:apply-templates select="*|comment()|processing-instruction()|text()" mode="#current"/>
 </xsl:template>
 
 <xsl:template match="*|@*|comment()|processing-instruction()|text()" mode="add-HDF">
   <xsl:copy>
-    <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="add-HDF"/>
+    <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()" mode="#current"/>
   </xsl:copy>
 </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
@@ -159,7 +159,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- CONTENT: Type -->
 <xsl:template match="dita" mode="gen-type-metadata">
-  <xsl:apply-templates select="*[1]" mode="gen-type-metadata"/>
+  <xsl:apply-templates select="*[1]" mode="#current"/>
 </xsl:template>
 <xsl:template match="*" mode="gen-type-metadata">
   <meta name="DC.type" content="{name(.)}"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
@@ -96,7 +96,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:choose>
       <xsl:when test="@imageref">
         <img src="{@imageref}">
-          <xsl:apply-templates select="alt-text" mode="ditaval-outputflag"/>
+          <xsl:apply-templates select="alt-text" mode="#current"/>
         </img>
       </xsl:when>
       <xsl:otherwise>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -106,7 +106,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="$include.roles = 'previous'">
           <!--output previous link first, if it exists-->
           <xsl:if test="*[@href][@role = 'previous']">
-            <xsl:apply-templates select="*[@href][@role = 'previous'][1]" mode="breadcrumb"/>
+            <xsl:apply-templates select="*[@href][@role = 'previous'][1]" mode="#current"/>
           </xsl:if>
         </xsl:if>
         <!--if both previous and next links exist, output a separator bar-->
@@ -118,7 +118,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="$include.roles = 'next'">
           <!--output next link, if it exists-->
           <xsl:if test="*[@href][@role = 'next']">
-            <xsl:apply-templates select="*[@href][@role = 'next'][1]" mode="breadcrumb"/>
+            <xsl:apply-templates select="*[@href][@role = 'next'][1]" mode="#current"/>
           </xsl:if>
         </xsl:if>
         <xsl:if test="$include.roles = 'previous' and $include.roles = 'next' and $include.roles = 'ancestor'">
@@ -158,7 +158,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </dt>
         <xsl:value-of select="$newline"/>
-        <xsl:apply-templates select="$prereqs" mode="prereqs"/>
+        <xsl:apply-templates select="$prereqs" mode="#current"/>
       </dl>
       <xsl:value-of select="$newline"/>
     </xsl:if>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/svg-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/svg-d.xsl
@@ -39,13 +39,13 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="svg:*" mode="dita-ot:svg-prefix" priority="10">
     <xsl:element name="{local-name()}" namespace="http://www.w3.org/2000/svg">
-      <xsl:apply-templates select="@* | node()" mode="dita-ot:svg-prefix"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:element>
   </xsl:template>
   
   <xsl:template match="@* | node()" mode="dita-ot:svg-prefix">
     <xsl:copy>
-      <xsl:apply-templates select="@* | node()" mode="dita-ot:svg-prefix"/>
+      <xsl:apply-templates select="@* | node()" mode="#current"/>
     </xsl:copy>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
@@ -26,7 +26,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
   <div>
   <a name="{*[contains(@class,' topic/title ')]}"> </a>
-  <xsl:apply-templates mode="process-syntaxdiagram"/>
+  <xsl:apply-templates mode="#current"/>
   </div>
 </xsl:template>
 
@@ -48,7 +48,7 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' pr-d/fragment ')]/*[contains(@class,' topic/title ')]" mode="process-syntaxdiagram">
-  <h4><xsl:apply-templates mode="process-syntaxdiagram"/></h4>
+  <h4><xsl:apply-templates mode="#current"/></h4>
 </xsl:template>
 
 
@@ -254,7 +254,7 @@ and if so, produce an associative link. -->
     <xsl:otherwise>
         <a href="#">
           <xsl:attribute name="onMouseOver">
-            <xsl:text>alert('</xsl:text><xsl:apply-templates mode="process-syntaxdiagram"/><xsl:text>')</xsl:text>
+            <xsl:text>alert('</xsl:text><xsl:apply-templates mode="#current"/><xsl:text>')</xsl:text>
           </xsl:attribute>
           <xsl:text>*</xsl:text>
         </a>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -621,7 +621,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:when test="number($endCurrentRow) &lt; number($startMatchRow)">
       <!-- Call this template again with the next entry in column one -->
       <xsl:if test="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">
-        <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
+        <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="#current">
           <xsl:with-param name="startMatchRow" select="$startMatchRow"/>
           <xsl:with-param name="endMatchRow" select="$endMatchRow"/>
           <xsl:with-param name="startCurrentRow" select="number($endCurrentRow)+1"/>
@@ -637,7 +637,7 @@ See the accompanying LICENSE file for applicable license.
       <!-- If we are not at the end of the tbody cell, and more rows exist, continue testing column 1 -->
       <xsl:if test="number($endCurrentRow) &lt; number($endMatchRow) and
                     parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]">
-        <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="check-first-column">
+        <xsl:apply-templates select="parent::*/parent::*/*[contains(@class, ' topic/row ')][number($endCurrentRow)+1]/*[contains(@class, ' topic/entry ')][1]" mode="#current">
           <xsl:with-param name="startMatchRow" select="$startMatchRow"/>
           <xsl:with-param name="endMatchRow" select="$endMatchRow"/>
           <xsl:with-param name="startCurrentRow" select="number($endCurrentRow)+1"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -212,7 +212,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:apply-templates select="." mode="steps">
     <xsl:with-param name="step_expand" select="$step_expand"/>
   </xsl:apply-templates>
-  <xsl:apply-templates select="following-sibling::*[1][contains(@class,' task/step ')]" mode="sequence-of-steps">
+  <xsl:apply-templates select="following-sibling::*[1][contains(@class,' task/step ')]" mode="#current">
     <xsl:with-param name="step_expand" select="$step_expand"/>
   </xsl:apply-templates>
 </xsl:template>


### PR DESCRIPTION
Signed-off-by: Jarno Elovirta <jarno@elovirta.com>

## Description
Use `#current` in mode where possible.

## Motivation and Context
Simplify code and improve readability.

## How Has This Been Tested?
Existing tests pass.
## Type of Changes
- Enhancement

## Documentation and Compatibility
None needed

