### PR TITLE
Save submap metadata inside `<mapref>` elements

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
@@ -27,6 +27,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' ditaot-d/submap-title ')]"/>
   <xsl:template match="*[contains(@class, ' ditaot-d/submap-topicmeta ')]"/>
   <xsl:template match="*[contains(@class, ' ditaot-d/submap-topicmeta-container ')]"/>
+  <xsl:template match="*[contains(@class, ' ditaot-d/mapref-topicmeta-container ')]"/>
   
   <xsl:template match="*[contains(@class, ' ditaot-d/keydef ')]"/>
   

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -202,7 +202,9 @@ See the accompanying LICENSE file for applicable license.
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="targetTitleAndTopicmeta" as="element()*"
-              select="$file/*/*[contains(@class,' topic/title ') or contains(@class,' map/topicmeta ')]"/>
+              select="$file/*/*[contains(@class,' topic/title ') or contains(@class,' map/topicmeta ')]"/>  <!-- submap title and topicmeta -->
+            <xsl:variable name="maprefTopicmeta" as="element()?"
+              select="*[contains(@class,' map/topicmeta ')]"/>  <!-- mapref topicmeta -->
             <xsl:variable name="contents" as="node()*">
               <xsl:choose>
                 <xsl:when test="not(contains($href,'://') or empty($element-id) or $file/*[contains(@class,' map/map ')][@id = $element-id])">
@@ -275,6 +277,7 @@ See the accompanying LICENSE file for applicable license.
                   </xsl:choose>
                 </xsl:with-param>
               </xsl:apply-templates>
+              <xsl:apply-templates select="$maprefTopicmeta" mode="preserve-mapref-topicmeta"/>
               <xsl:apply-templates select="*[contains(@class, ' ditavalref-d/ditavalref ')]"/>
               <xsl:apply-templates select="$contents">
                 <xsl:with-param name="refclass" select="$refclass"/>
@@ -536,6 +539,11 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
       <xsl:apply-templates select="*|processing-instruction()|text()"/>
     </submap-topicmeta-container>
+  </xsl:template>
+  <xsl:template match="*[contains(@class,' map/topicmeta ')]" mode="preserve-mapref-topicmeta">
+    <mapref-topicmeta-container class="+ topic/foreign ditaot-d/mapref-topicmeta-container ">
+      <xsl:apply-templates select="*|processing-instruction()|text()"/>
+    </mapref-topicmeta-container>
   </xsl:template>
 
   <xsl:template match="*" mode="reltable-copy" priority="10">

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -530,19 +530,19 @@ See the accompanying LICENSE file for applicable license.
     <submap-topicmeta class="+ map/topicmeta ditaot-d/submap-topicmeta ">
       <submap-title class="+ topic/navtitle ditaot-d/submap-title ">
         <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
-        <xsl:apply-templates select="*|processing-instruction()|text()"/>
+        <xsl:apply-templates/>
       </submap-title>
     </submap-topicmeta>
   </xsl:template>
   <xsl:template match="*[contains(@class,' map/topicmeta ')]" mode="preserve-submap-title-and-topicmeta">
     <submap-topicmeta-container class="+ topic/foreign ditaot-d/submap-topicmeta-container ">
       <xsl:apply-templates select="@*" mode="preserve-submap-attributes"/>
-      <xsl:apply-templates select="*|processing-instruction()|text()"/>
+      <xsl:apply-templates/>
     </submap-topicmeta-container>
   </xsl:template>
   <xsl:template match="*[contains(@class,' map/topicmeta ')]" mode="preserve-mapref-topicmeta">
     <mapref-topicmeta-container class="+ topic/foreign ditaot-d/mapref-topicmeta-container ">
-      <xsl:apply-templates select="*|processing-instruction()|text()"/>
+      <xsl:apply-templates/>
     </mapref-topicmeta-container>
   </xsl:template>
 

