### PR TITLE
Update Jackson YAML support to update snakeyaml to 1.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.8'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.0'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.13.0'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.13.4'
     implementation group: 'org.relaxng', name: 'jing', version: '20181222'
     implementation group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.12'
     testImplementation  group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'


### PR DESCRIPTION
Signed-off-by: Jarno Elovirta <jarno@elovirta.com>

## Description
Update Jackson YAML dependency to update snakeyaml to 1.31.

## Motivation and Context
Fixes #3999 

## How Has This Been Tested?
Tests pass

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_


