### PR TITLE
Do not issue information messages if the filter has default exclude rules

### DIFF
--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -29,6 +29,7 @@ import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageUtils;
 
 import org.dita.dost.module.filter.SubjectScheme;
+import org.dita.dost.util.FilterUtils.FilterKey;
 import org.w3c.dom.*;
 import org.xml.sax.*;
 
@@ -473,7 +474,10 @@ public final class FilterUtils {
         for (final String attSubValue: attValue) {
             final FilterKey filterKey = new FilterKey(attName, attSubValue);
             final Action filterAction = filterMap.get(filterKey);
-            if (filterAction == null && logMissingAction) {
+            if (filterAction == null 
+                    && logMissingAction
+                    && filterMap.get(DEFAULT) == null
+                    && filterMap.get(new FilterKey(attName, null)) == null) {
                 if (!alreadyShowed(filterKey)) {
                     logger.info(MessageUtils.getMessage("DOTJ031I", filterKey.toString()).toString());
                 }

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -263,6 +263,41 @@ public class FilterUtilsTest {
     }
     
     @Test
+    public void testNoInfoMessageFilter() {
+        //Do not issue information messages that certain values
+        //were not specified in the ditaval filter if the filter has default exclude rules.
+        final Map<FilterKey, Action> fm = new HashMap<>();
+        fm.put(new FilterKey(OS, null), Action.EXCLUDE);
+        fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
+        FilterUtils f = new FilterUtils(false, fm, null, null);
+        StringBuilder infoMsg = new StringBuilder();
+        f.setLogger(new TestUtils.TestLogger() {
+            @Override
+            public void info(String msg) {
+                infoMsg.append(msg);
+            }
+        });
+
+        assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
+        assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
+        
+        fm.clear();
+        fm.put(FilterUtils.DEFAULT, Action.EXCLUDE);
+        fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
+        f = new FilterUtils(false, fm, null, null);
+        infoMsg.setLength(0);
+        f.setLogger(new TestUtils.TestLogger() {
+            @Override
+            public void info(String msg) {
+                infoMsg.append(msg);
+            }
+        });
+
+        assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
+        assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
+    }
+    
+    @Test
     public void testNeedExcludeGroup() {
         final Map<FilterKey, Action> fm = new HashMap<>();
         fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -266,35 +266,22 @@ public class FilterUtilsTest {
     public void testNoInfoMessageFilter() {
         //Do not issue information messages that certain values
         //were not specified in the ditaval filter if the filter has default exclude rules.
-        final Map<FilterKey, Action> fm = new HashMap<>();
-        fm.put(new FilterKey(OS, null), Action.EXCLUDE);
-        fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
-        FilterUtils f = new FilterUtils(false, fm, null, null);
-        StringBuilder infoMsg = new StringBuilder();
-        f.setLogger(new TestUtils.TestLogger() {
-            @Override
-            public void info(String msg) {
-                infoMsg.append(msg);
-            }
-        });
+        for (FilterKey filterKey: new FilterKey[]{ new FilterKey(OS, null), FilterUtils.DEFAULT }) {
+            final Map<FilterKey, Action> fm = new HashMap<>();
+            fm.put(filterKey, Action.EXCLUDE);
+            fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
+            FilterUtils f = new FilterUtils(false, fm, null, null);
+            StringBuilder infoMsg = new StringBuilder();
+            f.setLogger(new TestUtils.TestLogger() {
+                @Override
+                public void info(String msg) {
+                   infoMsg.append(msg);
+               }
+            });
 
-        assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
-        assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
-        
-        fm.clear();
-        fm.put(FilterUtils.DEFAULT, Action.EXCLUDE);
-        fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
-        f = new FilterUtils(false, fm, null, null);
-        infoMsg.setLength(0);
-        f.setLogger(new TestUtils.TestLogger() {
-            @Override
-            public void info(String msg) {
-                infoMsg.append(msg);
-            }
-        });
-
-        assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
-        assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
+            assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
+            assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
+        }
     }
     
     @Test


### PR DESCRIPTION
Do not issue information messages that certain values were not specified in the ditaval filter if the filter has default exclude rules

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Sometimes the DITA OT issues an information message like this:

     [filter] [DOTJ031I][INFO] No specified rule for 'product=B' was found in the ditaval file.

but if the DITAVAL has default exclude rules like this:

     <val>
	<prop action="exclude"/>
	<prop action="include" att="product" val="product_A"/>
    </val>

or like this:

     <val>
	<prop action="exclude" att="product"/>
	<prop action="include" att="product" val="product_A"/>
     </val>

there is no need to issue such information messages because the default exclude rules take care of all other attribute values.

## Motivation and Context
Fixes most of the problems reported in #4048

## How Has This Been Tested?
Automatic test

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
