### PR TITLE
Change default encoding for coderefs to UTF-8

### DIFF
--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -9,6 +9,7 @@ temp-file-name-scheme = org.dita.dost.module.reader.DefaultTempFileScheme
 #filter-attributes =
 #flag-attributes =
 cli.color = true
+default.coderef-charset=UTF-8
 
 # Integration
 plugindirs = plugins;demo


### PR DESCRIPTION
## Description
Change default encoding for`<coderef>` to UTF-8.

## Motivation and Context
Default encoding for `<coderef>` target resources is currently system default encoding. Changing the default encoding to UTF-8 will allow wider range of characters without needing to change the coderef default encoding per DITA-OT installation.

## How Has This Been Tested?
DITA-OT docs work because Roger likes to use UTF-8.

## Type of Changes
- Breaking change _(fix or feature that changes existing functionality)_

## Documentation and Compatibility

Note in the release notes.

https://www.dita-ot.org/dev/reference/extended-functionality.html#code-reference__coderef-charset should specify the default is UTF-8 as of 4.0.


