### PR TITLE
Add processing mode to default error handler

### DIFF
--- a/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
@@ -9,7 +9,7 @@
 package org.dita.dost.exception;
 
 import org.dita.dost.log.DITAOTLogger;
-
+import org.dita.dost.util.Configuration;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -26,14 +26,16 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
      */
     private final String filePath;
     private final DITAOTLogger logger;
+    private final Configuration.Mode mode;
 
     /**
      * Constructor.
      * @param file File
      */
-    public DITAOTXMLErrorHandler(final String file, final DITAOTLogger logger) {
+    public DITAOTXMLErrorHandler(final String file, final DITAOTLogger logger, final Configuration.Mode mode) {
         filePath = file;
         this.logger = logger;
+        this.mode = mode;
     }
 
     /**
@@ -43,8 +45,11 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
      */
     @Override
     public void error(final SAXParseException saxException) throws SAXException {
-        throw new SAXExceptionWrapper(filePath, saxException);
-        //throw new SAXParseException();
+        if (mode == Configuration.Mode.STRICT) {
+            throw new SAXExceptionWrapper(filePath, saxException);
+        } else {
+            logger.error(saxException.getMessage(), saxException);
+        }
     }
 
     /**

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -144,7 +144,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
 
         InputSource in = null;
         try {
-            reader.setErrorHandler(new DITAOTXMLErrorHandler(currentFile.toString(), logger));
+            reader.setErrorHandler(new DITAOTXMLErrorHandler(currentFile.toString(), logger, processingMode));
 
             XMLReader parser = XMLUtils.getXmlReader(f.format).orElse(reader);
             XMLReader xmlSource = parser;

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -372,11 +372,11 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
         }
 
         keydefFilter.setCurrentDir(fileToParse.resolve("."));
-        keydefFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
+        keydefFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
         pipe.add(keydefFilter);
 
         listFilter.setCurrentFile(fileToParse);
-        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
+        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
         pipe.add(listFilter);
 
         return pipe;

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -102,11 +102,11 @@ public final class MapReaderModule extends AbstractReaderModule {
         pipe.add(normalizeFilter);
 
         keydefFilter.setCurrentDir(fileToParse.resolve("."));
-        keydefFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
+        keydefFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
         pipe.add(keydefFilter);
 
         listFilter.setCurrentFile(fileToParse);
-        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
+        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
         pipe.add(listFilter);
 
         ditaWriterFilter.setDefaultValueMap(defaultValueMap);

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -266,7 +266,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
         pipe.add(topicFragmentFilter);
 
         listFilter.setCurrentFile(fileToParse);
-        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger));
+        listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
         pipe.add(listFilter);
 
         ditaWriterFilter.setDefaultValueMap(defaultValueMap);

--- a/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
@@ -8,9 +8,11 @@
  */
 package org.dita.dost.writer;
 
-import static org.apache.commons.io.FileUtils.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.XMLUtils.*;
+import org.dita.dost.exception.DITAOTXMLErrorHandler;
+import org.dita.dost.util.Configuration;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -19,10 +21,11 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import org.dita.dost.exception.DITAOTXMLErrorHandler;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
+
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.io.FileUtils.moveFile;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.*;
 
 
 /*
@@ -309,7 +312,7 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
             output = new OutputStreamWriter(job.getStore().getOutputStream(outputFile.toURI()), StandardCharsets.UTF_8);
 
             topicIdList.clear();
-            reader.setErrorHandler(new DITAOTXMLErrorHandler(file, logger));
+            reader.setErrorHandler(new DITAOTXMLErrorHandler(file, logger, Configuration.Mode.STRICT));
             reader.parse(file);
         } catch (final RuntimeException e) {
             throw e;

--- a/src/test/java/org/dita/dost/exception/DITAOTXMLErrorHandlerTest.java
+++ b/src/test/java/org/dita/dost/exception/DITAOTXMLErrorHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package org.dita.dost.exception;
 
+import org.dita.dost.util.Configuration;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -16,28 +17,37 @@ import org.dita.dost.log.DITAOTLogger;
 public class DITAOTXMLErrorHandlerTest {
 
     private final DITAOTLogger logger = new TestLogger();
-    private final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger);
     private final SAXParseException se = new SAXParseException("message", "publicId", "systemId", 3, 1,
             new RuntimeException("msg"));
 
     @Test
     public void testDITAOTXMLErrorHandler() {
-        new DITAOTXMLErrorHandler("path", logger);
-        new DITAOTXMLErrorHandler(null, logger);
+        new DITAOTXMLErrorHandler("path", logger, null);
+        new DITAOTXMLErrorHandler(null, logger, null);
     }
 
     @Test(expected = SAXExceptionWrapper.class)
-    public void testError() throws SAXException {
+    public void testError_strict() throws SAXException {
+        final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger, Configuration.Mode.STRICT);
         e.error(se);
     }
 
+    @Test(expected = AssertionError.class)
+    public void testError_lax() throws SAXException {
+        final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger, Configuration.Mode.LAX);
+        e.error(se);
+    }
+
+
     @Test(expected = SAXExceptionWrapper.class)
     public void testFatalError() throws SAXException {
+        final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger, Configuration.Mode.STRICT);
         e.fatalError(se);
     }
 
     @Test
     public void testWarning() throws SAXException {
+        final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger, Configuration.Mode.STRICT);
         e.warning(se);
     }
 


### PR DESCRIPTION
## Description
Add processing mode to default SAX error handler. Instead of always treating errors as fatal errors by throwing an exception, the handler can throw the error only in strict processing mode.

## Motivation and Context
Per SAX interface documentation, default behaviour for error should be to ignore them. We don't want to ignore them, but we don't want to treat all errors as fatal errors either. By using processing mode to decide how to handle errors, we allow parsing to continue in lax mode and only log the error.

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

