### PR TITLE
Working around a bug in CMD.exe on Windows: lower-case drive letter stored as CWD by cd command

### DIFF
--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -198,7 +198,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
                     final File p = new File(URLUtils.setQuery(URLUtils.stripFragment(abs), null));
                     try {
                         final File canFile = p.getCanonicalFile();
-                        final String absPath = p.getAbsolutePath();
+                        final String absPath = p.toPath().toRealPath().toString();
                         final String canPath = canFile.toString();
                         if (!Objects.equals(absPath, canPath) && Objects.equals(absPath.toLowerCase(), canPath.toLowerCase())) {
                             switch (processingMode) {


### PR DESCRIPTION
This PR is working around a bug in CMD.exe on Windows: The `cd` command does not only change into a directory, but also stores the drive letter in the case *given by the command issuer*, resulting in CWD sometimes starting with `c:` instead of `C:`. As this happens on all versions on Windows, and as it happens to everybody running DITA-OT on Windows, we should working around this using a simple trick: Not just "absoluting" the CWD using `getAbsolutePath`, but actually finding out the *correct* case by reading the *real* name from the file system using `toRealPath`.