### PR TITLE
filter <indexterm> elements when computing <xref> target text for `pdf2`

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -238,7 +238,7 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="*[contains(@class,' topic/dt ')][1]" mode="#current"/>
     </xsl:template>
     <xsl:template match="*[contains(@class, ' topic/dt ')]" mode="retrieveReferenceTitle">
-      <xsl:apply-templates select="." mode="text-only"/>
+      <xsl:apply-templates select="." mode="insert-text"/>
     </xsl:template>
   
     <xsl:template match="*[contains(@class, ' topic/title ')]" mode="retrieveReferenceTitle">
@@ -249,7 +249,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="retrieveReferenceTitle" >
         <xsl:choose>
             <xsl:when test="*[contains(@class,' topic/title ')]">
-                <xsl:value-of select="string(*[contains(@class, ' topic/title ')])"/>
+                <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="insert-text"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>#none#</xsl:text>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -7,6 +7,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
+  xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
@@ -264,6 +265,7 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/indexterm ')]" mode="insert-text"/>
+    <xsl:template match="opentopic-index:*" mode="insert-text"/>
 
     <xsl:template match="text()[contains(., '[') and contains(., ']')][ancestor::*[contains(@class, ' topic/dl ')][contains(@otherprops,'sortable')]]" priority="10">
         <xsl:value-of select="substring-before(.,'[')"/>


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
When an `<xref>` computes target text from content that contains an `<indexterm>` element, preprocessing filters index term text when computing the target text. However, the `pdf2` transformation recomputes new target text, and this recomputation also needed to filter out index term text in a couple more cases.

This probably stems from the fact that these elements don't directly allow `<indexterm>` in their content models, but they do allow `<ph>`, which in turn allows `<indexterm>`.

## Motivation and Context
Fixes #4017.

## How Has This Been Tested?
I tested the `pdf2` transformation with the following topic: [topic.zip](https://github.com/dita-ot/dita-ot/files/9847105/topic.zip)

The test topic is as follows:

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="urn:oasis:names:tc:dita:rng:topic.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
<topic id="topic">
  <title id="title-id">title<ph><indexterm>FINDME</indexterm></ph></title>
  <body>

    <p>fig: <xref href="#./fig-id"/></p>
    <p>section: <xref href="#./section-id"/>.</p>
    <p>table: <xref href="#./table-id"/>.</p>
    <p>dlentry: <xref href="#./dlentry-id"/>.</p>
    <p>dt: <xref href="#./dt-id"/>.</p>
    <p>title-id: <xref href="#./title-id"/>.</p>
    <p>example-id: <xref href="#./example-id"/>.</p>

    <fig id="fig-id">
      <title>fig<ph><indexterm>FINDME</indexterm></ph></title>
    </fig>
    <section id="section-id">
      <title>section<ph><indexterm>FINDME</indexterm></ph></title>
    </section>
    <table id="table-id">
      <title>table<ph><indexterm>FINDME</indexterm></ph></title>
      <tgroup cols="1">
        <colspec colname="c1" colnum="1" colwidth="1*"/>
        <tbody>
          <row>
            <entry/>
          </row>
        </tbody>
      </tgroup>
    </table>
    <dl>
      <dlentry id="dlentry-id">
        <dt id="dt-id">term<ph><indexterm>FINDME</indexterm></ph></dt>
        <dd>definition</dd>
      </dlentry>
    </dl>
    <example id="example-id">
      <title>example<ph><indexterm>FINDME</indexterm></ph></title>
    </example>

  </body>
</topic>
```

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

In `links.xsl`,

* The `topic/dt` template called a `mode="text-only"` template, but I think this was intended to be `mode="dita-ot:text-only"`. This mode also did not work correctly, but `mode="insert-text"` (which the other templates used) did.

* The `topic/title` template used `<xsl:value-of>` to perform a plaintext evaluation of the title. This template was updated to use `mode="insert-text"`.

In `tables.xsl`,

* The `mode="insert-text"` template was updated to filter out elements in the `opentopic-index:*` namespace.

   (Why are the text evaluation templates in a table-related file?)

## Documentation and Compatibility
A release notes mention is sufficient.

This change should not adversely affect any existing plugins or flows.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I do not think there are any unit tests for `pdf2` PDF output.