### PR TITLE
Log deliverable description #3948

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -84,6 +84,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             "args.input", "input",
             "args.filter", "profiles"
     );
+    private static final String DELIVERABLE_DESC = "deliverable.desc";
 
     /**
      * File that we are using for configuration.
@@ -213,7 +214,13 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
             for (int i = 0; i < this.args.repeat; i++) {
                 final long start = System.currentTimeMillis();
                 try {
-                    for (Map<String, Object> props : projectProps) {
+                    int nuOfProject = projectProps.size();
+                    for (int j = 0; j < nuOfProject; j++) {
+                        Map<String, Object> props = projectProps.get(j);
+                        if(props.containsKey(DELIVERABLE_DESC)) {
+                          props.put(DELIVERABLE_DESC,
+                              (j + 1) + " of " + nuOfProject + ": " + props.get(DELIVERABLE_DESC));
+                        }
                         runBuild(coreLoader, props);
                     }
                     exitCode = 0;
@@ -445,6 +452,16 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     props.put(ANT_PROJECT_DELIVERABLE, deliverable.id() != null
                             ? deliverable.id()
                             : String.format("deliverable-%d", entry.getValue() + 1));
+                    
+                    StringBuilder deliverableDesc = new StringBuilder();
+                    if (deliverable.name() != null) {
+                      deliverableDesc.append(deliverable.name());
+                    }
+                    if(deliverable.id() != null) {
+                      deliverableDesc.append(" [").append(deliverable.id()).append("]");
+                    } 
+                    props.put(DELIVERABLE_DESC, deliverableDesc.toString());
+                    
                     final Context context = deliverable.context();
                     final URI input = base.resolve(context.inputs().inputs().get(0).href());
                     props.put(ANT_ARGS_INPUT, input.toString());
@@ -689,6 +706,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
                     }
                 }
 
+                if(definedProps.containsKey(DELIVERABLE_DESC)) {
+                  project.log("\nPublishing deliverable " + definedProps.get(DELIVERABLE_DESC));
+                }
+                
                 project.init();
 
                 // resolve properties

--- a/src/test/java/org/dita/dost/invoker/MainProjectTest.java
+++ b/src/test/java/org/dita/dost/invoker/MainProjectTest.java
@@ -51,7 +51,6 @@ public class MainProjectTest {
         final List<Map<String, Object>> act = main.collectProperties(project, projectFile, emptyMap());
 
         final Map<String, Object> exp = ImmutableMap.<String, Object>builder()
-                .put("project.deliverable", "site")
                 .put("output.dir", Paths.get("out", "site").toAbsolutePath().toString())
                 .put("args.input", baseDir.resolve("site.ditamap").toString())
                 .put("transtype", "html5")
@@ -61,6 +60,8 @@ public class MainProjectTest {
                 .put("args.filter", Paths.get(baseDir).resolve("site.ditaval").toAbsolutePath().toString())
                 .put("args.gen.task.lbl", "YES")
                 .put("args.uri", baseDir.resolve("foo%20bar").toString())
+                .put("deliverable.desc", "Name [site]")
+                .put("project.deliverable", "site")
                 .build();
         assertEquals(singletonList(exp), act);
     }
@@ -74,13 +75,14 @@ public class MainProjectTest {
         final List<Map<String, Object>> act = main.collectProperties(project, projectFile, emptyMap());
 
         final Map<String, Object> exp = ImmutableMap.<String, Object>builder()
-                .put("project.deliverable", "site")
                 .put("output.dir", Paths.get("out", "site").toAbsolutePath().toString())
                 .put("args.input", baseDir.resolve("site.ditamap").toString())
                 .put("transtype", "html5")
                 .put("args.filter", Stream.of("site-html5.ditaval", "site.ditaval")
                         .map(ditaval -> Paths.get(baseDir).resolve(ditaval).toAbsolutePath().toString())
                         .collect(Collectors.joining(File.pathSeparator)))
+                .put("deliverable.desc", "Name [site]")
+                .put("project.deliverable", "site")
                 .build();
         assertEquals(singletonList(exp), act);
     }


### PR DESCRIPTION
## Description
I added an info log with the current deliverable description when publishing DITA-OT project. 
The log message has the following format: 
`Publishing deliverable 1 of 3: Product A Online Help [del-olh-A-map]`

This is a continuation of https://github.com/dita-ot/dita-ot/pull/4097

## Motivation and Context
This is a fix for the following issue:  #3948 
