### PR TITLE
Fix flagging with specialized attribute

### DIFF
--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -182,21 +182,19 @@ public final class FilterUtils {
                 }
             }
         }
-        if (res.isEmpty()) {
-            if (extProps != null && extProps.length != 0) {
-                for (final QName[] propList : extProps) {
-                    int propListIndex = propList.length - 1;
-                    final QName propName = propList[propListIndex];
-                    String propValue = atts.getValue(propName.getNamespaceURI(), propName.getLocalPart());
+        if (extProps != null && extProps.length != 0) {
+            for (final QName[] propList : extProps) {
+                int propListIndex = propList.length - 1;
+                final QName propName = propList[propListIndex];
+                String propValue = atts.getValue(propName.getNamespaceURI(), propName.getLocalPart());
 
-                    while ((propValue == null || propValue.trim().isEmpty()) && propListIndex > 0) {
-                        propListIndex--;
-                        final QName current = propList[propListIndex];
-                        propValue = getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
-                    }
-                    if (propValue != null) {
-                        res.addAll(extCheckFlag(propList, Arrays.asList(propValue.split("\\s+"))));
-                    }
+                while ((propValue == null || propValue.trim().isEmpty()) && propListIndex > 0) {
+                    propListIndex--;
+                    final QName current = propList[propListIndex];
+                    propValue = getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
+                }
+                if (propValue != null) {
+                    res.addAll(extCheckFlag(propList, Arrays.asList(propValue.split("\\s+"))));
                 }
             }
         }

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -255,7 +255,7 @@ public class FilterUtilsTest {
         f.setLogger(new TestUtils.TestLogger());
 
         assertEquals(
-                singleton(flagBase),
+                Set.of(flagBase, flagSpecialization),
                 f.getFlags(new AttributesBuilder().add(OS, "amiga").add(PLATFORM, "unix").build(),
                            new QName[][] {{PROPS, OS}}));
     }

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -7,31 +7,28 @@
  */
 package org.dita.dost.util;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.*;
-import static javax.xml.XMLConstants.XML_NS_PREFIX;
-import static javax.xml.XMLConstants.XML_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.*;
-
-import java.util.*;
-import java.util.stream.Stream;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.dita.dost.TestUtils;
 import org.dita.dost.util.FilterUtils.Action;
 import org.dita.dost.util.FilterUtils.FilterKey;
-
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
+import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
-import org.junit.Test;
-
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import java.util.*;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static javax.xml.XMLConstants.XML_NS_PREFIX;
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_PLATFORM;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_REV;
+import static org.junit.Assert.*;
 
 public class FilterUtilsTest {
 
@@ -244,6 +241,23 @@ public class FilterUtilsTest {
         assertEquals(
                 emptySet(),
                 f.getFlags(attr(PLATFORM, "windows"), new QName[0][0]));
+    }
+
+    @Test
+    public void testGetFlagsForSpecialization() {
+        final Flag flagBase = new Flag("prop", "red", null, null, null, null, null, null);
+        final Flag flagSpecialization = new Flag("prop", "blue", null, null, null, null, null, null);
+        final FilterUtils f = new FilterUtils(false,
+                ImmutableMap.<FilterKey, Action>builder()
+                        .put(new FilterKey(PLATFORM, "unix"), flagBase)
+                        .put(new FilterKey(OS, "amiga"), flagSpecialization)
+                        .build(), null, null);
+        f.setLogger(new TestUtils.TestLogger());
+
+        assertEquals(
+                singleton(flagBase),
+                f.getFlags(new AttributesBuilder().add(OS, "amiga").add(PLATFORM, "unix").build(),
+                           new QName[][] {{PROPS, OS}}));
     }
 
     // DITA 1.3


### PR DESCRIPTION
Signed-off-by: Toshihiko Makita <tmakita@antenna.co.jp>

## Description
Correct  the `flagging` module to work with specialized flitering (flagging) attributes.

## Motivation and Context
Fixes #4043

## How Has This Been Tested?
Tested via DITA-OT 4.0 (and old DITA-OT 3.4.1).
I attached the test result reported in #4043 .
[test-2022-11-16.zip](https://github.com/dita-ot/dita-ot/files/10017900/test-2022-11-16.zip)

Environment: Windows 11 (or 10) with DITA-OT 4.0.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No official document changing is needed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
