### PR TITLE
Avoid overwriting input files

### DIFF
--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -118,6 +118,9 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         if (f.src == null || !exists(f.src) || !f.src.equals(f.result)) {
             logger.warn("Ignoring a copy-to file " + f.result);
             return;
+        } else if (f.uri.isAbsolute() && ! f.uri.toString().startsWith(job.tempDirURI.toString())) {
+            //The file is outside the temp dir, we cannot write to itself
+            throw new RuntimeException("Cannot write outside of the temporary files folder: " + f.uri);
         }
         outputFile = new File(job.tempDirURI.resolve(f.uri));
         logger.info("Processing " + f.src + " to " + outputFile.toURI());

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -503,6 +503,9 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
             updateUplevels(target);
 
         }
+        for(final URI reference: resources) {
+            updateUplevels(reference);
+        }
         final Set<URI> nonTopicrefReferenceSet = new HashSet<>();
         nonTopicrefReferenceSet.addAll(listFilter.getNonTopicrefReferenceSet());
         nonTopicrefReferenceSet.removeAll(listFilter.getNormalProcessingRoleSet());

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -375,4 +375,30 @@ public class TestGenMapAndTopicListModule {
         TestUtils.forceDelete(tempDir);
     }
 
+    @Test
+    public void testResourcesUplevels() throws Exception{
+        final File inputDir = new File(".");
+        final File inputMap = new File(inputDir, "image-keydef/svg.ditamap");
+        final File outerMap = new File(srcDir, "root-map.ditamap");
+        final File outDirAbove = new File(tempDir, "out");
+        final PipelineHashIO pipelineInput = new PipelineHashIO();
+        pipelineInput.setAttribute(ANT_INVOKER_PARAM_INPUTMAP, inputMap.getPath());
+        pipelineInput.setAttribute(ANT_INVOKER_PARAM_BASEDIR, srcDir.getAbsolutePath());
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, inputDir.getPath());
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR, outDirAbove.getPath());
+        pipelineInput.setAttribute(ANT_INVOKER_PARAM_TEMPDIR, tempDir.getPath());
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, new File("src" + File.separator + "main").getAbsolutePath());
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER, Integer.toString(NOT_GENERATEOUTTER.type));
+        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL, "warn");
+        pipelineInput.setAttribute(ANT_INVOKER_PARAM_RESOURCES, outerMap.getCanonicalPath());
+
+        final GenMapAndTopicListModule module = new GenMapAndTopicListModule();
+        module.setLogger(new TestUtils.TestLogger());
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+        module.setJob(job);
+        module.setXmlUtils(new XMLUtils());
+        module.execute(pipelineInput);
+        assertEquals(srcDir.toURI().toString(), job.getInputDir().toString());
+    }
+
 }

--- a/src/test/resources/TestGenMapAndTopicListModule/src/root-map.ditamap
+++ b/src/test/resources/TestGenMapAndTopicListModule/src/root-map.ditamap
@@ -1,0 +1,6 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+  domains="(topic delay-d)                          (map mapgroup-d)                           (topic indexing-d)                          (map glossref-d)                          (topic hi-d)                           (topic ut-d)                           (topic hazard-d)                          (topic abbrev-d)                          (topic pr-d)                           (topic sw-d)                          (topic ui-d)                         "
+  ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Root Map 0</title>
+  <topicref class="- map/topicref " href="image-keydef/svg.ditamap" format="ditamap"/>
+</map>


### PR DESCRIPTION
## Description
Avoid overwriting files from the input folders when providing additional args.resources.
Added also extra check to break processing completely if there is an attempt to write content outside of temporary files folder.

## Motivation and Context
Fixes #4104

## How Has This Been Tested?
Automatic tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
