### PR TITLE
Support note type `other` in HTML output

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -548,7 +548,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:choose>
       <xsl:when test="@othertype">
         <xsl:apply-templates select="." mode="process.note.common-processing">
-          <xsl:with-param name="type" select="'note'"/>
+          <xsl:with-param name="type" select="replace(normalize-space(@othertype), ' ', '_')"/>
           <xsl:with-param name="title" select="string(@othertype)"/>
         </xsl:apply-templates>
       </xsl:when>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -645,7 +645,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:choose>
     <xsl:when test="@othertype">
       <xsl:apply-templates select="." mode="process.note.common-processing">
-        <xsl:with-param name="type" select="'note'"/>
+        <xsl:with-param name="type" select="replace(normalize-space(@othertype), ' ', '_')"/>
         <xsl:with-param name="title" select="string(@othertype)"/>
       </xsl:apply-templates>
     </xsl:when>


### PR DESCRIPTION
## Description
Added the othertype attribute value in the <note> class.

## Motivation and Context
Fixes #4136.

## Type of Changes
- Bug fix

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
