### PR TITLE
Properly compute topic id when using copy-to with keydefs

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -23,6 +23,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import static java.util.Arrays.asList;
@@ -536,6 +537,19 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 String topicId = null;
                                 if (relativeTarget.getFragment() == null && !"".equals(elementId)) {
                                     topicId = getFirstTopicId(topicFile);
+                                    if(topicId == null) {
+                                        String directHref = keyDef.element.attribute(ATTRIBUTE_NAME_HREF);
+                                        if(directHref != null && ! directHref.equals(href.toString())) {
+                                            //Try to also resolve the topic ID using the direct href
+                                            try {
+                                                URI directTarget = keyDef.source.resolve(new URI(directHref));
+                                                URI directTopicFile = currentFile.resolve(stripFragment(directTarget));
+                                                topicId = getFirstTopicId(directTopicFile);
+                                            } catch (URISyntaxException e) {
+                                                //Ignore
+                                            }
+                                        }
+                                    }
                                 }
                                 final URI targetOutput = normalizeHrefValue(relativeTarget, elementId, topicId);
                                 XMLUtils.addOrSetAttribute(resAtts, refAttr, targetOutput.toString());

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -537,9 +537,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
                                 String topicId = null;
                                 if (relativeTarget.getFragment() == null && !"".equals(elementId)) {
                                     topicId = getFirstTopicId(topicFile);
-                                    if(topicId == null) {
+                                    if (topicId == null) {
                                         String directHref = keyDef.element.attribute(ATTRIBUTE_NAME_HREF);
-                                        if(directHref != null && ! directHref.equals(href.toString())) {
+                                        if (directHref != null && !directHref.equals(href.toString())) {
                                             //Try to also resolve the topic ID using the direct href
                                             try {
                                                 URI directTarget = keyDef.source.resolve(new URI(directHref));

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -12,44 +12,25 @@ import static org.dita.dost.TestUtils.createTempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamSource;
+
+import org.dita.dost.TestUtils;
+import org.dita.dost.reader.KeyrefReader;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.KeyScope;
+import org.dita.dost.util.XMLUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.InputSource;
 
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
-import org.apache.commons.io.IOUtils;
-import org.dita.dost.reader.KeyrefReader;
-import org.dita.dost.store.StreamStore;
-import org.dita.dost.util.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
-import org.dita.dost.TestUtils;
 
 public class KeyrefPaserTest {
 

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -16,6 +16,7 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -183,5 +184,19 @@ public class KeyrefPaserTest {
         } catch (SaxonApiException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testTopicWriteCopyTo() throws Exception {
+        final KeyrefPaser parser = new KeyrefPaser();
+        parser.setLogger(new TestUtils.TestLogger());
+        parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
+        KeyScope kd = readKeyMap(Paths.get("copy-to-keys.ditamap"));
+        parser.setKeyDefinition(kd);
+        parser.setCurrentFile(new File(tempDir, "copy-to-keys.dita").toURI());
+        parser.write(new File(tempDir, "copy-to-keys.dita"));
+        
+        assertXMLEqual(new InputSource(new File(expDir, "copy-to-keys.dita").toURI().toString()),
+                new InputSource(new File(tempDir, "copy-to-keys.dita").toURI().toString()));
     }
 }

--- a/src/test/resources/KeyrefPaserTest/exp/copy-to-keys.dita
+++ b/src/test/resources/KeyrefPaserTest/exp/copy-to-keys.dita
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="common" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                          (topic equation-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic mathml-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic svg-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- topic/topic ">
+	<title class="- topic/title ">Common Topic</title>
+	<body class="- topic/body ">
+		
+		<p class="- topic/p ">Original topic: <xref keyref="topic1" class="- topic/xref " href="copy-to-keys.dita"/></p>
+		<p class="- topic/p ">copy-to topic: <xref keyref="topic2" class="- topic/xref " href="topic2.dita"/></p>
+		<p class="- topic/p ">Figure in original topic: <xref keyref="topic1/my-fig-id" class="- topic/xref " href="copy-to-keys.dita#common/my-fig-id"/></p>
+		<p class="- topic/p ">Figure in copy-to topic: <xref keyref="topic2/my-fig-id" class="- topic/xref " href="topic2.dita#common/my-fig-id"/></p>
+		
+		
+		<p class="- topic/p ">Original subtopic: <xref keyref="topic1-subtopic" class="- topic/xref " href="copy-to-keys.dita#common-subtopic"/></p>
+		<p class="- topic/p ">copy-to subtopic: <xref keyref="topic2-subtopic" class="- topic/xref " href="topic2.dita#common-subtopic"/></p>
+		<p class="- topic/p ">Figure in original subtopic: <xref keyref="topic1-subtopic/my-subtopic-fig-id" class="- topic/xref " href="copy-to-keys.dita#common-subtopic/my-subtopic-fig-id"/></p>
+		<p class="- topic/p ">Figure in copy-to subtopic: <xref keyref="topic2-subtopic/my-subtopic-fig-id" class="- topic/xref " href="topic2.dita#common-subtopic/my-subtopic-fig-id"/></p>
+		<fig id="my-fig-id" class="- topic/fig ">
+			<title class="- topic/title ">Figure Title</title>
+		</fig>
+	</body>
+	<topic id="common-subtopic" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                          (topic equation-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic mathml-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic svg-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- topic/topic ">
+		<title class="- topic/title ">Common Subtopic</title>
+		<body class="- topic/body ">
+			<fig id="my-subtopic-fig-id" class="- topic/fig ">
+				<title class="- topic/title ">Subtopic Figure Title</title>
+			</fig>
+		</body>
+	</topic>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/exp/copy-to-keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/exp/copy-to-keys.ditamap
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.3" domains="                          (topic abbrev-d)                          (topic delay-d)                          (map ditavalref-d)                          (map glossref-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (map mapgroup-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- map/map ">
+	<title class="- topic/title ">My Map</title>
+	<topicref href="copy-to-keys.dita" keys="topic1" class="- map/topicref ">
+		<topicref href="copy-to-keys.dita#common-subtopic" keys="topic1-subtopic" class="- map/topicref "/>
+	</topicref>
+	<topicref href="copy-to-keys.dita" keys="topic2" copy-to="topic2.dita" class="- map/topicref ">
+		<topicref href="copy-to-keys.dita#common-subtopic" keys="topic2-subtopic" copy-to="topic2.dita#common-subtopic" class="- map/topicref "/>
+	</topicref>
+</map>

--- a/src/test/resources/KeyrefPaserTest/src/copy-to-keys.dita
+++ b/src/test/resources/KeyrefPaserTest/src/copy-to-keys.dita
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" id="common" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                          (topic equation-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic mathml-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic svg-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- topic/topic ">
+	<title class="- topic/title ">Common Topic</title>
+	<body class="- topic/body ">
+		<!-- these are links to the top-level <topic> -->
+		<p class="- topic/p ">Original topic: <xref keyref="topic1" class="- topic/xref "/></p>
+		<p class="- topic/p ">copy-to topic: <xref keyref="topic2" class="- topic/xref "/></p>
+		<p class="- topic/p ">Figure in original topic: <xref keyref="topic1/my-fig-id" class="- topic/xref "/></p>
+		<p class="- topic/p ">Figure in copy-to topic: <xref keyref="topic2/my-fig-id" class="- topic/xref "/></p>
+		
+		<!-- these are links to the nested (subtopic) <topic> -->
+		<p class="- topic/p ">Original subtopic: <xref keyref="topic1-subtopic" class="- topic/xref "/></p>
+		<p class="- topic/p ">copy-to subtopic: <xref keyref="topic2-subtopic" class="- topic/xref "/></p>
+		<p class="- topic/p ">Figure in original subtopic: <xref keyref="topic1-subtopic/my-subtopic-fig-id" class="- topic/xref "/></p>
+		<p class="- topic/p ">Figure in copy-to subtopic: <xref keyref="topic2-subtopic/my-subtopic-fig-id" class="- topic/xref "/></p>
+		<fig id="my-fig-id" class="- topic/fig ">
+			<title class="- topic/title ">Figure Title</title>
+		</fig>
+	</body>
+	<topic id="common-subtopic" ditaarch:DITAArchVersion="1.3" domains="(topic abbrev-d)                          (topic equation-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic mathml-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic svg-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- topic/topic ">
+		<title class="- topic/title ">Common Subtopic</title>
+		<body class="- topic/body ">
+			<fig id="my-subtopic-fig-id" class="- topic/fig ">
+				<title class="- topic/title ">Subtopic Figure Title</title>
+			</fig>
+		</body>
+	</topic>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/copy-to-keys.ditamap
+++ b/src/test/resources/KeyrefPaserTest/src/copy-to-keys.ditamap
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="1.3" domains="                          (topic abbrev-d)                          (topic delay-d)                          (map ditavalref-d)                          (map glossref-d)                          (topic hazard-d)                          (topic hi-d)                          (topic indexing-d)                          (map mapgroup-d)                          (topic markup-d xml-d)                          (topic markup-d)                          (topic pr-d)                          (topic relmgmt-d)                          (topic sw-d)                          (topic ui-d)                          (topic ut-d)                          a(props deliveryTarget)" class="- map/map ">
+	<title class="- topic/title ">My Map</title>
+	<topicref href="copy-to-keys.dita" keys="topic1" class="- map/topicref ">
+		<topicref href="copy-to-keys.dita#common-subtopic" keys="topic1-subtopic" class="- map/topicref "/>
+	</topicref>
+	<topicref href="copy-to-keys.dita" keys="topic2" copy-to="topic2.dita" class="- map/topicref ">
+		<topicref href="copy-to-keys.dita#common-subtopic" keys="topic2-subtopic" copy-to="topic2.dita#common-subtopic" class="- map/topicref "/>
+	</topicref>
+</map>


### PR DESCRIPTION
## Description
Properly compute topic id when using copy-to with keydefs

## Motivation and Context
Fixes #4076

## How Has This Been Tested?
Automatic tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
