### PR TITLE
#3903 strip fragments when determining what to branch-filter

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -11,11 +11,9 @@ import static java.util.Collections.singletonList;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.StringUtils.getExtProps;
 import static org.dita.dost.util.StringUtils.getExtPropsFromSpecializations;
-import static org.dita.dost.util.URLUtils.stripFragment;
-import static org.dita.dost.util.URLUtils.toURI;
+import static org.dita.dost.util.URLUtils.*;
 import static org.dita.dost.util.XMLUtils.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
@@ -419,7 +417,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
     final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
     final Attr skipFilter = topicref.getAttributeNode(SKIP_FILTER);
-    final URI srcAbsUri = job.tempDirURI.resolve(map.resolve(href));
+    final URI srcAbsUri = setFragment(job.tempDirURI.resolve(map.resolve(href)), null);
     if (
       !fs.isEmpty() &&
       skipFilter == null &&


### PR DESCRIPTION
## Description
This is a code change suggested by @raducoravu to remove fragment suffixes when processing the branch-filtering file list.

## Motivation and Context
Fixes #3903.

## How Has This Been Tested?
I tested this on the testcase provided in #3903. I also ran a large heavily branch-filtered testcase from my company. In both cases, the fix behaved as expected and the output diffed identically.

I also ran the recommended Gradle tests (`test`, `integrationtest`, `e2etest`).

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

Other than fixing the multiple filtering invocations, there is no change in processing behavior.

## Documentation and Compatibility
There is no change to output or plugins; this is a performance improvement.

A release notes mention is sufficient, something along the following lines:

> When a map contained references to nested subtopics within the same topic file, branch filtering processed the file multiple times. The output was correct but runtime was increased. This issue has been fixed so that the topic file is only filtered once.

Please attribute this bug fix to Radu Coravu (@raducoravu).

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I did not update the unit tests because there is no change in output to test.