### PR TITLE
Mark obsolete template as deprecated #3435

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -363,6 +363,7 @@ See the accompanying LICENSE file for applicable license.
   +-->
   
   <!-- table caption -->
+  <!-- Deprecated in 4.0.1, this template is not called from HTML5 code. -->
   <xsl:template name="place-tbl-lbl">
     <xsl:param name="stringName"/>
     <!-- Number of table/title's before this one -->


### PR DESCRIPTION
Signed-off-by: Robert D Anderson <gorodki@gmail.com>

## Description

Adds a comment to mark an unused template as deprecated, so we can remove it in 4.1

## Motivation and Context

Requested in #3435

## How Has This Been Tested?

n/a, only adds an XML comment

## Type of Changes

no functional change

## Documentation and Compatibility

For release notes, can just note that the `place-tbl-lbl` template in HTML5 processing has been marked deprecated. This template was carried over from XHTML code (which still has a copy that is used), but the copy in HTML5 is not called.

