### PR TITLE
Refactor for Java 11 migration

### DIFF
--- a/src/main/java/org/dita/dost/Processor.java
+++ b/src/main/java/org/dita/dost/Processor.java
@@ -3,6 +3,7 @@ package org.dita.dost;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.BuildException;
@@ -236,7 +237,7 @@ public final class Processor {
     private ch.qos.logback.classic.Logger openDebugLogger(File tempDir) {
         final LoggerContext loggerContext = new LoggerContext();
 
-        final FileAppender fileAppender = new FileAppender();
+        final FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
         fileAppender.setFile(new File(tempDir.getAbsolutePath() + ".log").getAbsolutePath());
         fileAppender.setContext(loggerContext);
         fileAppender.setAppend(false);

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -795,7 +795,7 @@ public final class ExtensibleAntInvoker extends Task {
         public String getValue() {
             if (!rcs.isEmpty()) {
                 return rcs.stream()
-                        .flatMap(rc -> rc.stream())
+                        .flatMap(ResourceCollection::stream)
                         .map(ParamElem::resourceToString)
                         .collect(Collectors.joining(File.pathSeparator));
             } else {

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -348,7 +348,7 @@ public class ConversionArguments extends Arguments {
             }
 
             // ensure that -D properties take precedence
-            final Enumeration propertyNames = props.propertyNames();
+            final Enumeration<?> propertyNames = props.propertyNames();
             while (propertyNames.hasMoreElements()) {
                 final String name = propertyNames.nextElement().toString();
                 if (!definedProps.containsKey(name)) {

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -288,9 +288,7 @@ class DefaultLogger implements BuildLogger {
                 String label = "[" + name + "] ";
                 final int size = LEFT_COLUMN_SIZE - label.length();
                 final StringBuilder tmp = new StringBuilder();
-                for (int i = 0; i < size; i++) {
-                    tmp.append(" ");
-                }
+                tmp.append(" ".repeat(Math.max(0, size)));
                 tmp.append(label);
                 label = tmp.toString();
 

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -132,9 +132,7 @@ public class UsageBuilder {
             max = Math.max(max, key.toString().length());
         }
         StringBuilder padding = new StringBuilder();
-        for (int i = -2; i < max; i++) {
-            padding.append(' ');
-        }
+        padding.append(" ".repeat(Math.max(0, max + 2)));
         return padding.toString();
     }
 

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -77,7 +77,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
     }
 
     private void init(AbstractPipelineInput input) {
-        forceUnique = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAN_FORCE_UNIQUE));
+        forceUnique = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAN_FORCE_UNIQUE));
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -292,9 +292,9 @@ public final class DebugAndFilterModule extends SourceReaderModule {
             ditavalFile = new File(job.tempDir, FILE_NAME_MERGED_DITAVAL);
         }
         gramcache = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAM_GRAMCACHE));
-        validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
+        validate = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         setSystemId = "yes".equals(input.getAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID));
-        genDebugInfo = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
+        genDebugInfo = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
         final String mode = input.getAttribute(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
         processingMode = mode != null ? Mode.valueOf(mode.toUpperCase()) : Mode.LAX;
 

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -261,7 +261,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
     private void parseInputParameters(final AbstractPipelineInput input) {
         ditavalFile = new File(job.tempDir, FILE_NAME_MERGED_DITAVAL);
-        validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
+        validate = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         if (!validate) {
             final String msg = MessageUtils.getMessage("DOTJ037W").toString();
             logger.warn(msg);
@@ -271,12 +271,12 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         setSystemid = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID));
         final String mode = input.getAttribute(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
         processingMode = mode != null ? Mode.valueOf(mode.toUpperCase()) : Mode.LAX;
-        genDebugInfo = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
+        genDebugInfo = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
 
         // For the output control
         job.setGeneratecopyouter(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER));
         job.setOutterControl(input.getAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL));
-        job.setOnlyTopicInMap(Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP)));
+        job.setOnlyTopicInMap(Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP)));
         job.setCrawl(input.getAttribute(ANT_INVOKER_EXT_PARAM_CRAWL));
 
         // Set the OutputDir

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -315,10 +315,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             rootFile = ditaInput;
         } else if (ditaInput.getPath() != null && ditaInput.getPath().startsWith(URI_SEPARATOR)) {
             rootFile = setScheme(ditaInput, "file");
-        } else if (baseInputDir != null) {
-            rootFile = baseInputDir.resolve(ditaInput);
         } else {
-            rootFile = basedir.toURI().resolve(ditaInput);
+            rootFile = Objects.requireNonNullElseGet(baseInputDir, () -> basedir.toURI()).resolve(ditaInput);
         }
         assert rootFile.isAbsolute();
 

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -83,8 +83,6 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             throw new DITAOTException("Failed to read links from " + inputFile, e);
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final SaxonApiException e) {
-            throw new DITAOTException("Failed to read links from " + inputFile + ": " + e.getMessage(), e);
         } catch (final Exception e) {
             throw new DITAOTException("Failed to read links from " + inputFile + ": " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -107,8 +107,6 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
                 throw new DITAOTException("Failed to transform document", e);
             } catch (final RuntimeException e) {
                 throw e;
-            } catch (final SaxonApiException e) {
-                throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
             } catch (final Exception e) {
                 throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
             }

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -132,7 +132,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
                                 throw new UncheckedDITAOTException(e);
                             }
                         })
