### PR TITLE
Allow empty sequence in named template

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -308,7 +308,7 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- Reference wrapper for HTML: "Related reference" in <div>. -->
   <xsl:template match="*[contains(@class, ' topic/link ')][@type='reference']" mode="related-links:result-group"
-                name="related-links:result.reference" as="element()">
+                name="related-links:result.reference" as="element()?">
     <xsl:param name="links"/>
     <xsl:if test="normalize-space(string-join($links, ''))">
       <linklist class="- topic/linklist " xsl:use-attribute-sets="linklist linklist-reference">


### PR DESCRIPTION
Allow empty sequence in named template.
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Allow empty sequence in named template.

## Motivation and Context
Fixes #3991

## How Has This Been Tested?
Manual tests.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc.

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
