### PR TITLE
Fix `args.xhtml.toc.class` and `args.html5.toc.class`

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -13,6 +13,10 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot ditamsg">
 
+  <!-- optional @class attribute for TOC <body> element
+       (value comes from args.html5.toc.class parameter) -->
+  <xsl:param name="OUTPUTCLASS" as="xs:string?"/>
+
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="toc">
     <xsl:param name="pathFromMaplist"/>
     <xsl:if test="descendant::*[contains(@class, ' map/topicref ')]
@@ -127,8 +131,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="chapterBody">
     <body>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
-      <xsl:if test="@outputclass">
-        <xsl:attribute name="class" select="@outputclass"/>
+      <xsl:if test="(@outputclass ne '') or ($OUTPUTCLASS ne '')">
+        <xsl:attribute name="class" select="string-join(distinct-values((tokenize(@outputclass, '\s+'), tokenize($OUTPUTCLASS, '\s+'))), ' ')"/>
       </xsl:if>
       <xsl:apply-templates select="." mode="addAttributesToBody"/>
       <xsl:call-template name="setidaname"/>

--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -131,7 +131,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="chapterBody">
     <body>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
-      <xsl:if test="(@outputclass ne '') or ($OUTPUTCLASS ne '')">
+      <xsl:if test="normalize-space(@outputclass) or normalize-space($OUTPUTCLASS)">
         <xsl:attribute name="class" select="string-join(distinct-values((tokenize(@outputclass, '\s+'), tokenize($OUTPUTCLASS, '\s+'))), ' ')"/>
       </xsl:if>
       <xsl:apply-templates select="." mode="addAttributesToBody"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -23,7 +23,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="chapterBody">
     <body>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
-      <xsl:if test="(@outputclass ne '') or ($OUTPUTCLASS ne '')">
+      <xsl:if test="normalize-space(@outputclass) or normalize-space($OUTPUTCLASS)">
         <xsl:attribute name="class" select="string-join(distinct-values((tokenize(@outputclass, '\s+'), tokenize($OUTPUTCLASS, '\s+'))), ' ')"/>
       </xsl:if>
       <xsl:apply-templates select="." mode="addAttributesToBody"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -12,6 +12,10 @@ See the accompanying LICENSE file for applicable license.
                 version="2.0"
                 exclude-result-prefixes="xs dita-ot">
 
+  <!-- optional @class attribute for TOC <body> element
+       (value comes from args.xhtml.toc.class parameter) -->
+  <xsl:param name="OUTPUTCLASS" as="xs:string?"/>
+
   <xsl:template match="*[contains(@class, ' map/map ')]">
     <xsl:apply-templates select="." mode="root_element"/>
   </xsl:template>
@@ -19,8 +23,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="chapterBody">
     <body>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style"/>
-      <xsl:if test="@outputclass">
-        <xsl:attribute name="class" select="@outputclass"/>
+      <xsl:if test="(@outputclass ne '') or ($OUTPUTCLASS ne '')">
+        <xsl:attribute name="class" select="string-join(distinct-values((tokenize(@outputclass, '\s+'), tokenize($OUTPUTCLASS, '\s+'))), ' ')"/>
       </xsl:if>
       <xsl:apply-templates select="." mode="addAttributesToBody"/>
       <xsl:call-template name="setidaname"/>


### PR DESCRIPTION
## Description
This pull request re-implements the `args.xhtml.toc.class` and `args.html5.toc.class` parameters, which were documented but somehow became omitted from the processing pipeline.

## Motivation and Context
Fixes #4015.

## How Has This Been Tested?
I tested all four combinations of defining `@outputclass` on the `<map>` and setting the DITA-OT parameter, for both the `xhtml` and `html5` transformation types.

I ran `gradlew test` and `gradle e2etest`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

The DITA-OT `args.xhtml.toc.class` and `args.html5.toc.class` parameters are converted to `$OUTPUTCLASS` stylesheet parameters. This fix updates the `@outputclass` attribute creation for TOC page `<body>` elements to also consider `$OUTPUTCLASS`.

There is some orphaned code, as described in #4015. I will clean up that code in a more generalized cleanup commit later, if I can figure out how to do it.

## Documentation and Compatibility
A release notes mention is sufficient.

This change should not adversely affect any existing plugins or flows.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
