### PR TITLE
Print plug-in version in plugins subcommand output #4137

### DIFF
--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -68,7 +68,7 @@ public final class PluginInstallTask extends Task {
         } catch (IOException e) {
             throw new BuildException("Failed to create temporary directory: " + e.getMessage(), e);
         }
-        installedPlugins = Plugins.getInstalledPlugins();
+        installedPlugins = Plugins.getInstalledPlugins().stream().map(Map.Entry::getKey).toList();
 
         final DITAOTAntLogger logger;
         logger = new DITAOTAntLogger(getProject());

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -547,9 +547,14 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
      * Handle the --plugins argument
      */
     private void printPlugins() {
-        final List<String> installedPlugins = Plugins.getInstalledPlugins();
-        for (final String plugin : installedPlugins) {
-            System.out.println(plugin);
+        final List<Map.Entry<String, String>> installedPlugins = Plugins.getInstalledPlugins();
+        for (final Map.Entry<String, String> entry : installedPlugins) {
+            System.out.print(entry.getKey());
+            if (entry.getValue() != null) {
+                System.out.print('@');
+                System.out.print(entry.getValue());
+            }
+            System.out.println();
         }
     }
 

--- a/src/main/java/org/dita/dost/platform/Plugins.java
+++ b/src/main/java/org/dita/dost/platform/Plugins.java
@@ -17,8 +17,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.dita.dost.util.Constants.PLUGIN_CONF;
@@ -29,13 +28,15 @@ public class Plugins {
     /**
      * Read the list of installed plugins
      */
-    public static List<String> getInstalledPlugins() {
+    public static List<Map.Entry<String, String>> getInstalledPlugins() {
         final List<Element> plugins = toList(getPluginConfiguration().getElementsByTagName("plugin"));
         return plugins.stream()
-                .map((Element elem) -> elem.getAttributeNode("id"))
-                .filter(Objects::nonNull)
-                .map(Attr::getValue)
-                .sorted()
+                .map((Element elem) -> new AbstractMap.SimpleImmutableEntry<>(
+                        Optional.ofNullable(elem.getAttributeNode("id")).map(Attr::getValue).orElse(null),
+                        Optional.ofNullable(elem.getAttributeNode("version")).map(Attr::getValue).orElse(null))
+                )
+                .filter(entry -> Objects.nonNull(entry.getKey()))
+                .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Description
List plug-in version in `plugins` subcommand output. The output is `<plug-in id>@<version>` to match common convention in dependency management tools; if version has not been set, only `<plug-in id>` is output.

## Motivation and Context
Fixes #4137

## How Has This Been Tested?
Manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Both plug-in ID and version are read from `plugin.xml` file, not from registry metadata.
