### PR TITLE
Relaxed match to find ancestor map or topic

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -869,7 +869,7 @@ See the accompanying LICENSE file for applicable license.
             <xsl:sequence select="."/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:variable name="topic" select="ancestor::*[contains(@class, ' topic/topic ')][1]" as="element()"/>
+            <xsl:variable name="topic" select="ancestor::*[contains(@class, ' topic/topic ') or contains(@class, ' map/map ')][1]" as="element()"/>
             <xsl:sequence select="$topic/*[not(contains(@class, ' topic/topic '))]"/>
           </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
## Description
Using a content reference in the title of a DITA Map to a phrase with an inner phrase no longer properly resolved.

## Motivation and Context
Fix for #4117

## How Has This Been Tested?
Manual testing.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No doc.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
