### PR TITLE
Change matcher functions to accept empty sequence as argument #3814

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/functions.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/functions.xsl
@@ -17,17 +17,17 @@ See the accompanying LICENSE file for applicable license.
   <!-- DITA 1.3 and 2.0 compatibility -->
   
   <xsl:function name="dita-ot:matches-linktext-class" as="xs:boolean">
-    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:param name="class" as="attribute(class)?"/>
     <xsl:sequence select="contains($class, ' topic/linktext ') or contains($class, ' map/linktext ')"/>
   </xsl:function>
   
   <xsl:function name="dita-ot:matches-shortdesc-class" as="xs:boolean">
-    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:param name="class" as="attribute(class)?"/>
     <xsl:sequence select="contains($class, ' topic/shortdesc ') or contains($class, ' map/shortdesc ')"/>
   </xsl:function>
   
   <xsl:function name="dita-ot:matches-searchtitle-class" as="xs:boolean">
-    <xsl:param name="class" as="attribute(class)"/>
+    <xsl:param name="class" as="attribute(class)?"/>
     <xsl:sequence select="contains($class, ' topic/searchtitle ') or contains($class, ' map/searchtitle ')"/>
   </xsl:function>
 


### PR DESCRIPTION
## Description
Change XSLT matcher functions to accept empty sequence as argument. When the `class` argument is an empty sequence, function always returns `false`.

## Motivation and Context
Fixes #3814

## How Has This Been Tested?
Existing tests pass

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Note in release notes about the bug fix.
