### PR TITLE
Resolve <longdescref> @keyref references to @href

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -103,6 +103,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         ki.add(new KeyrefInfo(TOPIC_INDEX_BASE, ATTRIBUTE_NAME_HREF, false, false));
         ki.add(new KeyrefInfo(TOPIC_INDEXTERMREF, ATTRIBUTE_NAME_HREF, false, false));
         ki.add(new KeyrefInfo(TOPIC_LONGQUOTEREF, ATTRIBUTE_NAME_HREF, false, false));
+        ki.add(new KeyrefInfo(TOPIC_LONGDESCREF, ATTRIBUTE_NAME_HREF, false, false));
         final Map<String, String> objectAttrs = new HashMap<>();
         objectAttrs.put(ATTRIBUTE_NAME_ARCHIVEKEYREFS, ATTRIBUTE_NAME_ARCHIVE);
         objectAttrs.put(ATTRIBUTE_NAME_CLASSIDKEYREF, ATTRIBUTE_NAME_CLASSID);


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
Adds `<longdescref>` element to the list of elements considered for `@keyref` resolution.

Thanks to @raducoravu for identifying the fix!

## Motivation and Context
Fixes #4071.

## How Has This Been Tested?
I ran the testcase from #4071 and confirmed that `@keyref` is now resolved to `@href`:

```
$ diff temp-orig-06-keyref/topic.dita temp-fixed-06-keyref/topic.dita
55c55
<          <longdescref keyref="topic"/>
---
>          <longdescref keyref="topic" href="topic.dita"/>
```

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
A release notes mention should be sufficient.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>

I did not update any tests for this fix, as the code change is simple and I would not expect future code updates to break the fix for this specific element.