-                        .filter(entry -> entry != null)
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toList());
                 for (Entry<File, File> entry : tmps) {
                     try {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -279,10 +279,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             rootFile = ditaInput;
         } else if (ditaInput.getPath() != null && ditaInput.getPath().startsWith(URI_SEPARATOR)) {
             rootFile = setScheme(ditaInput, "file");
-        } else if (baseInputDir != null) {
-            rootFile = baseInputDir.resolve(ditaInput);
         } else {
-            rootFile = basedir.toURI().resolve(ditaInput);
+            rootFile = Objects.requireNonNullElseGet(baseInputDir, () -> basedir.toURI()).resolve(ditaInput);
         }
         job.setInputFile(rootFile);
 

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -226,19 +226,19 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     }
 
     void parseInputParameters(final AbstractPipelineInput input) {
-        validate = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
+        validate = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_VALIDATE));
         transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
         gramcache = "yes".equalsIgnoreCase(input.getAttribute(ANT_INVOKER_EXT_PARAM_GRAMCACHE));
         processingMode = Optional.ofNullable(input.getAttribute(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE))
                 .map(String::toUpperCase)
                 .map(Mode::valueOf)
                 .orElse(Mode.LAX);
-        genDebugInfo = Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
+        genDebugInfo = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR));
 
         // For the output control
         job.setGeneratecopyouter(input.getAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER));
         job.setOutterControl(input.getAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL));
-        job.setOnlyTopicInMap(Boolean.valueOf(input.getAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP)));
+        job.setOnlyTopicInMap(Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP)));
         job.setCrawl(Optional.ofNullable(input.getAttribute(ANT_INVOKER_EXT_PARAM_CRAWL))
                 .orElse(ANT_INVOKER_EXT_PARAM_CRAWL_VALUE_TOPIC));
 

