### PR TITLE
remove "mailto:" prefix from default "mailto:" link target text

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -77,6 +77,9 @@ See the accompanying LICENSE file for applicable license.
                   <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text()"/>
                   <!--use xref content-->
                 </xsl:when>
+                <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+                  <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
+                </xsl:when>
                 <xsl:otherwise>
                   <xsl:call-template name="href"/><!--use href text-->
                 </xsl:otherwise>
@@ -313,7 +316,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     </xsl:call-template>
   </xsl:template>
 
-  <!--calculate href-->
+  <!--calculate href - used for both @href attribute values and target text -->
   <xsl:template name="href">
     <xsl:apply-templates select="." mode="determine-final-href"/>
   </xsl:template>
@@ -561,6 +564,9 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
       <xsl:choose>
         <xsl:when test="*[contains(@class, ' topic/linktext ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/linktext ')]"/>
+        </xsl:when>
+        <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+          <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
         </xsl:when>
         <xsl:otherwise>
           <!--use href-->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -599,10 +599,6 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute name="target">_blank</xsl:attribute>
     <xsl:attribute name="rel">external noopener</xsl:attribute>
   </xsl:template>
-
-  <xsl:template match="node()[@scope = 'external' and starts-with(@href, 'mailto:')]" mode="external-link" as="attribute()*">
-    <!-- mailto: links do not need browser tab or search engine directives -->
-  </xsl:template>
   
   <!-- =========== SINGLE PART LISTS =========== -->
   

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -599,6 +599,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute name="target">_blank</xsl:attribute>
     <xsl:attribute name="rel">external noopener</xsl:attribute>
   </xsl:template>
+
+  <xsl:template match="node()[@scope = 'external' and starts-with(@href, 'mailto:')]" mode="external-link" as="attribute()*">
+    <!-- mailto: links do not need browser tab or search engine directives -->
+  </xsl:template>
   
   <!-- =========== SINGLE PART LISTS =========== -->
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -295,6 +295,9 @@ See the accompanying LICENSE file for applicable license.
             <xsl:when test="*[not(contains(@class,' topic/desc '))] | text()">
               <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))] | text()" />
             </xsl:when>
+            <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+              <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
+            </xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="@href"/>
             </xsl:otherwise>
@@ -536,6 +539,9 @@ See the accompanying LICENSE file for applicable license.
                   </xsl:when>
                   <xsl:when test="*[contains(@class, ' topic/linktext ')]">
                     <xsl:apply-templates select="*[contains(@class, ' topic/linktext ')]"/>
+                  </xsl:when>
+                  <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+                    <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
                   </xsl:when>
                   <xsl:otherwise>
                     <xsl:value-of select="@href"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -66,6 +66,9 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text()"/>
                     <!--use xref content-->
                   </xsl:when>
+                  <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+                    <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
+                  </xsl:when>
                   <xsl:otherwise>
                     <xsl:call-template name="href"/><!--use href text-->
                   </xsl:otherwise>
@@ -323,7 +326,7 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     </xsl:call-template>
   </xsl:template>
 
-  <!--calculate href-->
+  <!--calculate href - used for both @href attribute values and target text -->
   <xsl:template name="href">
     <xsl:apply-templates select="." mode="determine-final-href"/>
   </xsl:template>
@@ -580,6 +583,9 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
         <xsl:when test="*[contains(@class, ' topic/linktext ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/linktext ')]"/>
         </xsl:when>
+        <xsl:when test="@scope = 'external' and starts-with(@href, 'mailto:')">
+          <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
+        </xsl:when>
         <xsl:otherwise>
           <!--use href-->
           <xsl:call-template name="href"/>
@@ -763,6 +769,10 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     <xsl:if test="@scope = 'external' or @type = 'external' or ((lower-case(@format) = 'pdf') and not(@scope = 'local'))">
       <xsl:attribute name="target">_blank</xsl:attribute>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="*[@scope = 'external' and starts-with(@href, 'mailto:')]" mode="add-link-target-attribute">
+    <!-- mailto: links do not need browser tab or search engine directives -->
   </xsl:template>
 
   <xsl:template match="*" mode="ditamsg:link-may-be-duplicate">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -771,10 +771,6 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
     </xsl:if>
   </xsl:template>
 
-  <xsl:template match="*[@scope = 'external' and starts-with(@href, 'mailto:')]" mode="add-link-target-attribute">
-    <!-- mailto: links do not need browser tab or search engine directives -->
-  </xsl:template>
-
   <xsl:template match="*" mode="ditamsg:link-may-be-duplicate">
     <xsl:param name="href" select="@href" as="xs:string"/>
     <xsl:param name="outfile" as="xs:string">


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
For `mailto:` links,

* In `pdf2`, `xhtml`, and `html5`, removes the `mailto:` prefix from the default target text.
* In `xhtml` and `html5`, suppresses `target="_blank"` to avoid a blank browser tab from briefly appearing before the mail client opens.

Both `<xref>` and `<link>` elements are updated. If explicit target text is provided, it is used normally, but `target="_blank"` is still suppressed.

## Motivation and Context
Fixes #4020.

## How Has This Been Tested?
I ran this testcase: [4020.zip](https://github.com/dita-ot/dita-ot/files/10316747/4020.zip) (`dita --project project.xml`).

I also ran `gradlew test` and `gradlew e2etest`.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

I initially tried to override the `name="href"` template, but I found that it is used to compute `@href` attribute values as well as to compute target text.

## Documentation and Compatibility
A release notes mention should be sufficient. I would not expect any plugins to break. If plugins override the default processing, they will still override this updated default processing.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

I did not update unit tests because no tests broke with the change.