### PR TITLE
Fix for #3989, consider @filter-copy-to (from branch filtering) when creating links

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -95,6 +95,9 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="@copy-to and (not(@format) or @format = 'dita') and not(contains(@chunk, 'to-content'))">
           <xsl:value-of select="dita-ot:normalize-uri(@copy-to)"/>
         </xsl:when>
+        <xsl:when test="@filter-copy-to and (not(@format) or @format = 'dita') and not(contains(@chunk, 'to-content'))">
+          <xsl:value-of select="dita-ot:normalize-uri(@filter-copy-to)"/>
+        </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="dita-ot:normalize-uri(@href)"/>
         </xsl:otherwise>


### PR DESCRIPTION
## Description
In the `maplink` preprocessing step, related link processing is updated to consider references to topics duplicated by branch filtering.

## Motivation and Context
Fixes #3989.

## How Has This Been Tested?
This fix was confirmed with the testcase from #3989. I also ran `gradlew test` and `gradlew e2etest`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

In `maplink`, an extra `<xsl:when>` branch was added for `@filter-copy-to` (based on the existing processing for `@copy-to`).

## Documentation and Compatibility
A release notes mention is sufficient.

This change should not adversely affect any existing plugins or flows.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

However, note the following:

* I do not know Java, so I could not update the unit tests.
* Further down in `maplinkImpl.xsl`, there is a [second template](https://github.com/dita-ot/dita-ot/blob/hotfix/3.7.3/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl#L575) that references `@copy-to` but not `@filter-copy-to`. However, I was not able to create a testcase that pushed a `@filter-copy-to` reference through this code for testing a potential fix.