### PR TITLE
Take into account root chunk override earlier

### DIFF
--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -119,16 +119,15 @@ public final class ChunkMapReader extends AbstractDomFilter {
         if (ditaVersion == null ||ditaVersion >= 2.0f) {
             return doc;
         }
-
-        readLinks(doc);
-        readProcessingInstructions(doc);
-
         final Element root = doc.getDocumentElement();
         if (rootChunkOverride != null) {
             final String c = join(rootChunkOverride, " ");
             logger.debug("Use override root chunk \"" + c + "\"");
             root.setAttribute(ATTRIBUTE_NAME_CHUNK, c);
         }
+        readLinks(doc);
+        readProcessingInstructions(doc);
+
         final Collection<String> rootChunk = split(root.getAttribute(ATTRIBUTE_NAME_CHUNK));
         defaultChunkByToken = getChunkByToken(rootChunk, "by-", CHUNK_BY_DOCUMENT);
 

--- a/src/test/resources/ChunkMapReaderTest/src/mapNoChunk.ditamap
+++ b/src/test/resources/ChunkMapReaderTest/src/mapNoChunk.ditamap
@@ -1,0 +1,8 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  ditaarch:DITAArchVersion="1.3">
+  <topicref class="- map/topicref " href="1.dita"/>
+  <topicref class="- map/topicref " href="2.dita">
+    <topicref class="- map/topicref " href="3.dita"/>
+  </topicref>
+</map>


### PR DESCRIPTION
Fix for #4019. Take into account root chunk override before the links are read.
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
When using the param "root-chunk-override"="to-content" extra HTML files are not created on disk for each individual topic.

## Motivation and Context
Fixes #4019

## How Has This Been Tested?
Automatic test

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
