### PR TITLE
Remove obsolete FINALOUTPUTTYPE param

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -21,7 +21,6 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- =========== DEFAULT VALUES FOR EXTERNALLY MODIFIABLE PARAMETERS =========== -->
   <!-- output type -->
-  <xsl:param name="FINALOUTPUTTYPE" select="''"/>
   <xsl:param name="INPUTMAP" select="''"/>
   <xsl:param name="WORKDIR">
     <xsl:apply-templates select="/processing-instruction('workdir-uri')[1]" mode="get-work-dir"/>
@@ -119,17 +118,14 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
       </xsl:call-template>
     </xsl:variable>
-    <!-- If going to print, and @print=no, do not create links for this topicref -->
-    <xsl:if test="not(($FINALOUTPUTTYPE = 'PDF' or $FINALOUTPUTTYPE = 'IDD') and @print = 'no')">
-      <xsl:variable name="newlinks">
-        <maplinks href="{$hrefFromOriginalMap}">
-          <xsl:apply-templates select="." mode="generate-all-links">
-            <xsl:with-param name="pathBackToMapDirectory" select="$pathBackToMapDirectory" tunnel="yes"/>
-          </xsl:apply-templates>
-        </maplinks>
-      </xsl:variable>
-      <xsl:apply-templates select="$newlinks" mode="add-links-to-temp-file"/>
-    </xsl:if>
+    <xsl:variable name="newlinks">
+      <maplinks href="{$hrefFromOriginalMap}">
+        <xsl:apply-templates select="." mode="generate-all-links">
+          <xsl:with-param name="pathBackToMapDirectory" select="$pathBackToMapDirectory" tunnel="yes"/>
+        </xsl:apply-templates>
+      </maplinks>
+    </xsl:variable>
+    <xsl:apply-templates select="$newlinks" mode="add-links-to-temp-file"/>
     <xsl:apply-templates>
       <xsl:with-param name="pathFromMaplist" select="$pathFromMaplist"/>
     </xsl:apply-templates>
@@ -535,8 +531,7 @@ See the accompanying LICENSE file for applicable license.
     <!-- child found tag -->
     <xsl:param name="found" select="true()" as="xs:boolean"/>
     <!-- If going to print, and @print=no, do not create links for this topicref -->
-    <xsl:if test="not(($FINALOUTPUTTYPE = 'PDF' or $FINALOUTPUTTYPE = 'IDD') and @print = 'no') and 
-                  not(@processing-role = 'resource-only') and $found">
+    <xsl:if test="not(@processing-role = 'resource-only') and $found">
       <link class="- topic/link ">
         <xsl:if test="@class">
           <xsl:attribute name="mapclass" select="@class"/>
@@ -591,15 +586,10 @@ See the accompanying LICENSE file for applicable license.
         <!--figure out the linktext and desc-->
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="add-props-to-link"/>
         <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]">
-          <!--Do not output linktext when The final output type is PDF or IDD
-            The target of the HREF is a local DITA file
-            The user has not specified locktitle to override the title -->
-          <xsl:if test="not(($FINALOUTPUTTYPE = 'PDF' or $FINALOUTPUTTYPE = 'IDD') and (not(@scope) or @scope = 'local') and (not(@format) or @format = 'dita') and (not(@locktitle) or @locktitle = 'no'))">
-            <linktext class="- topic/linktext ">
-              <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/processing-instruction()[name()='ditaot'][.='usertext' or .='gentext']"/>
-              <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]/node()"/>
-            </linktext>
-          </xsl:if>
+          <linktext class="- topic/linktext ">
+            <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/processing-instruction()[name()='ditaot'][.='usertext' or .='gentext']"/>
+            <xsl:copy-of select="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-linktext-class(@class)]/node()"/>
+          </linktext>
         </xsl:if>
         <xsl:if test="*[contains(@class, ' map/topicmeta ')]/*[dita-ot:matches-shortdesc-class(@class)]">
           <!-- add desc node and text -->

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -43,8 +43,6 @@ Other modes can be found within the code, and may or may not prove useful for ov
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
-  <!-- If converting to PDF, never try to pull info from targets with print="no" -->
-  <xsl:param name="FINALOUTPUTTYPE" select="''" as="xs:string"/>
   <xsl:param name="conserve-memory" select="'false'" as="xs:string"/>
   
   <!-- Equivalent to document() but may discard documents from cache when instructed and able. -->
@@ -174,7 +172,6 @@ Other modes can be found within the code, and may or may not prove useful for ov
             <xsl:when test="@href=''">
               <xsl:apply-templates select="." mode="ditamsg:empty-href"/>
             </xsl:when>
-            <xsl:when test="$print='no' and ($FINALOUTPUTTYPE='PDF' or $FINALOUTPUTTYPE='IDD')"/>
             <xsl:when test="@href">
               <xsl:call-template name="get-stuff">
                 <xsl:with-param name="type" select="$type"/>


### PR DESCRIPTION
## Description

Removes the obsolete `FINALOUTPUTTYPE` parameter. This is never passed in from our scripts, and refers to legacy formats and attributes.

## Motivation and Context

Motivation is code cleanup and removing technical debt.

The check for `IDD` as an output format is a legacy of DITA-OT 1.0 and the beta code that came from IBM, this referred to the SGML format "IBMIDDoc" that was used for a PDF path at the time. This is no longer used in IBM and should not be in this code even if it was.

Because the parameter is never passed in by any of our Ant scripts, the tests always evaluate to false. In many cases the tests were for `not(FINALOUTPUTTYPE=X)` which is equivalent to `not(false())`, so these tests always passed; direct tests of the value always fail.

## How Has This Been Tested?

Unit tests continue to pass

## Type of Changes

Technically a breaking change as anyone setting this parameter and passing it to `maplink` or `mappull` with a plugin will no longer see it passed in.

## Documentation and Compatibility

n/a
