### PR TITLE
PDF2: Remove duplicate `space-before` attribute

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -75,7 +75,6 @@ See the accompanying LICENSE file for applicable license.
     </xsl:attribute-set>
 
     <xsl:attribute-set name="topic.topic.title" use-attribute-sets="common.title common.border__bottom">
-        <xsl:attribute name="space-before">15pt</xsl:attribute>
         <xsl:attribute name="space-before">12pt</xsl:attribute>
         <xsl:attribute name="space-after">5pt</xsl:attribute>
         <xsl:attribute name="font-size">14pt</xsl:attribute>


### PR DESCRIPTION
The `topic.topic.title` attribute set currently contains 2 lines that both set the `space-before` attribute to different values.

Assuming the second instance here overrides the first, this change removes the redundant `15pt` setting, leaving only the effective `12pt` value.
