### PR TITLE
Preprocess2 non-dita files not copied correctly to output dir

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -449,7 +449,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="copy-files2"
           description="Copy files to the output directory"
           depends="copy-image2,
-                   copy-html,
+                   copy-html2,
                    copy-flag"/>
 
   <target name="copy-image2"
@@ -461,4 +461,18 @@ See the accompanying LICENSE file for applicable license.
     </copy>
   </target>
   
+  <target name="copy-html2" 
+          unless="preprocess.copy-html.skip" 
+		  description="Copy html files">
+    <copy todir="${dita.output.dir}" failonerror="false" overwrite="true">
+      <ditafileset>
+        <excludes format="dita"/>
+        <excludes format="ditamap"/>
+        <excludes format="ditaval"/>
+        <excludes format="image"/>
+        <excludes format="coderef"/>
+      </ditafileset>
+      <jobmapper/>
+    </copy>
+  </target>  
 </project>


### PR DESCRIPTION

## Description
For target **copy-html2** I followed the same change that was made to **copy-image** and **copy-image2** for preprocess2. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
In preprocess2, non dita/ditamap/ditaval/image/coderef resources are not being copied to output directory.

Fixes #3966

@raducoravu , does this help with #3242 since you mentioned #3966 may be a duplicate. 

I am not exactly sure how to submit this as a patch to v3.7.x but I would like to. Does someone need to create a hotfix/3.7.5 and I would create a PR against that branch?

## How Has This Been Tested?
I have tested this change with v4.0.2, v3.7.4 and the develop branch using these sample files [preprocess2_test.zip](https://github.com/dita-ot/dita-ot/files/9099007/preprocess2_test.zip)

<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes
Bug fix _(non-breaking change which fixes an issue)_


## Documentation and Compatibility
no doc change necessary

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code. 
I am not sure what if any unit tests need to be updated. Please let me know if I need to do this as it is my first PR to dita-ot. 