### PR TITLE
Fix for #3937, <abbreviated-form> should ignore non-<glossentry> elements

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
@@ -25,9 +25,9 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' abbrev-d/abbreviated-form ')]" name="topic.abbreviated-form">
     <xsl:variable name="keys" select="@keyref"/>
-    <xsl:variable name="target" select="key('id', substring(@href, 2))[1]" as="element()?"/>
+    <xsl:variable name="target" select="key('id', substring(@href, 2))[contains(@class,' glossentry/glossentry ')][1]" as="element()?"/>
     <xsl:choose>
-      <xsl:when test="$keys and $target/self::*[contains(@class,' glossentry/glossentry ')]">
+      <xsl:when test="$keys and $target">
         <xsl:call-template name="topic.term">
           <xsl:with-param name="contents">
             <xsl:variable name="use-abbreviated-form" as="xs:boolean">


### PR DESCRIPTION
## Description
In the `pdf2` transformation, the processing for `<abbreviated-form>` is updated to ignore non-`<glossentry>` elements.

In the `abbrev-domain.xsl` template for `pdf2`, the lookup by `@id` was incorrectly matching both `<topicref>` and `<glossentry>` elements with the same `@id` value (see #3937 for details).

## Motivation and Context
Fixes #3937.

## How Has This Been Tested?
The fix was confirmed with the testcase from #3937. (Unresolved term references are still handled correctly). I ran `gradlew test` and `gradlew e2etest`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
A release notes mention is sufficient.

This change should not adversely affect any existing plugins or flows.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I did not update any unit tests.