### PR TITLE
Don't log about missing target when target is external

### DIFF
--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -106,7 +106,7 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:if>
         <xsl:if test="@href and @id">
-            <xsl:if test="not(@id = '') and empty(key('topic-id', @id))">
+            <xsl:if test="not(@id = '') and not(@scope = 'external') and empty(key('topic-id', @id))">
               <xsl:call-template name="output-message">
                 <xsl:with-param name="id" select="'PDFX005F'"/>
                 <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>


### PR DESCRIPTION
## Description
Disable `PDFX005F` when topicref target `@scope` is `external`.

## Motivation and Context
PDF incorrectly logs `PDFX005F` when  topicrefs with `scope="external"` target external resources.

## How Has This Been Tested?
Manual testing.
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