--- a/src/main/java/org/dita/dost/platform/Registry.java
+++ b/src/main/java/org/dita/dost/platform/Registry.java
@@ -14,11 +14,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Registry {
@@ -37,7 +35,7 @@ public class Registry {
                     @JsonProperty("cksum") String cksum) {
         this.name = name;
         this.vers = new SemVer(vers);
-        this.deps = deps == null ? emptyList() : unmodifiableList(Arrays.asList(deps));
+        this.deps = deps == null ? emptyList() : List.of(deps);
         try {
             this.url = url != null ? new URL(url) : null;
         } catch (MalformedURLException e) {

--- a/src/main/java/org/dita/dost/platform/SemVer.java
+++ b/src/main/java/org/dita/dost/platform/SemVer.java
@@ -45,9 +45,9 @@ public class SemVer implements Comparable<SemVer> {
             }
         }
         String[] tokens = value.split("\\.");
-        major = Integer.valueOf(tokens[0]);
-        minor = tokens.length >= 2 ? Integer.valueOf(tokens[1]) : 0;
-        patch = tokens.length >= 3 ? Integer.valueOf(tokens[2]) : 0;
+        major = Integer.parseInt(tokens[0]);
+        minor = tokens.length >= 2 ? Integer.parseInt(tokens[1]) : 0;
+        patch = tokens.length >= 3 ? Integer.parseInt(tokens[2]) : 0;
         preRelease = preRel != null
                 ? Stream.of(preRel.split("\\."))
                 .map(token -> {

--- a/src/main/java/org/dita/dost/project/ProjectFactory.java
+++ b/src/main/java/org/dita/dost/project/ProjectFactory.java
@@ -150,14 +150,14 @@ public class ProjectFactory {
             return project;
         }
         final List<Deliverable> deliverables = project.deliverables != null
-                ? new ArrayList(project.deliverables)
-                : new ArrayList();
+                ? new ArrayList<>(project.deliverables)
+                : new ArrayList<>();
         final List<Publication> publications = project.publications != null
-                ? new ArrayList(project.publications)
-                : new ArrayList();
+                ? new ArrayList<>(project.publications)
+                : new ArrayList<>();
         final List<Context> contexts = project.contexts != null
-                ? new ArrayList(project.contexts)
-                : new ArrayList();
+                ? new ArrayList<>(project.contexts)
+                : new ArrayList<>();
         if (project.includes != null) {
             for (final ProjectRef projectRef : project.includes) {
                 final URI href = projectRef.href.isAbsolute() ? projectRef.href : base.resolve(projectRef.href);

--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -34,7 +34,6 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
 import static net.sf.saxon.s9api.streams.Predicates.isElement;
 import static net.sf.saxon.s9api.streams.Steps.child;
 import static net.sf.saxon.s9api.streams.Steps.precedingSibling;
@@ -49,7 +48,7 @@ import static org.dita.dost.util.XMLUtils.rootElement;
  */
 public final class KeyrefReader implements AbstractReader {
 
-    private static final List<String> ATTS = Collections.unmodifiableList(asList(
+    private static final List<String> ATTS = List.of(
             ATTRIBUTE_NAME_HREF,
             ATTRIBUTE_NAME_AUDIENCE,
             ATTRIBUTE_NAME_PLATFORM,
@@ -68,7 +67,7 @@ public final class KeyrefReader implements AbstractReader {
             "dir",
             "translate",
             ATTRIBUTE_NAME_PROCESSING_ROLE,
-            ATTRIBUTE_NAME_CASCADE));
+            ATTRIBUTE_NAME_CASCADE);
 
     private DITAOTLogger logger;
     private Job job;

--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -431,7 +431,7 @@ public final class KeyrefReader implements AbstractReader {
 
     private XdmNode getTopicmeta(final XdmNode topicref) {
         return topicref
-                .select(child(c -> MAP_TOPICMETA.matches(c)).first())
+                .select(child(MAP_TOPICMETA::matches).first())
                 .findAny()
                 .orElse(null);
     }

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -411,8 +411,6 @@ public class CacheStore extends AbstractStore implements Store {
             throw new DITAOTException("Failed to transform document", e);
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final SaxonApiException e) {
-            throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
         } catch (final Exception e) {
             throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -223,8 +223,6 @@ public class StreamStore extends AbstractStore implements Store {
             throw new DITAOTException("Failed to transform document", e);
         } catch (final RuntimeException e) {
             throw e;
-        } catch (final SaxonApiException e) {
-            throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
         } catch (final Exception e) {
             throw new DITAOTException("Failed to transform document: " + e.getMessage(), e);
         }

--- a/src/main/java/org/dita/dost/util/DITAOTCollator.java
+++ b/src/main/java/org/dita/dost/util/DITAOTCollator.java
@@ -19,7 +19,7 @@ import java.util.Locale;
  *
  * @author Wu, Zhi Qiang
  */
-public final class DITAOTCollator implements Comparator {
+public final class DITAOTCollator implements Comparator<Object> {
     private static final HashMap<Locale, DITAOTCollator> cache = new HashMap<>();
 
     /**

--- a/src/main/java/org/dita/dost/util/KeyScope.java
+++ b/src/main/java/org/dita/dost/util/KeyScope.java
@@ -7,13 +7,10 @@
  */
 package org.dita.dost.util;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.*;
 
-import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 /**
@@ -35,7 +32,7 @@ public class KeyScope {
         this.id = id;
         this.name = name;
         this.keyDefinition = unmodifiableMap(keyDefinition);
-        this.childScopes = unmodifiableList(new ArrayList<>(childScopes));
+        this.childScopes = List.copyOf(childScopes);
     }
 
     public KeyDef get(final String key) {

--- a/src/main/java/org/dita/dost/util/LangUtils.java
+++ b/src/main/java/org/dita/dost/util/LangUtils.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 
 public class LangUtils {
     public static <T, S> Map.Entry<T, S> pair(T left, S right) {
-        return new AbstractMap.SimpleImmutableEntry(left, right);
+        return new AbstractMap.SimpleImmutableEntry<T, S>(left, right);
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/LangUtils.java
+++ b/src/main/java/org/dita/dost/util/LangUtils.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 
 public class LangUtils {
     public static <T, S> Map.Entry<T, S> pair(T left, S right) {
-        return new AbstractMap.SimpleImmutableEntry<T, S>(left, right);
+        return new AbstractMap.SimpleImmutableEntry<>(left, right);
     }
 
     /**

--- a/src/main/java/org/dita/dost/util/Pool.java
+++ b/src/main/java/org/dita/dost/util/Pool.java
@@ -25,7 +25,7 @@ public class Pool<T> {
 
     public Pool(Supplier<T> create) {
         this.create = create;
-        this.objects = new ConcurrentLinkedQueue<T>();
+        this.objects = new ConcurrentLinkedQueue<>();
     }
 
     public T borrowObject() {

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -86,7 +86,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     private ChunkFilenameGenerator chunkFilenameGenerator;
 
     NamespaceSupport namespaces = new NamespaceSupport();
-    HashMap<String, Integer> namespaceMap = new HashMap<String, Integer>();
+    HashMap<String, Integer> namespaceMap = new HashMap<>();
 
     @Override
     public void setJob(final Job job) {

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -256,7 +256,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                 // need to pull matching content from the key definition
                 // If keyref on topicref, and no topicmeta, copy topicmeta from key definition
                 if (elemName.peek().equals(MAP_TOPICREF.localName)) {
-                    final Optional<XdmNode> topicmetaNode = elem.select(child().where(c -> MAP_TOPICMETA.matches(c)).first()).findFirst();
+                    final Optional<XdmNode> topicmetaNode = elem.select(child().where(MAP_TOPICMETA::matches).first()).findFirst();
                     if (topicmetaNode.isPresent()) {
                         domToSax(topicmetaNode.get(), true, false);
                     }

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.net.URI;
 import java.util.*;
 
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static javax.xml.XMLConstants.NULL_NS_URI;
 import static net.sf.saxon.s9api.streams.Predicates.hasLocalName;
@@ -47,16 +46,15 @@ public final class KeyrefPaser extends AbstractXMLFilter {
      */
     private static final Set<String> no_copy;
     static {
-        final Set<String> nc = new HashSet<>();
-        nc.add(ATTRIBUTE_NAME_ID);
-        nc.add(ATTRIBUTE_NAME_CLASS);
-        nc.add(ATTRIBUTE_NAME_XTRC);
-        nc.add(ATTRIBUTE_NAME_XTRF);
-        nc.add(ATTRIBUTE_NAME_HREF);
-        nc.add(ATTRIBUTE_NAME_KEYS);
-        nc.add(ATTRIBUTE_NAME_TOC);
-        nc.add(ATTRIBUTE_NAME_PROCESSING_ROLE);
-        no_copy = Collections.unmodifiableSet(nc);
+        no_copy = Set.of(
+                ATTRIBUTE_NAME_ID,
+                ATTRIBUTE_NAME_CLASS,
+                ATTRIBUTE_NAME_XTRC,
+                ATTRIBUTE_NAME_XTRF,
+                ATTRIBUTE_NAME_HREF,
+                ATTRIBUTE_NAME_KEYS,
+                ATTRIBUTE_NAME_TOC,
+                ATTRIBUTE_NAME_PROCESSING_ROLE);
     }
 
     /**
@@ -115,13 +113,12 @@ public final class KeyrefPaser extends AbstractXMLFilter {
         keyrefInfos = Collections.unmodifiableList(ki);
     }
 
-    private final static List<String> KEYREF_ATTRIBUTES = Collections.unmodifiableList(asList(
+    private final static List<String> KEYREF_ATTRIBUTES = List.of(
             ATTRIBUTE_NAME_KEYREF,
             ATTRIBUTE_NAME_ARCHIVEKEYREFS,
             ATTRIBUTE_NAME_CLASSIDKEYREF,
             ATTRIBUTE_NAME_CODEBASEKEYREF,
-            ATTRIBUTE_NAME_DATAKEYREF
-    ));
+            ATTRIBUTE_NAME_DATAKEYREF);
 
 
     /**

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
@@ -157,7 +157,7 @@ XMLComponent, XMLDocumentSource {
     /**
      * The prefix mapping stack
      */
-    private final Stack<Set<String>> prefixMappingStack = new Stack<Set<String>>();
+    private final Stack<Set<String>> prefixMappingStack = new Stack<>();
 
     /**
      * Constructor.

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
@@ -850,9 +850,7 @@ XMLComponent, XMLDocumentSource {
         if(!prefixMappingStack.isEmpty()) {
             Set<String> prefixes = prefixMappingStack.pop();
             if(prefixes != null) {
-                Iterator<String> iter = prefixes.iterator();
-                while(iter.hasNext()) {
-                    String prefix = iter.next();
+                for (String prefix : prefixes) {
                     validator.getContentHandler().endPrefixMapping(prefix);
                 }
             }


### PR DESCRIPTION
## Description
Run automatic IntelliJ IDEA Java migration to Java 11.

## Motivation and Context
Automatically use Java language and library features for Java 11.

## How Has This Been Tested?
Existing tests pass.
## Type of Changes

- Refactoring

## Documentation and Compatibility
Internal changes, not need to document separately. Can be listed in release notes.