--- a/src/test/resources/MaprefModuleTest/exp/mapref_topicrefID/ff698d09fad412d8af8bfdb6e5da6c2bed4f356f.ditamap
+++ b/src/test/resources/MaprefModuleTest/exp/mapref_topicrefID/ff698d09fad412d8af8bfdb6e5da6c2bed4f356f.ditamap
@@ -10,6 +10,9 @@
           dita-ot:submap-DITAArchVersion="1.3" dita-ot:submap-cascade="nomerge" dita-ot:submap-class="- map/map "
           dita-ot:submap-domains="(map mapgroup-d) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (map glossref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic markup-d xml-d)"
           dita-ot:submap-id="rootElementId" dita-ot:submap-specializations="@props/deliveryTarget">
+    <mapref-topicmeta-container class="+ topic/foreign ditaot-d/mapref-topicmeta-container ">
+      <othermeta class="- topic/othermeta " content="value" name="key"/>
+    </mapref-topicmeta-container>
     <topicref class="- map/topicref bookmap/chapter " id="tr1"/>
     <topicref class="- map/topicref bookmap/chapter " id="tr2"/>
   </submap>

--- a/src/test/resources/MaprefModuleTest/src/mapref_topicrefID/ff698d09fad412d8af8bfdb6e5da6c2bed4f356f.ditamap
+++ b/src/test/resources/MaprefModuleTest/src/mapref_topicrefID/ff698d09fad412d8af8bfdb6e5da6c2bed4f356f.ditamap
@@ -4,5 +4,9 @@
     domains="(map mapgroup-d) (map bookmap) (topic abbrev-d) (topic delay-d) a(props deliveryTarget) (map ditavalref-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic ui-d) (topic ut-d) (topic xnal-d) (topic markup-d xml-d)"
     class="- map/map bookmap/bookmap " cascade="nomerge" specializations="@props/deliveryTarget">
   <chapter href="c4ccbe11b58d24a18ce41f7c9d44000cf9b7c282.ditamap#rootElementId" format="ditamap"
-           class="- map/topicref bookmap/chapter "/>
+           class="- map/topicref bookmap/chapter ">
+    <topicmeta class="- map/topicmeta ">
+      <othermeta class="- topic/othermeta " content="value" name="key"/>
+    </topicmeta>
+  </chapter>
 </bookmap>


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

## Description
This pull request updates `mapref` processing to also save metadata inside `<mapref>` elements.

## Motivation and Context
`mapref` preprocessing copies submap metadata into a temporary `<submap-topicmeta-container>` element:

```
<map>
   <title>My Map</title>
   <submap>
      <submap-topicmeta>
         <submap-title>My Submap</submap-title>
      </submap-topicmeta>
      <submap-topicmeta-container>
         ....
      </submap-topicmeta-container>
```

Currently metadata in the submap is saved ([Example 4 here](https://github.com/dita-ot/dita-ot/issues/4105#issuecomment-1399501514)):

![4105_ex4](https://user-images.githubusercontent.com/50950969/215870094-0301af5f-c654-4bae-b060-6187de97896d.svg)

but metadata in the `<mapref>` element is not ([Example 3 here](https://github.com/dita-ot/dita-ot/issues/4105#issuecomment-1399501514)):

![4105_ex3](https://user-images.githubusercontent.com/50950969/215870109-1270a2f2-f826-4a1d-9dcc-a8f8122401a3.svg)

This pull request updates `mapref.xsl` to also save the `<mapref>` metadata in Example 3 into a new `<mapref-topicmeta-container>` container (named similarly to `<submap-topicmeta-container>`).

This change to `mapref.xsl` applies to both `preprocess` and `preprocess2`.

This change does not affect any DITA-OT transformation results because both container elements are specialized from `<foreign>` and thus ignored by DITA-OT preprocessing, then deleted during cleanup. This is an incremental step toward a solution for #4105.

## How Has This Been Tested?
All tests passed. In addition, I also tested examples 3 and 4 from [here](https://github.com/dita-ot/dita-ot/issues/4105#issuecomment-1399501514), plus a combined 3+4 testcase.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
A release notes mention is sufficient.

There should be no compatibility issues; the existing `<submap-topicmeta-container>` behavior is unchanged, and the new additional data is saved in a new `<mapref-topicmeta-container>` container.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

No unit test changes were needed.