### PR TITLE
Fix elements without class attribute in force unique

### DIFF
--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -15,10 +15,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.net.URI;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.dita.dost.chunk.ChunkModule.isLocalScope;
 import static org.dita.dost.util.Constants.*;
@@ -42,7 +39,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     /**
      * Stack used to detect the current element type. 
      */
-    private final Deque<String> classElementStack = new ArrayDeque<>();
+    private final Deque<Optional<String>> classElementStack = new ArrayDeque<>();
     
     /**
      * Stack used to hold the current topicref parent.
@@ -57,7 +54,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
         ignoreStack.push(MAP_RELTABLE.matches(atts) ? false : ignoreStack.isEmpty() || ignoreStack.peek());
 
         final String classValue = atts.getValue(ATTRIBUTE_NAME_CLASS);
-        classElementStack.addFirst(classValue);
+        classElementStack.addFirst(Optional.ofNullable(classValue));
 
         Attributes res = atts;
         if (ignoreStack.peek() && MAP_TOPICREF.matches(res)) {
@@ -116,8 +113,8 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         getContentHandler().endElement(uri, localName, qName);
 
-        final String classValue = classElementStack.removeFirst();
-        if (classValue != null && ignoreStack.peek() && MAP_TOPICREF.matches(classValue)) {
+        final Optional<String> classValue = classElementStack.removeFirst();
+        if (classValue.isPresent() && ignoreStack.peek() && MAP_TOPICREF.matches(classValue.get())) {
             topicrefParentsStack.pop();
         }
         ignoreStack.pop();

--- a/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
@@ -1,5 +1,5 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
-  <title class="- topic/title ">DITA Topic Map</title>
+  <title class="- topic/title ">DITA Topic Map <foreign class="- topic/foreign "><foo/></foreign></title>
   <topicref class="- map/topicref " href="test.dita"></topicref>
   <topicref class="- map/topicref " href="test.dita#test" copy-to="test_2.dita#test"></topicref>
   <topicref class="- map/topicref " href="test.dita" copy-to="test_3.dita"></topicref>

--- a/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
@@ -1,5 +1,5 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
-  <title class="- topic/title ">DITA Topic Map</title>
+  <title class="- topic/title ">DITA Topic Map <foreign class="- topic/foreign "><foo/></foreign></title>
   <topicref class="- map/topicref " href="test.dita"></topicref>
   <topicref class="- map/topicref " href="test.dita#test"></topicref>
   <topicref class="- map/topicref " href="test.dita"></topicref>


### PR DESCRIPTION

## Description
In force unique processing, support DITA maps that contain elements without `@class` attribute, e.g. inside `<foreign>`.

## Motivation and Context
Fixes #3980

## How Has This Been Tested?
Added unit test.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Mention in release notes.
