### PR TITLE
Disable debug logging for non-DITA-OT loggers

### DIFF
--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -8,12 +8,12 @@
       </pattern-->
     </encoder>
   </appender>
-  <logger name="FOP" level="INFO"/>
-  <logger name="org.apache.fop" level="INFO"/>
   <logger name="org.apache.fop.apps.FopConfParser" level="WARN"/>
-  <logger name="org.apache.xmlgraphics" level="INFO"/>
-  <logger name="org.apache.http" level="INFO"/>
-  <root level="DEBUG">
+  <logger name="org.dita" level="DEBUG"/>
+  <logger name="org.ditang" level="DEBUG"/>
+  <logger name="com.idiominc" level="DEBUG"/>
+  <logger name="com.suite" level="DEBUG"/>
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
Leave full debug logging by default only on DITA OT provided Java packages.
Signed-off-by: Radu Coravu <radu_coravu@sync.ro>

## Description
Avoid debugging Java code from third party plugins on full debug.

## Motivation and Context
Fixes #4106

## How Has This Been Tested?
No automatic tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
