### PR TITLE
#3940 Propagate scope and processing-role in ForceUniqueFilter

### DIFF
--- a/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/exp/test.ditamap
@@ -25,4 +25,7 @@
       <topicref class="- map/topicref " href="topic.dita#option" copy-to="topic_2.dita#option"></topicref>
     </topicref>
   </topicref>
+  <topicref class="- map/topicref " processing-role="resource-only">
+    <topicref class="- map/topicref " href="topic.dita"/>
+  </topicref>
 </map>

--- a/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
+++ b/src/test/resources/ForceUniqueFilterTest/src/test.ditamap
@@ -25,4 +25,7 @@
       <topicref class="- map/topicref " href="topic.dita#option"/>
     </topicref>
   </topicref>
+   <topicref class="- map/topicref " processing-role="resource-only">
+    <topicref class="- map/topicref " href="topic.dita"/>
+  </topicref>
 </map>


### PR DESCRIPTION
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Propagate scope and processing-role attributes from ancestors in the ForceUniqueFilter stage.

## Motivation and Context
Fixes #3940

## How Has This Been Tested?
Auto test.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
