### PR TITLE
#3948 Log the current deliverable when publishing DITA-OT project

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -84,6 +84,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             "args.input", "input",
             "args.filter", "profiles"
     );
+    private static final String DELIVERABLE_DESC = "deliverable.desc";
 
     /**
      * File that we are using for configuration.
@@ -213,7 +214,12 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             for (int i = 0; i < this.args.repeat; i++) {
                 final long start = System.currentTimeMillis();
                 try {
-                    for (Map<String, Object> props : projectProps) {
+                    int nuOfProject = projectProps.size();
+                    for (int j = 0; j < nuOfProject; j++) {
+                        Map<String, Object> props = projectProps.get(j);
+                        if(props.containsKey(DELIVERABLE_DESC)) {
+                          props.put(DELIVERABLE_DESC, "\""+ props.get(DELIVERABLE_DESC) + "\" (" + (j + 1) + " of " + nuOfProject +")");
+                        }
                         runBuild(coreLoader, props);
                     }
                     exitCode = 0;
@@ -445,6 +451,15 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     props.put(ANT_PROJECT_DELIVERABLE, deliverable.id() != null
                             ? deliverable.id()
                             : String.format("deliverable-%d", entry.getValue() + 1));
+                    
+                    String deliverableDesc = "";
+                    if(deliverable.id() != null) {
+                      deliverableDesc = deliverable.id();
+                    } else if (deliverable.name() != null) {
+                      deliverableDesc = deliverable.name();
+                    }
+                    props.put(DELIVERABLE_DESC, deliverableDesc);
+                    
                     final Context context = deliverable.context();
                     final URI input = base.resolve(context.inputs().inputs().get(0).href());
                     props.put(ANT_ARGS_INPUT, input.toString());
@@ -689,6 +704,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     }
                 }
 
+                if(definedProps.containsKey(DELIVERABLE_DESC)) {
+                  project.log("\nPublishing deliverable: " + definedProps.get(DELIVERABLE_DESC));
+                }
+                
                 project.init();
 
                 // resolve properties


### PR DESCRIPTION
## Description
I added an info log with the current deliverable description. 
The log message has the following format: 'Publishing deliverable: "_deliverable.id/deliverable.name_" (x of y)'

## Motivation and Context
This is a fix for the following issue:  #3948 
