### PR TITLE
Update normalize plug-in to version 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
 def bundled = [
         "eclipsehelp": "https://github.com/dita-ot/org.dita.eclipsehelp/releases/download/3.4/org.dita.eclipsehelp-3.4.0.zip",
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/3.3.0/org.lwdita-3.3.0.zip",
-        "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/1.0.zip",
+        "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/1.1.0.zip",
         "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
         "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20221107/org.oasis-open.dita.v2_0.zip",


### PR DESCRIPTION
## Description
Update normalize plug-in to version 1.1.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Document new properties in https://github.com/dita-ot/org.dita.normalize/pull/14.

