### PR TITLE
3985  No alternate text specified when reading out loud TOC entries

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -34,6 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
+    xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:opentopic="http://www.idiominc.com/opentopic"
     xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
@@ -76,6 +77,9 @@ See the accompanying LICENSE file for applicable license.
                           <fo:basic-link xsl:use-attribute-sets="__toc__link">
                             <xsl:attribute name="internal-destination">
                               <xsl:call-template name="generate-toc-id"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="fox:alt-text">
+                              <xsl:call-template name="getNavTitle"/>
                             </xsl:attribute>
                             <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]/revprop[@changebar]" mode="changebar">
                                 <xsl:with-param name="changebar-id" select="concat(dita-ot:generate-changebar-id(.),'-toc')"/>


### PR DESCRIPTION
Signed-off-by: Julien Lacour <julien@sync.ro>

## Description
Add a fox:alt-text attribute for each TOC entry, this attribute is set with the navtitle.

## Motivation and Context
Fix https://github.com/dita-ot/dita-ot/issues/3985.

## How Has This Been Tested?
Not tested, I don't know if this is possible.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
