### PR TITLE
Fix custom parser use in preprocess2

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -39,8 +39,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.dita.dost.reader.GenListModuleReader.ROOT_URI;
-import static org.dita.dost.reader.GenListModuleReader.Reference;
+import static org.dita.dost.reader.GenListModuleReader.*;
 import static org.dita.dost.util.Configuration.*;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.Job.FileInfo;
@@ -538,7 +537,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
 
         if (listFilter.isDitaTopic()) {
-            if (ref.format != null && !ref.format.equals(ATTR_FORMAT_VALUE_DITA)) {
+            if (!isFormatDita(ref.format)) {
                 assert currentFile.getFragment() == null;
                 final URI f = currentFile.normalize();
                 if (!fileinfos.containsKey(f)) {
@@ -654,7 +653,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         }
         for (final URI file: fullTopicSet) {
             createOrUpdateFileInfo(file, fi -> {
-                if (fi.format == null) {
+                if (isFormatDita(fi.format)) {
                     fi.format = ATTR_FORMAT_VALUE_DITA;
                 }
             });

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -126,7 +126,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
                     if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
                         getStartDocuments(fi).forEach(this::addToWaitList);
                     } else {
-                        if (fi.format == null) {
+                        if (isFormatDita(fi.format)) {
                             fi.format = ATTR_FORMAT_VALUE_DITA;
                             job.add(fi);
                         }


### PR DESCRIPTION
## Description
Correctly categorize files parsed using a custom parser in preprocess2.

## Motivation and Context
Currently when files are parsed with a custom parser, the file is categorized to be the original file format. For example when LwDITA parser is used to parse Markdown, the file is categorized to be format `markdown`. This fix changes the categorization to match preprocess functionality and files parsed with a custom parser are categorized as `dita`.

## How Has This Been Tested?
Existing tests and manual testing.
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Mention in release notes.

