### PR TITLE
Add ID for syntax diagram #4021

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -13,15 +13,16 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ')]">
     <div>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:apply-templates mode="process-syntaxdiagram"/>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setidaname"/>
+      <xsl:apply-templates mode="process-syntaxdiagram"/>
     </div>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' pr-d/fragment ')]" mode="process-syntaxdiagram">
     <div>
-    <a name="{*[contains(@class,' topic/title ')]}"> </a>
-    <xsl:apply-templates mode="#current"/>
+      <a name="{*[contains(@class,' topic/title ')]}"> </a>
+      <xsl:apply-templates mode="#current"/>
     </div>
   </xsl:template>
   


### PR DESCRIPTION
## Description

Includes a syntax diagram ID in the HTML5 output when specified on the source.

Also fixes indentation in this template and the one that follows.

## Motivation and Context

Fixes #4021 

## How Has This Been Tested?

Tested with topics in the linked issue - DITA 1.3 topic is missing an ID, now with the update it has an ID.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

For release notes: In earlier releases, syntax diagrams with an ID did not preserve the ID in HTML5 output. This is now fixed.
