### PR TITLE
Add Spotless with Palantir format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Check formatting
+        run: ./gradlew spotlessCheck
       - name: Build with Gradle
         run: ./gradlew
       - name: Run unit tests

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 
+plugins {
+    id "com.diffplug.spotless" version "6.17.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -21,6 +25,8 @@ description = """DITA Open Toolkit"""
 
 sourceCompatibility = 17
 targetCompatibility = 17
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 repositories {
     mavenCentral()
@@ -30,13 +36,13 @@ repositories {
 }
 dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
-    implementation group: 'xerces', name: 'xercesImpl', version:'2.12.2'
-    implementation group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
-    implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'
+    implementation group: 'xerces', name: 'xercesImpl', version: '2.12.2'
+    implementation group: 'xml-apis', name: 'xml-apis', version: '1.4.01'
+    implementation group: 'xml-resolver', name: 'xml-resolver', version: '1.2'
     implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '10.6'
-    implementation group: 'com.ibm.icu', name: 'icu4j', version:'70.1'
-    implementation group: 'org.apache.ant', name: 'ant', version:'1.10.12'
-    implementation group: 'org.apache.ant', name: 'ant-launcher', version:'1.10.12'
+    implementation group: 'com.ibm.icu', name: 'icu4j', version: '70.1'
+    implementation group: 'org.apache.ant', name: 'ant', version: '1.10.12'
+    implementation group: 'org.apache.ant', name: 'ant-launcher', version: '1.10.12'
     implementation(group: 'com.google.guava', name: 'guava', version: '25.1-jre') {
         exclude group: 'org.checkerframework', module: 'checker-qual'
         exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
@@ -50,10 +56,10 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.13.4'
     implementation group: 'org.relaxng', name: 'jing', version: '20181222'
-    implementation group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.12'
-    testImplementation  group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
-    testImplementation  group: 'junit', name: 'junit', version:'4.13.2'
-    testImplementation  group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.0'
+    implementation group: 'org.apache.ant', name: 'ant-apache-resolver', version: '1.10.12'
+    testImplementation group: 'nu.validator.htmlparser', name: 'htmlparser', version: '1.4'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.6.0'
 }
 
 jar {
@@ -92,8 +98,8 @@ test.maxParallelForks = 4
 // Integration test
 
 def integrationTestSystemProperties = [
-        temp_dir : "${buildDir}/tmp/integrationTest",
-        dita_dir : "${projectDir}/src/main",
+        temp_dir: "${buildDir}/tmp/integrationTest",
+        dita_dir: "${projectDir}/src/main",
         basedir : "${projectDir}/src/test"
 ]
 if (System.getProperty("test") != null) {
@@ -113,14 +119,14 @@ task integrationTest(type: Test, dependsOn: 'buildLocal') {
 // End to end test
 
 dependencies {
-    testImplementation  project(':htmlhelp')
-    testImplementation  project(':fo')
-    testImplementation  project(':fop')
+    testImplementation project(':htmlhelp')
+    testImplementation project(':fo')
+    testImplementation project(':fop')
 }
 
 def e2eTestSystemProperties = [
-        temp_dir : "${buildDir}/tmp/e2eTest",
-        dita_dir : "${projectDir}/src/main",
+        temp_dir: "${buildDir}/tmp/e2eTest",
+        dita_dir: "${projectDir}/src/main",
         basedir : "${projectDir}/src/test"
 ]
 if (System.getProperty("log_level") != null) {
@@ -147,9 +153,9 @@ clean {
 }
 
 task copyInstall(type: Copy) {
-    from (jar)
-    from (configurations.runtimeClasspath.allArtifacts.files)
-    from (configurations.runtimeClasspath) {
+    from(jar)
+    from(configurations.runtimeClasspath.allArtifacts.files)
+    from(configurations.runtimeClasspath) {
         rename "ant-launcher(-\\d+(\\.\\d+(\\.\\d+)?)?)\\.jar", "ant-launcher.jar"
         rename "ant(-\\d+(\\.\\d+(\\.\\d+)?)?)\\.jar", "ant.jar"
     }
@@ -172,24 +178,24 @@ def cleanVersion = project.version.split('\\.').toList()[2] == "0" ?
         project.version.split('\\.').toList().subList(0, 2).join('.').toString() :
         project.version
 def distVersion = project.hasProperty("commit") && (!project.hasProperty("tag") || tag.empty) ?
-                  "${project.version}@${commit.substring(0, 7)}" :
-                  "${cleanVersion}"
+        "${project.version}@${commit.substring(0, 7)}" :
+        "${cleanVersion}"
 def distFileName = (project.hasProperty("tag") && tag.empty) ?
-                   "develop" :
-                   "${cleanVersion}"
+        "develop" :
+        "${cleanVersion}"
 def bundled = [
-        "eclipsehelp": "https://github.com/dita-ot/org.dita.eclipsehelp/releases/download/3.4/org.dita.eclipsehelp-3.4.0.zip",
-        "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/3.3.0/org.lwdita-3.3.0.zip",
-        "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/1.1.0.zip",
-        "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
-        "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
-        "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20221107/org.oasis-open.dita.v2_0.zip",
+        "eclipsehelp"    : "https://github.com/dita-ot/org.dita.eclipsehelp/releases/download/3.4/org.dita.eclipsehelp-3.4.0.zip",
+        "markdown"       : "https://github.com/jelovirt/org.lwdita/releases/download/3.3.0/org.lwdita-3.3.0.zip",
+        "normalize"      : "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/1.1.0.zip",
+        "dita11"         : "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
+        "dita12"         : "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
+        "dita20"         : "https://github.com/dita-ot/dita/releases/download/2.0.0-20221107/org.oasis-open.dita.v2_0.zip",
         "dita20-techcomm": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20221107/org.oasis-open.dita.techcomm.v2_0.zip",
-        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
-        "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",
-        "axf": "https://github.com/dita-ot/org.dita.pdf2.axf/releases/download/3.6.1/org.dita.pdf2.axf-3.6.1.zip",
-        "xep": "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.3/org.dita.pdf2.xep-3.6.3.zip",
-        "theme": "https://github.com/jelovirt/pdf-generator/releases/download/0.6.1/com.elovirta.pdf.zip",
+        "xdita"          : "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
+        "index"          : "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",
+        "axf"            : "https://github.com/dita-ot/org.dita.pdf2.axf/releases/download/3.6.1/org.dita.pdf2.axf-3.6.1.zip",
+        "xep"            : "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.3/org.dita.pdf2.xep-3.6.3.zip",
+        "theme"          : "https://github.com/jelovirt/pdf-generator/releases/download/0.6.1/com.elovirta.pdf.zip",
 ]
 
 apply from: 'gradle/dist.gradle'
@@ -207,27 +213,27 @@ task initDist(dependsOn: [jar, cleanDistTemp]) {
 }
 
 task copyDistTemp(type: Copy, dependsOn: initDist) {
-    from (jar) {
+    from(jar) {
         into "lib"
     }
-    from (configurations.runtimeClasspath.allArtifacts.files) {
+    from(configurations.runtimeClasspath.allArtifacts.files) {
         into "lib"
     }
-    from (configurations.runtimeClasspath) {
+    from(configurations.runtimeClasspath) {
         into "lib"
         rename "ant-launcher(-\\d+(\\.\\d+(\\.\\d+)?)?)\\.jar", "ant-launcher.jar"
         rename "ant(-\\d+(\\.\\d+(\\.\\d+)?)?)\\.jar", "ant.jar"
     }
-    from (".") {
+    from(".") {
         include "LICENSE"
     }
-    from ("src/main") {
+    from("src/main") {
         include "plugins/*/plugin.xml"
         expand(
                 version: project.version
         )
     }
-    from ("src/main") {
+    from("src/main") {
         exclude ".gradle"
         exclude "plugins/**/build.gradle"
         exclude "plugins/**/settings.gradle"
@@ -291,7 +297,7 @@ task integrateDistTemp(type: JavaExec, dependsOn: [copyDistTemp, ":fo:copyDistTe
 }
 
 task integrateDistPlugins() {
-    dependsOn bundled.collect{ name, url ->
+    dependsOn bundled.collect { name, url ->
         return tasks.create("integrateDist${name}", JavaExec) {
             dependsOn(integrateDistTemp)
             mainClass = "org.apache.tools.ant.launch.Launcher"
@@ -345,11 +351,11 @@ def plugins = [
 ]
 
 task distPlugins() {
-    dependsOn plugins.collect{ name ->
-        def taskName = "distPlugin${name.split("\\.").collect{token -> return token.capitalize()}.join("")}"
+    dependsOn plugins.collect { name ->
+        def taskName = "distPlugin${name.split("\\.").collect { token -> return token.capitalize() }.join("")}"
         return tasks.create(taskName, Zip) {
             dependsOn(integrateDistTemp)
-            from ("${distTempDir}/plugins/${name}") {
+            from("${distTempDir}/plugins/${name}") {
                 exclude "build"
                 exclude "src"
                 exclude "out"
@@ -374,7 +380,7 @@ generateNotices.mustRunAfter distPlugins
 
 task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, distPlugins, distPluginChecksums, generateNotices, generateDocs, cleanGenerateDocs, generateJavadocs]) {
     into("dita-ot-${distVersion}") {
-        from (distTempDir) {
+        from(distTempDir) {
             exclude "bin/dita"
             exclude "bin/dita.bat"
             // legacy build scripts
@@ -382,7 +388,7 @@ task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, d
             exclude "bin/ant"
             exclude "bin/ant.*"
         }
-        from (distTempDir) {
+        from(distTempDir) {
             fileMode = 0755
             include "bin/dita"
             include "bin/dita.bat"
@@ -396,17 +402,17 @@ task dist(type: Zip, dependsOn: [jar, integrateDistTemp, integrateDistPlugins, d
 }
 
 test {
-    inputs.files (
-        'src/test/xsl/common/dita-utilities.xspec',
-        'src/test/xsl/common/uri-utils.xspec',
-        'src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec',
-        'src/test/xsl/plugins/org.dita.html5/xsl/object.xspec',
-        'src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec',
-        'src/test/xsl/plugins/org.dita.html5/xsl/tables.xspec',
-        'src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec',
-        'src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xspec',
-        'src/test/xsl/preprocess/conrefImpl.xspec',
-        'src/test/xsl/preprocess/maplinkImpl.xspec'
+    inputs.files(
+            'src/test/xsl/common/dita-utilities.xspec',
+            'src/test/xsl/common/uri-utils.xspec',
+            'src/test/xsl/plugins/org.dita.html5/xsl/functions.xspec',
+            'src/test/xsl/plugins/org.dita.html5/xsl/object.xspec',
+            'src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xspec',
+            'src/test/xsl/plugins/org.dita.html5/xsl/tables.xspec',
+            'src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xspec',
+            'src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xspec',
+            'src/test/xsl/preprocess/conrefImpl.xspec',
+            'src/test/xsl/preprocess/maplinkImpl.xspec'
     )
 }
 
@@ -484,7 +490,19 @@ signing {
 }
 
 javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
+    if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
+    }
+}
+
+spotless {
+    encoding 'UTF-8'
+    java {
+        palantirJavaFormat()
+        importOrder()
+        removeUnusedImports()
+        formatAnnotations()
+        trimTrailingWhitespace()
+        endWithNewline()
     }
 }

--- a/src/main/java/org/dita/dost/Processor.java
+++ b/src/main/java/org/dita/dost/Processor.java
@@ -5,6 +5,12 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -13,13 +19,6 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.LoggerListener;
 import org.dita.dost.util.Configuration.Mode;
 import org.slf4j.Logger;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Vector;
 
 /**
  * DITA-OT processer. Not thread-safe, but can be reused.
@@ -161,7 +160,6 @@ public final class Processor {
         return this;
     }
 
-
     /**
      * Set error recovery mode.
      *
@@ -212,7 +210,7 @@ public final class Processor {
             }
             ProjectHelper.configureProject(project, buildFile);
             final Vector<String> targets = new Vector<>();
-//            targets.addElement(project.getDefaultTarget());
+            //            targets.addElement(project.getDefaultTarget());
             targets.addElement("dita2" + args.get("transtype"));
             project.executeTargets(targets);
         } catch (final BuildException e) {
@@ -251,7 +249,8 @@ public final class Processor {
         fileAppender.setEncoder(encoder);
         fileAppender.start();
 
-        final ch.qos.logback.classic.Logger debugLogger = loggerContext.getLogger(getClass().getCanonicalName() + "_"  + System.currentTimeMillis());
+        final ch.qos.logback.classic.Logger debugLogger =
+                loggerContext.getLogger(getClass().getCanonicalName() + "_" + System.currentTimeMillis());
         debugLogger.addAppender(fileAppender);
         debugLogger.setLevel(Level.DEBUG);
         return debugLogger;
@@ -282,5 +281,4 @@ public final class Processor {
         }
         throw new RuntimeException("Unable to create temporary directory");
     }
-
 }

--- a/src/main/java/org/dita/dost/ProcessorFactory.java
+++ b/src/main/java/org/dita/dost/ProcessorFactory.java
@@ -1,11 +1,10 @@
 package org.dita.dost;
 
-import org.dita.dost.util.Configuration;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.dita.dost.util.Configuration;
 
 /**
  * DITA-OT processer factory. Not thread-safe, but can be reused.
@@ -59,5 +58,4 @@ public final class ProcessorFactory {
         }
         return new Processor(ditaDir, transtype, Collections.unmodifiableMap(args));
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/DITAOTCopy.java
+++ b/src/main/java/org/dita/dost/ant/DITAOTCopy.java
@@ -17,10 +17,8 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.util.FileUtils;
@@ -43,8 +41,7 @@ public final class DITAOTCopy extends Task {
      * Default Constructor.
      *
      */
-    public DITAOTCopy() {
-    }
+    public DITAOTCopy() {}
 
     /**
      * Set the copy files.
@@ -105,7 +102,7 @@ public final class DITAOTCopy extends Task {
             final FileUtils fileUtils = FileUtils.newFileUtils();
             final List<String> incs = getIncludes();
             if (relativePaths == null) {
-                for (final String inc: incs) {
+                for (final String inc : incs) {
                     final File srcFile = new File(inc);
                     if (srcFile.exists()) {
                         final File destFile = new File(destDir, srcFile.getName());
@@ -113,10 +110,10 @@ public final class DITAOTCopy extends Task {
                     }
                 }
             } else {
-                for (final String inc: incs) {
+                for (final String inc : incs) {
                     final File srcFile = new File(inc);
                     File destFile = null;
-                    for (final String rel: relativePaths.split(COMMA)) {
+                    for (final String rel : relativePaths.split(COMMA)) {
                         final File temp = new File(destDir, rel);
                         if (temp.getName().equalsIgnoreCase(srcFile.getName())) {
                             destFile = temp;
@@ -136,9 +133,7 @@ public final class DITAOTCopy extends Task {
     private List<String> getIncludes() throws IOException {
         if (includes == null && includesFile == null) {
             final Job job = getProject().getReference(ANT_REFERENCE_JOB);
-            return job
-                    .getFileInfo(fi -> fi.isFlagImage)
-                    .stream()
+            return job.getFileInfo(fi -> fi.isFlagImage).stream()
                     .map(fi -> fi.file.toString())
                     .collect(Collectors.toList());
         }
@@ -157,5 +152,4 @@ public final class DITAOTCopy extends Task {
             return Arrays.asList(includes.split(COMMA));
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/DITAOTEchoTask.java
+++ b/src/main/java/org/dita/dost/ant/DITAOTEchoTask.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.Echo;
 import org.dita.dost.ant.ExtensibleAntInvoker.ParamElem;
-import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.DITAOTAntLogger;
+import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageBean;
 import org.dita.dost.log.MessageUtils;
 
@@ -29,14 +29,14 @@ public final class DITAOTEchoTask extends Echo {
 
     /** Nested params. */
     private final ArrayList<ParamElem> params = new ArrayList<>();
+
     private DITAOTLogger logger;
 
     /**
      * Default Construtor.
      *
      */
-    public DITAOTEchoTask() {
-    }
+    public DITAOTEchoTask() {}
     /**
      * Setter function for id.
      * @param identifier The id to set.
@@ -103,5 +103,4 @@ public final class DITAOTEchoTask extends Echo {
         }
         return prop.toArray(new String[0]);
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/DITAOTFailTask.java
+++ b/src/main/java/org/dita/dost/ant/DITAOTFailTask.java
@@ -7,6 +7,10 @@
  */
 package org.dita.dost.ant;
 
+import static org.dita.dost.ant.ExtensibleAntInvoker.isValid;
+import static org.dita.dost.log.MessageBean.*;
+
+import java.util.ArrayList;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Exit;
@@ -18,11 +22,6 @@ import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.log.MessageBean;
 import org.dita.dost.log.MessageUtils;
-
-import java.util.ArrayList;
-
-import static org.dita.dost.ant.ExtensibleAntInvoker.isValid;
-import static org.dita.dost.log.MessageBean.*;
 
 /**
  * Ant echo task for custom error message.
@@ -37,8 +36,7 @@ public final class DITAOTFailTask extends Exit {
      * Default Construtor.
      *
      */
-    public DITAOTFailTask() {
-    }
+    public DITAOTFailTask() {}
 
     /**
      * Set the id.
@@ -79,9 +77,8 @@ public final class DITAOTFailTask extends Exit {
                     .toString();
             getProject().log(msg, Project.MSG_WARN);
         }
-        final boolean fail = nestedConditionPresent()
-                       ? testNestedCondition()
-                       : (testIfCondition() && testUnlessCondition());
+        final boolean fail =
+                nestedConditionPresent() ? testNestedCondition() : (testIfCondition() && testUnlessCondition());
         if (!fail) {
             return;
         }
@@ -99,7 +96,7 @@ public final class DITAOTFailTask extends Exit {
                 try {
                     super.execute();
                 } catch (final BuildException ex) {
-                    throw new BuildException(msgBean.toString(),new DITAOTException(msgBean, ex, msgBean.toString()));
+                    throw new BuildException(msgBean.toString(), new DITAOTException(msgBean, ex, msgBean.toString()));
                 }
             } else if (ERROR.equals(type)) {
                 logger.error(msgBean.toString());
@@ -111,8 +108,6 @@ public final class DITAOTFailTask extends Exit {
                 logger.debug(msgBean.toString());
             }
         }
-
-        
     }
 
     /**
@@ -146,8 +141,7 @@ public final class DITAOTFailTask extends Exit {
         @Override
         public boolean eval() {
             if (countConditions() != 1) {
-                throw new BuildException(
-                    "A single nested condition is required.");
+                throw new BuildException("A single nested condition is required.");
             }
             return getConditions().nextElement().eval();
         }
@@ -241,8 +235,7 @@ public final class DITAOTFailTask extends Exit {
         final boolean result = nestedConditionPresent();
 
         if (result && ifCondition != null || unlessCondition != null) {
-            throw new BuildException("Nested conditions "
-                + "not permitted in conjunction with if/unless attributes");
+            throw new BuildException("Nested conditions " + "not permitted in conjunction with if/unless attributes");
         }
 
         return result && nestedCondition.eval();
@@ -255,5 +248,4 @@ public final class DITAOTFailTask extends Exit {
     private boolean nestedConditionPresent() {
         return (nestedCondition != null);
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -7,7 +7,21 @@
  */
 package org.dita.dost.ant;
 
+import static java.util.Arrays.asList;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.supportedImageExtensions;
+import static org.dita.dost.util.URLUtils.toFile;
+
 import com.google.common.collect.ImmutableSet;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 import org.apache.tools.ant.*;
 import org.apache.tools.ant.types.*;
 import org.apache.tools.ant.types.resources.FileResource;
@@ -28,21 +42,6 @@ import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static java.util.Arrays.asList;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.supportedImageExtensions;
-import static org.dita.dost.util.URLUtils.toFile;
 
 /**
  * Ant task for executing pipeline modules.
@@ -77,7 +76,6 @@ public final class ExtensibleAntInvoker extends Task {
         super();
         pipelineParams = new ArrayList<>();
         modules = new ArrayList<>();
-
     }
 
     /**
@@ -134,7 +132,7 @@ public final class ExtensibleAntInvoker extends Task {
     }
 
     public void addConfiguredSax(final SaxPipeElem filters) {
-//        filters.setProject(getProject());
+        //        filters.setProject(getProject());
         modules.add(filters);
     }
 
@@ -148,7 +146,8 @@ public final class ExtensibleAntInvoker extends Task {
         if (modules.isEmpty()) {
             throw new BuildException("ModuleElem must be specified");
         }
-        attrs.computeIfAbsent(ANT_INVOKER_PARAM_BASEDIR, k -> getProject().getBaseDir().getAbsolutePath());
+        attrs.computeIfAbsent(
+                ANT_INVOKER_PARAM_BASEDIR, k -> getProject().getBaseDir().getAbsolutePath());
         for (final ParamElem p : pipelineParams) {
             if (!p.isValid()) {
                 throw new BuildException("Incomplete parameter");
@@ -195,7 +194,8 @@ public final class ExtensibleAntInvoker extends Task {
         }
     }
 
-    private AbstractPipelineModule getPipelineModule(final ModuleElem m, final PipelineHashIO pipelineInput) throws DITAOTException {
+    private AbstractPipelineModule getPipelineModule(final ModuleElem m, final PipelineHashIO pipelineInput)
+            throws DITAOTException {
         if (m instanceof final XsltElem xm) {
             if (xm.reloadstylesheet && xm.parallel) {
                 throw new BuildException("Both reloadstylesheet and parallel cannot be true");
@@ -275,7 +275,8 @@ public final class ExtensibleAntInvoker extends Task {
         if (style instanceof FileResource) {
             return new StreamSource(((FileResource) style).getFile());
         } else {
-            throw new BuildException(String.format("%s not supported", style.getClass().toString()));
+            throw new BuildException(
+                    String.format("%s not supported", style.getClass().toString()));
         }
     }
 
@@ -283,9 +284,8 @@ public final class ExtensibleAntInvoker extends Task {
         if (filters.isEmpty()) {
             return f -> true;
         }
-        final List<Predicate<FileInfo>> res = filters.stream()
-                .map(FileInfoFilterElem::toFilter)
-                .collect(Collectors.toList());
+        final List<Predicate<FileInfo>> res =
+                filters.stream().map(FileInfoFilterElem::toFilter).collect(Collectors.toList());
         return f -> {
             for (final Predicate<FileInfo> filter : res) {
                 if (filter.test(f)) {
@@ -381,7 +381,8 @@ public final class ExtensibleAntInvoker extends Task {
         return inc;
     }
 
-    public static boolean isValid(final Project project, final Location location, final String ifProperty, final String unlessProperty) {
+    public static boolean isValid(
+            final Project project, final Location location, final String ifProperty, final String unlessProperty) {
         if (ifProperty != null) {
             final String msg = MessageUtils.getMessage("DOTA014W", "if", "if:set")
                     .setLocation(location)
@@ -442,8 +443,8 @@ public final class ExtensibleAntInvoker extends Task {
                                 })
                                 .collect(Collectors.toMap(ParamElem::getName, ParamElem::getValue));
                         final List<FileInfoFilterElem> predicates = new ArrayList<>(f.fileInfoFilters);
-//                            predicates.addAll(getFormat());
-//                            assert !predicates.isEmpty();
+                        //                            predicates.addAll(getFormat());
+                        //                            assert !predicates.isEmpty();
                         Predicate<FileInfo> fs = combine(predicates);
                         return new FilterPair(f.getImplementation(), fs, params);
                     })
@@ -473,7 +474,6 @@ public final class ExtensibleAntInvoker extends Task {
         public void setParallel(final boolean parallel) {
             this.parallel = parallel;
         }
-
     }
 
     /**
@@ -516,8 +516,7 @@ public final class ExtensibleAntInvoker extends Task {
             this.destDir = destDir;
         }
 
-        public void setTaskname(final String taskname) {
-        }
+        public void setTaskname(final String taskname) {}
 
         public void setClasspathref(final String classpath) {
             // Ignore classpathref attribute
@@ -638,12 +637,12 @@ public final class ExtensibleAntInvoker extends Task {
         private Boolean isResourceOnly;
 
         public void setFormat(final String format) {
-            final ImmutableSet.Builder<String> builder = ImmutableSet.<String>builder().add(format);
+            final ImmutableSet.Builder<String> builder =
+                    ImmutableSet.<String>builder().add(format);
             if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
                 supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
             }
             this.formats = builder.build();
-
         }
 
         public void setConref(final boolean conref) {
@@ -663,11 +662,11 @@ public final class ExtensibleAntInvoker extends Task {
         }
 
         public Predicate<FileInfo> toFilter() {
-            return f -> (formats.isEmpty() || formats.contains(f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA)) &&
-                    (hasConref == null || f.hasConref == hasConref) &&
-                    (isInput == null || f.isInput == isInput) &&
-                    (isInputResource == null || f.isInputResource == isInputResource) &&
-                    (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
+            return f -> (formats.isEmpty() || formats.contains(f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA))
+                    && (hasConref == null || f.hasConref == hasConref)
+                    && (isInput == null || f.isInput == isInput)
+                    && (isInputResource == null || f.isInputResource == isInputResource)
+                    && (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
         }
     }
 
@@ -709,14 +708,14 @@ public final class ExtensibleAntInvoker extends Task {
         }
 
         public List<FileInfoFilterElem> getFormat() {
-            return (format != null ? format : asList(ATTR_FORMAT_VALUE_DITA, ATTR_FORMAT_VALUE_DITAMAP)).stream()
-                    .map(f -> {
-                        final FileInfoFilterElem ff = new FileInfoFilterElem();
-                        ff.setFormat(f);
-                        return ff;
-                    })
-                    .collect(Collectors.toList());
-
+            return (format != null ? format : asList(ATTR_FORMAT_VALUE_DITA, ATTR_FORMAT_VALUE_DITAMAP))
+                    .stream()
+                            .map(f -> {
+                                final FileInfoFilterElem ff = new FileInfoFilterElem();
+                                ff.setFormat(f);
+                                return ff;
+                            })
+                            .collect(Collectors.toList());
         }
     }
 
@@ -747,7 +746,6 @@ public final class ExtensibleAntInvoker extends Task {
             }
             return cls;
         }
-
     }
 
     /**
@@ -851,7 +849,7 @@ public final class ExtensibleAntInvoker extends Task {
      * @deprecated since 3.0
      */
     @Deprecated
-    public static abstract class ConfElem {
+    public abstract static class ConfElem {
 
         String ifProperty;
         String unlessProperty;
@@ -871,7 +869,5 @@ public final class ExtensibleAntInvoker extends Task {
         public void setUnless(final String p) {
             unlessProperty = p;
         }
-
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -7,6 +7,11 @@
  */
 package org.dita.dost.ant;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toFile;
+
+import java.io.File;
+import java.util.ServiceLoader;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
@@ -15,12 +20,6 @@ import org.dita.dost.store.Store;
 import org.dita.dost.store.StoreBuilder;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
-
-import java.io.File;
-import java.util.ServiceLoader;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toFile;
 
 /**
  * Initialize Ant references.

--- a/src/main/java/org/dita/dost/ant/IntegratorTask.java
+++ b/src/main/java/org/dita/dost/ant/IntegratorTask.java
@@ -8,10 +8,8 @@
 package org.dita.dost.ant;
 
 import java.io.File;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
-
 import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.platform.Integrator;
 
@@ -29,7 +27,8 @@ public final class IntegratorTask extends Task {
         final DITAOTAntLogger logger = new DITAOTAntLogger(getProject());
         logger.setTarget(getOwningTarget());
         logger.setTask(this);
-        final Integrator adaptee = new Integrator(ditaDir != null ? ditaDir : getProject().getBaseDir());
+        final Integrator adaptee =
+                new Integrator(ditaDir != null ? ditaDir : getProject().getBaseDir());
         adaptee.setLogger(logger);
         if (propertiesFile != null) {
             adaptee.setProperties(propertiesFile);
@@ -60,7 +59,5 @@ public final class IntegratorTask extends Task {
     @Deprecated
     public void setProperties(final File propertiesFile) {
         this.propertiesFile = propertiesFile;
-
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/IsAbsolute.java
+++ b/src/main/java/org/dita/dost/ant/IsAbsolute.java
@@ -8,7 +8,6 @@
 package org.dita.dost.ant;
 
 import java.io.File;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.condition.Condition;
 
@@ -25,8 +24,7 @@ public final class IsAbsolute implements Condition {
      * Default Constructor.
      *
      */
-    public IsAbsolute() {
-    }
+    public IsAbsolute() {}
 
     /**
      * Set the path.
@@ -44,5 +42,4 @@ public final class IsAbsolute implements Condition {
     public boolean eval() throws BuildException {
         return new File(path).isAbsolute();
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/JobPropertyTask.java
+++ b/src/main/java/org/dita/dost/ant/JobPropertyTask.java
@@ -11,7 +11,6 @@ import static org.dita.dost.ant.ExtensibleAntInvoker.getJob;
 
 import java.io.File;
 import java.util.Map;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.dita.dost.util.Job;
@@ -24,7 +23,7 @@ public final class JobPropertyTask extends Task {
     @Override
     public void execute() throws BuildException {
         final Job job = getJob(getProject());
-        for (final Map.Entry<String, String> e: job.getProperties().entrySet()) {
+        for (final Map.Entry<String, String> e : job.getProperties().entrySet()) {
             getProject().setProperty(e.getKey(), e.getValue());
         }
     }
@@ -36,5 +35,4 @@ public final class JobPropertyTask extends Task {
     public void setDir(final File dir) {
         // NOOP
     }
-
 }

--- a/src/main/java/org/dita/dost/ant/LangParser.java
+++ b/src/main/java/org/dita/dost/ant/LangParser.java
@@ -32,14 +32,12 @@ final class LangParser extends DefaultHandler {
         return langCode;
     }
 
-    public LangParser() {
-
-    }
+    public LangParser() {}
 
     @Override
-    public void startElement(final String uri, final String localName, final String name,
-            final Attributes attributes) throws SAXException {
-        //String processedString;
+    public void startElement(final String uri, final String localName, final String name, final Attributes attributes)
+            throws SAXException {
+        // String processedString;
         final String classAttr = attributes.getValue(ATTRIBUTE_NAME_CLASS);
         final String langAttr = attributes.getValue(ATTRIBUTE_NAME_XML_LANG);
 
@@ -48,7 +46,6 @@ final class LangParser extends DefaultHandler {
                 langCode = langAttr.toLowerCase();
             }
         }
-
     }
 
     @Override

--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -12,23 +12,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.Task;
-import org.apache.tools.ant.taskdefs.Expand;
-import org.apache.tools.ant.taskdefs.Get;
-import org.dita.dost.log.DITAOTAntLogger;
-import org.dita.dost.platform.*;
-import org.dita.dost.platform.Registry.Dependency;
-import org.dita.dost.util.Configuration;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -43,6 +26,22 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.taskdefs.Expand;
+import org.apache.tools.ant.taskdefs.Get;
+import org.dita.dost.log.DITAOTAntLogger;
+import org.dita.dost.platform.*;
+import org.dita.dost.platform.Registry.Dependency;
+import org.dita.dost.util.Configuration;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 public final class PluginInstallTask extends Task {
 
@@ -60,7 +59,8 @@ public final class PluginInstallTask extends Task {
 
     @Override
     public void init() {
-        registries = Arrays.stream(Configuration.configuration.get("registry").trim().split("\\s+"))
+        registries = Arrays.stream(
+                        Configuration.configuration.get("registry").trim().split("\\s+"))
                 .map(registry -> registry.endsWith("/") ? registry : (registry + "/"))
                 .collect(Collectors.toList());
         try {
@@ -68,7 +68,8 @@ public final class PluginInstallTask extends Task {
         } catch (IOException e) {
             throw new BuildException("Failed to create temporary directory: " + e.getMessage(), e);
         }
-        installedPlugins = Plugins.getInstalledPlugins().stream().map(Map.Entry::getKey).toList();
+        installedPlugins =
+                Plugins.getInstalledPlugins().stream().map(Map.Entry::getKey).toList();
 
         final DITAOTAntLogger logger;
         logger = new DITAOTAntLogger(getProject());
@@ -125,7 +126,8 @@ public final class PluginInstallTask extends Task {
                         integrator.addRemoved(name);
                         FileUtils.deleteDirectory(pluginDir);
                     } else {
-                        throw new BuildException(new IllegalStateException(String.format("Plug-in %s already installed: %s", name, pluginDir)));
+                        throw new BuildException(new IllegalStateException(
+                                String.format("Plug-in %s already installed: %s", name, pluginDir)));
                     }
                 }
                 FileUtils.copyDirectory(tempPluginDir, pluginDir);
@@ -143,8 +145,8 @@ public final class PluginInstallTask extends Task {
     }
 
     private String getFileHash(final File file) {
-        try (DigestInputStream digestInputStream = new DigestInputStream(new BufferedInputStream(
-                new FileInputStream(file)), MessageDigest.getInstance("SHA-256"))) {
+        try (DigestInputStream digestInputStream = new DigestInputStream(
+                new BufferedInputStream(new FileInputStream(file)), MessageDigest.getInstance("SHA-256"))) {
             IOUtils.copy(digestInputStream, new NullOutputStream());
             final MessageDigest digest = digestInputStream.getMessageDigest();
             final byte[] sha256 = digest.digest();
@@ -167,7 +169,8 @@ public final class PluginInstallTask extends Task {
     private String getPluginName(final File pluginDir) {
         final File config = new File(pluginDir, "plugin.xml");
         try {
-            final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(config);
+            final Document doc =
+                    DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(config);
             return doc.getDocumentElement().getAttribute("id");
         } catch (SAXException | IOException | ParserConfigurationException e) {
             throw new BuildException("Failed to read plugin name: " + e.getMessage(), e);
@@ -184,7 +187,8 @@ public final class PluginInstallTask extends Task {
         for (final String registry : registries) {
             final URI registryUrl = URI.create(registry + name + ".json");
             log(String.format("Read registry %s", registry), Project.MSG_INFO);
-            try (BufferedInputStream in = new BufferedInputStream(registryUrl.toURL().openStream())) {
+            try (BufferedInputStream in =
+                    new BufferedInputStream(registryUrl.toURL().openStream())) {
                 log("Parse registry", Project.MSG_INFO);
                 final JsonFactory factory = mapper.getFactory();
                 final JsonParser parser = factory.createParser(in);
@@ -207,7 +211,10 @@ public final class PluginInstallTask extends Task {
             } catch (FileNotFoundException e) {
                 log(String.format("Registry configuration %s not found", registryUrl), e, Project.MSG_INFO);
             } catch (IOException e) {
-                log(String.format("Failed to read registry configuration %s: %s", registryUrl, e.getMessage()), e, Project.MSG_ERR);
+                log(
+                        String.format("Failed to read registry configuration %s: %s", registryUrl, e.getMessage()),
+                        e,
+                        Project.MSG_ERR);
             }
         }
         if (res == null) {
@@ -243,7 +250,9 @@ public final class PluginInstallTask extends Task {
         if (expectedChecksum != null) {
             final String checksum = getFileHash(tempPluginFile);
             if (!checksum.equalsIgnoreCase(expectedChecksum)) {
-                throw new BuildException(new IllegalArgumentException(String.format("Downloaded plugin file checksum %s does not match expected value %s", checksum, expectedChecksum)));
+                throw new BuildException(new IllegalArgumentException(String.format(
+                        "Downloaded plugin file checksum %s does not match expected value %s",
+                        checksum, expectedChecksum)));
             }
         }
 
@@ -280,9 +289,7 @@ public final class PluginInstallTask extends Task {
 
     private Optional<Registry> findPlugin(final Collection<Registry> regs, final SemVerMatch version) {
         if (version == null) {
-            return regs.stream()
-                    .filter(this::matchingPlatformVersion)
-                    .max(Comparator.comparing(o -> o.vers));
+            return regs.stream().filter(this::matchingPlatformVersion).max(Comparator.comparing(o -> o.vers));
         } else {
             return regs.stream()
                     .filter(this::matchingPlatformVersion)

--- a/src/main/java/org/dita/dost/ant/UriBasenameTask.java
+++ b/src/main/java/org/dita/dost/ant/UriBasenameTask.java
@@ -10,7 +10,6 @@ package org.dita.dost.ant;
 import static org.dita.dost.util.Constants.*;
 
 import java.net.URI;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
@@ -40,7 +39,6 @@ import org.apache.tools.ant.Task;
  * @since Ant 1.5
  *
  */
-
 public class UriBasenameTask extends Task {
 
     private URI file;
@@ -55,15 +53,15 @@ public class UriBasenameTask extends Task {
     }
 
     /**
-    * Property to set base name to.
-    */
+     * Property to set base name to.
+     */
     public void setProperty(final String property) {
-        this.property  = property;
+        this.property = property;
     }
 
     /**
-    * Suffix to remove from base name.
-    */
+     * Suffix to remove from base name.
+     */
     public void setSuffix(final String suffix) {
         this.suffix = suffix;
     }
@@ -82,8 +80,7 @@ public class UriBasenameTask extends Task {
             // char preceding the suffix is a '.', we assume the user
             // wants to remove the '.' as well (see docs)
             int pos = value.length() - suffix.length();
-            if (pos > 0 && suffix.charAt(0) != '.'
-                && value.charAt(pos - 1) == '.') {
+            if (pos > 0 && suffix.charAt(0) != '.' && value.charAt(pos - 1) == '.') {
                 pos--;
             }
             value = value.substring(0, pos);
@@ -101,6 +98,4 @@ public class UriBasenameTask extends Task {
             return path;
         }
     }
-
 }
-

--- a/src/main/java/org/dita/dost/ant/UriDirnameTask.java
+++ b/src/main/java/org/dita/dost/ant/UriDirnameTask.java
@@ -10,7 +10,6 @@ package org.dita.dost.ant;
 import static org.dita.dost.util.Constants.*;
 
 import java.net.URI;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
@@ -29,7 +28,6 @@ import org.apache.tools.ant.Task;
  * element. If file is a file, the directory will be the current
  * directory.
  */
-
 public class UriDirnameTask extends Task {
 
     private URI file;

--- a/src/main/java/org/dita/dost/ant/types/JobMapper.java
+++ b/src/main/java/org/dita/dost/ant/types/JobMapper.java
@@ -7,21 +7,18 @@
  */
 package org.dita.dost.ant.types;
 
+import static org.dita.dost.util.URLUtils.toFile;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.EnumeratedAttribute;
 import org.apache.tools.ant.util.*;
 import org.dita.dost.ant.ExtensibleAntInvoker;
 import org.dita.dost.util.Job;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
-import static org.dita.dost.util.URLUtils.toFile;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * File mapper that uses job configuration's {@link org.dita.dost.util.Job.FileInfo#result result}
@@ -33,7 +30,8 @@ import static org.dita.dost.util.URLUtils.toURI;
 public class JobMapper implements FileNameMapper {
 
     private enum Type {
-        TEMP, RESULT
+        TEMP,
+        RESULT
     }
 
     private Type type = Type.RESULT;
@@ -87,7 +85,7 @@ public class JobMapper implements FileNameMapper {
             default:
                 throw new IllegalArgumentException();
         }
-        return new String[]{extension != null ? (FilenameUtils.removeExtension(res) + extension) : res};
+        return new String[] {extension != null ? (FilenameUtils.removeExtension(res) + extension) : res};
     }
 
     public static class TypeAttribute extends EnumeratedAttribute {

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -7,8 +7,17 @@
  */
 package org.dita.dost.ant.types;
 
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
+import static org.dita.dost.util.FileUtils.supportedImageExtensions;
+import static org.dita.dost.util.URLUtils.toFile;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.AbstractFileSet;
 import org.apache.tools.ant.types.Resource;
@@ -22,16 +31,6 @@ import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
-
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.*;
-
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_IMAGE;
-import static org.dita.dost.util.FileUtils.supportedImageExtensions;
-import static org.dita.dost.util.URLUtils.toFile;
 
 /**
  * Resource collection that finds matching resources from job configuration.
@@ -68,7 +67,8 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
                     final File srcFile = new File(URLUtils.setQuery(f.src, null));
                     if (srcFile.exists()) {
                         log("Found source directory file " + srcFile, Project.MSG_VERBOSE);
-                        final File rel = FileUtils.getRelativePath(new File(new File(job.getInputDir()), "dummy"), srcFile);
+                        final File rel =
+                                FileUtils.getRelativePath(new File(new File(job.getInputDir()), "dummy"), srcFile);
                         res.add(new FileResource(toFile(job.getInputDir()), rel.getPath()));
                     } else {
                         log("File " + f.src + " not found", Project.MSG_ERR);
@@ -145,7 +145,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     @VisibleForTesting
     public boolean filter(final FileInfo f) {
-        for (final SelectorElem excl: excludes) {
+        for (final SelectorElem excl : excludes) {
             if (filter(f, excl)) {
                 return false;
             }
@@ -153,7 +153,7 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         if (includes.isEmpty()) {
             return true;
         } else {
-            for (final SelectorElem incl: includes) {
+            for (final SelectorElem incl : includes) {
                 if (filter(f, incl)) {
                     return true;
                 }
@@ -164,15 +164,16 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
 
     private boolean filter(final FileInfo f, final SelectorElem incl) {
         final String format = f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA;
-        return (incl.formats.isEmpty() || (incl.formats.contains(format))) &&
-                (incl.hasConref == null || f.hasConref == incl.hasConref) &&
-                (incl.isInput == null || f.isInput == incl.isInput) &&
-                (incl.isInputResource == null || f.isInputResource == incl.isInputResource) &&
-                (incl.isResourceOnly == null || f.isResourceOnly == incl.isResourceOnly);
+        return (incl.formats.isEmpty() || (incl.formats.contains(format)))
+                && (incl.hasConref == null || f.hasConref == incl.hasConref)
+                && (incl.isInput == null || f.isInput == incl.isInput)
+                && (incl.isInputResource == null || f.isInputResource == incl.isInputResource)
+                && (incl.isResourceOnly == null || f.isResourceOnly == incl.isResourceOnly);
     }
 
     private static class JobResource extends URLResource {
         private final String relPath;
+
         public JobResource(final URL baseURL, final String relPath) {
             super();
             setBaseURL(baseURL);
@@ -187,7 +188,8 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         @Override
         public synchronized String getName() {
             if (isReference()) {
-                return getCheckedRef(getClass(), getDataTypeName(), getProject()).getName();
+                return getCheckedRef(getClass(), getDataTypeName(), getProject())
+                        .getName();
             }
             return relPath;
         }
@@ -200,11 +202,14 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         private Boolean isInputResource;
         private Boolean isResourceOnly;
 
-        public SelectorElem() {
-        }
+        public SelectorElem() {}
 
-        public SelectorElem(Set<String> formats, Boolean hasConref, Boolean isInput,
-                            Boolean isInputResource, Boolean isResourceOnly) {
+        public SelectorElem(
+                Set<String> formats,
+                Boolean hasConref,
+                Boolean isInput,
+                Boolean isInputResource,
+                Boolean isResourceOnly) {
             this.formats = formats != null ? formats : Collections.emptySet();
             this.hasConref = hasConref;
             this.isInput = isInput;
@@ -213,7 +218,8 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         }
 
         public void setFormat(final String format) {
-            final ImmutableSet.Builder<String> builder = ImmutableSet.<String>builder().add(format);
+            final ImmutableSet.Builder<String> builder =
+                    ImmutableSet.<String>builder().add(format);
             if (format.equals(ATTR_FORMAT_VALUE_IMAGE)) {
                 supportedImageExtensions.stream().map(ext -> ext.substring(1)).forEach(builder::add);
             }
@@ -237,11 +243,11 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
         }
 
         public boolean isEmpty() {
-            return formats.isEmpty() &&
-                    hasConref == null &&
-                    isInput == null &&
-                    isInputResource == null &&
-                    isResourceOnly == null;
+            return formats.isEmpty()
+                    && hasConref == null
+                    && isInput == null
+                    && isInputResource == null
+                    && isResourceOnly == null;
         }
     }
 }

--- a/src/main/java/org/dita/dost/chunk/ChunkOperation.java
+++ b/src/main/java/org/dita/dost/chunk/ChunkOperation.java
@@ -8,21 +8,21 @@
 
 package org.dita.dost.chunk;
 
-import org.w3c.dom.Element;
+import static java.util.Collections.unmodifiableList;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.w3c.dom.Element;
 
-import static java.util.Collections.unmodifiableList;
-
-record ChunkOperation(org.dita.dost.chunk.ChunkOperation.Operation operation,
-                      URI src,
-                      URI dst,
-                      String id,
-                      Element topicref,
-                      List<ChunkOperation> children) {
+record ChunkOperation(
+        org.dita.dost.chunk.ChunkOperation.Operation operation,
+        URI src,
+        URI dst,
+        String id,
+        Element topicref,
+        List<ChunkOperation> children) {
 
     public enum Operation {
         COMBINE("combine"),
@@ -36,13 +36,12 @@ record ChunkOperation(org.dita.dost.chunk.ChunkOperation.Operation operation,
 
     @Override
     public String toString() {
-        return "ChunkOperation{" +
-                "operation=" + operation +
-                ", src=" + src +
-                ", dst=" + dst +
-                ", id=" + id +
-                ", children=" + children +
-                '}';
+        return "ChunkOperation{" + "operation="
+                + operation + ", src="
+                + src + ", dst="
+                + dst + ", id="
+                + id + ", children="
+                + children + '}';
     }
 
     public static ChunkBuilder builder(final Operation operation) {
@@ -71,13 +70,13 @@ record ChunkOperation(org.dita.dost.chunk.ChunkOperation.Operation operation,
         }
 
         public ChunkBuilder src(final URI src) {
-//            assert src.isAbsolute();
+            //            assert src.isAbsolute();
             this.src = src;
             return this;
         }
 
         public ChunkBuilder dst(final URI dst) {
-//            assert dst.isAbsolute();
+            //            assert dst.isAbsolute();
             this.dst = dst;
             return this;
         }
@@ -100,9 +99,8 @@ record ChunkOperation(org.dita.dost.chunk.ChunkOperation.Operation operation,
         public ChunkOperation build() {
             final URI src = this.src;
             final URI dst = this.dst;
-            final List<ChunkOperation> cos = children.stream()
-                    .map(ChunkBuilder::build)
-                    .collect(Collectors.toList());
+            final List<ChunkOperation> cos =
+                    children.stream().map(ChunkBuilder::build).collect(Collectors.toList());
             return new ChunkOperation(operation, src, dst, id, topicref, unmodifiableList(cos));
         }
     }

--- a/src/main/java/org/dita/dost/exception/DITAOTException.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTException.java
@@ -1,18 +1,17 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.exception;
 
+import java.io.Serial;
 import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
 import org.dita.dost.log.MessageBean;
-
-import java.io.Serial;
 
 /**
  * Exception class for DITAOT, used to handle exceptions in Java modules.
@@ -98,5 +97,4 @@ public final class DITAOTException extends Exception {
         super(message, cause);
         messageBean = msgBean;
     }
-
 }

--- a/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.exception;
 
 import org.dita.dost.log.DITAOTLogger;
-
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -25,6 +24,7 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
      * The xml file where the error occured.
      */
     private final String filePath;
+
     private final DITAOTLogger logger;
 
     /**
@@ -44,7 +44,7 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
     @Override
     public void error(final SAXParseException saxException) throws SAXException {
         throw new SAXExceptionWrapper(filePath, saxException);
-        //throw new SAXParseException();
+        // throw new SAXParseException();
     }
 
     /**
@@ -67,6 +67,4 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
         final String msg = new SAXExceptionWrapper(filePath, saxException).getMessage();
         logger.warn(msg);
     }
-
 }
-

--- a/src/main/java/org/dita/dost/exception/SAXExceptionWrapper.java
+++ b/src/main/java/org/dita/dost/exception/SAXExceptionWrapper.java
@@ -1,19 +1,18 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.exception;
 
 import static org.dita.dost.util.Constants.*;
 
+import java.io.Serial;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXParseException;
-
-import java.io.Serial;
 
 /**
  * SAXExceptionWrapper which wrapper the SAXParseException.
@@ -68,8 +67,12 @@ public final class SAXExceptionWrapper extends SAXParseException {
      * @deprecated since 2.3
      */
     @Deprecated
-    public SAXExceptionWrapper(final String message, final String publicId,
-            final String systemId, final int lineNumber, final int columnNumber) {
+    public SAXExceptionWrapper(
+            final String message,
+            final String publicId,
+            final String systemId,
+            final int lineNumber,
+            final int columnNumber) {
         super(message, publicId, systemId, lineNumber, columnNumber);
     }
 
@@ -85,8 +88,13 @@ public final class SAXExceptionWrapper extends SAXParseException {
      * @deprecated since 2.3
      */
     @Deprecated
-    public SAXExceptionWrapper(final String message, final String publicId,
-            final String systemId, final int lineNumber, final int columnNumber, final Exception e) {
+    public SAXExceptionWrapper(
+            final String message,
+            final String publicId,
+            final String systemId,
+            final int lineNumber,
+            final int columnNumber,
+            final Exception e) {
         super(message, publicId, systemId, lineNumber, columnNumber, e);
     }
 
@@ -97,7 +105,13 @@ public final class SAXExceptionWrapper extends SAXParseException {
      * @param inner SAXParseException
      */
     public SAXExceptionWrapper(final String file, final SAXParseException inner) {
-        super(inner.getMessage(), inner.getPublicId(), inner.getSystemId(), inner.getLineNumber(), inner.getColumnNumber(), inner.getException());
+        super(
+                inner.getMessage(),
+                inner.getPublicId(),
+                inner.getSystemId(),
+                inner.getLineNumber(),
+                inner.getColumnNumber(),
+                inner.getException());
         saxParseException = inner;
         sourceFile = file;
     }
@@ -110,7 +124,7 @@ public final class SAXExceptionWrapper extends SAXParseException {
     @Override
     public String getMessage() {
 
-        return sourceFile + " Line " + saxParseException.getLineNumber() + ":" + saxParseException.getMessage() + LINE_SEPARATOR;
+        return sourceFile + " Line " + saxParseException.getLineNumber() + ":" + saxParseException.getMessage()
+                + LINE_SEPARATOR;
     }
-
 }

--- a/src/main/java/org/dita/dost/index/IndexTerm.java
+++ b/src/main/java/org/dita/dost/index/IndexTerm.java
@@ -1,17 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.index;
 
 import static org.dita.dost.util.Constants.*;
 
 import java.util.*;
-
 import org.dita.dost.util.DITAOTCollator;
 
 /**
@@ -24,7 +23,8 @@ import org.dita.dost.util.DITAOTCollator;
 public final class IndexTerm implements Comparable<IndexTerm> {
 
     public enum IndexTermPrefix {
-        SEE("See"), SEE_ALSO("See also");
+        SEE("See"),
+        SEE_ALSO("See also");
 
         public final String message;
 
@@ -67,8 +67,8 @@ public final class IndexTerm implements Comparable<IndexTerm> {
      */
     private boolean leaf = true;
 
-    //initialization for rtlLocaleList
-    static{
+    // initialization for rtlLocaleList
+    static {
         rtlLocaleList = new ArrayList<>(2);
         rtlLocaleList.add("ar_EG");
         rtlLocaleList.add("he_IL");
@@ -171,7 +171,6 @@ public final class IndexTerm implements Comparable<IndexTerm> {
      * Set the end attribute.
      * @param end attribute
      */
-
     public void setEndAttribute(final String end) {
         this.end = end;
     }
@@ -185,7 +184,7 @@ public final class IndexTerm implements Comparable<IndexTerm> {
         final int subTermNum = subTerms.size();
 
         if (IndexTermPrefix.SEE != term.getTermPrefix() && IndexTermPrefix.SEE_ALSO != term.getTermPrefix()) {
-            //if the term is not "index-see" or "index-see-also"
+            // if the term is not "index-see" or "index-see-also"
             leaf = false;
         }
 
@@ -246,11 +245,13 @@ public final class IndexTerm implements Comparable<IndexTerm> {
         boolean eqSubTerms;
         boolean eqTermPrefix;
 
-        eqTermName = Objects.equals(termName, it.getTermName()) || termName != null && termName.equals(it.getTermName());
-        eqTermPrefix = Objects.equals(termPrefix, it.getTermPrefix()) || termPrefix != null && termPrefix.equals(it.getTermPrefix());
+        eqTermName =
+                Objects.equals(termName, it.getTermName()) || termName != null && termName.equals(it.getTermName());
+        eqTermPrefix = Objects.equals(termPrefix, it.getTermPrefix())
+                || termPrefix != null && termPrefix.equals(it.getTermPrefix());
         eqTermKey = Objects.equals(termKey, it.getTermKey()) || termKey != null && termKey.equals(it.getTermKey());
         eqTargetList = targetList == it.getTargetList() || targetList != null && targetList.equals(it.getTargetList());
-        eqSubTerms =  subTerms == it.getSubTerms() || subTerms != null && subTerms.equals(it.getSubTerms());
+        eqSubTerms = subTerms == it.getSubTerms() || subTerms != null && subTerms.equals(it.getSubTerms());
 
         return eqTermName && eqTermKey && eqTargetList && eqSubTerms && eqTermPrefix;
     }
@@ -350,7 +351,8 @@ public final class IndexTerm implements Comparable<IndexTerm> {
     @Override
     public String toString() {
 
-        return "{Term name: " + termName + ", Term key: " + termKey + ", Target list: " + targetList.toString() + ", Sub-terms: " + subTerms.toString() + "}";
+        return "{Term name: " + termName + ", Term key: " + termKey + ", Target list: " + targetList.toString()
+                + ", Sub-terms: " + subTerms.toString() + "}";
     }
 
     /**
@@ -380,7 +382,8 @@ public final class IndexTerm implements Comparable<IndexTerm> {
             if (termLocale == null) {
                 return termPrefix.message + STRING_BLANK + termName;
             } else {
-                final String key = "IndexTerm." + termPrefix.message.toLowerCase().trim().replace(' ', '-');
+                final String key =
+                        "IndexTerm." + termPrefix.message.toLowerCase().trim().replace(' ', '-');
                 final String msg = Messages.getString(key, termLocale);
                 if (rtlLocaleList.contains(termLocale.toString())) {
                     return termName + STRING_BLANK + msg;
@@ -399,10 +402,10 @@ public final class IndexTerm implements Comparable<IndexTerm> {
             // if there is only one subterm, it is necessary to update
             final IndexTerm term = subTerms.get(0); // get the only subterm
             if (term.getTermPrefix() == IndexTermPrefix.SEE) {
-                //if the only subterm is index-see update it to index-see-also
+                // if the only subterm is index-see update it to index-see-also
                 term.setTermPrefix(IndexTermPrefix.SEE_ALSO);
             }
-//            subTerms.set(0, term);
+            //            subTerms.set(0, term);
         }
     }
 

--- a/src/main/java/org/dita/dost/index/IndexTermCollection.java
+++ b/src/main/java/org/dita/dost/index/IndexTermCollection.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.index;
 
 import static org.dita.dost.util.Constants.*;
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.PipelineHashIO;
@@ -47,12 +46,11 @@ public final class IndexTermCollection {
     /** The logger. */
     private DITAOTLogger javaLogger;
 
-    //RFE 2987769 Eclipse index-see
+    // RFE 2987769 Eclipse index-see
     /* Parameters passed in from ANT module */
     private PipelineHashIO pipelineHashIO = null;
 
-    public IndexTermCollection() {
-    }
+    public IndexTermCollection() {}
 
     public void setLogger(final DITAOTLogger logger) {
         this.javaLogger = logger;
@@ -89,7 +87,6 @@ public final class IndexTermCollection {
     public void setIndexClass(final String indexClass) {
         this.indexClass = indexClass;
     }
-
 
     /**
      * All a new term into the collection.
@@ -133,10 +130,9 @@ public final class IndexTermCollection {
      * Sort term list extracted from dita files base on Locale.
      */
     public void sort() {
-        if (IndexTerm.getTermLocale() == null ||
-                IndexTerm.getTermLocale().getLanguage().trim().length() == 0) {
-            IndexTerm.setTermLocale(new Locale(LANGUAGE_EN,
-                    COUNTRY_US));
+        if (IndexTerm.getTermLocale() == null
+                || IndexTerm.getTermLocale().getLanguage().trim().length() == 0) {
+            IndexTerm.setTermLocale(new Locale(LANGUAGE_EN, COUNTRY_US));
         }
 
         /*
@@ -159,14 +155,14 @@ public final class IndexTermCollection {
         AbstractWriter abstractWriter = null;
 
         if (indexClass != null && indexClass.length() > 0) {
-            //Instantiate the class value
+            // Instantiate the class value
             Class<?> anIndexClass;
             try {
-                anIndexClass = Class.forName( indexClass );
+                anIndexClass = Class.forName(indexClass);
                 abstractWriter = (AbstractWriter) anIndexClass.newInstance();
                 final IDitaTranstypeIndexWriter indexWriter = (IDitaTranstypeIndexWriter) anIndexClass.newInstance();
 
-                //RFE 2987769 Eclipse index-see
+                // RFE 2987769 Eclipse index-see
                 try {
 
                     ((AbstractExtendDitaWriter) abstractWriter).setPipelineHashIO(this.getPipelineHashIO());
@@ -175,24 +171,20 @@ public final class IndexTermCollection {
                     javaLogger.info(e.getMessage());
                     javaLogger.info(e.toString());
                     e.printStackTrace();
-
                 }
 
-
                 buff = new StringBuilder(indexWriter.getIndexFileName(outputFileRoot));
-
 
             } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                 e.printStackTrace();
             }
 
-
         } else {
             throw new IllegalArgumentException("Index writer class not defined");
         }
 
-        //Even if there is no term in the list create an empty index file
-        //otherwise the compiler will report error.
+        // Even if there is no term in the list create an empty index file
+        // otherwise the compiler will report error.
         abstractWriter.setLogger(javaLogger);
         ((IDitaTranstypeIndexWriter) abstractWriter).setTermList(this.getTermList());
         abstractWriter.write(new File(buff.toString()));
@@ -206,7 +198,7 @@ public final class IndexTermCollection {
         outputFileRoot = fileRoot;
     }
 
-    //RFE 2987769 Eclipse index-see
+    // RFE 2987769 Eclipse index-see
     /**
      *  Get input parameters from ANT pipeline module.
      *  @return PipelineHashIO The hashmap containing some module parameters.
@@ -222,7 +214,4 @@ public final class IndexTermCollection {
     public void setPipelineHashIO(final PipelineHashIO hashIO) {
         pipelineHashIO = hashIO;
     }
-
-
-
 }

--- a/src/main/java/org/dita/dost/index/IndexTermTarget.java
+++ b/src/main/java/org/dita/dost/index/IndexTermTarget.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.index;
 
 /**
@@ -25,8 +25,7 @@ public final class IndexTermTarget {
     /**
      * Create a empty target.
      */
-    public IndexTermTarget() {
-    }
+    public IndexTermTarget() {}
 
     /**
      * Get the target topic's name (title).
@@ -72,8 +71,7 @@ public final class IndexTermTarget {
     public boolean equals(final Object obj) {
         if (obj instanceof final IndexTermTarget target) {
 
-            return targetName.equals(target.getTargetName())
-                    && targetURI.equals(target.getTargetURI());
+            return targetName.equals(target.getTargetName()) && targetURI.equals(target.getTargetURI());
         }
 
         return false;

--- a/src/main/java/org/dita/dost/index/Messages.java
+++ b/src/main/java/org/dita/dost/index/Messages.java
@@ -1,36 +1,36 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.index;
 
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+
 /**
  * Class to store messages.
  *
  */
 final class Messages {
     /**message bundle name.*/
-    private static final String BUNDLE_NAME = "org.dita.dost.index.messages"; //$NON-NLS-1$
+    private static final String BUNDLE_NAME = "org.dita.dost.index.messages"; // $NON-NLS-1$
 
     /**
      * private constructor.
      */
-    private Messages() {
-    }
+    private Messages() {}
     /**
      * get specific message by key and locale.
      * @param key key
      * @param msgLocale locale
      * @return string
      */
-    public static String getString (final String key, final Locale msgLocale) {
+    public static String getString(final String key, final Locale msgLocale) {
         /*read message resource file.*/
         ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME, msgLocale);
         try {

--- a/src/main/java/org/dita/dost/index/TopicrefElement.java
+++ b/src/main/java/org/dita/dost/index/TopicrefElement.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.index;
 
 /**
@@ -27,8 +27,7 @@ public final class TopicrefElement {
     /**
      * Default constructor.
      */
-    public TopicrefElement() {
-    }
+    public TopicrefElement() {}
 
     /**
      * Get the format attribute.
@@ -70,7 +69,7 @@ public final class TopicrefElement {
      * Set navtitle attribute with the given value.
      * @param aNavtitle The navtitle to set.
      */
-    public void setNavTitle (final String aNavtitle) {
+    public void setNavTitle(final String aNavtitle) {
         navtitle = aNavtitle;
     }
 
@@ -82,6 +81,4 @@ public final class TopicrefElement {
     public String getNavTitle() {
         return navtitle;
     }
-
-
 }

--- a/src/main/java/org/dita/dost/invoker/ArgumentParser.java
+++ b/src/main/java/org/dita/dost/invoker/ArgumentParser.java
@@ -9,19 +9,18 @@
 /* Derived from Apache Ant. */
 package org.dita.dost.invoker;
 
+import static org.dita.dost.util.XMLUtils.getChildElements;
+import static org.dita.dost.util.XMLUtils.toList;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.dita.dost.platform.Plugins;
-import org.dita.dost.util.XMLUtils;
-import org.w3c.dom.Element;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.dita.dost.util.XMLUtils.getChildElements;
-import static org.dita.dost.util.XMLUtils.toList;
+import org.dita.dost.platform.Plugins;
+import org.dita.dost.util.XMLUtils;
+import org.w3c.dom.Element;
 
 /**
  * Command line argument parser.
@@ -64,9 +63,8 @@ final class ArgumentParser {
             case "file":
                 return new Arguments.FileArgument(name, desc);
             case "enum":
-                final Set<String> vals = getChildElements(param).stream()
-                        .map(XMLUtils::getText)
-                        .collect(Collectors.toSet());
+                final Set<String> vals =
+                        getChildElements(param).stream().map(XMLUtils::getText).collect(Collectors.toSet());
                 if (vals.size() == 2) {
                     for (Map.Entry<String, String> pair : TRUTHY_VALUES.entrySet()) {
                         if (vals.contains(pair.getKey()) && vals.contains(pair.getValue())) {
@@ -88,10 +86,8 @@ final class ArgumentParser {
             final List<Element> params = toList(Plugins.getPluginConfiguration().getElementsByTagName("param"));
             PLUGIN_ARGUMENTS = params.stream()
                     .map(ArgumentParser::getArgument)
-                    .collect(Collectors.toMap(
-                            arg -> ("--" + arg.property),
-                            arg -> arg,
-                            ArgumentParser::mergeArguments));
+                    .collect(
+                            Collectors.toMap(arg -> ("--" + arg.property), arg -> arg, ArgumentParser::mergeArguments));
         }
         return PLUGIN_ARGUMENTS;
     }
@@ -126,6 +122,6 @@ final class ArgumentParser {
     private String getName(final String subcommand) {
         final int start = subcommand.startsWith("--") ? 2 : (subcommand.startsWith("-") ? 1 : 0);
         final int end = subcommand.indexOf('=');
-        return subcommand.substring(start, end != -1 ? end :subcommand.length());
+        return subcommand.substring(start, end != -1 ? end : subcommand.length());
     }
 }

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -9,9 +9,7 @@
 /* Derived from Apache Ant. */
 package org.dita.dost.invoker;
 
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
-import org.dita.dost.util.Configuration;
+import static org.dita.dost.util.LangUtils.pair;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -19,8 +17,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static org.dita.dost.util.LangUtils.pair;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.dita.dost.util.Configuration;
 
 /**
  * Command line arguments.
@@ -73,6 +72,7 @@ abstract class Arguments {
      * proxy flag: default is false
      */
     boolean proxy;
+
     boolean justPrintUsage;
     boolean justPrintVersion;
     boolean justPrintDiagnostics;
@@ -185,7 +185,7 @@ abstract class Arguments {
         }
     }
 
-    static abstract class Argument {
+    abstract static class Argument {
         final String property;
         final String desc;
 
@@ -294,5 +294,4 @@ abstract class Arguments {
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -8,24 +8,23 @@
 
 package org.dita.dost.invoker;
 
+import static org.dita.dost.invoker.ArgumentParser.getPluginArguments;
+import static org.dita.dost.invoker.Main.locale;
+import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
+import static org.dita.dost.util.XMLUtils.toList;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.util.FileUtils;
-import org.dita.dost.platform.Plugins;
-import org.w3c.dom.Element;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static org.dita.dost.invoker.ArgumentParser.getPluginArguments;
-import static org.dita.dost.invoker.Main.locale;
-import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
-import static org.dita.dost.util.XMLUtils.toList;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.util.FileUtils;
+import org.dita.dost.platform.Plugins;
+import org.w3c.dom.Element;
 
 public class ConversionArguments extends Arguments {
 
@@ -33,14 +32,8 @@ public class ConversionArguments extends Arguments {
      * A Set of args are are handled by the launcher and should not be seen by
      * Main.
      */
-    private static final Set<String> LAUNCH_COMMANDS = ImmutableSet.of(
-            "-lib",
-            "-cp",
-            "-noclasspath",
-            "-nouserlib",
-            "-main"
-    );
-
+    private static final Set<String> LAUNCH_COMMANDS =
+            ImmutableSet.of("-lib", "-cp", "-noclasspath", "-nouserlib", "-main");
 
     private static final Map<String, Argument> ARGUMENTS = new HashMap<>();
 
@@ -68,12 +61,7 @@ public class ConversionArguments extends Arguments {
     }
 
     private static final Map<String, String> RESERVED_PROPERTIES = ImmutableMap.of(
-            "transtype", "-f",
-            "args.input", "-i",
-            "output.dir", "-o",
-            "args.filter", "--filter",
-            ANT_TEMP_DIR, "-t"
-    );
+            "transtype", "-f", "args.input", "-i", "output.dir", "-o", "args.filter", "--filter", ANT_TEMP_DIR, "-t");
 
     /**
      * Project file
@@ -118,7 +106,7 @@ public class ConversionArguments extends Arguments {
                 allowInput = false;
             } else if (isLongForm(arg, "-logfile") || arg.equals("-l")) {
                 handleArgLogFile(arg, args);
-            } else if (isLongForm(arg, "-buildfile") || isLongForm(arg, "-file")) { //|| arg.equals("-f")
+            } else if (isLongForm(arg, "-buildfile") || isLongForm(arg, "-file")) { // || arg.equals("-f")
                 handleArgBuildFile(args);
             } else if (isLongForm(arg, "-listener")) {
                 handleArgListener(args);
@@ -147,7 +135,8 @@ public class ConversionArguments extends Arguments {
             } else if (ARGUMENTS.containsKey(getArgumentName(arg))) {
                 definedProps.putAll(handleParameterArg(arg, args, ARGUMENTS.get(getArgumentName(arg))));
             } else if (getPluginArguments().containsKey(getArgumentName(arg))) {
-                definedProps.putAll(handleParameterArg(arg, args, getPluginArguments().get(getArgumentName(arg))));
+                definedProps.putAll(
+                        handleParameterArg(arg, args, getPluginArguments().get(getArgumentName(arg))));
             } else if (LAUNCH_COMMANDS.contains(arg)) {
                 // catch script/ant mismatch with a meaningful message
                 // we could ignore it, but there are likely to be other
@@ -207,7 +196,8 @@ public class ConversionArguments extends Arguments {
         }
 
         if (RESERVED_PROPERTIES.containsKey(entry.getKey())) {
-            throw new BuildException("Property " + entry.getKey() + " cannot be set with -D, use " + RESERVED_PROPERTIES.get(entry.getKey()) + " instead");
+            throw new BuildException("Property " + entry.getKey() + " cannot be set with -D, use "
+                    + RESERVED_PROPERTIES.get(entry.getKey()) + " instead");
         }
         return ImmutableMap.of(entry.getKey(), entry.getValue());
     }
@@ -246,7 +236,8 @@ public class ConversionArguments extends Arguments {
     /**
      * Handler parameter argument
      */
-    private Map<String, Object> handleParameterArg(final String arg, final Deque<String> args, final Argument argument) {
+    private Map<String, Object> handleParameterArg(
+            final String arg, final Deque<String> args, final Argument argument) {
         final Map.Entry<String, String> entry = parse(arg, args);
         if (entry.getValue() == null) {
             throw new BuildException("Missing value for property " + entry.getKey());
@@ -370,7 +361,7 @@ public class ConversionArguments extends Arguments {
         final UsageBuilder buf = UsageBuilder.builder(compact)
                 .usage(locale.getString("conversion.usage.input"))
                 .usage(locale.getString("conversion.usage.project"))
-//                .usage("dita --propertyfile=<file> [options]")
+                //                .usage("dita --propertyfile=<file> [options]")
                 .subcommands("deliverables", locale.getString("conversion.subcommand.deliverables"))
                 .subcommands("install", locale.getString("conversion.subcommand.install"))
                 .subcommands("plugins", locale.getString("conversion.subcommand.plugins"))
@@ -384,20 +375,17 @@ public class ConversionArguments extends Arguments {
                 .options(null, "filter", "files", locale.getString("conversion.option.filter"))
                 .options("o", "output", "dir", locale.getString("conversion.option.output"));
         if (!compact) {
-            buf
-                    .options("l", "logfile", "file", locale.getString("conversion.option.logfile"))
+            buf.options("l", "logfile", "file", locale.getString("conversion.option.logfile"))
                     .options(null, "propertyfile", "file", locale.getString("conversion.option.propertyfile"))
                     .options(null, "repeat", "num", locale.getString("conversion.option.repeat"))
                     .options("t", "temp", "dir", locale.getString("conversion.option.temp"));
-            final Set<String> builtin = ARGUMENTS.values().stream().map(arg -> arg.property).collect(Collectors.toSet());
+            final Set<String> builtin =
+                    ARGUMENTS.values().stream().map(arg -> arg.property).collect(Collectors.toSet());
             final List<Element> params = toList(Plugins.getPluginConfiguration().getElementsByTagName("param"));
             params.stream()
                     .map(ArgumentParser::getArgument)
                     .filter(a -> !builtin.contains(a.property))
-                    .collect(Collectors.toMap(
-                            arg -> arg.property,
-                            arg -> arg,
-                            ArgumentParser::mergeArguments))
+                    .collect(Collectors.toMap(arg -> arg.property, arg -> arg, ArgumentParser::mergeArguments))
                     .values()
                     .stream()
                     .sorted(Comparator.comparing(o -> o.property))

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -29,15 +29,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
-import java.util.Date;
 import java.text.DateFormat;
-
+import java.util.Date;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildLogger;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.util.DateUtils;
-import org.apache.tools.ant.util.StringUtils;
 import org.apache.tools.ant.util.FileUtils;
+import org.apache.tools.ant.util.StringUtils;
 
 /**
  * Writes build events to a PrintStream. Currently, it only writes which targets
@@ -84,6 +83,7 @@ class DefaultLogger implements BuildLogger {
 
     /** Whether or not to use emacs-style output */
     private boolean emacsMode = false;
+
     private boolean useColor = false;
 
     // CheckStyle:VisibilityModifier ON
@@ -91,8 +91,7 @@ class DefaultLogger implements BuildLogger {
     /**
      * Sole constructor.
      */
-    public DefaultLogger() {
-    }
+    public DefaultLogger() {}
 
     /**
      * Sets the highest level of message this logger should respond to.
@@ -168,7 +167,7 @@ class DefaultLogger implements BuildLogger {
             msg = msg.substring(i + 1).trim();
         }
         m.append(msg);
-//        m.append(lSep);
+        //        m.append(lSep);
     }
 
     /**
@@ -188,7 +187,7 @@ class DefaultLogger implements BuildLogger {
         } else {
             // message.append(StringUtils.LINE_SEP);
             // message.append(getBuildFailedMessage());
-//            message.append(StringUtils.LINE_SEP);
+            //            message.append(StringUtils.LINE_SEP);
             message.append("Error: ");
             throwableMessage(message, error, Project.MSG_VERBOSE <= msgOutputLevel);
         }
@@ -247,8 +246,7 @@ class DefaultLogger implements BuildLogger {
      * @param event Ignored.
      */
     @Override
-    public void targetFinished(final BuildEvent event) {
-    }
+    public void targetFinished(final BuildEvent event) {}
 
     /**
      * No-op implementation.
@@ -256,8 +254,7 @@ class DefaultLogger implements BuildLogger {
      * @param event Ignored.
      */
     @Override
-    public void taskStarted(final BuildEvent event) {
-    }
+    public void taskStarted(final BuildEvent event) {}
 
     /**
      * No-op implementation.
@@ -265,8 +262,7 @@ class DefaultLogger implements BuildLogger {
      * @param event Ignored.
      */
     @Override
-    public void taskFinished(final BuildEvent event) {
-    }
+    public void taskFinished(final BuildEvent event) {}
 
     /**
      * Logs a message, if the priority is suitable. In non-emacs mode, task
@@ -376,8 +372,7 @@ class DefaultLogger implements BuildLogger {
      *
      * @param message Message being logged. Should not be <code>null</code>.
      */
-    private void log(final String message) {
-    }
+    private void log(final String message) {}
 
     /**
      * Get the current time.
@@ -402,5 +397,4 @@ class DefaultLogger implements BuildLogger {
         final Project project = event.getProject();
         return (project != null) ? project.getName() : null;
     }
-
 }

--- a/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
@@ -8,15 +8,14 @@
 
 package org.dita.dost.invoker;
 
-import org.apache.tools.ant.BuildException;
+import static org.dita.dost.invoker.Main.locale;
 
 import java.io.File;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
-
-import static org.dita.dost.invoker.Main.locale;
+import org.apache.tools.ant.BuildException;
 
 public class DeliverablesArguments extends Arguments {
 
@@ -72,5 +71,4 @@ public class DeliverablesArguments extends Arguments {
                 .arguments(null, null, "file", locale.getString("deliverables.argument.file"))
                 .print();
     }
-
 }

--- a/src/main/java/org/dita/dost/invoker/InstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/InstallArguments.java
@@ -8,13 +8,12 @@
 
 package org.dita.dost.invoker;
 
-import org.apache.tools.ant.Project;
+import static org.dita.dost.invoker.Main.locale;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
-import static org.dita.dost.invoker.Main.locale;
+import org.apache.tools.ant.Project;
 
 public class InstallArguments extends Arguments {
 
@@ -85,5 +84,4 @@ public class InstallArguments extends Arguments {
                 .options(null, "force", null, locale.getString("install.option.force"))
                 .print();
     }
-
 }

--- a/src/main/java/org/dita/dost/invoker/PluginsArguments.java
+++ b/src/main/java/org/dita/dost/invoker/PluginsArguments.java
@@ -8,11 +8,11 @@
 
 package org.dita.dost.invoker;
 
+import static org.dita.dost.invoker.Main.locale;
+
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
-import static org.dita.dost.invoker.Main.locale;
 
 public class PluginsArguments extends Arguments {
 
@@ -32,8 +32,6 @@ public class PluginsArguments extends Arguments {
 
     @Override
     void printUsage(final boolean compact) {
-        UsageBuilder.builder(compact)
-                .usage(locale.getString("plugins.usage"))
-                .print();
+        UsageBuilder.builder(compact).usage(locale.getString("plugins.usage")).print();
     }
 }

--- a/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
@@ -8,11 +8,11 @@
 
 package org.dita.dost.invoker;
 
+import static org.dita.dost.invoker.Main.locale;
+
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
-import static org.dita.dost.invoker.Main.locale;
 
 public class TranstypesArguments extends Arguments {
 
@@ -36,5 +36,4 @@ public class TranstypesArguments extends Arguments {
                 .usage(locale.getString("transtypes.usage"))
                 .print();
     }
-
 }

--- a/src/main/java/org/dita/dost/invoker/UninstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/UninstallArguments.java
@@ -8,14 +8,13 @@
 
 package org.dita.dost.invoker;
 
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
+import static org.dita.dost.invoker.Main.locale;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
-import static org.dita.dost.invoker.Main.locale;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
 
 public class UninstallArguments extends Arguments {
 
@@ -80,6 +79,4 @@ public class UninstallArguments extends Arguments {
                 .arguments(null, null, "id", locale.getString("uninstall.argument.id"))
                 .print();
     }
-
-
 }

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -8,11 +8,11 @@
 
 package org.dita.dost.invoker;
 
-import java.util.*;
-
 import static org.dita.dost.invoker.DefaultLogger.ANSI_BOLD;
 import static org.dita.dost.invoker.DefaultLogger.ANSI_RESET;
 import static org.dita.dost.invoker.Main.locale;
+
+import java.util.*;
 
 public class UsageBuilder {
 
@@ -69,7 +69,11 @@ public class UsageBuilder {
             buf.append("  ").append(usage).append("\n");
         }
         if (!subcommands.isEmpty()) {
-            buf.append("\n").append(ANSI_BOLD).append("Subcommands").append(ANSI_RESET).append(":\n");
+            buf.append("\n")
+                    .append(ANSI_BOLD)
+                    .append("Subcommands")
+                    .append(ANSI_RESET)
+                    .append(":\n");
             for (Map.Entry<String, String> subcommand : sortSubCommands(subcommands)) {
                 buf.append("  ")
                         .append(subcommand.getKey())
@@ -80,7 +84,11 @@ public class UsageBuilder {
             buf.append("\n  See 'dita <subcommand> --help' for details about a specific subcommand.\n");
         }
         if (!arguments.isEmpty()) {
-            buf.append("\n").append(ANSI_BOLD).append("Arguments").append(ANSI_RESET).append(":\n");
+            buf.append("\n")
+                    .append(ANSI_BOLD)
+                    .append("Arguments")
+                    .append(ANSI_RESET)
+                    .append(":\n");
             for (Map.Entry<Key, String> argument : arguments.entrySet()) {
                 buf.append("  ")
                         .append(argument.getKey())
@@ -90,7 +98,11 @@ public class UsageBuilder {
             }
         }
         if (!options.isEmpty()) {
-            buf.append("\n").append(ANSI_BOLD).append("Options").append(ANSI_RESET).append(":\n");
+            buf.append("\n")
+                    .append(ANSI_BOLD)
+                    .append("Options")
+                    .append(ANSI_RESET)
+                    .append(":\n");
             for (Map.Entry<Key, String> option : sort(options)) {
                 buf.append("  ")
                         .append(option.getKey())
@@ -175,9 +187,9 @@ public class UsageBuilder {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Key key = (Key) o;
-            return Objects.equals(shortKey, key.shortKey) &&
-                    Objects.equals(longKey, key.longKey) &&
-                    Objects.equals(value, key.value);
+            return Objects.equals(shortKey, key.shortKey)
+                    && Objects.equals(longKey, key.longKey)
+                    && Objects.equals(value, key.value);
         }
 
         @Override
@@ -188,7 +200,6 @@ public class UsageBuilder {
         @Override
         public String toString() {
             return string;
-
         }
 
         @Override

--- a/src/main/java/org/dita/dost/invoker/VersionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/VersionArguments.java
@@ -8,11 +8,11 @@
 
 package org.dita.dost.invoker;
 
+import static org.dita.dost.invoker.Main.locale;
+
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
-import static org.dita.dost.invoker.Main.locale;
 
 class VersionArguments extends Arguments {
 
@@ -32,8 +32,6 @@ class VersionArguments extends Arguments {
 
     @Override
     void printUsage(final boolean compact) {
-        UsageBuilder.builder(compact)
-                .usage(locale.getString("version.usage"))
-                .print();
+        UsageBuilder.builder(compact).usage(locale.getString("version.usage")).print();
     }
 }

--- a/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
@@ -7,12 +7,11 @@
  */
 package org.dita.dost.log;
 
+import java.text.MessageFormat;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
 import org.slf4j.helpers.MarkerIgnoringBase;
-
-import java.text.MessageFormat;
 
 /**
  * Logger proxy to Ant logger.
@@ -223,9 +222,8 @@ public final class DITAOTAntLogger extends MarkerIgnoringBase implements DITAOTL
             project.log(task, msg, level);
         } else if (target != null) {
             project.log(target, msg, level);
-        } else  {
+        } else {
             project.log(msg, level);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/log/DITAOTLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTLogger.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.log;
 
 import org.slf4j.Logger;
@@ -15,5 +15,4 @@ import org.slf4j.Logger;
  *
  * <p>The original interface has been retrofitted to extend SLF4J Logger.</p>
  */
-public interface DITAOTLogger extends Logger {
-}
+public interface DITAOTLogger extends Logger {}

--- a/src/main/java/org/dita/dost/log/LoggerListener.java
+++ b/src/main/java/org/dita/dost/log/LoggerListener.java
@@ -1,11 +1,10 @@
 package org.dita.dost.log;
 
+import java.util.regex.Pattern;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildListener;
 import org.apache.tools.ant.Project;
 import org.slf4j.Logger;
-
-import java.util.regex.Pattern;
 
 /**
  * Logger adapter from Ant logger to SLF4J logger.
@@ -26,32 +25,32 @@ public final class LoggerListener implements BuildListener {
 
     @Override
     public void buildStarted(BuildEvent event) {
-        //System.out.println("build started: " + event.getMessage());
+        // System.out.println("build started: " + event.getMessage());
     }
 
     @Override
     public void buildFinished(BuildEvent event) {
-        //System.out.println("build finished: " + event.getMessage());
+        // System.out.println("build finished: " + event.getMessage());
     }
 
     @Override
     public void targetStarted(BuildEvent event) {
-        //System.out.println(event.getTarget().getName() + ":");
+        // System.out.println(event.getTarget().getName() + ":");
     }
 
     @Override
     public void targetFinished(BuildEvent event) {
-        //System.out.println("target finished: " + event.getTarget().getName());
+        // System.out.println("target finished: " + event.getTarget().getName());
     }
 
     @Override
     public void taskStarted(BuildEvent event) {
-        //System.out.println("task started: " + event.getTask().getTaskName());
+        // System.out.println("task started: " + event.getTask().getTaskName());
     }
 
     @Override
     public void taskFinished(BuildEvent event) {
-        //System.out.println("task finished: " + event.getTask().getTaskName());
+        // System.out.println("task finished: " + event.getTask().getTaskName());
     }
 
     @Override

--- a/src/main/java/org/dita/dost/log/MessageBean.java
+++ b/src/main/java/org/dita/dost/log/MessageBean.java
@@ -1,25 +1,24 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.log;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import net.sf.saxon.s9api.XdmNode;
 import org.apache.tools.ant.Location;
 import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Class description goes here.
@@ -29,7 +28,11 @@ import static org.dita.dost.util.URLUtils.toURI;
 public final class MessageBean {
 
     public enum Type {
-        FATAL, ERROR, WARN, INFO, DEBUG
+        FATAL,
+        ERROR,
+        WARN,
+        INFO,
+        DEBUG
     }
 
     public static final String FATAL = Type.FATAL.name();
@@ -242,10 +245,7 @@ public final class MessageBean {
         if (srcFile != null) {
             buff.append(srcFile);
             if (srcLine != -1 && srcColumn != -1) {
-                buff.append(':')
-                    .append(Integer.valueOf(srcLine))
-                    .append(':')
-                    .append(Integer.valueOf(srcColumn));
+                buff.append(':').append(Integer.valueOf(srcLine)).append(':').append(Integer.valueOf(srcColumn));
             }
             buff.append(": ");
         }
@@ -265,5 +265,4 @@ public final class MessageBean {
     public DITAOTException toException() {
         return new DITAOTException(toString());
     }
-
 }

--- a/src/main/java/org/dita/dost/log/MessageUtils.java
+++ b/src/main/java/org/dita/dost/log/MessageUtils.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.log;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -34,7 +33,8 @@ public final class MessageUtils {
 
     // Variables
 
-    public static final ResourceBundle msgs = ResourceBundle.getBundle("messages", new Locale("en", "US"), MessageUtils.class.getClassLoader());
+    public static final ResourceBundle msgs =
+            ResourceBundle.getBundle("messages", new Locale("en", "US"), MessageUtils.class.getClassLoader());
 
     // Constructors
 
@@ -42,8 +42,7 @@ public final class MessageUtils {
      * Default construtor
      */
     @VisibleForTesting
-    MessageUtils() {
-    }
+    MessageUtils() {}
 
     /**
      * Get the message respond to the given id with all of the parameters
@@ -59,15 +58,15 @@ public final class MessageUtils {
             throw new IllegalArgumentException("Message for ID '" + id + "' not found");
         }
         final String msg = MessageFormat.format(msgs.getString(id), (Object[]) params);
-        MessageBean.Type type = switch (id.substring(id.length() - 1)) {
-            case "F" -> MessageBean.Type.FATAL;
-            case "E" -> MessageBean.Type.ERROR;
-            case "W" -> MessageBean.Type.WARN;
-            case "I" -> MessageBean.Type.INFO;
-            case "D" -> MessageBean.Type.DEBUG;
-            default -> null;
-        };
+        MessageBean.Type type =
+                switch (id.substring(id.length() - 1)) {
+                    case "F" -> MessageBean.Type.FATAL;
+                    case "E" -> MessageBean.Type.ERROR;
+                    case "W" -> MessageBean.Type.WARN;
+                    case "I" -> MessageBean.Type.INFO;
+                    case "D" -> MessageBean.Type.DEBUG;
+                    default -> null;
+                };
         return new MessageBean(id, type, msg, null);
     }
-
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -1,13 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -16,10 +19,6 @@ import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
 
 /**
  * Abstract class for Modules which contains the method that every module class
@@ -68,8 +67,7 @@ public interface AbstractPipelineModule {
 
     void setFileInfoFilter(Predicate<FileInfo> fileInfoFilter);
 
-    default void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {
-    }
+    default void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {}
 
     void setParallel(boolean parallel);
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -7,6 +7,8 @@
  */
 package org.dita.dost.module;
 
+import java.util.List;
+import java.util.function.Predicate;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -14,9 +16,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 /**
  * Abstract class for modules.

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -1,13 +1,25 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
+import static net.sf.saxon.s9api.streams.Steps.attribute;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.getExtension;
+import static org.dita.dost.util.URLUtils.getRelativePath;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.XMLUtils.rootElement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -19,26 +31,13 @@ import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.TopicRefWriter;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static net.sf.saxon.s9api.streams.Steps.attribute;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FileUtils.getExtension;
-import static org.dita.dost.util.URLUtils.getRelativePath;
-import static org.dita.dost.util.URLUtils.stripFragment;
-import static org.dita.dost.util.XMLUtils.rootElement;
-
 /**
  * The chunking module class.
  * <p>
  * Starting from map files, it parses and processes chunk attribute, writes out the chunked
  * results and finally updates reference pointing to chunked topics in other topics.
  */
-final public class ChunkModule extends AbstractPipelineModuleImpl {
+public final class ChunkModule extends AbstractPipelineModuleImpl {
 
     private static final DitaClass ECLIPSEMAP_PLUGIN = DitaClass.getInstance("- map/map eclipsemap/plugin ");
     public static final String ROOT_CHUNK_OVERRIDE = "root-chunk-override";
@@ -124,8 +123,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
         } catch (final IOException e) {
             throw new DITAOTException("Failed to parse input map: " + e.getMessage(), e);
         }
-        return doc
-                .select(rootElement().then(attribute(ATTRIBUTE_NAME_CLASS)))
+        return doc.select(rootElement().then(attribute(ATTRIBUTE_NAME_CLASS)))
                 .anyMatch(xdmItems -> ECLIPSEMAP_PLUGIN.matches(xdmItems.getStringValue()));
     }
 
@@ -149,13 +147,13 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
         } catch (final DITAOTException ex) {
             logger.error(ex.getMessage(), ex);
         }
-
     }
 
     /**
      * Update Job configuration to include new generated files
      */
-    private void updateList(final Map<URI, URI> changeTable, final Map<URI, URI> conflictTable, final ChunkMapReader mapReader) {
+    private void updateList(
+            final Map<URI, URI> changeTable, final Map<URI, URI> conflictTable, final ChunkMapReader mapReader) {
         final URI xmlDitalist = job.tempDirURI.resolve("dummy.xml");
 
         final Set<URI> hrefTopics = new HashSet<>();
@@ -176,8 +174,7 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
                     // be fully chunked. Thus it should not produce any output.
                     // The entry in hrefTopics points to the same target
                     // as entry in chunkTopics, it should be removed.
-                    hrefTopics.removeIf(ent -> job.tempDirURI.resolve(ent).equals(
-                            job.tempDirURI.resolve(s)));
+                    hrefTopics.removeIf(ent -> job.tempDirURI.resolve(ent).equals(job.tempDirURI.resolve(s)));
                 } else {
                     hrefTopics.remove(s);
                 }
@@ -226,7 +223,6 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
                     }
                     chunkedDitamapSet.add(newChunkedFile);
                 }
-
             }
         }
         // removed extra topic files
@@ -259,8 +255,13 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
                         URI relativePath = getRelativePath(xmlDitalist, from);
                         final URI relativeTargetPath = getRelativePath(xmlDitalist, target);
                         if (relativeTargetPath.getPath().contains(URI_SEPARATOR)) {
-                            relativePath2fix.put(relativeTargetPath,
-                                    relativeTargetPath.getPath().substring(0, relativeTargetPath.getPath().lastIndexOf(URI_SEPARATOR) + 1));
+                            relativePath2fix.put(
+                                    relativeTargetPath,
+                                    relativeTargetPath
+                                            .getPath()
+                                            .substring(
+                                                    0,
+                                                    relativeTargetPath.getPath().lastIndexOf(URI_SEPARATOR) + 1));
                         }
                         // ensure the newly chunked file to the old one
                         try {
@@ -276,7 +277,6 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
                             }
                         } catch (final IOException e) {
                             logger.error("Failed to replace chunk topic: " + e.getMessage(), e);
-
                         }
                         topicList.remove(relativePath);
                         chunkedTopicSet.remove(relativePath);
@@ -348,7 +348,6 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
                 return new RandomChunkFilenameGenerator();
             }
         }
-
     }
 
     /**
@@ -371,7 +370,6 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
          * @return generated ID
          */
         String generateID();
-
     }
 
     public static class RandomChunkFilenameGenerator implements ChunkFilenameGenerator {
@@ -401,5 +399,4 @@ final public class ChunkModule extends AbstractPipelineModuleImpl {
             return "unique_" + counter.getAndIncrement();
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -1,13 +1,18 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
+import java.io.File;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
@@ -16,12 +21,6 @@ import org.dita.dost.reader.ConrefPushReader.MoveKey;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.ConrefPushParser;
 import org.w3c.dom.DocumentFragment;
-
-import java.io.File;
-import java.util.Collection;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Conref push module.
@@ -37,22 +36,22 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
             final ConrefPushReader reader = new ConrefPushReader();
             reader.setLogger(logger);
             reader.setJob(job);
-            for (final FileInfo f: fis) {
+            for (final FileInfo f : fis) {
                 final File file = new File(job.tempDirURI.resolve(f.uri));
                 logger.info("Reading " + file.toURI());
-                //FIXME: this reader calculate parent directory
+                // FIXME: this reader calculate parent directory
                 reader.read(file.getAbsoluteFile());
             }
             final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = reader.getPushMap();
-            for (final Map.Entry<File, Hashtable<MoveKey, DocumentFragment>> entry: pushSet.entrySet()) {
-//                logger.info("Processing " + entry.getKey().toURI());
+            for (final Map.Entry<File, Hashtable<MoveKey, DocumentFragment>> entry : pushSet.entrySet()) {
+                //                logger.info("Processing " + entry.getKey().toURI());
                 final ConrefPushParser parser = new ConrefPushParser();
                 parser.setJob(job);
                 parser.setLogger(logger);
                 parser.setMoveTable(entry.getValue());
-                //pass the tempdir to ConrefPushParser
+                // pass the tempdir to ConrefPushParser
                 parser.setTempDir(job.tempDir);
-                //FIXME:This writer creates and renames files, have to
+                // FIXME:This writer creates and renames files, have to
                 try {
                     parser.read(entry.getKey());
                 } catch (final DITAOTException e) {
@@ -62,5 +61,4 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -7,6 +7,15 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Job.FileInfo;
+import static org.dita.dost.util.Job.Generate;
+import static org.dita.dost.util.URLUtils.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -23,16 +32,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
 import org.xml.sax.helpers.XMLFilterImpl;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.Job.FileInfo;
-import static org.dita.dost.util.Job.Generate;
-import static org.dita.dost.util.URLUtils.*;
-
 /**
  * Process copy-to mapping.
  */
@@ -47,7 +46,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
     public void setJob(final Job job) {
         super.setJob(job);
         try {
-            tempFileNameScheme = (TempFileNameScheme) Class.forName(job.getProperty("temp-file-name-scheme")).newInstance();
+            tempFileNameScheme = (TempFileNameScheme)
+                    Class.forName(job.getProperty("temp-file-name-scheme")).newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
@@ -84,7 +84,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
      * Process start map to read copy-to map and write unique topic references.
      */
     private void processMap() throws DITAOTException {
-        final URI in = job.tempDirURI.resolve(job.getFileInfo(fi -> fi.isInput).iterator().next().uri);
+        final URI in = job.tempDirURI.resolve(
+                job.getFileInfo(fi -> fi.isInput).iterator().next().uri);
 
         final List<XMLFilter> pipe = getProcessingPipe(in);
 
@@ -136,8 +137,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             final FileInfo sourceFi = job.getFileInfo(source);
             // Filter when copy-to was ignored (so target is not in job),
             // or where target is used directly
-            if (targetFi == null ||
-                    (targetFi != null && targetFi.src != null)) {
+            if (targetFi == null || (targetFi != null && targetFi.src != null)) {
                 continue;
             }
             copyToMap.put(targetFi, sourceFi);
@@ -159,9 +159,11 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             final URI targetFile = job.tempDirURI.resolve(copytoTarget);
 
             if (job.getStore().exists(targetFile)) {
-                logger.warn(MessageUtils.getMessage("DOTX064W", copytoTarget.getPath()).toString());
+                logger.warn(MessageUtils.getMessage("DOTX064W", copytoTarget.getPath())
+                        .toString());
             } else {
-                final FileInfo input = job.getFileInfo(fi -> fi.isInput).iterator().next();
+                final FileInfo input =
+                        job.getFileInfo(fi -> fi.isInput).iterator().next();
                 final URI inputMapInTemp = job.tempDirURI.resolve(input.uri);
                 copyFileWithPIReplaced(srcFile, targetFile, copytoTarget, inputMapInTemp);
                 // add new file info into job
@@ -187,7 +189,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
      * @param copytoTargetFilename target URI relative to temporary directory
      * @param inputMapInTemp       input map URI in temporary directory
      */
-    private void copyFileWithPIReplaced(final URI src, final URI target, final URI copytoTargetFilename, final URI inputMapInTemp) {
+    private void copyFileWithPIReplaced(
+            final URI src, final URI target, final URI copytoTargetFilename, final URI inputMapInTemp) {
         assert src.isAbsolute();
         assert target.isAbsolute();
         assert !copytoTargetFilename.isAbsolute();
@@ -225,7 +228,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
         private final URI src;
         private final URI dst;
 
-        CopyToFilter(final File workdir, final File path2project, final File path2rootmap, final URI src, final URI dst) {
+        CopyToFilter(
+                final File workdir, final File path2project, final File path2rootmap, final URI src, final URI dst) {
             super();
             assert workdir != null;
             this.workdir = workdir;
@@ -268,7 +272,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
                             d = UNIX_SEPARATOR + workdir.getCanonicalPath();
                         }
                     } catch (final IOException e) {
-                        throw new RuntimeException("Failed to get canonical path for working directory: " + e.getMessage(), e);
+                        throw new RuntimeException(
+                                "Failed to get canonical path for working directory: " + e.getMessage(), e);
                     }
                 }
                 case PI_WORKDIR_TARGET_URI -> d = toDirURI(workdir).toString();
@@ -302,7 +307,6 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
             }
             getContentHandler().processingInstruction(target, d);
         }
-
     }
 
     /**
@@ -314,7 +318,8 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
      * @return path to base directory, {@code null} if not available
      */
     // TODO return URI
-    public static File getPathtoProject(final URI filename, final URI traceFilename, final URI inputMap, final Job job) {
+    public static File getPathtoProject(
+            final URI filename, final URI traceFilename, final URI inputMap, final Job job) {
         assert traceFilename.isAbsolute();
         assert inputMap.isAbsolute();
         // FIXME out generation has already been determined, why do it here again?
@@ -372,5 +377,4 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
         final URI relativePath = URLUtils.getRelativePath(inputMap, filePathName);
         return !(relativePath.getPath().length() == 0 || !relativePath.getPath().startsWith(".."));
     }
-
 }

--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -17,7 +17,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import org.apache.tools.ant.util.FileUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -49,8 +48,11 @@ final class FilterModule extends AbstractPipelineModuleImpl {
         final FilterUtils filterUtils;
         if (ditavalFile != null) {
             ditaValReader.read(ditavalFile.toURI());
-            filterUtils = new FilterUtils(printTranstype.contains(transtype), ditaValReader.getFilterMap(),
-                    ditaValReader.getForegroundConflictColor(), ditaValReader.getBackgroundConflictColor());
+            filterUtils = new FilterUtils(
+                    printTranstype.contains(transtype),
+                    ditaValReader.getFilterMap(),
+                    ditaValReader.getForegroundConflictColor(),
+                    ditaValReader.getBackgroundConflictColor());
         } else {
             filterUtils = new FilterUtils(printTranstype.contains(transtype));
         }
@@ -71,7 +73,7 @@ final class FilterModule extends AbstractPipelineModuleImpl {
             throw new DITAOTException(e);
         }
 
-        for (final FileInfo f: job.getFileInfo(fileInfoFilter)) {
+        for (final FileInfo f : job.getFileInfo(fileInfoFilter)) {
             final File file = new File(job.tempDir, f.file.getPath());
             logger.info("Processing " + file.getAbsolutePath());
 
@@ -110,5 +112,4 @@ final class FilterModule extends AbstractPipelineModuleImpl {
 
         return null;
     }
-
 }

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -7,13 +7,7 @@
  */
 package org.dita.dost.module;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.pipeline.AbstractPipelineInput;
-import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.Pool;
-import org.dita.dost.writer.ImageMetadataFilter;
-import org.xml.sax.Attributes;
+import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,8 +16,13 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-
-import static org.dita.dost.util.Constants.*;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.Pool;
+import org.dita.dost.writer.ImageMetadataFilter;
+import org.xml.sax.Attributes;
 
 /**
  * Image metadata module.
@@ -45,12 +44,12 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
      * @throws DITAOTException exception
      */
     @Override
-    public AbstractPipelineOutput execute(final AbstractPipelineInput input)
-            throws DITAOTException {
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
         if (logger == null) {
             throw new IllegalStateException("Logger not set");
         }
-        final Collection<FileInfo> images = job.getFileInfo(f -> ATTR_FORMAT_VALUE_IMAGE.equals(f.format) || ATTR_FORMAT_VALUE_HTML.equals(f.format));
+        final Collection<FileInfo> images = job.getFileInfo(
+                f -> ATTR_FORMAT_VALUE_IMAGE.equals(f.format) || ATTR_FORMAT_VALUE_HTML.equals(f.format));
         if (!images.isEmpty()) {
             final File outputDir = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR));
             final Predicate<FileInfo> filter = fileInfoFilter != null
@@ -113,5 +112,4 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/IndexTermExtractModule.java
+++ b/src/main/java/org/dita/dost/module/IndexTermExtractModule.java
@@ -1,13 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.index.IndexTerm;
 import org.dita.dost.index.IndexTermCollection;
@@ -21,13 +27,6 @@ import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.StringUtils;
 import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * This class extends AbstractPipelineModule, used to extract indexterm from
@@ -55,12 +54,10 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
     /**
      * Create a default instance.
      */
-    public IndexTermExtractModule() {
-    }
+    public IndexTermExtractModule() {}
 
     @Override
-    public AbstractPipelineOutput execute(final AbstractPipelineInput input)
-            throws DITAOTException {
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
         if (logger == null) {
             throw new IllegalStateException("Logger not set");
         }
@@ -74,7 +71,7 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
 
         return null;
@@ -97,26 +94,25 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
          * Parse topic list and ditamap list from the input dita.list file
          */
         topicList = new ArrayList<>();
-        for (final FileInfo f: job.getFileInfo()) {
+        for (final FileInfo f : job.getFileInfo()) {
             if (ATTR_FORMAT_VALUE_DITA.equals(f.format) && !f.isResourceOnly) {
                 topicList.add(job.tempDirURI.resolve(f.uri));
             }
         }
         ditamapList = new ArrayList<>();
-        for (final FileInfo f: job.getFileInfo()) {
+        for (final FileInfo f : job.getFileInfo()) {
             if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format) && !f.isResourceOnly) {
                 ditamapList.add(job.tempDirURI.resolve(f.uri));
             }
         }
 
         final int lastIndexOfDot = output.lastIndexOf(".");
-        final String outputRoot = (lastIndexOfDot == -1) ? output : output.substring(0,
-                lastIndexOfDot);
+        final String outputRoot = (lastIndexOfDot == -1) ? output : output.substring(0, lastIndexOfDot);
 
         indexTermCollection.setOutputFileRoot(outputRoot);
         indexTermCollection.setIndexType(indextype);
         indexTermCollection.setIndexClass(indexclass);
-        //RFE 2987769 Eclipse index-see
+        // RFE 2987769 Eclipse index-see
         indexTermCollection.setPipelineHashIO((PipelineHashIO) input);
 
         if (encoding != null && encoding.trim().length() > 0) {
@@ -138,11 +134,8 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
             String targetPathFromMapWithoutExt;
             handler.reset();
             target = aTopicList;
-            targetPathFromMap = FileUtils.getRelativeUnixPath(
-                    tempInputMap.toString(),
-                    target.toString());
-            targetPathFromMapWithoutExt = targetPathFromMap
-                    .substring(0, targetPathFromMap.lastIndexOf("."));
+            targetPathFromMap = FileUtils.getRelativeUnixPath(tempInputMap.toString(), target.toString());
+            targetPathFromMapWithoutExt = targetPathFromMap.substring(0, targetPathFromMap.lastIndexOf("."));
             handler.setTargetFile(targetPathFromMapWithoutExt + targetExt);
 
             try {
@@ -158,13 +151,12 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
         }
 
         for (final URI ditamap : ditamapList) {
-            final String currentMapPathName = FileUtils.getRelativeUnixPath(
-                    tempInputMap.toString(), ditamap.toString());
+            final String currentMapPathName =
+                    FileUtils.getRelativeUnixPath(tempInputMap.toString(), ditamap.toString());
             String mapPathFromInputMap = "";
 
             if (currentMapPathName.lastIndexOf(SLASH) != -1) {
-                mapPathFromInputMap = currentMapPathName.substring(0,
-                        currentMapPathName.lastIndexOf(SLASH));
+                mapPathFromInputMap = currentMapPathName.substring(0, currentMapPathName.lastIndexOf(SLASH));
             }
 
             ditamapIndexTermReader.setMapPath(mapPathFromInputMap);
@@ -179,5 +171,4 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -7,6 +7,16 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.reader.GenListModuleReader.KEYREF_ATTRS;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
@@ -19,17 +29,6 @@ import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-
-import static org.dita.dost.reader.GenListModuleReader.KEYREF_ATTRS;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.XMLUtils.*;
 
 /**
  * Recursively inline map references in maps.
@@ -49,9 +48,9 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
         try {
             templates = xsltCompiler.compile(new StreamSource(style));
         } catch (SaxonApiException e) {
-            throw new RuntimeException("Failed to compile stylesheet '" + style.getAbsolutePath() + "': " + e.getMessage(), e);
+            throw new RuntimeException(
+                    "Failed to compile stylesheet '" + style.getAbsolutePath() + "': " + e.getMessage(), e);
         }
-
     }
 
     /**
@@ -142,18 +141,17 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
                     .anyMatch(e -> e.hasAttribute(ATTRIBUTE_NAME_CONREF) || e.hasAttribute(ATTRIBUTE_NAME_CONKEYREF)));
         }
         if (!fileInfo.hasKeyref) {
-            builder.hasKeyref(elements.stream()
-                    .anyMatch(e -> {
-                        if (SUBJECTSCHEME_SUBJECTDEF.matches(e)) {
-                            return false;
-                        }
-                        for (final String attr : KEYREF_ATTRS) {
-                            if (e.hasAttribute(attr)) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    }));
+            builder.hasKeyref(elements.stream().anyMatch(e -> {
+                if (SUBJECTSCHEME_SUBJECTDEF.matches(e)) {
+                    return false;
+                }
+                for (final String attr : KEYREF_ATTRS) {
+                    if (e.hasAttribute(attr)) {
+                        return true;
+                    }
+                }
+                return false;
+            }));
         }
 
         return builder.build();
@@ -168,5 +166,4 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
             throw new DITAOTException("Failed to replace temporary file " + inputFile + ": " + e.getMessage(), e);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -16,23 +16,20 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.*;
 
 /**
@@ -71,14 +68,16 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
     private void parseInputParameters(final AbstractPipelineInput input) {
         final File basedir = toFile(input.getAttribute(ANT_INVOKER_PARAM_BASEDIR));
         if (input.getAttribute(ANT_INVOKER_PARAM_DITAVAL) != null) {
-            final String[] allDitavalFiles = input.getAttribute(ANT_INVOKER_PARAM_DITAVAL).split(File.pathSeparator);
+            final String[] allDitavalFiles =
+                    input.getAttribute(ANT_INVOKER_PARAM_DITAVAL).split(File.pathSeparator);
             for (final String oneDitavalFile : allDitavalFiles) {
                 logger.debug("Evaluating ditaval: " + oneDitavalFile);
                 final URI ditavalInput = toURI(oneDitavalFile);
                 URI usingDitavalInput;
                 if (ditavalInput.isAbsolute()) {
                     usingDitavalInput = ditavalInput;
-                } else if (ditavalInput.getPath() != null && ditavalInput.getPath().startsWith(URI_SEPARATOR)) {
+                } else if (ditavalInput.getPath() != null
+                        && ditavalInput.getPath().startsWith(URI_SEPARATOR)) {
                     usingDitavalInput = setScheme(ditavalInput, "file");
                 } else {
                     usingDitavalInput = basedir.toURI().resolve(ditavalInput);
@@ -86,8 +85,8 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
                 if (new File(usingDitavalInput).exists()) {
                     ditavalFiles.add(new File(usingDitavalInput));
                 } else {
-                    logger.error(
-                            MessageUtils.getMessage("DOTJ071E", usingDitavalInput.toString()).toString());
+                    logger.error(MessageUtils.getMessage("DOTJ071E", usingDitavalInput.toString())
+                            .toString());
                 }
             }
         }
@@ -104,7 +103,8 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
         final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
         ditavalbuilder.setEntityResolver(CatalogUtils.getCatalogResolver());
         XMLStreamWriter export = null;
-        try (OutputStream exportStream = job.getStore().getOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL).toURI())) {
+        try (OutputStream exportStream =
+                job.getStore().getOutputStream(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL).toURI())) {
             export = XMLOutputFactory.newInstance().createXMLStreamWriter(exportStream, "UTF-8");
             export.writeStartDocument();
             export.writeStartElement("val");
@@ -133,7 +133,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
                 }
             }
         }
-
     }
 
     private void writeConditions(XMLStreamWriter export, NodeList conditionElements, URI ditavalDirectory) {
@@ -155,19 +154,27 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
                                 }
                             }
                         }
-                        if (atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null ||
-                                atts.getNamedItem(ATTRIBUTE_NAME_IMG) != null) {
-                            final String imagerefAtt = atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null ?
-                                    atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF).getNodeValue() :    // DITA 1.1 and later: use @imageref on <startflag>, <endflag>
-                                    atts.getNamedItem(ATTRIBUTE_NAME_IMG).getNodeValue();          // Pre-DITA 1.1: use @img on <prop>
+                        if (atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null
+                                || atts.getNamedItem(ATTRIBUTE_NAME_IMG) != null) {
+                            final String imagerefAtt = atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF) != null
+                                    ? atts.getNamedItem(ATTRIBUTE_NAME_IMAGEREF).getNodeValue()
+                                    : // DITA 1.1 and later: use @imageref on <startflag>, <endflag>
+                                    atts.getNamedItem(ATTRIBUTE_NAME_IMG)
+                                            .getNodeValue(); // Pre-DITA 1.1: use @img on <prop>
                             if (toURI(imagerefAtt).isAbsolute()) {
-                                export.writeAttribute(DITA_OT_NS_PREFIX, DITA_OT_NAMESPACE, ATTRIBUTE_NAME_IMAGEREF_URI, imagerefAtt);
+                                export.writeAttribute(
+                                        DITA_OT_NS_PREFIX, DITA_OT_NAMESPACE, ATTRIBUTE_NAME_IMAGEREF_URI, imagerefAtt);
                             } else {
-                                export.writeAttribute(DITA_OT_NS_PREFIX, DITA_OT_NAMESPACE, ATTRIBUTE_NAME_IMAGEREF_URI, ditavalDirectory.resolve(imagerefAtt).toString());
+                                export.writeAttribute(
+                                        DITA_OT_NS_PREFIX,
+                                        DITA_OT_NAMESPACE,
+                                        ATTRIBUTE_NAME_IMAGEREF_URI,
+                                        ditavalDirectory.resolve(imagerefAtt).toString());
                             }
                         }
                         for (int j = 0; j < atts.getLength(); j++) {
-                            export.writeAttribute(atts.item(j).getNodeName(), atts.item(j).getNodeValue());
+                            export.writeAttribute(
+                                    atts.item(j).getNodeName(), atts.item(j).getNodeValue());
                         }
                         writeConditions(export, node.getChildNodes(), ditavalDirectory);
                         export.writeEndElement();
@@ -179,5 +186,4 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
             logger.error("Failed to generate merged DITAVAL file: " + e.getMessage(), e);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/ModuleFactory.java
+++ b/src/main/java/org/dita/dost/module/ModuleFactory.java
@@ -1,16 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.MessageUtils;
 import org.dita.dost.log.MessageBean;
+import org.dita.dost.log.MessageUtils;
 
 /**
  * The factory to create instance for each module class.
@@ -24,9 +24,7 @@ public final class ModuleFactory {
     /**
      * Automatically generated constructor: ModuleFactory.
      */
-    private ModuleFactory() {
-
-    }
+    private ModuleFactory() {}
 
     /**
      * Method to get the only instance of ModuleFactory. ModuleFactory is a
@@ -57,7 +55,7 @@ public final class ModuleFactory {
             final MessageBean msgBean = MessageUtils.getMessage("DOTJ005F", moduleClass.getName());
             final String msg = msgBean.toString();
 
-            throw new DITAOTException(msgBean, e,msg);
+            throw new DITAOTException(msgBean, e, msg);
         }
     }
 }

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -1,13 +1,23 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.File;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
@@ -22,17 +32,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.*;
 
 /**
  * MoveLinksModule implements move links step in preprocess. It reads the map links
@@ -60,14 +59,15 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
         try {
             final XsltCompiler xsltCompiler = xmlUtils.getProcessor().newXsltCompiler();
 
-            final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
+            final XsltTransformer transformer =
+                    xsltCompiler.compile(new StreamSource(styleFile)).load();
             transformer.setErrorReporter(toErrorReporter(logger));
             transformer.setURIResolver(new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), job.getStore()));
             transformer.setMessageListener(toMessageListener(logger));
 
             if (input.getAttribute("include.rellinks") != null) {
-                transformer.setParameter(new QName("include.rellinks"),
-                        XdmItem.makeValue(input.getAttribute("include.rellinks")));
+                transformer.setParameter(
+                        new QName("include.rellinks"), XdmItem.makeValue(input.getAttribute("include.rellinks")));
             }
             transformer.setParameter(new QName("INPUTMAP"), XdmItem.makeValue(job.getInputMap()));
 
@@ -93,7 +93,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
             final DitaLinksWriter linkInserter = new DitaLinksWriter();
             linkInserter.setLogger(logger);
             linkInserter.setJob(job);
-            for (final Map.Entry<File, Map<String, Element>> entry: mapSet.entrySet()) {
+            for (final Map.Entry<File, Map<String, Element>> entry : mapSet.entrySet()) {
                 final URI uri = inputFile.toURI().resolve(toURI(entry.getKey().getPath()));
                 logger.info("Processing " + uri);
                 linkInserter.setLinks(entry.getValue());
@@ -133,5 +133,4 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
         }
         return map;
     }
-
 }

--- a/src/main/java/org/dita/dost/module/RewriteRule.java
+++ b/src/main/java/org/dita/dost/module/RewriteRule.java
@@ -8,9 +8,8 @@
 
 package org.dita.dost.module;
 
-import org.dita.dost.util.Job;
-
 import java.util.Collection;
+import org.dita.dost.util.Job;
 
 public interface RewriteRule {
     /**

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -7,6 +7,15 @@
  */
 package org.dita.dost.module;
 
+import static java.util.Collections.emptyMap;
+import static org.dita.dost.util.Configuration.parserFeatures;
+import static org.dita.dost.util.Configuration.parserMap;
+import static org.dita.dost.util.Constants.*;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xml.resolver.tools.CatalogResolver;
@@ -16,17 +25,6 @@ import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderFactory;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.Collections.emptyMap;
-import static org.dita.dost.util.Configuration.parserFeatures;
-import static org.dita.dost.util.Configuration.parserMap;
-import static org.dita.dost.util.Constants.*;
-
 
 /**
  * Common functionality for modules that read source documents.
@@ -47,6 +45,7 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
      * Use grammar pool cache
      */
     boolean gramcache = true;
+
     Processor processor;
 
     /**

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -7,21 +7,19 @@
  */
 package org.dita.dost.module;
 
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.XMLFilter;
-
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Map processes topics through XML filters. Filters are reused and should reset internal state on
@@ -36,8 +34,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
      * @return always returns {@code null}
      */
     @Override
-    public AbstractPipelineOutput execute(final AbstractPipelineInput input)
-            throws DITAOTException {
+    public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
         final Collection<FileInfo> fis = job.getFileInfo(fileInfoFilter);
         if (parallel) {
             fis.stream().parallel().forEach(f -> {
@@ -92,9 +89,10 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
         public final Predicate<FileInfo> predicate;
         public final Map<String, String> params;
 
-        public FilterPair(final Class<? extends AbstractXMLFilter> filterClass,
-                          final Predicate<FileInfo> fileInfoFilter,
-                          final Map<String, String> params) {
+        public FilterPair(
+                final Class<? extends AbstractXMLFilter> filterClass,
+                final Predicate<FileInfo> fileInfoFilter,
+                final Map<String, String> params) {
             this.filterClass = filterClass;
             this.predicate = fileInfoFilter;
             this.params = params;
@@ -105,10 +103,12 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
                 final AbstractXMLFilter f = filterClass.getDeclaredConstructor().newInstance();
                 params.forEach(f::setParam);
                 return f;
-            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            } catch (InstantiationException
+                    | IllegalAccessException
+                    | NoSuchMethodException
+                    | InvocationTargetException e) {
                 throw new RuntimeException(e);
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/filter/SubjectScheme.java
+++ b/src/main/java/org/dita/dost/module/filter/SubjectScheme.java
@@ -8,11 +8,10 @@
 
 package org.dita.dost.module.filter;
 
-import org.w3c.dom.Element;
-
-import javax.xml.namespace.QName;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.namespace.QName;
+import org.w3c.dom.Element;
 
 /**
  * Subject scheme bindings

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -7,16 +7,9 @@
  */
 package org.dita.dost.module.filter;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.pipeline.AbstractPipelineInput;
-import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.FilterUtils;
-import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.writer.ProfilingFilter;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.XMLFilter;
+import static java.util.Collections.singletonList;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.getChildElements;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,10 +20,16 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static java.util.Collections.singletonList;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.XMLUtils.getChildElements;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.FilterUtils;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.writer.ProfilingFilter;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.XMLFilter;
 
 /**
  * Branch filter module for topics.
@@ -50,6 +49,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
     /** Current map being processed, relative to temporary directory */
     private URI map;
+
     private final Set<URI> filtered = new HashSet<>();
 
     @Override
@@ -101,8 +101,8 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
     }
 
     /** Copy and filter topics for branches. These topics have a new name and will be added to job configuration. */
-    private void generateCopies(final Element topicref, final List<FilterUtils> filters,
-                                final SubjectScheme subjectSchemeMap) {
+    private void generateCopies(
+            final Element topicref, final List<FilterUtils> filters, final SubjectScheme subjectSchemeMap) {
         final List<FilterUtils> fs = combineFilterUtils(topicref, filters, subjectSchemeMap);
 
         final String copyTo = topicref.getAttribute(BRANCH_COPY_TO);
@@ -150,7 +150,7 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
                 topicref.setAttribute(SKIP_FILTER, Boolean.TRUE.toString());
             }
         }
-        for (final Element child: getChildElements(topicref, MAP_TOPICREF)) {
+        for (final Element child : getChildElements(topicref, MAP_TOPICREF)) {
             if (DITAVAREF_D_DITAVALREF.matches(child)) {
                 continue;
             }
@@ -159,14 +159,15 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
     }
 
     /** Modify and filter topics for branches. These files use an existing file name. */
-    private void filterTopics(final Element topicref, final List<FilterUtils> filters,
-                              final SubjectScheme subjectSchemeMap) {
+    private void filterTopics(
+            final Element topicref, final List<FilterUtils> filters, final SubjectScheme subjectSchemeMap) {
         final List<FilterUtils> fs = combineFilterUtils(topicref, filters, subjectSchemeMap);
 
         final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
         final Attr skipFilter = topicref.getAttributeNode(SKIP_FILTER);
         final URI srcAbsUri = job.tempDirURI.resolve(map.resolve(href));
-        if (!fs.isEmpty() && skipFilter == null
+        if (!fs.isEmpty()
+                && skipFilter == null
                 && !filtered.contains(srcAbsUri)
                 && !href.isEmpty()
                 && !ATTR_SCOPE_VALUE_EXTERNAL.equals(topicref.getAttribute(ATTRIBUTE_NAME_SCOPE))) {
@@ -189,12 +190,11 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
             topicref.removeAttributeNode(skipFilter);
         }
 
-        for (final Element child: getChildElements(topicref, MAP_TOPICREF)) {
+        for (final Element child : getChildElements(topicref, MAP_TOPICREF)) {
             if (DITAVAREF_D_DITAVALREF.matches(child)) {
                 continue;
             }
             filterTopics(child, fs, subjectSchemeMap);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/reader/DefaultTempFileScheme.java
+++ b/src/main/java/org/dita/dost/module/reader/DefaultTempFileScheme.java
@@ -8,20 +8,22 @@
 
 package org.dita.dost.module.reader;
 
-import java.net.URI;
-
 import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
 
 public class DefaultTempFileScheme implements TempFileNameScheme {
     URI b;
+
     @Override
     public void setBaseDir(final URI b) {
         this.b = b;
     }
+
     @Override
     public URI generateTempFileName(final URI src) {
         assert src.isAbsolute();
-        //final URI b = baseInputDir.toURI();
+        // final URI b = baseInputDir.toURI();
         final URI rel = toURI(b.relativize(src).toString());
         return rel;
     }

--- a/src/main/java/org/dita/dost/module/reader/FlattenTempFileScheme.java
+++ b/src/main/java/org/dita/dost/module/reader/FlattenTempFileScheme.java
@@ -8,16 +8,14 @@
 
 package org.dita.dost.module.reader;
 
-import java.net.URI;
-
 import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
 
 public class FlattenTempFileScheme implements TempFileNameScheme {
     @Override
     public URI generateTempFileName(final URI src) {
         assert src.isAbsolute();
-        return toURI(src.getPath().substring(1)
-                .replaceAll("[/\\\\]", "__")
-                .replaceAll("\\s+", "-"));
+        return toURI(src.getPath().substring(1).replaceAll("[/\\\\]", "__").replaceAll("\\s+", "-"));
     }
 }

--- a/src/main/java/org/dita/dost/module/reader/FullPathTempFileScheme.java
+++ b/src/main/java/org/dita/dost/module/reader/FullPathTempFileScheme.java
@@ -8,9 +8,9 @@
 
 package org.dita.dost.module.reader;
 
-import java.net.URI;
-
 import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
 
 public class FullPathTempFileScheme implements TempFileNameScheme {
     @Override

--- a/src/main/java/org/dita/dost/module/reader/HashTempFileScheme.java
+++ b/src/main/java/org/dita/dost/module/reader/HashTempFileScheme.java
@@ -8,14 +8,13 @@
 
 package org.dita.dost.module.reader;
 
-import com.google.common.base.Charsets;
-import com.google.common.hash.Hashing;
-import org.apache.commons.io.FilenameUtils;
-
-import java.net.URI;
-
 import static org.dita.dost.util.URLUtils.stripFragment;
 import static org.dita.dost.util.URLUtils.toURI;
+
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
+import java.net.URI;
+import org.apache.commons.io.FilenameUtils;
 
 public class HashTempFileScheme implements TempFileNameScheme {
     @Override
@@ -23,9 +22,7 @@ public class HashTempFileScheme implements TempFileNameScheme {
         assert src.isAbsolute();
         final String ext = FilenameUtils.getExtension(src.getPath());
         final String path = stripFragment(src.normalize()).toString();
-        final String hash = Hashing.sha1()
-                .hashString(path, Charsets.UTF_8)
-                .toString();
+        final String hash = Hashing.sha1().hashString(path, Charsets.UTF_8).toString();
         return toURI(ext.isEmpty() ? hash : (hash + "." + ext));
     }
 }

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -8,6 +8,13 @@
 
 package org.dita.dost.module.reader;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.exists;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
@@ -20,14 +27,6 @@ import org.dita.dost.writer.ProfilingFilter;
 import org.dita.dost.writer.ValidationFilter;
 import org.xml.sax.XMLFilter;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.exists;
-
 /**
  * ModuleElem for reading and serializing topics into temporary directory.
  *
@@ -37,7 +36,8 @@ public final class MapReaderModule extends AbstractReaderModule {
 
     public MapReaderModule() {
         super();
-        formatFilter = v -> Objects.equals(v, ATTR_FORMAT_VALUE_DITAMAP) || Objects.equals(v, ATTR_FORMAT_VALUE_DITAVAL);
+        formatFilter =
+                v -> Objects.equals(v, ATTR_FORMAT_VALUE_DITAMAP) || Objects.equals(v, ATTR_FORMAT_VALUE_DITAVAL);
     }
 
     @Override
@@ -123,19 +123,19 @@ public final class MapReaderModule extends AbstractReaderModule {
             return;
         }
         // Ignore topics
-//        if (formatFilter.test(file.format)) {
+        //        if (formatFilter.test(file.format)) {
         switch (file.format) {
             case ATTR_FORMAT_VALUE_DITAMAP -> addToWaitList(file);
             case ATTR_FORMAT_VALUE_IMAGE -> {
                 formatSet.add(file);
                 if (!exists(file.filename)) {
-                    logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
+                    logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString())
+                            .toString());
                 }
             }
             case ATTR_FORMAT_VALUE_DITAVAL -> formatSet.add(file);
             default -> htmlSet.put(file.format, file.filename);
         }
-//        }
+        //        }
     }
-
 }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -8,6 +8,21 @@
 
 package org.dita.dost.module.reader;
 
+import static net.sf.saxon.s9api.streams.Steps.descendant;
+import static org.dita.dost.reader.GenListModuleReader.isFormatDita;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.DitaUtils.isLocalScope;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.ancestors;
+import static org.dita.dost.util.XMLUtils.toList;
+import static org.dita.dost.writer.DitaWriterFilter.ATTRIBUTE_NAME_ORIG_FORMAT;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
@@ -30,22 +45,6 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Predicate;
-
-import static net.sf.saxon.s9api.streams.Steps.descendant;
-import static org.dita.dost.reader.GenListModuleReader.isFormatDita;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.DitaUtils.isLocalScope;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.ancestors;
-import static org.dita.dost.util.XMLUtils.toList;
-import static org.dita.dost.writer.DitaWriterFilter.ATTRIBUTE_NAME_ORIG_FORMAT;
-
 /**
  * ModuleElem for reading and serializing topics into temporary directory.
  *
@@ -61,7 +60,8 @@ public final class TopicReaderModule extends AbstractReaderModule {
 
     public TopicReaderModule() {
         super();
-        formatFilter = v -> !(Objects.equals(v, ATTR_FORMAT_VALUE_DITAMAP) || Objects.equals(v, ATTR_FORMAT_VALUE_DITAVAL));
+        formatFilter =
+                v -> !(Objects.equals(v, ATTR_FORMAT_VALUE_DITAMAP) || Objects.equals(v, ATTR_FORMAT_VALUE_DITAVAL));
     }
 
     @Override
@@ -98,7 +98,8 @@ public final class TopicReaderModule extends AbstractReaderModule {
                 subjectSchemeReader.setLogger(logger);
                 subjectSchemeReader.setJob(job);
                 logger.debug("Loading subject schemes");
-                final List<Element> subjectSchemes = toList(doc.getDocumentElement().getElementsByTagName("*"));
+                final List<Element> subjectSchemes =
+                        toList(doc.getDocumentElement().getElementsByTagName("*"));
                 subjectSchemes.stream()
                         .filter(SUBJECTSCHEME_ENUMERATIONDEF::matches)
                         .forEach(enumerationDef -> {
@@ -190,7 +191,8 @@ public final class TopicReaderModule extends AbstractReaderModule {
         try {
             final XdmNode source = job.getStore().getImmutableNode(tmp);
             logger.info("Reading " + tmp);
-            final Predicate<? super XdmNode> isTopicref = xdmItem -> MAP_TOPICREF.matches(xdmItem.getAttributeValue(QNAME_CLASS));
+            final Predicate<? super XdmNode> isTopicref =
+                    xdmItem -> MAP_TOPICREF.matches(xdmItem.getAttributeValue(QNAME_CLASS));
             source.select(descendant(isTopicref)).forEach(xdmItem -> {
                 final URI href = getHref(xdmItem);
                 if (href != null) {
@@ -284,18 +286,23 @@ public final class TopicReaderModule extends AbstractReaderModule {
             return;
         }
         if (formatFilter.test(file.format)) {
-            if (isFormatDita(file.format) && !job.crawlTopics() &&
-                    !listFilter.getConrefTargets().contains(file.filename)) {
-                return;  // Do not process topics linked from within topics
-            } else if (isFormatDita(file.format) && (!job.getOnlyTopicInMap() || listFilter.getConrefTargets().contains(file.filename))) {
+            if (isFormatDita(file.format)
+                    && !job.crawlTopics()
+                    && !listFilter.getConrefTargets().contains(file.filename)) {
+                return; // Do not process topics linked from within topics
+            } else if (isFormatDita(file.format)
+                    && (!job.getOnlyTopicInMap()
+                            || listFilter.getConrefTargets().contains(file.filename))) {
                 addToWaitList(file);
             } else if (ATTR_FORMAT_VALUE_IMAGE.equals(file.format)) {
                 formatSet.add(file);
                 if (!exists(file.filename)) {
                     if (processingMode == Configuration.Mode.STRICT) {
-                        throw new UncheckedDITAOTException(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toException());
+                        throw new UncheckedDITAOTException(MessageUtils.getMessage("DOTX008E", file.filename.toString())
+                                .toException());
                     } else {
-                        logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString()).toString());
+                        logger.warn(MessageUtils.getMessage("DOTX008E", file.filename.toString())
+                                .toString());
                     }
                 }
             } else {

--- a/src/main/java/org/dita/dost/module/saxon/DelegatingCollationUriResolver.java
+++ b/src/main/java/org/dita/dost/module/saxon/DelegatingCollationUriResolver.java
@@ -9,15 +9,13 @@ import net.sf.saxon.lib.CollationURIResolver;
  *
  */
 public interface DelegatingCollationUriResolver extends CollationURIResolver {
-  
-  /**
-   * Sets the base resolver to delegate to if the resolver does not
-   * handle the specified URI. This allows multiple plugins to 
-   * contribute collation URI resolvers.
-   * 
-   * @param baseResolver The resolver to delegate to.
-   */
-  public void setBaseResolver(CollationURIResolver baseResolver);
-  
 
+    /**
+     * Sets the base resolver to delegate to if the resolver does not
+     * handle the specified URI. This allows multiple plugins to
+     * contribute collation URI resolvers.
+     *
+     * @param baseResolver The resolver to delegate to.
+     */
+    public void setBaseResolver(CollationURIResolver baseResolver);
 }

--- a/src/main/java/org/dita/dost/pipeline/AbstractPipelineInput.java
+++ b/src/main/java/org/dita/dost/pipeline/AbstractPipelineInput.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.pipeline;
 
 import java.util.Map;
@@ -41,5 +41,4 @@ public interface AbstractPipelineInput {
      * @return Map of attribute values, empty Map is no attributes have been defined.
      */
     Map<String, String> getAttributes();
-
 }

--- a/src/main/java/org/dita/dost/pipeline/AbstractPipelineOutput.java
+++ b/src/main/java/org/dita/dost/pipeline/AbstractPipelineOutput.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.pipeline;
 
 /**
@@ -15,6 +15,4 @@ package org.dita.dost.pipeline;
  * @deprecated Deprecated since 2.3
  */
 @Deprecated
-public interface AbstractPipelineOutput {
-
-}
+public interface AbstractPipelineOutput {}

--- a/src/main/java/org/dita/dost/pipeline/PipelineHashIO.java
+++ b/src/main/java/org/dita/dost/pipeline/PipelineHashIO.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.pipeline;
 
 import java.util.HashMap;
@@ -20,10 +20,8 @@ import java.util.Map;
  * @deprecated use {@link java.util.Map} instead. Deprecated since 2.3
  */
 @Deprecated
-public final class PipelineHashIO implements AbstractPipelineInput,
-AbstractPipelineOutput {
+public final class PipelineHashIO implements AbstractPipelineInput, AbstractPipelineOutput {
     private final Map<String, String> hash;
-
 
     /**
      * Default contructor of PipelineHashIO class.
@@ -40,7 +38,6 @@ AbstractPipelineOutput {
         super();
         this.hash = new HashMap<>(hash);
     }
-
 
     /**
      * Set the attribute vale with name into hash map.

--- a/src/main/java/org/dita/dost/platform/Alias.java
+++ b/src/main/java/org/dita/dost/platform/Alias.java
@@ -11,5 +11,4 @@ package org.dita.dost.platform;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Alias(String alias) {
-}
+public record Alias(String alias) {}

--- a/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/CheckTranstypeAction.java
@@ -1,18 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
 
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
-import static javax.xml.XMLConstants.NULL_NS_URI;
 /**
  * CheckTranstypeAction class.
  *
@@ -25,16 +26,19 @@ final class CheckTranstypeAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String property = paramTable.getOrDefault("property", "transtype");
-        for (final Value value: valueSet) {
+        for (final Value value : valueSet) {
             buf.startElement(NULL_NS_URI, "not", "not", new AttributesBuilder().build());
-            buf.startElement(NULL_NS_URI, "equals", "equals", new AttributesBuilder()
-                .add("arg1", "${" + property + "}")
-                .add("arg2", value.value())
-                .add("casesensitive", "false")
-                .build());
+            buf.startElement(
+                    NULL_NS_URI,
+                    "equals",
+                    "equals",
+                    new AttributesBuilder()
+                            .add("arg1", "${" + property + "}")
+                            .add("arg2", value.value())
+                            .add("casesensitive", "false")
+                            .build());
             buf.endElement(NULL_NS_URI, "equals", "equals");
             buf.endElement(NULL_NS_URI, "not", "not");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/CustomIntegrator.java
+++ b/src/main/java/org/dita/dost/platform/CustomIntegrator.java
@@ -8,9 +8,8 @@
 
 package org.dita.dost.platform;
 
-import org.dita.dost.log.DITAOTLogger;
-
 import java.io.File;
+import org.dita.dost.log.DITAOTLogger;
 
 /**
  * Custom integration processor.

--- a/src/main/java/org/dita/dost/platform/ExtensionPoint.java
+++ b/src/main/java/org/dita/dost/platform/ExtensionPoint.java
@@ -4,7 +4,7 @@
  * Copyright 2011 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
- */package org.dita.dost.platform;
+ */ package org.dita.dost.platform;
 
 /**
  * Extension point.
@@ -40,5 +40,4 @@ final class ExtensionPoint {
         this.name = name;
         this.plugin = plugin;
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/Features.java
+++ b/src/main/java/org/dita/dost/platform/Features.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
 import java.io.File;
@@ -17,10 +17,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-
-import org.w3c.dom.Element;
-
 import org.dita.dost.util.FileUtils;
+import org.w3c.dom.Element;
 
 /**
  * Collection of features.

--- a/src/main/java/org/dita/dost/platform/IAction.java
+++ b/src/main/java/org/dita/dost/platform/IAction.java
@@ -1,16 +1,15 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
 import java.util.List;
 import java.util.Map;
-
 import org.dita.dost.log.DITAOTLogger;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;

--- a/src/main/java/org/dita/dost/platform/ImportAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAction.java
@@ -1,18 +1,17 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
+import java.util.*;
 import org.dita.dost.log.DITAOTLogger;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import java.util.*;
 
 /**
  * ImportAction implements IAction and import the resource
@@ -25,6 +24,7 @@ abstract class ImportAction implements IAction {
     final Set<Value> valueSet;
     /** Action parameters. */
     final Hashtable<String, String> paramTable;
+
     DITAOTLogger logger;
     /** Plug-in features. */
     Map<String, Features> featureTable = null;
@@ -74,5 +74,4 @@ abstract class ImportAction implements IAction {
     public void setLogger(final DITAOTLogger logger) {
         this.logger = logger;
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportAntAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntAction.java
@@ -1,19 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2017 Jarno Elovirta
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2017 Jarno Elovirta
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
 
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
 
 /**
  * Ant import task.
@@ -27,16 +27,19 @@ final class ImportAntAction extends ImportAction {
      */
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
-        for (final Value value: valueSet) {
+        for (final Value value : valueSet) {
             final String[] tokens = value.value().split("[/\\\\]", 2);
             buf.startElement(NULL_NS_URI, "import", "import", XMLUtils.EMPTY_ATTRIBUTES);
-            buf.startElement(NULL_NS_URI, "fileset", "fileset", new AttributesBuilder()
-                    .add("dir", tokens[0])
-                    .add("includes", tokens[1])
-                    .build());
+            buf.startElement(
+                    NULL_NS_URI,
+                    "fileset",
+                    "fileset",
+                    new AttributesBuilder()
+                            .add("dir", tokens[0])
+                            .add("includes", tokens[1])
+                            .build());
             buf.endElement(NULL_NS_URI, "fileset", "fileset");
             buf.endElement(NULL_NS_URI, "import", "import");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportAntLibAction.java
@@ -1,19 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.XMLUtils.AttributesBuilder;
 
 import org.dita.dost.util.FileUtils;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.XMLUtils.AttributesBuilder;
 
 /**
  * ImportAntLibAction class.
@@ -27,21 +27,26 @@ final class ImportAntLibAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler retBuf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final Value value: valueSet) {
+        for (final Value value : valueSet) {
             final String resolvedValue = FileUtils.getRelativeUnixPath(templateFilePath, value.value());
             if (FileUtils.isAbsolutePath(resolvedValue)) {
                 // if resolvedValue is absolute path
-                retBuf.startElement(NULL_NS_URI, "pathelement", "pathelement", new AttributesBuilder()
-                    .add("location", resolvedValue)
-                    .build());
+                retBuf.startElement(
+                        NULL_NS_URI,
+                        "pathelement",
+                        "pathelement",
+                        new AttributesBuilder().add("location", resolvedValue).build());
                 retBuf.endElement(NULL_NS_URI, "pathelement", "pathelement");
-            } else {// if resolvedValue is relative path
-                retBuf.startElement(NULL_NS_URI, "pathelement", "pathelement", new AttributesBuilder()
-                    .add("location", "${dita.dir}${file.separator}" + resolvedValue)
-                    .build());
+            } else { // if resolvedValue is relative path
+                retBuf.startElement(
+                        NULL_NS_URI,
+                        "pathelement",
+                        "pathelement",
+                        new AttributesBuilder()
+                                .add("location", "${dita.dir}${file.separator}" + resolvedValue)
+                                .build());
                 retBuf.endElement(NULL_NS_URI, "pathelement", "pathelement");
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/ImportCatalogActionRelative.java
@@ -7,12 +7,12 @@
  */
 package org.dita.dost.platform;
 
+import static org.dita.dost.util.Constants.OASIS_CATALOG_NAMESPACE;
+
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import static org.dita.dost.util.Constants.OASIS_CATALOG_NAMESPACE;
 
 /**
  * Import catalog file references.
@@ -25,12 +25,15 @@ final class ImportCatalogActionRelative extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final Value value: valueSet) {
-            buf.startElement(OASIS_CATALOG_NAMESPACE, "nextCatalog", "nextCatalog", new AttributesBuilder()
-                .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value.value()))
-                .build());
+        for (final Value value : valueSet) {
+            buf.startElement(
+                    OASIS_CATALOG_NAMESPACE,
+                    "nextCatalog",
+                    "nextCatalog",
+                    new AttributesBuilder()
+                            .add("catalog", FileUtils.getRelativeUnixPath(templateFilePath, value.value()))
+                            .build());
             buf.endElement(OASIS_CATALOG_NAMESPACE, "nextCatalog", "nextCatalog");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportPluginCatalogAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportPluginCatalogAction.java
@@ -12,7 +12,6 @@ import static org.dita.dost.util.Constants.*;
 import java.io.File;
 import java.util.List;
 import java.util.Map.Entry;
-
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
@@ -35,7 +34,7 @@ final class ImportPluginCatalogAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final File basePluginDir = featureTable.get("org.dita.base").getPluginDir();
-        for (final Entry<String, Features> e: featureTable.entrySet()) {
+        for (final Entry<String, Features> e : featureTable.entrySet()) {
             final Features f = e.getValue();
             final String name = PLUGIN_URI_SCHEME + ":" + e.getKey() + ":";
             final StringBuilder location = new StringBuilder();
@@ -43,23 +42,28 @@ final class ImportPluginCatalogAction extends ImportAction {
             final List<String> baseDirValues = f.getFeature("dita.basedir-resource-directory");
             if (Boolean.parseBoolean(baseDirValues == null || baseDirValues.isEmpty() ? null : baseDirValues.get(0))) {
                 location.append("./");
-            } else if (f.getPluginDir().getAbsolutePath().startsWith(f.getDitaDir().getAbsolutePath())) {
-                location.append(
-                        FileUtils.getRelativeUnixPath(
-                                new File(basePluginDir, "plugin.xml").toURI().toString(),
-                                f.getPluginDir().toURI().toString()));
+            } else if (f.getPluginDir()
+                    .getAbsolutePath()
+                    .startsWith(f.getDitaDir().getAbsolutePath())) {
+                location.append(FileUtils.getRelativeUnixPath(
+                        new File(basePluginDir, "plugin.xml").toURI().toString(),
+                        f.getPluginDir().toURI().toString()));
             } else {
                 location.append(f.getPluginDir().toURI());
             }
-            if (location.length() > 0 && !location.substring(location.length() - 1).equals(UNIX_SEPARATOR)) {
+            if (location.length() > 0
+                    && !location.substring(location.length() - 1).equals(UNIX_SEPARATOR)) {
                 location.append(UNIX_SEPARATOR);
             }
-            buf.startElement(OASIS_CATALOG_NAMESPACE, "rewriteURI", "rewriteURI", new AttributesBuilder()
-                .add("uriStartString", name)
-                .add("rewritePrefix", location.toString())
-                .build());
+            buf.startElement(
+                    OASIS_CATALOG_NAMESPACE,
+                    "rewriteURI",
+                    "rewriteURI",
+                    new AttributesBuilder()
+                            .add("uriStartString", name)
+                            .add("rewritePrefix", location.toString())
+                            .build());
             buf.endElement(OASIS_CATALOG_NAMESPACE, "rewriteURI", "rewriteURI");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportPluginInfoAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportPluginInfoAction.java
@@ -13,7 +13,6 @@ import static org.dita.dost.util.Constants.*;
 import java.io.File;
 import java.util.List;
 import java.util.Map.Entry;
-
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
@@ -34,28 +33,34 @@ final class ImportPluginInfoAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         // plugin properties
-        for (final Entry<String, Features> e: featureTable.entrySet()) {
+        for (final Entry<String, Features> e : featureTable.entrySet()) {
             final Features f = e.getValue();
-            final String name = "dita.plugin."+ e.getKey() + ".dir";
+            final String name = "dita.plugin." + e.getKey() + ".dir";
             final StringBuilder location = new StringBuilder();
 
             final List<String> baseDirValues = f.getFeature("dita.basedir-resource-directory");
             if (Boolean.parseBoolean(baseDirValues == null || baseDirValues.isEmpty() ? null : baseDirValues.get(0))) {
                 location.append("${dita.dir}");
-            } else if (f.getPluginDir().getAbsolutePath().startsWith(f.getDitaDir().getAbsolutePath())) {
-                location.append("${dita.dir}").append(UNIX_SEPARATOR)
-                .append(FileUtils.getRelativeUnixPath(
-                        new File(f.getDitaDir(), "plugin.xml").getAbsolutePath(),
-                        f.getPluginDir().getAbsolutePath()));
+            } else if (f.getPluginDir()
+                    .getAbsolutePath()
+                    .startsWith(f.getDitaDir().getAbsolutePath())) {
+                location.append("${dita.dir}")
+                        .append(UNIX_SEPARATOR)
+                        .append(FileUtils.getRelativeUnixPath(
+                                new File(f.getDitaDir(), "plugin.xml").getAbsolutePath(),
+                                f.getPluginDir().getAbsolutePath()));
             } else {
                 location.append(f.getPluginDir().getAbsolutePath());
             }
-            buf.startElement(NULL_NS_URI, "property", "property", new AttributesBuilder()
-                .add("name", name)
-                .add("location", location.toString())
-                .build());
+            buf.startElement(
+                    NULL_NS_URI,
+                    "property",
+                    "property",
+                    new AttributesBuilder()
+                            .add("name", name)
+                            .add("location", location.toString())
+                            .build());
             buf.endElement(NULL_NS_URI, "property", "property");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportStringsAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportStringsAction.java
@@ -1,19 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
 
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
 
 /**
  * ImportStringsAction class.
@@ -27,12 +27,12 @@ final class ImportStringsAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String templateFilePath = paramTable.get(FileGenerator.PARAM_TEMPLATE);
-        for (final Value value: valueSet) {
+        for (final Value value : valueSet) {
             buf.startElement(NULL_NS_URI, "stringfile", "stringfile", new AttributesBuilder().build());
-            final char[] location =  FileUtils.getRelativeUnixPath(templateFilePath, value.value()).toCharArray();
+            final char[] location = FileUtils.getRelativeUnixPath(templateFilePath, value.value())
+                    .toCharArray();
             buf.characters(location, 0, location.length);
             buf.endElement(NULL_NS_URI, "stringfile", "stringfile");
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/ImportXSLAction.java
+++ b/src/main/java/org/dita/dost/platform/ImportXSLAction.java
@@ -1,20 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
+import java.net.URI;
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.URLUtils;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import java.net.URI;
 
 /**
  * ImportXSLAction class.
@@ -27,11 +26,13 @@ final class ImportXSLAction extends ImportAction {
      */
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
-        for (final Value value: valueSet) {
+        for (final Value value : valueSet) {
             final URI href = getHref(value);
-            buf.startElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import", new AttributesBuilder()
-                .add("href", href.toString())
-                .build());
+            buf.startElement(
+                    "http://www.w3.org/1999/XSL/Transform",
+                    "import",
+                    "xsl:import",
+                    new AttributesBuilder().add("href", href.toString()).build());
             buf.endElement("http://www.w3.org/1999/XSL/Transform", "import", "xsl:import");
         }
     }
@@ -46,5 +47,4 @@ final class ImportXSLAction extends ImportAction {
         }
         return URI.create("plugin:" + value.id() + ":" + template);
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/InsertAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertAction.java
@@ -1,24 +1,23 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.*;
+import javax.xml.parsers.SAXParserFactory;
 import org.dita.dost.log.DITAOTLogger;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;
-
-import javax.xml.parsers.SAXParserFactory;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.*;
 
 /**
  * InsertAction implements IAction and insert the resource
@@ -83,8 +82,7 @@ class InsertAction extends XMLFilterImpl implements IAction {
     }
 
     @Override
-    public void setFeatures(final Map<String, Features> h) {
-    }
+    public void setFeatures(final Map<String, Features> h) {}
 
     @Override
     public void setLogger(final DITAOTLogger logger) {
@@ -94,30 +92,31 @@ class InsertAction extends XMLFilterImpl implements IAction {
     // XMLFilter methods
 
     @Override
-    public void startPrefixMapping (String prefix, String uri) throws SAXException {
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
         if (elemLevel != 0) {
             getContentHandler().startPrefixMapping(prefix, uri);
         }
     }
 
     @Override
-    public void endPrefixMapping (String prefix) throws SAXException {
+    public void endPrefixMapping(String prefix) throws SAXException {
         if (elemLevel != 0) {
             getContentHandler().endPrefixMapping(prefix);
         }
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+            throws SAXException {
         if (elemLevel != 0) {
             getContentHandler().startElement(uri, localName, qName, attributes);
         }
-        elemLevel ++;
+        elemLevel++;
     }
 
     @Override
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-        elemLevel --;
+        elemLevel--;
         if (elemLevel != 0) {
             getContentHandler().endElement(uri, localName, qName);
         }
@@ -133,5 +132,4 @@ class InsertAction extends XMLFilterImpl implements IAction {
     public void endDocument() throws SAXException {
         // suppress
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/InsertAntActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/InsertAntActionRelative.java
@@ -1,17 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.dita.dost.util.FileUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -30,14 +29,15 @@ import org.xml.sax.helpers.AttributesImpl;
 final class InsertAntActionRelative extends InsertAction {
 
     private static final Map<String, String> relativeAttrs = new HashMap<>();
+
     static {
         relativeAttrs.put("import", "file");
         relativeAttrs.put("lang", "filename");
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes attributes) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+            throws SAXException {
         final AttributesImpl attrBuf = new AttributesImpl();
 
         final int attLen = attributes.getLength();
@@ -47,17 +47,18 @@ final class InsertAntActionRelative extends InsertAction {
                     && relativeAttrs.get(localName).equals(attributes.getQName(i))
                     && !FileUtils.isAbsolutePath(attributes.getValue(i))) {
                 // Rewrite file path to be local to its final resting place.
-                final File targetFile = new File(
-                        new File(currentFile).getParentFile(),
-                        attributes.getValue(i));
+                final File targetFile = new File(new File(currentFile).getParentFile(), attributes.getValue(i));
                 value = FileUtils.getRelativeUnixPath(
-                        paramTable.get(FileGenerator.PARAM_TEMPLATE),
-                        targetFile.toString());
+                        paramTable.get(FileGenerator.PARAM_TEMPLATE), targetFile.toString());
             } else {
                 value = attributes.getValue(i);
             }
-            attrBuf.addAttribute(attributes.getURI(i), attributes.getLocalName(i),
-                    attributes.getQName(i), attributes.getType(i), value);
+            attrBuf.addAttribute(
+                    attributes.getURI(i),
+                    attributes.getLocalName(i),
+                    attributes.getQName(i),
+                    attributes.getType(i),
+                    value);
         }
 
         super.startElement(uri, localName, qName, attrBuf);

--- a/src/main/java/org/dita/dost/platform/InsertCatalogActionRelative.java
+++ b/src/main/java/org/dita/dost/platform/InsertCatalogActionRelative.java
@@ -1,22 +1,20 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
 
 import static org.dita.dost.util.Constants.COLON;
 
 import java.io.File;
-
 import org.dita.dost.util.FileUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
-
 
 /**
  * InsertCatalogActionRelative inserts the children of the root element of an XML document
@@ -35,8 +33,8 @@ import org.xml.sax.helpers.AttributesImpl;
 final class InsertCatalogActionRelative extends InsertAction {
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes attributes) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+            throws SAXException {
         final AttributesImpl attrBuf = new AttributesImpl();
 
         final int attLen = attributes.getLength();
@@ -44,46 +42,61 @@ final class InsertCatalogActionRelative extends InsertAction {
             String value;
             final File targetFile = new File(new File(currentFile).getParentFile(), attributes.getValue(i));
             final int index = attributes.getIndex("xml:base");
-            if ((("public".equals(localName) ||
-                    "system".equals(localName) ||
-                    "uri".equals(localName)) && "uri".equals(attributes.getQName(i)) ||
-                    ("nextCatalog".equals(localName) ||
-                            "delegateURI".equals(localName) ||
-                            "delegateSystem".equals(localName) ||
-                            "delegatePublic".equals(localName)) && "catalog".equals(attributes.getQName(i)) ||
-                            ("rewriteSystem".equals(localName) ||
-                                    "rewriteURI".equals(localName)) && "rewritePrefix".equals(attributes.getQName(i)))
-                                    && !attributes.getValue(i).contains(COLON)) {
+            if ((("public".equals(localName) || "system".equals(localName) || "uri".equals(localName))
+                                    && "uri".equals(attributes.getQName(i))
+                            || ("nextCatalog".equals(localName)
+                                            || "delegateURI".equals(localName)
+                                            || "delegateSystem".equals(localName)
+                                            || "delegatePublic".equals(localName))
+                                    && "catalog".equals(attributes.getQName(i))
+                            || ("rewriteSystem".equals(localName) || "rewriteURI".equals(localName))
+                                    && "rewritePrefix".equals(attributes.getQName(i)))
+                    && !attributes.getValue(i).contains(COLON)) {
                 // Rewrite URI to be local to its final resting place.
                 if (index == -1) {
-                    //If there are no xml:base attributes, then we need to split
+                    // If there are no xml:base attributes, then we need to split
                     final String path = FileUtils.getFullPathNoEndSeparator(FileUtils.getRelativeUnixPath(
-                            paramTable.get(FileGenerator.PARAM_TEMPLATE),
-                            targetFile.toString())) + "/";
+                                    paramTable.get(FileGenerator.PARAM_TEMPLATE), targetFile.toString()))
+                            + "/";
                     final String filename = FileUtils.getName(FileUtils.getRelativeUnixPath(
-                            paramTable.get(FileGenerator.PARAM_TEMPLATE),
-                            targetFile.toString()));
-                    attrBuf.addAttribute("http://www.w3.org/XML/1998/namespace", "base",
-                            "xml:base", attributes.getType(i), path);
-                    attrBuf.addAttribute(attributes.getURI(i), attributes.getLocalName(i),
-                            attributes.getQName(i), attributes.getType(i), filename);
+                            paramTable.get(FileGenerator.PARAM_TEMPLATE), targetFile.toString()));
+                    attrBuf.addAttribute(
+                            "http://www.w3.org/XML/1998/namespace", "base", "xml:base", attributes.getType(i), path);
+                    attrBuf.addAttribute(
+                            attributes.getURI(i),
+                            attributes.getLocalName(i),
+                            attributes.getQName(i),
+                            attributes.getType(i),
+                            filename);
                 } else {
-                    //If there is an xml:base attribute, then we do nothing.
+                    // If there is an xml:base attribute, then we do nothing.
                     value = attributes.getValue(i);
-                    attrBuf.addAttribute(attributes.getURI(i), attributes.getLocalName(i),
-                            attributes.getQName(i), attributes.getType(i), value);
+                    attrBuf.addAttribute(
+                            attributes.getURI(i),
+                            attributes.getLocalName(i),
+                            attributes.getQName(i),
+                            attributes.getType(i),
+                            value);
                 }
             } else if (i == index) {
-                //We've found xml:base.  Need to add parent plugin directory to the original value.
+                // We've found xml:base.  Need to add parent plugin directory to the original value.
                 value = FileUtils.getFullPathNoEndSeparator(FileUtils.getRelativeUnixPath(
-                        paramTable.get(FileGenerator.PARAM_TEMPLATE),
-                        targetFile.toString())) + "/" + attributes.getValue(i);
-                attrBuf.addAttribute(attributes.getURI(i), attributes.getLocalName(i),
-                        attributes.getQName(i), attributes.getType(i), value);
+                                paramTable.get(FileGenerator.PARAM_TEMPLATE), targetFile.toString()))
+                        + "/" + attributes.getValue(i);
+                attrBuf.addAttribute(
+                        attributes.getURI(i),
+                        attributes.getLocalName(i),
+                        attributes.getQName(i),
+                        attributes.getType(i),
+                        value);
             } else {
                 value = attributes.getValue(i);
-                attrBuf.addAttribute(attributes.getURI(i), attributes.getLocalName(i),
-                        attributes.getQName(i), attributes.getType(i), value);
+                attrBuf.addAttribute(
+                        attributes.getURI(i),
+                        attributes.getLocalName(i),
+                        attributes.getQName(i),
+                        attributes.getType(i),
+                        value);
             }
         }
 

--- a/src/main/java/org/dita/dost/platform/InsertDependsAction.java
+++ b/src/main/java/org/dita/dost/platform/InsertDependsAction.java
@@ -1,21 +1,20 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
-
-import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.util.StringUtils;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.SAXException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.util.StringUtils;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
 
 /**
  * InsertDependsAction implements IAction.
@@ -42,7 +41,7 @@ final class InsertDependsAction implements IAction {
     @Override
     public String getResult() {
         final List<String> result = new ArrayList<>();
-        for (final Value t: value) {
+        for (final Value t : value) {
             final String token = t.value().trim();
             // Pieces which are surrounded with braces are extension points.
             if (token.startsWith("{") && token.endsWith("}")) {
@@ -69,9 +68,9 @@ final class InsertDependsAction implements IAction {
     public void setInput(final List<Value> input) {
         value = input;
     }
+
     @Override
-    public void addParam(final String name, final String value) {
-    }
+    public void addParam(final String name, final String value) {}
     /**
      * Set the feature table.
      * @param h hastable
@@ -82,7 +81,5 @@ final class InsertDependsAction implements IAction {
     }
 
     @Override
-    public void setLogger(final DITAOTLogger logger) {
-    }
-
+    public void setLogger(final DITAOTLogger logger) {}
 }

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -1,47 +1,12 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.platform;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.Configuration;
-import org.dita.dost.util.FileUtils;
-import org.dita.dost.util.StringUtils;
-import org.dita.dost.util.XMLUtils;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.XMLReader;
-
-import javax.xml.XMLConstants;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.events.XMLEvent;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.stream.StreamSource;
-import java.io.*;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static javax.xml.XMLConstants.XML_NS_PREFIX;
@@ -54,6 +19,39 @@ import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.getRelativePath;
 import static org.dita.dost.util.URLUtils.toFile;
 import static org.dita.dost.util.XMLUtils.toList;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.*;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.Configuration;
+import org.dita.dost.util.FileUtils;
+import org.dita.dost.util.StringUtils;
+import org.dita.dost.util.XMLUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
 
 /**
  * Integrator is the main class to control and excute the integration of the
@@ -74,6 +72,7 @@ public final class Integrator {
     private static final String FEAT_RESOURCE_EXTENSIONS = "dita.resource.extensions";
     /** Feature name for print transformation types. */
     private static final String FEAT_PRINT_TRANSTYPES = "dita.transtype.print";
+
     private static final String FEAT_TRANSTYPES = "dita.conductor.transtype.check";
     private static final String FEAT_LIB_EXTENSIONS = "dita.conductor.lib.import";
     private static final String ELEM_PLUGINS = "plugins";
@@ -85,29 +84,39 @@ public final class Integrator {
     private static final String PARAM_VALUE_SEPARATOR = ";";
 
     private static final Set<PosixFilePermission> PERMISSIONS = ImmutableSet.<PosixFilePermission>builder()
-            .add(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
-                 PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-                 PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE)
+            .add(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.GROUP_EXECUTE,
+                    PosixFilePermission.OTHERS_READ,
+                    PosixFilePermission.OTHERS_EXECUTE)
             .build();
 
     public static final Pattern ID_PATTERN = Pattern.compile("[0-9a-zA-Z_\\-]+(?:\\.[0-9a-zA-Z_\\-]+)*");
-    public static final Pattern VERSION_PATTERN = Pattern.compile("\\d+(?:\\.\\d+(?:\\.\\d+(?:\\.[0-9a-zA-Z_\\-]+)?)?)?");
+    public static final Pattern VERSION_PATTERN =
+            Pattern.compile("\\d+(?:\\.\\d+(?:\\.\\d+(?:\\.[0-9a-zA-Z_\\-]+)?)?)?");
     public static final String CONF_PARSER_FORMAT = "parser.";
 
     /** Plugin table which contains detected plugins. */
     private final Map<String, Features> pluginTable;
+
     private final Map<String, Value> templateSet;
     private final File ditaDir;
     /** Plugin configuration file. */
     private final Set<File> descSet;
+
     private final XMLReader reader;
     private final Document pluginsDoc;
     private final PluginParser parser;
     private DITAOTLogger logger;
     private final Set<String> loadedPlugin;
     private final Hashtable<String, List<Value>> featureTable;
+
     @Deprecated
     private File propertiesFile;
+
     private final Set<String> extensionPoints;
     private final Map<String, Integer> pluginOrder = new HashMap<>();
     private Properties properties;
@@ -136,10 +145,12 @@ public final class Integrator {
             public void error(final SAXParseException e) throws SAXException {
                 throw e;
             }
+
             @Override
             public void fatalError(final SAXParseException e) throws SAXException {
                 throw e;
             }
+
             @Override
             public void warning(final SAXParseException e) throws SAXException {
                 throw e;
@@ -169,7 +180,7 @@ public final class Integrator {
                     try {
                         propertiesStream.close();
                     } catch (final IOException e) {
-                        logger.error(e.getMessage(), e) ;
+                        logger.error(e.getMessage(), e);
                     }
                 }
             }
@@ -188,7 +199,8 @@ public final class Integrator {
 
         final Set<String> pluginIgnores = new HashSet<>();
         if (properties.getProperty(CONF_PLUGIN_IGNORES) != null) {
-            pluginIgnores.addAll(Arrays.asList(properties.getProperty(CONF_PLUGIN_IGNORES).split(PARAM_VALUE_SEPARATOR)));
+            pluginIgnores.addAll(
+                    Arrays.asList(properties.getProperty(CONF_PLUGIN_IGNORES).split(PARAM_VALUE_SEPARATOR)));
         }
 
         final String pluginOrderProperty = properties.getProperty(CONF_PLUGIN_ORDER);
@@ -196,7 +208,7 @@ public final class Integrator {
             final List<String> plugins = asList(pluginOrderProperty.trim().split("\\s+"));
             Collections.reverse(plugins);
             int priority = 1;
-            for (final String plugin: plugins) {
+            for (final String plugin : plugins) {
                 pluginOrder.put(plugin, priority++);
             }
         }
@@ -204,7 +216,8 @@ public final class Integrator {
         for (final String tmpl : properties.getProperty(CONF_TEMPLATES, "").split(PARAM_VALUE_SEPARATOR)) {
             final String t = tmpl.trim();
             if (t.length() != 0) {
-                logger.warn(MessageUtils.getMessage("DOTJ080W", "templates", "template").toString());
+                logger.warn(MessageUtils.getMessage("DOTJ080W", "templates", "template")
+                        .toString());
                 templateSet.put(t, null);
             }
         }
@@ -262,7 +275,7 @@ public final class Integrator {
         for (final Entry<String, Value> template : templateSet.entrySet()) {
             final File templateFile = new File(ditaDir, template.getKey());
             logger.debug("Process template " + templateFile.getPath());
-//            fileGen.setPluginId(template.getValue().id);
+            //            fileGen.setPluginId(template.getValue().id);
             fileGen.generate(templateFile);
         }
 
@@ -270,7 +283,8 @@ public final class Integrator {
         final Properties configuration = new Properties();
         // image extensions, support legacy property file extension
         final Set<String> imgExts = new HashSet<>();
-        for (final String ext : properties.getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS, "").split(CONF_LIST_SEPARATOR)) {
+        for (final String ext :
+                properties.getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS, "").split(CONF_LIST_SEPARATOR)) {
             final String e = ext.trim();
             if (e.length() != 0) {
                 imgExts.add(e);
@@ -314,26 +328,35 @@ public final class Integrator {
         }
         configuration.put(CONF_PRINT_TRANSTYPES, StringUtils.join(printTranstypes, CONF_LIST_SEPARATOR));
 
-        for (final Entry<String, Features> e: pluginTable.entrySet()) {
+        for (final Entry<String, Features> e : pluginTable.entrySet()) {
             final Features f = e.getValue();
-            final String name = "plugin."+ e.getKey() + ".dir";
+            final String name = "plugin." + e.getKey() + ".dir";
             final List<String> baseDirValues = f.getFeature("dita.basedir-resource-directory");
             if (Boolean.parseBoolean(baseDirValues == null || baseDirValues.isEmpty() ? null : baseDirValues.get(0))) {
-                //configuration.put(name, ditaDir.getAbsolutePath());
+                // configuration.put(name, ditaDir.getAbsolutePath());
                 configuration.put(name, ".");
             } else {
-                configuration.put(name, FileUtils.getRelativeUnixPath(
-                        new File(ditaDir, "dummy").getAbsolutePath(),
-                        f.getPluginDir().getAbsolutePath()));
+                configuration.put(
+                        name,
+                        FileUtils.getRelativeUnixPath(
+                                new File(ditaDir, "dummy").getAbsolutePath(),
+                                f.getPluginDir().getAbsolutePath()));
             }
         }
         configuration.putAll(getParserConfiguration());
 
         OutputStream out = null;
         try {
-            final File outFile = new File(ditaDir, CONFIG_DIR + File.separator + getClass().getPackage().getName() + File.separator + GEN_CONF_PROPERTIES);
+            final File outFile = new File(
+                    ditaDir,
+                    CONFIG_DIR
+                            + File.separator
+                            + getClass().getPackage().getName()
+                            + File.separator
+                            + GEN_CONF_PROPERTIES);
             if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
-                throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
+                throw new RuntimeException(
+                        "Failed to make directory " + outFile.getParentFile().getAbsolutePath());
             }
             logger.debug("Generate configuration properties " + outFile.getPath());
             out = new BufferedOutputStream(new FileOutputStream(outFile));
@@ -345,14 +368,17 @@ public final class Integrator {
                 try {
                     out.close();
                 } catch (final IOException e) {
-                    logger.error(e.getMessage(), e) ;
+                    logger.error(e.getMessage(), e);
                 }
             }
         }
 
         // Write messages properties
         final Properties messages = readMessageBundle();
-        final File messagesFile = ditaDir.toPath().resolve(CONFIG_DIR).resolve("messages_en_US.properties").toFile();
+        final File messagesFile = ditaDir.toPath()
+                .resolve(CONFIG_DIR)
+                .resolve("messages_en_US.properties")
+                .toFile();
         try (final OutputStream messagesOut = new FileOutputStream(messagesFile)) {
             messages.store(messagesOut, null);
         }
@@ -363,10 +389,8 @@ public final class Integrator {
         writeEnvShell(jars);
         writeEnvBatch(jars);
 
-        final Collection<File> libJars = ImmutableList.<File>builder()
-                .addAll(getLibJars())
-                .addAll(jars)
-                .build();
+        final Collection<File> libJars =
+                ImmutableList.<File>builder().addAll(getLibJars()).addAll(jars).build();
         writeStartcmdShell(libJars);
         writeStartcmdBatch(libJars);
 
@@ -375,9 +399,10 @@ public final class Integrator {
 
     private Properties readMessageBundle() throws IOException, XMLStreamException {
         final Properties messages = new Properties();
-//        final Path basePluginDir = pluginTable.get("org.dita.base").getPluginDir().toPath();
-//        final File messagesXmlFile = basePluginDir.resolve(CONFIG_DIR).resolve("messages.xml").toFile();
-        final File messagesXmlFile = ditaDir.toPath().resolve(CONFIG_DIR).resolve("messages.xml").toFile();
+        //        final Path basePluginDir = pluginTable.get("org.dita.base").getPluginDir().toPath();
+        //        final File messagesXmlFile = basePluginDir.resolve(CONFIG_DIR).resolve("messages.xml").toFile();
+        final File messagesXmlFile =
+                ditaDir.toPath().resolve(CONFIG_DIR).resolve("messages.xml").toFile();
         if (messagesXmlFile.exists()) {
             try (final InputStream in = new FileInputStream(messagesXmlFile)) {
                 final XMLStreamReader src = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(in));
@@ -386,14 +411,14 @@ public final class Integrator {
                 while (src.hasNext()) {
                     final int type = src.next();
                     switch (type) {
-                        case  XMLEvent.START_ELEMENT:
+                        case XMLEvent.START_ELEMENT:
                             if (src.getLocalName().equals("message")) {
                                 id = src.getAttributeValue(XMLConstants.NULL_NS_URI, "id");
                             } else if (id != null) {
                                 buf.append(src.getElementText()).append(' ');
                             }
                             break;
-                        case  XMLEvent.END_ELEMENT:
+                        case XMLEvent.END_ELEMENT:
                             if (src.getLocalName().equals("message")) {
                                 messages.put(id, convertMessage(buf.toString()));
                                 id = null;
@@ -410,8 +435,7 @@ public final class Integrator {
 
     @VisibleForTesting
     static String convertMessage(final String src) {
-        final String res = src
-                .replaceAll("[\\s\\n]+", " ")
+        final String res = src.replaceAll("[\\s\\n]+", " ")
                 .replace("'", "''")
                 .replace("{", "'{")
                 .trim();
@@ -431,7 +455,7 @@ public final class Integrator {
     private Collection<File> getLibJars() {
         final String[] libJars = new File(ditaDir, LIB_DIR).list((dir, name) -> name.endsWith(".jar"));
         final List<File> res = new ArrayList<>(libJars.length);
-        for (String l: libJars) {
+        for (String l : libJars) {
             res.add(new File(LIB_DIR + File.separator + l));
         }
         res.sort(Comparator.comparing(File::getAbsolutePath));
@@ -446,8 +470,8 @@ public final class Integrator {
             try {
                 customIntegrator.process();
             } catch (final Exception e) {
-                logger.error("Custom integrator " + customIntegrator.getClass().getName() + " failed: " + e.getMessage(), e);
-
+                logger.error(
+                        "Custom integrator " + customIntegrator.getClass().getName() + " failed: " + e.getMessage(), e);
             }
         }
     }
@@ -482,7 +506,9 @@ public final class Integrator {
                             .map(f -> f.getAttribute("name") + "=" + f.getAttribute("value"))
                             .collect(Collectors.toList());
                     if (!fsv.isEmpty()) {
-                        res.put(CONF_PARSER_FORMAT + format + ".features", fsv.stream().collect(Collectors.joining(PARAM_VALUE_SEPARATOR)));
+                        res.put(
+                                CONF_PARSER_FORMAT + format + ".features",
+                                fsv.stream().collect(Collectors.joining(PARAM_VALUE_SEPARATOR)));
                     }
                 }
             }
@@ -493,7 +519,7 @@ public final class Integrator {
     private Collection<File> relativize(final Collection<Value> src) {
         final Collection<File> res = new ArrayList<>(src.size());
         final File base = new File(ditaDir, "dummy");
-        for (final Value lib: src) {
+        for (final Value lib : src) {
             final File libFile = toFile(lib.value());
             if (!libFile.exists()) {
                 throw new IllegalArgumentException("Library file not found: " + libFile.getAbsolutePath());
@@ -508,13 +534,14 @@ public final class Integrator {
         try {
             final File outFile = new File(ditaDir, CONFIG_DIR + File.separator + "env.sh");
             if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
-                throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
+                throw new RuntimeException(
+                        "Failed to make directory " + outFile.getParentFile().getAbsolutePath());
             }
             logger.debug("Generate environment shell " + outFile.getPath());
             out = new BufferedWriter(new FileWriter(outFile));
 
             out.write("#!/bin/sh\n");
-            for (final File relativeLib: jars) {
+            for (final File relativeLib : jars) {
                 out.write("CLASSPATH=\"$CLASSPATH:");
                 if (!relativeLib.isAbsolute()) {
                     out.write("$DITA_HOME" + UNIX_SEPARATOR);
@@ -539,12 +566,13 @@ public final class Integrator {
         try {
             final File outFile = new File(ditaDir, CONFIG_DIR + File.separator + "env.bat");
             if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
-                throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
+                throw new RuntimeException(
+                        "Failed to make directory " + outFile.getParentFile().getAbsolutePath());
             }
             logger.debug("Generate environment batch " + outFile.getPath());
             out = new BufferedWriter(new FileWriter(outFile));
 
-            for (final File relativeLib: jars) {
+            for (final File relativeLib : jars) {
                 out.write("set \"CLASSPATH=%CLASSPATH%;");
                 if (!relativeLib.isAbsolute()) {
                     out.write("%DITA_HOME%" + WINDOWS_SEPARATOR);
@@ -565,12 +593,14 @@ public final class Integrator {
         try {
             final File outFile = new File(ditaDir, "startcmd.sh");
             if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
-                throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
+                throw new RuntimeException(
+                        "Failed to make directory " + outFile.getParentFile().getAbsolutePath());
             }
             logger.debug("Generate start command shell " + outFile.getPath());
             out = new BufferedWriter(new FileWriter(outFile));
 
-            out.write("""
+            out.write(
+                    """
                     #!/bin/sh
                     # Generated file, do not edit manually"
                     echo "NOTE: The startcmd.sh has been deprecated, use the 'dita' command instead."
@@ -599,7 +629,7 @@ public final class Integrator {
 
                     NEW_CLASSPATH="$DITA_DIR/lib:$NEW_CLASSPATH"
                     """);
-            for (final File relativeLib: jars) {
+            for (final File relativeLib : jars) {
                 out.write("NEW_CLASSPATH=\"");
                 if (!relativeLib.isAbsolute()) {
                     out.write("$DITA_DIR" + UNIX_SEPARATOR);
@@ -607,7 +637,8 @@ public final class Integrator {
                 out.write(relativeLib.toString().replace(File.separator, UNIX_SEPARATOR));
                 out.write(":$NEW_CLASSPATH\"\n");
             }
-            out.write("""
+            out.write(
+                    """
                     if test -n "$CLASSPATH"; then
                       export CLASSPATH="$NEW_CLASSPATH":"$CLASSPATH"
                     else
@@ -634,12 +665,14 @@ public final class Integrator {
         try {
             final File outFile = new File(ditaDir, "startcmd.bat");
             if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
-                throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
+                throw new RuntimeException(
+                        "Failed to make directory " + outFile.getParentFile().getAbsolutePath());
             }
             logger.debug("Generate start command batch " + outFile.getPath());
             out = new BufferedWriter(new FileWriter(outFile));
 
-            out.write("""
+            out.write(
+                    """
                     @echo off\r
                     REM Generated file, do not edit manually\r
                     echo "NOTE: The startcmd.bat has been deprecated, use the dita.bat command instead."\r
@@ -655,7 +688,7 @@ public final class Integrator {
                     set PATH=%DITA_DIR%\\bin;%PATH%\r
                     set CLASSPATH=%DITA_DIR%lib;%CLASSPATH%\r
                     """);
-            for (final File relativeLib: jars) {
+            for (final File relativeLib : jars) {
                 out.write("set CLASSPATH=");
                 if (!relativeLib.isAbsolute()) {
                     out.write("%DITA_DIR%");
@@ -708,8 +741,7 @@ public final class Integrator {
                         .map(val -> new Value(plugin, val))
                         .collect(Collectors.toList());
                 if (!extensionPoints.contains(key)) {
-                    final String msg = "Plug-in " + plugin + " uses an undefined extension point "
-                            + key;
+                    final String msg = "Plug-in " + plugin + " uses an undefined extension point " + key;
                     throw new RuntimeException(msg);
                 }
                 if (featureTable.containsKey(key)) {
@@ -717,16 +749,16 @@ public final class Integrator {
                     value.addAll(values);
                     featureTable.put(key, value);
                 } else {
-                    //Make shallow clone to avoid making modifications directly to list inside the current feature.
+                    // Make shallow clone to avoid making modifications directly to list inside the current feature.
                     List<Value> currentFeatureValue = values;
                     featureTable.put(key, currentFeatureValue != null ? new ArrayList<>(currentFeatureValue) : null);
                 }
             }
 
             for (final Value templateName : pluginFeatures.getAllTemplates()) {
-                final String template = new File(pluginFeatures.getPluginDir().toURI().resolve(templateName.value())).getAbsolutePath();
-                final String templatePath = FileUtils.getRelativeUnixPath(ditaDir + File.separator + "dummy",
-                        template);
+                final String template =
+                        new File(pluginFeatures.getPluginDir().toURI().resolve(templateName.value())).getAbsolutePath();
+                final String templatePath = FileUtils.getRelativeUnixPath(ditaDir + File.separator + "dummy", template);
                 templateSet.put(templatePath, templateName);
             }
             loadedPlugin.add(plugin);
@@ -764,7 +796,8 @@ public final class Integrator {
             }
             if (!anyPluginFound && requirement.getRequired()) {
                 // not contain any plugin required by current plugin
-                final String msg = MessageUtils.getMessage("DOTJ020W", requirement.toString(), currentPlugin).toString();
+                final String msg = MessageUtils.getMessage("DOTJ020W", requirement.toString(), currentPlugin)
+                        .toString();
                 throw new RuntimeException(msg);
             }
         }
@@ -842,7 +875,8 @@ public final class Integrator {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final SAXParseException e) {
-            final RuntimeException ex = new RuntimeException("Failed to parse " + descFile.getAbsolutePath() + ": " + e.getMessage(), e);
+            final RuntimeException ex =
+                    new RuntimeException("Failed to parse " + descFile.getAbsolutePath() + ": " + e.getMessage(), e);
             throw ex;
         } catch (final Exception e) {
             throw new RuntimeException(e);
@@ -881,7 +915,9 @@ public final class Integrator {
             throw new IllegalArgumentException(msg);
         }
         final List<String> version = f.getFeature("package.version");
-        if (version != null && !version.isEmpty() && !VERSION_PATTERN.matcher(version.get(0)).matches()) {
+        if (version != null
+                && !version.isEmpty()
+                && !VERSION_PATTERN.matcher(version.get(0)).matches()) {
             final String msg = "Plug-in version '" + version.get(0) + "' doesn't follow syntax rules.";
             throw new IllegalArgumentException(msg);
         }

--- a/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
+++ b/src/main/java/org/dita/dost/platform/ListTranstypeAction.java
@@ -7,13 +7,11 @@
  */
 package org.dita.dost.platform;
 
-import org.xml.sax.ContentHandler;
-import org.xml.sax.SAXException;
-
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
 
 /**
  * List transtypes integration action.
@@ -29,11 +27,10 @@ final class ListTranstypeAction extends ImportAction {
     @Override
     public void getResult(final ContentHandler buf) throws SAXException {
         final String separator = paramTable.getOrDefault("separator", "|");
-        final List<String> v = valueSet.stream()
-                .map(Value::value)
-                .distinct().sorted().collect(Collectors.toList());
+        final List<String> v =
+                valueSet.stream().map(Value::value).distinct().sorted().collect(Collectors.toList());
         final StringBuilder retBuf = new StringBuilder();
-        for (final Iterator<String> i = v.iterator(); i.hasNext();) {
+        for (final Iterator<String> i = v.iterator(); i.hasNext(); ) {
             retBuf.append(i.next());
             if (i.hasNext()) {
                 retBuf.append(separator);
@@ -47,5 +44,4 @@ final class ListTranstypeAction extends ImportAction {
     public String getResult() {
         throw new UnsupportedOperationException();
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/PluginParser.java
+++ b/src/main/java/org/dita/dost/platform/PluginParser.java
@@ -7,19 +7,18 @@
  */
 package org.dita.dost.platform;
 
+import static org.dita.dost.util.XMLUtils.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
-import static org.dita.dost.util.XMLUtils.toList;
 
 /**
  * Parse plugin configuration file.
@@ -110,7 +109,8 @@ public class PluginParser {
                     features.addFeature(elem.getAttribute(FEATURE_ID_ATTR), elem);
                 } else if (REQUIRE_ELEM.equals(qName)) {
                     final String importance = elem.getAttribute(REQUIRE_IMPORTANCE_ATTR);
-                    features.addRequire(elem.getAttribute(REQUIRE_PLUGIN_ATTR), importance.isEmpty() ? null : importance);
+                    features.addRequire(
+                            elem.getAttribute(REQUIRE_PLUGIN_ATTR), importance.isEmpty() ? null : importance);
                 } else if (META_ELEM.equals(qName)) {
                     features.addMeta(elem.getAttribute(META_TYPE_ATTR), elem.getAttribute(META_VALUE_ATTR));
                 } else if (TEMPLATE_ELEM.equals(qName)) {
@@ -163,5 +163,4 @@ public class PluginParser {
         final String name = elem.getAttribute(EXTENSION_POINT_NAME_ATTR);
         features.addExtensionPoint(new ExtensionPoint(id, name, currentPlugin));
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/PluginRequirement.java
+++ b/src/main/java/org/dita/dost/platform/PluginRequirement.java
@@ -1,17 +1,18 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2008 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2008 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 
 package org.dita.dost.platform;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.StringTokenizer;
+
 /**
  * PluginRequirement class.
  *

--- a/src/main/java/org/dita/dost/platform/Plugins.java
+++ b/src/main/java/org/dita/dost/platform/Plugins.java
@@ -8,20 +8,19 @@
 
 package org.dita.dost.platform;
 
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
+import static org.dita.dost.util.Constants.PLUGIN_CONF;
+import static org.dita.dost.util.XMLUtils.toList;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Constants.PLUGIN_CONF;
-import static org.dita.dost.util.XMLUtils.toList;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 
 public class Plugins {
 
@@ -32,9 +31,12 @@ public class Plugins {
         final List<Element> plugins = toList(getPluginConfiguration().getElementsByTagName("plugin"));
         return plugins.stream()
                 .map((Element elem) -> new AbstractMap.SimpleImmutableEntry<>(
-                        Optional.ofNullable(elem.getAttributeNode("id")).map(Attr::getValue).orElse(null),
-                        Optional.ofNullable(elem.getAttributeNode("version")).map(Attr::getValue).orElse(null))
-                )
+                        Optional.ofNullable(elem.getAttributeNode("id"))
+                                .map(Attr::getValue)
+                                .orElse(null),
+                        Optional.ofNullable(elem.getAttributeNode("version"))
+                                .map(Attr::getValue)
+                                .orElse(null)))
                 .filter(entry -> Objects.nonNull(entry.getKey()))
                 .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toList());
@@ -50,5 +52,4 @@ public class Plugins {
             throw new RuntimeException("Failed to read plugin configuration: " + e.getMessage(), e);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/Registry.java
+++ b/src/main/java/org/dita/dost/platform/Registry.java
@@ -8,15 +8,14 @@
 
 package org.dita.dost.platform;
 
+import static java.util.Collections.emptyList;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-
-import static java.util.Collections.emptyList;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Registry {
@@ -28,11 +27,12 @@ public class Registry {
     public final String cksum;
 
     @JsonCreator
-    public Registry(@JsonProperty("name") String name,
-                    @JsonProperty("vers") String vers,
-                    @JsonProperty("deps") Dependency[] deps,
-                    @JsonProperty("url") String url,
-                    @JsonProperty("cksum") String cksum) {
+    public Registry(
+            @JsonProperty("name") String name,
+            @JsonProperty("vers") String vers,
+            @JsonProperty("deps") Dependency[] deps,
+            @JsonProperty("url") String url,
+            @JsonProperty("cksum") String cksum) {
         this.name = name;
         this.vers = new SemVer(vers);
         this.deps = deps == null ? emptyList() : List.of(deps);
@@ -50,11 +50,9 @@ public class Registry {
         public final SemVerMatch req;
 
         @JsonCreator
-        public Dependency(@JsonProperty("name") String name,
-                          @JsonProperty("req") String req) {
+        public Dependency(@JsonProperty("name") String name, @JsonProperty("req") String req) {
             this.name = name;
             this.req = new SemVerMatch(req);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/SemVer.java
+++ b/src/main/java/org/dita/dost/platform/SemVer.java
@@ -50,14 +50,14 @@ public class SemVer implements Comparable<SemVer> {
         patch = tokens.length >= 3 ? Integer.parseInt(tokens[2]) : 0;
         preRelease = preRel != null
                 ? Stream.of(preRel.split("\\."))
-                .map(token -> {
-                    try {
-                        return Integer.valueOf(token);
-                    } catch (NumberFormatException e) {
-                        return token;
-                    }
-                })
-                .collect(Collectors.toList())
+                        .map(token -> {
+                            try {
+                                return Integer.valueOf(token);
+                            } catch (NumberFormatException e) {
+                                return token;
+                            }
+                        })
+                        .collect(Collectors.toList())
                 : Collections.emptyList();
     }
 
@@ -66,9 +66,7 @@ public class SemVer implements Comparable<SemVer> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SemVer semVer = (SemVer) o;
-        return major == semVer.major &&
-                minor == semVer.minor &&
-                patch == semVer.patch;
+        return major == semVer.major && minor == semVer.minor && patch == semVer.patch;
     }
 
     @Override

--- a/src/main/java/org/dita/dost/platform/SemVerMatch.java
+++ b/src/main/java/org/dita/dost/platform/SemVerMatch.java
@@ -76,8 +76,7 @@ public class SemVerMatch {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Range range = (Range) o;
-            return match == range.match &&
-                    Objects.equals(version, range.version);
+            return match == range.match && Objects.equals(version, range.version);
         }
 
         @Override
@@ -96,8 +95,7 @@ public class SemVerMatch {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SemVerMatch that = (SemVerMatch) o;
-        return Objects.equals(start, that.start) &&
-                Objects.equals(end, that.end);
+        return Objects.equals(start, that.start) && Objects.equals(end, that.end);
     }
 
     @Override
@@ -129,8 +127,7 @@ public class SemVerMatch {
                 case "<=" -> Match.LE;
                 case ">" -> Match.GT;
                 case ">=" -> Match.GE;
-                default -> throw new IllegalArgumentException();
-            };
+                default -> throw new IllegalArgumentException();};
         } else {
             match = Match.EQ;
         }
@@ -141,52 +138,38 @@ public class SemVerMatch {
 
         switch (match) {
             case TILDE -> {
-                start = new Range(Match.GE,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                start = new Range(
+                        Match.GE, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
                 end = tilde(Match.LT, major, minor);
             }
             case CARET -> {
-                start = new Range(Match.GE,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                start = new Range(
+                        Match.GE, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
                 end = caret(Match.LT, major, minor, patch);
             }
             case LT -> {
                 start = new Range(Match.GE, 0, 0, 0);
-                end = new Range(Match.LT,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                end = new Range(
+                        Match.LT, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
             }
             case LE -> {
                 start = new Range(Match.GE, 0, 0, 0);
-                end = new Range(Match.LE,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                end = new Range(
+                        Match.LE, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
             }
             case GT -> {
-                start = new Range(Match.GT,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                start = new Range(
+                        Match.GT, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
                 end = null;
             }
             case GE -> {
-                start = new Range(Match.GE,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                start = new Range(
+                        Match.GE, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
                 end = null;
             }
             case EQ -> {
-                start = new Range(Match.GE,
-                        major != null ? major : 0,
-                        minor != null ? minor : 0,
-                        patch != null ? patch : 0);
+                start = new Range(
+                        Match.GE, major != null ? major : 0, minor != null ? minor : 0, patch != null ? patch : 0);
                 end = inc(Match.LT, major, minor, patch);
             }
             default -> throw new IllegalArgumentException();
@@ -197,20 +180,14 @@ public class SemVerMatch {
         final Integer major1 = major != null && minor == null && patch == null ? Integer.valueOf(major + 1) : major;
         final Integer minor1 = null != minor && patch == null ? Integer.valueOf(minor + 1) : minor;
         final Integer patch1 = patch != null ? Integer.valueOf(patch + 1) : patch;
-        return new Range(match,
-                major1 != null ? major1 : 0,
-                minor1 != null ? minor1 : 0,
-                patch1 != null ? patch1 : 0);
+        return new Range(match, major1 != null ? major1 : 0, minor1 != null ? minor1 : 0, patch1 != null ? patch1 : 0);
     }
 
     private static Range tilde(Match match, Integer major, Integer minor) {
         final Integer major1 = major != null && minor == null ? Integer.valueOf(major + 1) : major;
         final Integer minor1 = minor != null ? minor + 1 : null;
         final Integer patch1 = null;
-        return new Range(match,
-                major1 != null ? major1 : 0,
-                minor1 != null ? minor1 : 0,
-                patch1 != null ? patch1 : 0);
+        return new Range(match, major1 != null ? major1 : 0, minor1 != null ? minor1 : 0, patch1 != null ? patch1 : 0);
     }
 
     private static Range caret(Match match, Integer major, Integer minor, Integer patch) {
@@ -242,7 +219,8 @@ public class SemVerMatch {
             tokens.set(i, 0);
         }
 
-        return new Range(match,
+        return new Range(
+                match,
                 tokens.size() > 0 && tokens.get(0) != null ? tokens.get(0) : 0,
                 tokens.size() > 1 && tokens.get(1) != null ? tokens.get(1) : 0,
                 tokens.size() > 2 && tokens.get(2) != null ? tokens.get(2) : 0);
@@ -291,5 +269,4 @@ public class SemVerMatch {
         }
         return buf.toString();
     }
-
 }

--- a/src/main/java/org/dita/dost/platform/Value.java
+++ b/src/main/java/org/dita/dost/platform/Value.java
@@ -8,5 +8,4 @@
 
 package org.dita.dost.platform;
 
-public record Value(String id, String value) {
-}
+public record Value(String id, String value) {}

--- a/src/main/java/org/dita/dost/project/IgnoringXmlFilter.java
+++ b/src/main/java/org/dita/dost/project/IgnoringXmlFilter.java
@@ -8,16 +8,15 @@
 
 package org.dita.dost.project;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.XMLFilterImpl;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Objects;
 
 public class IgnoringXmlFilter extends XMLFilterImpl {
 
@@ -27,8 +26,8 @@ public class IgnoringXmlFilter extends XMLFilterImpl {
         super(parent);
     }
 
-    public void startElement(final String uri, final String localName,
-                             final String qName, final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
         if (Objects.equals(uri, XmlReader.NS)) {
             include.push(true);
             super.startElement(uri, localName, qName, filterAttributes(atts));
@@ -69,8 +68,7 @@ public class IgnoringXmlFilter extends XMLFilterImpl {
         return res;
     }
 
-    public void endElement(final String uri, final String localName,
-                           final String qName) throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (include.pop()) {
             super.endElement(uri, localName, qName);
         }

--- a/src/main/java/org/dita/dost/project/Project.java
+++ b/src/main/java/org/dita/dost/project/Project.java
@@ -17,10 +17,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public record Project(List<Deliverable> deliverables,
-                      List<ProjectRef> includes,
-                      List<Publication> publications,
-                      List<Context> contexts) {
+public record Project(
+        List<Deliverable> deliverables,
+        List<ProjectRef> includes,
+        List<Publication> publications,
+        List<Context> contexts) {
 
     public static Project build(final ProjectBuilder src, final URI base) {
         final Project project = new Project(
@@ -30,8 +31,7 @@ public record Project(List<Deliverable> deliverables,
                                 deliverable.id,
                                 build(deliverable.context, base),
                                 deliverable.output,
-                                build(deliverable.publication, base)
-                        ))
+                                build(deliverable.publication, base)))
                         .collect(Collectors.toList()),
                 toStream(src.includes)
                         .map(include -> new ProjectRef(resolveURI(include, base)))
@@ -39,10 +39,7 @@ public record Project(List<Deliverable> deliverables,
                 toStream(src.publications)
                         .map(publication -> build(publication, base))
                         .collect(Collectors.toList()),
-                toStream(src.contexts)
-                        .map(context -> build(context, base))
-                        .collect(Collectors.toList())
-        );
+                toStream(src.contexts).map(context -> build(context, base)).collect(Collectors.toList()));
         return project;
     }
 
@@ -75,20 +72,14 @@ public record Project(List<Deliverable> deliverables,
                 publication.transtype,
                 toStream(publication.params)
                         .map(param -> new Publication.Param(
-                                param.name,
-                                param.value,
-                                resolveURI(param.href, base),
-                                resolvePath(param.path, base))
-                        )
+                                param.name, param.value, resolveURI(param.href, base), resolvePath(param.path, base)))
                         .collect(Collectors.toList()),
                 new Deliverable.Profile(
                         publication.profiles != null
                                 ? publication.profiles.ditavals.stream()
-                                .map(ditaval -> new Deliverable.Profile.DitaVal(resolveURI(ditaval, base)))
-                                .collect(Collectors.toList())
-                                : Collections.emptyList()
-                )
-        );
+                                        .map(ditaval -> new Deliverable.Profile.DitaVal(resolveURI(ditaval, base)))
+                                        .collect(Collectors.toList())
+                                : Collections.emptyList()));
     }
 
     private static Context build(final ProjectBuilder.Context context, final URI base) {
@@ -100,58 +91,37 @@ public record Project(List<Deliverable> deliverables,
                 context.id,
                 context.idref,
                 context.input != null
-                        ? new Deliverable.Inputs(
-                        context.input.stream()
+                        ? new Deliverable.Inputs(context.input.stream()
                                 .map(input -> new Deliverable.Inputs.Input(resolveURI(input, base)))
-                                .collect(Collectors.toList())
-                )
+                                .collect(Collectors.toList()))
                         : new Deliverable.Inputs(Collections.emptyList()),
                 new Deliverable.Profile(
                         context.profiles != null
                                 ? context.profiles.ditavals.stream()
-                                .map(ditaval -> new Deliverable.Profile.DitaVal(resolveURI(ditaval, base)))
-                                .collect(Collectors.toList())
-                                : Collections.emptyList()
-                )
-        );
+                                        .map(ditaval -> new Deliverable.Profile.DitaVal(resolveURI(ditaval, base)))
+                                        .collect(Collectors.toList())
+                                : Collections.emptyList()));
     }
 
-    public record Deliverable(String name,
-                              String id,
-                              Context context,
-                              URI output,
-                              Publication publication) {
+    public record Deliverable(String name, String id, Context context, URI output, Publication publication) {
         public record Inputs(List<Input> inputs) {
-            public record Input(URI href) {
-            }
+            public record Input(URI href) {}
         }
+
         public record Profile(List<DitaVal> ditavals) {
-            public record DitaVal(URI href) {
-            }
+            public record DitaVal(URI href) {}
         }
     }
 
-    public record ProjectRef(URI href) {
-    }
+    public record ProjectRef(URI href) {}
 
-    public record Context(String name,
-                          String id,
-                          String idref,
-                          Deliverable.Inputs inputs,
-                          Deliverable.Profile profiles) {
-    }
+    public record Context(
+            String name, String id, String idref, Deliverable.Inputs inputs, Deliverable.Profile profiles) {}
 
-    public record Publication(String name,
-                              String id,
-                              String idref,
-                              String transtype,
-                              List<Param> params,
-                              Deliverable.Profile profiles) {
+    public record Publication(
+            String name, String id, String idref, String transtype, List<Param> params, Deliverable.Profile profiles) {
 
-        public record Param(String name,
-                            String value,
-                            URI href,
-                            Path path) {
+        public record Param(String name, String value, URI href, Path path) {
             public Param {
                 Objects.requireNonNull(name);
                 if (value == null && href == null && path == null) {

--- a/src/main/java/org/dita/dost/project/ProjectBuilder.java
+++ b/src/main/java/org/dita/dost/project/ProjectBuilder.java
@@ -10,7 +10,6 @@ package org.dita.dost.project;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.net.URI;
 import java.util.List;
 
@@ -21,18 +20,22 @@ public class ProjectBuilder {
 
     @JsonProperty("deliverables")
     public List<Deliverable> deliverables;
+
     @JsonProperty("includes")
     public List<URI> includes;
+
     @JsonProperty("publications")
     public List<Publication> publications;
+
     @JsonProperty("contexts")
     public List<Context> contexts;
 
     @JsonCreator
-    public ProjectBuilder(@JsonProperty("deliverables") List<Deliverable> deliverables,
-                          @JsonProperty("includes") List<URI> includes,
-                          @JsonProperty("publications") List<Publication> publications,
-                          @JsonProperty("contexts") List<Context> contexts) {
+    public ProjectBuilder(
+            @JsonProperty("deliverables") List<Deliverable> deliverables,
+            @JsonProperty("includes") List<URI> includes,
+            @JsonProperty("publications") List<Publication> publications,
+            @JsonProperty("contexts") List<Context> contexts) {
         this.deliverables = deliverables;
         this.includes = includes;
         this.publications = publications;
@@ -47,11 +50,12 @@ public class ProjectBuilder {
         public final Publication publication;
 
         @JsonCreator
-        public Deliverable(@JsonProperty("name") String name,
-                           @JsonProperty("id") String id,
-                           @JsonProperty("context") Context context,
-                           @JsonProperty("output") URI output,
-                           @JsonProperty("publication") Publication publication) {
+        public Deliverable(
+                @JsonProperty("name") String name,
+                @JsonProperty("id") String id,
+                @JsonProperty("context") Context context,
+                @JsonProperty("output") URI output,
+                @JsonProperty("publication") Publication publication) {
             this.name = name;
             this.id = id;
             this.context = context;
@@ -67,7 +71,6 @@ public class ProjectBuilder {
                 this.ditavals = ditavals;
             }
         }
-
     }
 
     public static class Context {
@@ -78,11 +81,12 @@ public class ProjectBuilder {
         public final Deliverable.Profile profiles;
 
         @JsonCreator
-        public Context(@JsonProperty("name") String name,
-                       @JsonProperty("id") String id,
-                       @JsonProperty("idref") String idref,
-                       @JsonProperty("input") List<URI> input,
-                       @JsonProperty("profiles") Deliverable.Profile profiles) {
+        public Context(
+                @JsonProperty("name") String name,
+                @JsonProperty("id") String id,
+                @JsonProperty("idref") String idref,
+                @JsonProperty("input") List<URI> input,
+                @JsonProperty("profiles") Deliverable.Profile profiles) {
             this.name = name;
             this.id = id;
             this.idref = idref;
@@ -100,12 +104,13 @@ public class ProjectBuilder {
         public final Deliverable.Profile profiles;
 
         @JsonCreator
-        public Publication(@JsonProperty("name") String name,
-                           @JsonProperty("id") String id,
-                           @JsonProperty("idref") String idref,
-                           @JsonProperty("transtype") String transtype,
-                           @JsonProperty("params") List<Param> params,
-                           @JsonProperty("profiles") Deliverable.Profile profiles) {
+        public Publication(
+                @JsonProperty("name") String name,
+                @JsonProperty("id") String id,
+                @JsonProperty("idref") String idref,
+                @JsonProperty("transtype") String transtype,
+                @JsonProperty("params") List<Param> params,
+                @JsonProperty("profiles") Deliverable.Profile profiles) {
             this.name = name;
             this.id = id;
             this.idref = idref;

--- a/src/main/java/org/dita/dost/project/XmlReader.java
+++ b/src/main/java/org/dita/dost/project/XmlReader.java
@@ -8,17 +8,17 @@
 
 package org.dita.dost.project;
 
-import com.thaiopensource.relaxng.jaxp.CompactSyntaxSchemaFactory;
-import org.dita.dost.util.XMLUtils;
-import org.slf4j.Logger;
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.XMLReader;
+import static org.dita.dost.util.XMLUtils.getValue;
 
+import com.thaiopensource.relaxng.jaxp.CompactSyntaxSchemaFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -33,16 +33,15 @@ import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.dita.dost.util.XMLUtils.getValue;
+import org.dita.dost.util.XMLUtils;
+import org.slf4j.Logger;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
 
 public class XmlReader {
 
@@ -141,10 +140,7 @@ public class XmlReader {
                 getChildren(project, ELEM_PUBLICATION)
                         .map(this::readPublication)
                         .collect(Collectors.toList()),
-                getChildren(project, ELEM_CONTEXT)
-                        .map(this::readContext)
-                        .collect(Collectors.toList())
-        );
+                getChildren(project, ELEM_CONTEXT).map(this::readContext).collect(Collectors.toList()));
     }
 
     /**
@@ -194,16 +190,11 @@ public class XmlReader {
         return new ProjectBuilder.Deliverable(
                 getValue(deliverable, ATTR_NAME),
                 getValue(deliverable, ATTR_ID),
-                getChild(deliverable, ELEM_CONTEXT)
-                        .map(this::readContext)
-                        .orElse(null),
-                getChild(deliverable, ELEM_OUTPUT)
-                        .flatMap(this::getHref)
-                        .orElse(null),
+                getChild(deliverable, ELEM_CONTEXT).map(this::readContext).orElse(null),
+                getChild(deliverable, ELEM_OUTPUT).flatMap(this::getHref).orElse(null),
                 getChild(deliverable, ELEM_PUBLICATION)
                         .map(this::readPublication)
-                        .orElse(null)
-        );
+                        .orElse(null));
     }
 
     private ProjectBuilder.Publication readPublication(final Element publication) {
@@ -217,19 +208,16 @@ public class XmlReader {
                                 getValue(param, ATTR_NAME),
                                 param.getAttributeNode(ATTR_VALUE) != null ? param.getAttribute(ATTR_VALUE) : null,
                                 getHref(param).orElse(null),
-                                getFile(param).orElse(null)
-                        ))
+                                getFile(param).orElse(null)))
                         .collect(Collectors.toList()),
                 getChild(publication, ELEM_PROFILE)
                         .map(inputs -> getChildren(inputs, ELEM_DITAVAL)
                                 .map(this::getHref)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
-                                .collect(Collectors.toList())
-                        )
+                                .collect(Collectors.toList()))
                         .map(ProjectBuilder.Deliverable.Profile::new)
-                        .orElse(null)
-        );
+                        .orElse(null));
     }
 
     private ProjectBuilder.Context readContext(final Element context) {
@@ -247,11 +235,9 @@ public class XmlReader {
                                 .map(this::getHref)
                                 .filter(Optional::isPresent)
                                 .map(Optional::get)
-                                .collect(Collectors.toList())
-                        )
+                                .collect(Collectors.toList()))
                         .map(ProjectBuilder.Deliverable.Profile::new)
-                        .orElse(null)
-        );
+                        .orElse(null));
     }
 
     private Optional<Element> getChild(final Element project, final String localName) {
@@ -285,5 +271,4 @@ public class XmlReader {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/AbstractReader.java
+++ b/src/main/java/org/dita/dost/reader/AbstractReader.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
 import java.io.File;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
@@ -42,5 +41,4 @@ public interface AbstractReader {
      * @param job job configuration to use for processing
      */
     void setJob(Job job);
-
 }

--- a/src/main/java/org/dita/dost/reader/AbstractXMLReader.java
+++ b/src/main/java/org/dita/dost/reader/AbstractXMLReader.java
@@ -1,16 +1,15 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
 import org.xml.sax.Attributes;
@@ -28,8 +27,7 @@ import org.xml.sax.SAXException;
  *
  * @author Wu, Zhi Qiang
  */
-public abstract class AbstractXMLReader implements AbstractReader,
-ContentHandler, EntityResolver {
+public abstract class AbstractXMLReader implements AbstractReader, ContentHandler, EntityResolver {
 
     protected DITAOTLogger logger;
     protected Job job;
@@ -65,8 +63,7 @@ ContentHandler, EntityResolver {
     }
 
     @Override
-    public void startPrefixMapping(final String prefix, final String uri)
-            throws SAXException {
+    public void startPrefixMapping(final String prefix, final String uri) throws SAXException {
         // NOOP
     }
 
@@ -76,32 +73,28 @@ ContentHandler, EntityResolver {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes atts) throws SAXException {
-        // NOOP
-    }
-
-    @Override
-    public void endElement(final String uri, final String localName, final String qName)
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
             throws SAXException {
         // NOOP
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         // NOOP
     }
 
     @Override
-    public void ignorableWhitespace(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         // NOOP
     }
 
     @Override
-    public void processingInstruction(final String target, final String data)
-            throws SAXException {
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
+        // NOOP
+    }
+
+    @Override
+    public void processingInstruction(final String target, final String data) throws SAXException {
         // NOOP
     }
 
@@ -111,9 +104,7 @@ ContentHandler, EntityResolver {
     }
 
     @Override
-    public InputSource resolveEntity(final String publicId, final String systemId)
-            throws SAXException, IOException {
+    public InputSource resolveEntity(final String publicId, final String systemId) throws SAXException, IOException {
         return null;
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -1,32 +1,31 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toFile;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.io.File;
+import java.net.URI;
+import java.util.*;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.dom.DOMResult;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.util.FileUtils;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.dom.DOMResult;
-import java.io.File;
-import java.net.URI;
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toFile;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Class for reading conref push content.
@@ -40,34 +39,34 @@ public final class ConrefPushReader extends AbstractXMLReader {
     private final Document pushDocument;
 
     /**keep the file path of current file under parse
-    filePath is useful to get the absolute path of the target file.*/
+     * filePath is useful to get the absolute path of the target file.*/
     private File fileDir = null;
 
     /**keep the file name of  current file under parse */
     private File parsefilename = null;
     /**pushcontent is used to store the content copied to target
-     in pushcontent href will be resolved if it is relative path
-     if @conref is in pushconref the target name should be recorded so that it
-     could be added to conreflist for conref resolution.*/
+     * in pushcontent href will be resolved if it is relative path
+     * if @conref is in pushconref the target name should be recorded so that it
+     * could be added to conreflist for conref resolution.*/
     private XMLStreamWriter pushcontentWriter;
     /** Common document for all push content document fragments. */
     private DocumentFragment pushcontentDocumentFragment;
 
     /**boolean start is used to control whether sax parser can start to
-     record push content into String pushcontent.*/
+     * record push content into String pushcontent.*/
     private boolean start = false;
     /**level is used to record the level number to the root element in pushcontent
-     In endElement(...) we can turn start off to terminate adding content to pushcontent
-     if level is zero. That means we reach the end tag of the starting element.*/
+     * In endElement(...) we can turn start off to terminate adding content to pushcontent
+     * if level is zero. That means we reach the end tag of the starting element.*/
     private int level = 0;
 
     /**target is used to record the target of the conref push
-     if we reach pushafter action but there is no target recorded before, we need
-     to report error.*/
+     * if we reach pushafter action but there is no target recorded before, we need
+     * to report error.*/
     private URI target = null;
 
     /**pushType is used to record the current type of push
-     it is used in endElement(....) to tell whether it is pushafter or replace.*/
+     * it is used in endElement(....) to tell whether it is pushafter or replace.*/
     private String pushType = null;
 
     /**
@@ -92,7 +91,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -115,12 +114,12 @@ public final class ConrefPushReader extends AbstractXMLReader {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String name,
-            final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String name, final Attributes atts)
+            throws SAXException {
         if (start) {
-            //if start is true, we need to record content in pushcontent
-            //also we need to add level to make sure start is turn off
-            //at the corresponding end element
+            // if start is true, we need to record content in pushcontent
+            // also we need to add level to make sure start is turn off
+            // at the corresponding end element
             level++;
             putElement(name, atts, false);
         }
@@ -139,7 +138,9 @@ public final class ConrefPushReader extends AbstractXMLReader {
                             }
                         }
                         pushcontentWriter = getXMLStreamWriter();
-                        logger.warn(MessageUtils.getMessage("DOTJ044W").setLocation(atts).toString());
+                        logger.warn(MessageUtils.getMessage("DOTJ044W")
+                                .setLocation(atts)
+                                .toString());
                     }
                     start = true;
                     level = 1;
@@ -150,7 +151,9 @@ public final class ConrefPushReader extends AbstractXMLReader {
                     start = true;
                     level = 1;
                     if (target == null) {
-                        logger.error(MessageUtils.getMessage("DOTJ039E").setLocation(atts).toString());
+                        logger.error(MessageUtils.getMessage("DOTJ039E")
+                                .setLocation(atts)
+                                .toString());
                     } else {
                         putElement(name, atts, true);
                         pushType = ATTR_CONACTION_VALUE_PUSHAFTER;
@@ -161,7 +164,9 @@ public final class ConrefPushReader extends AbstractXMLReader {
                     level = 1;
                     target = toURI(atts.getValue(ATTRIBUTE_NAME_CONREF));
                     if (target == null) {
-                        logger.error(MessageUtils.getMessage("DOTJ040E").setLocation(atts).toString());
+                        logger.error(MessageUtils.getMessage("DOTJ040E")
+                                .setLocation(atts)
+                                .toString());
                     } else {
                         pushType = ATTR_CONACTION_VALUE_PUSHREPLACE;
                         putElement(name, atts, true);
@@ -170,13 +175,16 @@ public final class ConrefPushReader extends AbstractXMLReader {
                 case ATTR_CONACTION_VALUE_MARK -> {
                     target = toURI(atts.getValue(ATTRIBUTE_NAME_CONREF));
                     if (target == null) {
-                        logger.error(MessageUtils.getMessage("DOTJ068E").setLocation(atts).toString());
+                        logger.error(MessageUtils.getMessage("DOTJ068E")
+                                .setLocation(atts)
+                                .toString());
                     }
-                    if (target != null &&
-                            pushcontentDocumentFragment != null && pushcontentDocumentFragment.getChildNodes().getLength() > 0 &&
-                            ATTR_CONACTION_VALUE_PUSHBEFORE.equals(pushType)) {
-                        //pushcontent != null means it is pushbefore action
-                        //we need to add target and content to pushtable
+                    if (target != null
+                            && pushcontentDocumentFragment != null
+                            && pushcontentDocumentFragment.getChildNodes().getLength() > 0
+                            && ATTR_CONACTION_VALUE_PUSHBEFORE.equals(pushType)) {
+                        // pushcontent != null means it is pushbefore action
+                        // we need to add target and content to pushtable
                         if (pushcontentWriter != null) {
                             try {
                                 pushcontentWriter.close();
@@ -214,8 +222,9 @@ public final class ConrefPushReader extends AbstractXMLReader {
         }
         return pushcontent;
     }
+
     private void replaceLinkAttributes(final Element pushcontent) {
-        for (final String attName: new String[] { ATTRIBUTE_NAME_HREF, ATTRIBUTE_NAME_CONREF }) {
+        for (final String attName : new String[] {ATTRIBUTE_NAME_HREF, ATTRIBUTE_NAME_CONREF}) {
             final Attr att = pushcontent.getAttributeNode(attName);
             if (att != null) {
                 att.setNodeValue(replaceURL(att.getNodeValue()));
@@ -231,18 +240,18 @@ public final class ConrefPushReader extends AbstractXMLReader {
      * @param removeConref whether remeove conref info
      * @throws SAXException if writing element failed
      */
-    private void putElement(final String elemName, final Attributes atts, final boolean removeConref) throws SAXException {
-        //parameter boolean removeConref specifies whether to remove
-        //conref information like @conref @conaction in current element
-        //when copying it to pushcontent. True means remove and false means
-        //not remove.
+    private void putElement(final String elemName, final Attributes atts, final boolean removeConref)
+            throws SAXException {
+        // parameter boolean removeConref specifies whether to remove
+        // conref information like @conref @conaction in current element
+        // when copying it to pushcontent. True means remove and false means
+        // not remove.
         final Set<String> namespaces = new HashSet<>();
         try {
             pushcontentWriter.writeStartElement(elemName);
             for (int index = 0; index < atts.getLength(); index++) {
                 final String name = atts.getQName(index);
-                if (!removeConref ||
-                        !ATTRIBUTE_NAME_CONREF.equals(name) && !ATTRIBUTE_NAME_CONACTION.equals(name)) {
+                if (!removeConref || !ATTRIBUTE_NAME_CONREF.equals(name) && !ATTRIBUTE_NAME_CONACTION.equals(name)) {
                     String value = atts.getValue(index);
                     if (ATTRIBUTE_NAME_HREF.equals(name) || ATTRIBUTE_NAME_CONREF.equals(name)) {
                         // adjust href for pushbefore and replace
@@ -259,24 +268,26 @@ public final class ConrefPushReader extends AbstractXMLReader {
                     pushcontentWriter.writeAttribute(prefix, atts.getURI(index), atts.getLocalName(index), value);
                 }
             }
-            //id attribute should only be added to the starting element
-            //which dosen't have id attribute set
-            if (ATTR_CONACTION_VALUE_PUSHREPLACE.equals(pushType) &&
-                    atts.getValue(ATTRIBUTE_NAME_ID) == null &&
-                    level == 1) {
+            // id attribute should only be added to the starting element
+            // which dosen't have id attribute set
+            if (ATTR_CONACTION_VALUE_PUSHREPLACE.equals(pushType)
+                    && atts.getValue(ATTRIBUTE_NAME_ID) == null
+                    && level == 1) {
                 final String fragment = target.getFragment();
                 if (fragment == null) {
-                    //if there is no '#' in target string, report error
-                    logger.error(MessageUtils.getMessage("DOTJ041E", target.toString()).setLocation(atts).toString());
+                    // if there is no '#' in target string, report error
+                    logger.error(MessageUtils.getMessage("DOTJ041E", target.toString())
+                            .setLocation(atts)
+                            .toString());
                 } else {
                     String id;
-                    //has element id
+                    // has element id
                     if (fragment.contains(SLASH)) {
                         id = fragment.substring(fragment.lastIndexOf(SLASH) + 1);
                     } else {
                         id = fragment;
                     }
-                    //add id attribute
+                    // add id attribute
                     pushcontentWriter.writeAttribute(ATTRIBUTE_NAME_ID, id);
                 }
             }
@@ -292,10 +303,10 @@ public final class ConrefPushReader extends AbstractXMLReader {
     private String replaceURL(final String value) {
         if (value == null) {
             return null;
-        } else if (target == null ||
-                FileUtils.isAbsolutePath(value) ||
-                value.contains(COLON_DOUBLE_SLASH) ||
-                value.startsWith(SHARP)) {
+        } else if (target == null
+                || FileUtils.isAbsolutePath(value)
+                || value.contains(COLON_DOUBLE_SLASH)
+                || value.startsWith(SHARP)) {
             return value;
         } else {
             final String source = FileUtils.resolve(fileDir, target).getPath();
@@ -311,22 +322,22 @@ public final class ConrefPushReader extends AbstractXMLReader {
      */
     private void addtoPushTable(URI target, final DocumentFragment pushcontent, final String type) {
         if (target.getFragment() == null) {
-            //if there is no '#' in target string, report error
+            // if there is no '#' in target string, report error
             logger.error(MessageUtils.getMessage("DOTJ041E", target.toString()).toString());
             return;
         }
 
         if (target.getPath().isEmpty()) {
-            //means conref the file itself
+            // means conref the file itself
             target = toURI(parsefilename.getPath() + target);
         }
         final File key = toFile(FileUtils.resolve(fileDir, target));
         Hashtable<MoveKey, DocumentFragment> table;
         if (pushtable.containsKey(key)) {
-            //if there is something else push to the same file
+            // if there is something else push to the same file
             table = pushtable.get(key);
         } else {
-            //if there is nothing else push to the same file
+            // if there is nothing else push to the same file
             table = new Hashtable<>();
             pushtable.put(key, table);
         }
@@ -334,17 +345,18 @@ public final class ConrefPushReader extends AbstractXMLReader {
         final MoveKey moveKey = new MoveKey(SHARP + target.getFragment(), type);
 
         if (table.containsKey(moveKey)) {
-            //if there is something else push to the same target
-            //append content if type is 'pushbefore' or 'pushafter'
-            //report error if type is 'replace'
+            // if there is something else push to the same target
+            // append content if type is 'pushbefore' or 'pushafter'
+            // report error if type is 'replace'
             if (ATTR_CONACTION_VALUE_PUSHREPLACE.equals(type)) {
-                logger.error(MessageUtils.getMessage("DOTJ042E", target.toString()).toString());
+                logger.error(
+                        MessageUtils.getMessage("DOTJ042E", target.toString()).toString());
             } else {
                 table.put(moveKey, appendPushContent(pushcontent, table.get(moveKey)));
             }
 
         } else {
-            //if there is nothing else push to the same target
+            // if there is nothing else push to the same target
             table.put(moveKey, appendPushContent(pushcontent, null));
         }
     }
@@ -362,8 +374,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         if (this.start) {
             try {
                 pushcontentWriter.writeCharacters(ch, start, length);
@@ -374,8 +385,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String name)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String name) throws SAXException {
         if (start) {
             level--;
             try {
@@ -385,11 +395,11 @@ public final class ConrefPushReader extends AbstractXMLReader {
             }
         }
         if (level == 0) {
-            //turn off start if we reach the end tag of staring element
+            // turn off start if we reach the end tag of staring element
             start = false;
             if (ATTR_CONACTION_VALUE_PUSHAFTER.equals(pushType) || ATTR_CONACTION_VALUE_PUSHREPLACE.equals(pushType)) {
-                //if it is pushafter or replace, we need to record content in pushtable
-                //if target == null we have already reported error in startElement;
+                // if it is pushafter or replace, we need to record content in pushtable
+                // if target == null we have already reported error in startElement;
                 if (target != null) {
                     if (pushcontentWriter != null) {
                         try {
@@ -407,8 +417,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
         }
     }
 
-    public record MoveKey(String idPath,
-                          String action) {
+    public record MoveKey(String idPath, String action) {
         @Override
         public String toString() {
             return idPath + STICK + action;

--- a/src/main/java/org/dita/dost/reader/CopyToReader.java
+++ b/src/main/java/org/dita/dost/reader/CopyToReader.java
@@ -7,22 +7,20 @@
  */
 package org.dita.dost.reader;
 
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.DitaClass;
-import org.dita.dost.writer.AbstractXMLFilter;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Stack;
-
 import static org.dita.dost.reader.ChunkMapReader.CHUNK_TO_CONTENT;
 import static org.dita.dost.util.Configuration.ditaFormat;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.stripFragment;
 import static org.dita.dost.util.URLUtils.toURI;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.writer.AbstractXMLFilter;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
 
 /**
  * Collect copy-to information from a map.
@@ -140,9 +138,11 @@ public final class CopyToReader extends AbstractXMLFilter {
         final String attrScope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
 
         // external resource is filtered here.
-        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope) || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
+        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope)
+                || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
                 // FIXME: testing for :// here is incorrect, rely on source scope instead
-                || target.toString().contains(COLON_DOUBLE_SLASH) || target.toString().startsWith(SHARP)) {
+                || target.toString().contains(COLON_DOUBLE_SLASH)
+                || target.toString().startsWith(SHARP)) {
             return;
         }
 
@@ -163,10 +163,11 @@ public final class CopyToReader extends AbstractXMLFilter {
                     if (copyToSourceAbs != null) {
                         if (!sourceAbs.equals(copyToSourceAbs)) {
                             logger.warn(MessageUtils.getMessage("DOTX065W", source.toString(), targetAbs.toString())
-                                    .setLocation(atts).toString());
+                                    .setLocation(atts)
+                                    .toString());
                         }
-                    } else if (atts.getValue(ATTRIBUTE_NAME_CHUNK) != null &&
-                            atts.getValue(ATTRIBUTE_NAME_CHUNK).contains(CHUNK_TO_CONTENT)) {
+                    } else if (atts.getValue(ATTRIBUTE_NAME_CHUNK) != null
+                            && atts.getValue(ATTRIBUTE_NAME_CHUNK).contains(CHUNK_TO_CONTENT)) {
                         // Ignore
                     } else {
                         copyToMap.put(targetAbs, sourceAbs);
@@ -182,7 +183,7 @@ public final class CopyToReader extends AbstractXMLFilter {
             return ATTR_FORMAT_VALUE_IMAGE;
         } else if (TOPIC_OBJECT.matches(attrClass)) {
             throw new IllegalArgumentException();
-            //return ATTR_FORMAT_VALUE_HTML;
+            // return ATTR_FORMAT_VALUE_HTML;
         } else {
             return atts.getValue(ATTRIBUTE_NAME_FORMAT);
         }
@@ -205,5 +206,4 @@ public final class CopyToReader extends AbstractXMLFilter {
         }
         return false;
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/DitamapIndexTermReader.java
+++ b/src/main/java/org/dita/dost/reader/DitamapIndexTermReader.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 
 package org.dita.dost.reader;
 
@@ -17,7 +17,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
-
 import org.dita.dost.index.IndexTerm;
 import org.dita.dost.index.IndexTermCollection;
 import org.dita.dost.index.IndexTermTarget;
@@ -36,7 +35,6 @@ import org.xml.sax.SAXException;
  *
  * @author Wu, Zhi Qiang
  */
-
 public final class DitamapIndexTermReader extends AbstractXMLReader {
     /** The stack used to store elements */
     private final Stack<Object> elementStack;
@@ -71,37 +69,36 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         String temp = new String(ch, start, length);
         IndexTerm indexTerm;
-        //boolean withSpace = (ch[start] == '\n' || temp.startsWith(LINE_SEPARATOR));
+        // boolean withSpace = (ch[start] == '\n' || temp.startsWith(LINE_SEPARATOR));
         if (ch[start] == '\n' || temp.startsWith(LINE_SEPARATOR)) {
             temp = " " + temp.substring(1);
         }
 
-        //used for store the space
+        // used for store the space
         final char[] chars = temp.toCharArray();
         char flag = '\n';
-        //used for store the new String
+        // used for store the new String
         final StringBuilder sb = new StringBuilder();
         for (final char c : chars) {
-            //when a whitespace is met
+            // when a whitespace is met
             if (c == ' ') {
-                //this is the first whitespace
+                // this is the first whitespace
                 if (flag != ' ') {
-                    //put it in the result string
+                    // put it in the result string
                     sb.append(c);
-                    //store the space in the flag
+                    // store the space in the flag
                     flag = c;
                 } else {
-                    //abundant space, ignore it
+                    // abundant space, ignore it
                 }
-                //the consecutive whitespace is interrupted
+                // the consecutive whitespace is interrupted
             } else {
-                //put it in the result string
+                // put it in the result string
                 sb.append(c);
-                //clear the flag
+                // clear the flag
                 flag = c;
             }
         }
@@ -114,12 +111,10 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
         indexTerm = (IndexTerm) elementStack.peek();
 
         indexTerm.setTermName(StringUtils.setOrAppend(indexTerm.getTermName(), temp, false));
-
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (topicrefSpecList.contains(localName)) {
             elementStack.pop();
             return;
@@ -131,7 +126,8 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
             final IndexTerm indexTerm = (IndexTerm) elementStack.pop();
             Object obj;
 
-            if (indexTerm.getTermName() == null || indexTerm.getTermName().trim().equals("")) {
+            if (indexTerm.getTermName() == null
+                    || indexTerm.getTermName().trim().equals("")) {
                 if (indexTerm.getEndAttribute() != null && !indexTerm.hasSubTerms()) {
                     return;
                 } else {
@@ -147,9 +143,9 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
             obj = elementStack.peek();
 
             if (obj instanceof TopicrefElement) {
-                if (((TopicrefElement)obj).getHref() != null) {
-                    genTargets(indexTerm, (TopicrefElement)obj);
-                    //IndexTermCollection.getInstantce().addTerm(indexTerm);
+                if (((TopicrefElement) obj).getHref() != null) {
+                    genTargets(indexTerm, (TopicrefElement) obj);
+                    // IndexTermCollection.getInstantce().addTerm(indexTerm);
                     result.addTerm(indexTerm);
                 }
             } else {
@@ -160,8 +156,7 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
 
         // Check to see if the index-see or index-see-also or a specialized
         // version is in the list.
-        if (indexSeeSpecList.contains(localName)
-                || indexSeeAlsoSpecList.contains(localName)) {
+        if (indexSeeSpecList.contains(localName) || indexSeeAlsoSpecList.contains(localName)) {
             final IndexTerm term = (IndexTerm) elementStack.pop();
             if (term.getTermKey() == null) {
                 term.setTermKey(term.getTermFullName());
@@ -200,7 +195,6 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
         target.setTargetURI(targetURI);
 
         assignTarget(indexTerm, target);
-
     }
 
     private void assignTarget(final IndexTerm indexTerm, final IndexTermTarget target) {
@@ -210,18 +204,17 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
 
         if (indexTerm.hasSubTerms()) {
             for (final Object subTerm : indexTerm.getSubTerms()) {
-                assignTarget((IndexTerm)subTerm, target);
+                assignTarget((IndexTerm) subTerm, target);
             }
         }
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes attributes) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+            throws SAXException {
         final String classAttr = attributes.getValue(ATTRIBUTE_NAME_CLASS);
 
-        if (classAttr != null
-                && TOPIC_INDEXTERM.matches(classAttr)) {
+        if (classAttr != null && TOPIC_INDEXTERM.matches(classAttr)) {
             // add the element name to the indexterm specialization element
             // list if it does not already exist in that list.
             if (!indexTermSpecList.contains(localName)) {
@@ -229,22 +222,19 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
             }
         }
 
-        if (classAttr != null
-                && MAP_TOPICREF.matches(classAttr)) {
+        if (classAttr != null && MAP_TOPICREF.matches(classAttr)) {
             if (!topicrefSpecList.contains(localName)) {
                 topicrefSpecList.add(localName);
             }
         }
 
-        if (classAttr != null
-                && INDEXING_D_INDEX_SEE.matches(classAttr)) {
+        if (classAttr != null && INDEXING_D_INDEX_SEE.matches(classAttr)) {
             if (!indexSeeSpecList.contains(localName)) {
                 indexSeeSpecList.add(localName);
             }
         }
 
-        if (classAttr != null
-                && INDEXING_D_INDEX_SEE_ALSO.matches(classAttr)) {
+        if (classAttr != null && INDEXING_D_INDEX_SEE_ALSO.matches(classAttr)) {
             if (!indexSeeAlsoSpecList.contains(localName)) {
                 indexSeeAlsoSpecList.add(localName);
             }
@@ -252,9 +242,8 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
 
         if (topicrefSpecList.contains(localName)) {
             final String href = attributes.getValue(ATTRIBUTE_NAME_HREF);
-            final String format = attributes
-                    .getValue(ATTRIBUTE_NAME_FORMAT);
-            final String navtitle =  attributes.getValue(ATTRIBUTE_NAME_NAVTITLE);
+            final String format = attributes.getValue(ATTRIBUTE_NAME_FORMAT);
+            final String navtitle = attributes.getValue(ATTRIBUTE_NAME_NAVTITLE);
             final TopicrefElement topicref = new TopicrefElement();
 
             topicref.setHref(href);
@@ -268,19 +257,16 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
         parseIndexTerm(localName, attributes);
         parseIndexSee(localName);
         parseIndexSeeAlso(localName);
-
     }
 
     private void parseIndexSeeAlso(final String localName) {
         // check to see it the index-see-also element or a specialized version
         // is in the list.
-        if (indexSeeAlsoSpecList.contains(localName)
-                && needPushTerm()) {
+        if (indexSeeAlsoSpecList.contains(localName) && needPushTerm()) {
             final IndexTerm indexTerm = new IndexTerm();
             IndexTerm parentTerm;
-            if (!elementStack.isEmpty()
-                    && elementStack.peek() instanceof IndexTerm) {
-                parentTerm = (IndexTerm)elementStack.peek();
+            if (!elementStack.isEmpty() && elementStack.peek() instanceof IndexTerm) {
+                parentTerm = (IndexTerm) elementStack.peek();
                 if (parentTerm.hasSubTerms()) {
                     parentTerm.updateSubTerm();
                 }
@@ -293,16 +279,14 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
     private void parseIndexSee(final String localName) {
         // check to see it the index-see element or a specialized version is
         // in the list.
-        if (indexSeeSpecList.contains(localName)
-                && needPushTerm()) {
+        if (indexSeeSpecList.contains(localName) && needPushTerm()) {
             final IndexTerm indexTerm = new IndexTerm();
             IndexTerm parentTerm;
 
             indexTerm.setTermPrefix(SEE);
 
-            if (!elementStack.isEmpty()
-                    && elementStack.peek() instanceof IndexTerm) {
-                parentTerm = (IndexTerm)elementStack.peek();
+            if (!elementStack.isEmpty() && elementStack.peek() instanceof IndexTerm) {
+                parentTerm = (IndexTerm) elementStack.peek();
                 if (parentTerm.hasSubTerms()) {
                     parentTerm.updateSubTerm();
                     indexTerm.setTermPrefix(SEE_ALSO);
@@ -320,9 +304,8 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
             indexTerm.setStartAttribute(attributes.getValue(ATTRIBUTE_NAME_END));
             indexTerm.setEndAttribute(attributes.getValue(ATTRIBUTE_NAME_END));
             IndexTerm parentTerm;
-            if (!elementStack.isEmpty()
-                    && elementStack.peek() instanceof IndexTerm) {
-                parentTerm = (IndexTerm)elementStack.peek();
+            if (!elementStack.isEmpty() && elementStack.peek() instanceof IndexTerm) {
+                parentTerm = (IndexTerm) elementStack.peek();
                 if (parentTerm.hasSubTerms()) {
                     parentTerm.updateSubTerm();
                 }
@@ -339,11 +322,13 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
             return false;
         }
 
-
         if (elementStack.peek() instanceof final TopicrefElement elem) {
             // for dita files the indexterm has been moved to its <prolog>
             // therefore we don't need to collect these terms again.
-            if (indexMoved && (elem.getFormat() == null || elem.getFormat().equals(ATTR_FORMAT_VALUE_DITA) || elem.getFormat().equals(ATTR_FORMAT_VALUE_DITAMAP))) {
+            if (indexMoved
+                    && (elem.getFormat() == null
+                            || elem.getFormat().equals(ATTR_FORMAT_VALUE_DITA)
+                            || elem.getFormat().equals(ATTR_FORMAT_VALUE_DITAMAP))) {
                 return false;
             }
         }
@@ -358,5 +343,4 @@ public final class DitamapIndexTermReader extends AbstractXMLReader {
     public void setMapPath(final String mappath) {
         mapPath = mappath;
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/GenListModuleReader.java
+++ b/src/main/java/org/dita/dost/reader/GenListModuleReader.java
@@ -1,13 +1,22 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
+import static org.dita.dost.util.Configuration.ditaFormat;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.nonDitaContext;
+
+import java.net.URI;
+import java.util.*;
+import java.util.function.Predicate;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageBean;
 import org.dita.dost.log.MessageUtils;
@@ -17,16 +26,6 @@ import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-
-import java.net.URI;
-import java.util.*;
-import java.util.function.Predicate;
-
-import static org.dita.dost.util.Configuration.ditaFormat;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.nonDitaContext;
-import static org.dita.dost.util.FileUtils.*;
 
 /**
  * Parse relevant DITA files and collect information.
@@ -137,6 +136,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
      * are subject scheme map paths, both relative to base directory. A key {@link #ROOT_URI} contains all subject scheme maps.
      */
     private final Map<URI, Set<URI>> schemeRelationGraph = new LinkedHashMap<>();
+
     private boolean isRootElement = true;
     private DitaClass rootClass = null;
     private Predicate<String> formatFilter;
@@ -410,10 +410,12 @@ public final class GenListModuleReader extends AbstractXMLFilter {
                 case "http", "https", "ftp", "ftps", "sftp", "mailto" -> scope = ATTR_SCOPE_VALUE_EXTERNAL;
             }
         }
-        if (href != null && href.getPath() != null && !href.getPath().isEmpty() &&
-                !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope) && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
-            if (isFormatDita(atts.getValue(ATTRIBUTE_NAME_FORMAT)) && !isDitaMap() &&
-                    !job.crawlTopics()) {
+        if (href != null
+                && href.getPath() != null
+                && !href.getPath().isEmpty()
+                && !ATTR_SCOPE_VALUE_EXTERNAL.equals(scope)
+                && !ATTR_SCOPE_VALUE_PEER.equals(scope)) {
+            if (isFormatDita(atts.getValue(ATTRIBUTE_NAME_FORMAT)) && !isDitaMap() && !job.crawlTopics()) {
                 // Topic link within a topic, ignore if only crawling map
             } else if (!(MAP_TOPICREF.matches(cls))) {
                 nonTopicrefReferenceSet.add(stripFragment(currentDir.resolve(href)));
@@ -434,9 +436,13 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             if (nonDitaContext(classes)) {
                 // Normal case for bad class: in non DITA context, no message
             } else if (atts.getValue(ATTRIBUTE_NAME_CLASS) == null) { // Missing @class
-                logger.info(MessageUtils.getMessage("DOTJ030I", localName).setLocation(atts).toString());
+                logger.info(MessageUtils.getMessage("DOTJ030I", localName)
+                        .setLocation(atts)
+                        .toString());
             } else { // Invalid DITA @class
-                logger.info(MessageUtils.getMessage("DOTJ070I", atts.getValue(ATTRIBUTE_NAME_CLASS), localName).setLocation(atts).toString());
+                logger.info(MessageUtils.getMessage("DOTJ070I", atts.getValue(ATTRIBUTE_NAME_CLASS), localName)
+                        .setLocation(atts)
+                        .toString());
             }
         } else {
             if ((MAP_MAP.matches(cls)) || (TOPIC_TITLE.matches(cls))) {
@@ -468,7 +474,8 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             return;
         }
         final String attrScope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
-        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope) || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
+        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope)
+                || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
                 || href.toString().startsWith(SHARP)) {
             return;
         }
@@ -509,14 +516,16 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         if (SUBJECTSCHEME_SUBJECTSCHEME.matches(classValue)) {
             // Make it easy to do the BFS later.
             final URI key = ROOT_URI;
-            final Set<URI> children = schemeRelationGraph.containsKey(key) ? schemeRelationGraph.get(key) : new LinkedHashSet<>();
+            final Set<URI> children =
+                    schemeRelationGraph.containsKey(key) ? schemeRelationGraph.get(key) : new LinkedHashSet<>();
             children.add(currentFile);
             schemeRelationGraph.put(key, children);
             schemeRefSet.add(currentFile);
         } else if (SUBJECTSCHEME_SCHEMEREF.matches(classValue)) {
             if (href != null) {
                 final URI key = currentFile;
-                final Set<URI> children = schemeRelationGraph.containsKey(key) ? schemeRelationGraph.get(key) : new LinkedHashSet<>();
+                final Set<URI> children =
+                        schemeRelationGraph.containsKey(key) ? schemeRelationGraph.get(key) : new LinkedHashSet<>();
                 final URI child = currentFile.resolve(href);
                 children.add(child);
                 schemeRelationGraph.put(key, children);
@@ -565,9 +574,11 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             return;
         }
 
-        //Check if this attribute will be ignored due to conref
+        // Check if this attribute will be ignored due to conref
         final String attrConref = atts.getValue(ATTRIBUTE_NAME_CONREF);
-        if (attrConref != null && !attrConref.isEmpty() && ATTR_VALUE_DITA_USE_CONREF_TARGET.equals(attrValue.toString())) {
+        if (attrConref != null
+                && !attrConref.isEmpty()
+                && ATTR_VALUE_DITA_USE_CONREF_TARGET.equals(attrValue.toString())) {
             return;
         }
 
@@ -580,7 +591,8 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         }
 
         // external resource is filtered here.
-        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope) || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
+        if (ATTR_SCOPE_VALUE_EXTERNAL.equals(attrScope)
+                || ATTR_SCOPE_VALUE_PEER.equals(attrScope)
                 || attrValue.toString().startsWith(SHARP)) {
             return;
         }
@@ -598,8 +610,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         if (ATTRIBUTE_NAME_HREF.equals(attrName)) {
             hasHref = true;
             // Collect non-conref and non-copyto targets
-            if (isFormatDita(attrFormat) && !isDitaMap() &&
-                    !job.crawlTopics()) {
+            if (isFormatDita(attrFormat) && !isDitaMap() && !job.crawlTopics()) {
                 // DITA link in a topic, but not crawling topics
             } else if ((followLinks() && canFollow(attrValue))
                     || TOPIC_IMAGE.matches(attrClass)
@@ -625,7 +636,8 @@ public final class GenListModuleReader extends AbstractXMLFilter {
                         if (copytoMap.get(filename) != null) {
                             if (!value.equals(copytoMap.get(filename))) {
                                 logger.warn(MessageUtils.getMessage("DOTX065W", copyTo.toString(), filename.toString())
-                                        .setLocation(atts).toString());
+                                        .setLocation(atts)
+                                        .toString());
                             }
                             ignoredCopytoSourceSet.add(value);
                         } else {
@@ -653,7 +665,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             return ATTR_FORMAT_VALUE_IMAGE;
         } else if (TOPIC_OBJECT.matches(attrClass)) {
             throw new IllegalArgumentException();
-            //return ATTR_FORMAT_VALUE_HTML;
+            // return ATTR_FORMAT_VALUE_HTML;
         } else {
             String format = atts.getValue(ATTRIBUTE_NAME_FORMAT);
             if (format != null && isSupportedImageFile("." + format)) {
@@ -667,7 +679,8 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         String attrValue = atts.getValue(ATTRIBUTE_NAME_CONREF);
         if (attrValue != null) {
             if (attrValue.isEmpty()) {
-                logger.warn(MessageUtils.getMessage("DOTJ081W").setLocation(atts).toString());
+                logger.warn(
+                        MessageUtils.getMessage("DOTJ081W").setLocation(atts).toString());
             } else {
                 hasConRef = true;
 
@@ -696,13 +709,13 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         }
     }
 
-    public final static String[] KEYREF_ATTRS = new String[]{
-            ATTRIBUTE_NAME_KEYREF,
-            ATTRIBUTE_NAME_CONKEYREF,
-            ATTRIBUTE_NAME_ARCHIVEKEYREFS,
-            ATTRIBUTE_NAME_CLASSIDKEYREF,
-            ATTRIBUTE_NAME_CODEBASEKEYREF,
-            ATTRIBUTE_NAME_DATAKEYREF
+    public static final String[] KEYREF_ATTRS = new String[] {
+        ATTRIBUTE_NAME_KEYREF,
+        ATTRIBUTE_NAME_CONKEYREF,
+        ATTRIBUTE_NAME_ARCHIVEKEYREFS,
+        ATTRIBUTE_NAME_CLASSIDKEYREF,
+        ATTRIBUTE_NAME_CODEBASEKEYREF,
+        ATTRIBUTE_NAME_DATAKEYREF
     };
 
     private void parseKeyrefAttr(final Attributes atts) {
@@ -774,10 +787,12 @@ public final class GenListModuleReader extends AbstractXMLFilter {
         if (job.getGeneratecopyouter() == Job.Generate.NOT_GENERATEOUTTER) {
             if (isOutFile(filename)) {
                 if (job.getOutterControl() == Job.OutterControl.FAIL) {
-                    final MessageBean msgBean = MessageUtils.getMessage("DOTJ035F", prop).setLocation(atts);
+                    final MessageBean msgBean =
+                            MessageUtils.getMessage("DOTJ035F", prop).setLocation(atts);
                     throw new SAXParseException(null, null, new DITAOTException(msgBean, null, msgBean.toString()));
                 } else if (job.getOutterControl() == Job.OutterControl.WARN) {
-                    final MessageBean msgBean = MessageUtils.getMessage("DOTJ036W", prop).setLocation(atts);
+                    final MessageBean msgBean =
+                            MessageUtils.getMessage("DOTJ036W", prop).setLocation(atts);
                     logger.warn(msgBean.toString());
                 }
                 addToOutFilesSet(filename);
@@ -817,7 +832,7 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             final int prime = 31;
             int result = 1;
             result = prime * result + ((filename == null) ? 0 : filename.hashCode());
-//            result = prime * result + ((format == null) ? 0 : format.hashCode());
+            //            result = prime * result + ((format == null) ? 0 : format.hashCode());
             return result;
         }
 
@@ -839,15 +854,14 @@ public final class GenListModuleReader extends AbstractXMLFilter {
             } else if (!filename.equals(other.filename)) {
                 return false;
             }
-//            if (format == null) {
-//                if (other.format != null) {
-//                    return false;
-//                }
-//            } else if (!format.equals(other.format)) {
-//                return false;
-//            }
+            //            if (format == null) {
+            //                if (other.format != null) {
+            //                    return false;
+            //                }
+            //            } else if (!format.equals(other.format)) {
+            //                return false;
+            //            }
             return true;
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/GrammarPoolManager.java
+++ b/src/main/java/org/dita/dost/reader/GrammarPoolManager.java
@@ -36,6 +36,4 @@ public final class GrammarPoolManager {
         }
         return pool;
     }
-
 }
-

--- a/src/main/java/org/dita/dost/reader/IndexTermReader.java
+++ b/src/main/java/org/dita/dost/reader/IndexTermReader.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
 import static org.dita.dost.index.IndexTerm.IndexTermPrefix.*;
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-
 import org.dita.dost.index.IndexTerm;
 import org.dita.dost.index.IndexTermCollection;
 import org.dita.dost.index.IndexTermTarget;
@@ -126,8 +125,7 @@ public final class IndexTermReader extends AbstractXMLReader {
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         final StringBuilder tempBuf = new StringBuilder(length);
         tempBuf.append(ch, start, length);
         normalizeAndCollapseWhitespace(tempBuf);
@@ -136,8 +134,7 @@ public final class IndexTermReader extends AbstractXMLReader {
         /*
          * For title info
          */
-        if (processRoleStack.isEmpty() ||
-                !ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(processRoleStack.peek())) {
+        if (processRoleStack.isEmpty() || !ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(processRoleStack.peek())) {
             if (!insideSortingAs && !termStack.empty()) {
                 final IndexTerm indexTerm = termStack.peek();
                 temp = trimSpaceAtStart(temp, indexTerm.getTermName());
@@ -148,7 +145,7 @@ public final class IndexTermReader extends AbstractXMLReader {
                 indexTerm.setTermKey(setOrAppend(indexTerm.getTermKey(), temp, false));
             } else if (inTitleElement) {
                 temp = trimSpaceAtStart(temp, title);
-                //Always append space if: <title>abc<ph/>df</title>
+                // Always append space if: <title>abc<ph/>df</title>
                 title = setOrAppend(title, temp, false);
             }
         }
@@ -158,24 +155,22 @@ public final class IndexTermReader extends AbstractXMLReader {
     public void endDocument() throws SAXException {
         updateIndexTermTargetName();
         for (final IndexTerm indexterm : indexTermList) {
-            //IndexTermCollection.getInstantce().addTerm(indexterm);
+            // IndexTermCollection.getInstantce().addTerm(indexterm);
             result.addTerm(indexterm);
         }
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
 
-        //Skip the topic if @processing-role="resource-only"
+        // Skip the topic if @processing-role="resource-only"
         if (processRoleLevel > 0) {
             String role = processRoleStack.peek();
             if (processRoleLevel == processRoleStack.size()) {
                 role = processRoleStack.pop();
             }
             processRoleLevel--;
-            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY
-                    .equals(role)) {
+            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(role)) {
                 return;
             }
         }
@@ -197,21 +192,21 @@ public final class IndexTermReader extends AbstractXMLReader {
                 term.setTermKey(term.getTermName());
             }
 
-            //if this term is the leaf term
-            //leaf means the current indexterm element doesn't contains any subterms
-            //or only has "index-see" or "index-see-also" subterms.
+            // if this term is the leaf term
+            // leaf means the current indexterm element doesn't contains any subterms
+            // or only has "index-see" or "index-see-also" subterms.
             if (term.isLeaf()) {
-                //generate a target which points to current topic and
-                //assign it to current term.
+                // generate a target which points to current topic and
+                // assign it to current term.
                 final IndexTermTarget target = genTarget();
                 term.addTarget(target);
             }
 
             if (termStack.empty()) {
-                //most parent indexterm
+                // most parent indexterm
                 indexTermList.add(term);
             } else {
-                //Assign parent indexterm to
+                // Assign parent indexterm to
                 final IndexTerm parentTerm = termStack.peek();
                 parentTerm.addSubTerm(term);
             }
@@ -219,15 +214,14 @@ public final class IndexTermReader extends AbstractXMLReader {
 
         // Check to see if the index-see or index-see-also or a specialized
         // version is in the list.
-        if (indexSeeSpecList.contains(localName)
-                || indexSeeAlsoSpecList.contains(localName)) {
+        if (indexSeeSpecList.contains(localName) || indexSeeAlsoSpecList.contains(localName)) {
             final IndexTerm term = termStack.pop();
             final IndexTerm parentTerm = termStack.peek();
             if (term.getTermKey() == null) {
                 term.setTermKey(term.getTermFullName());
             }
-            //term.addTargets(parentTerm.getTargetList());
-            term.addTarget(genTarget()); //assign current topic as the target of index-see or index-see-also term
+            // term.addTargets(parentTerm.getTargetList());
+            term.addTarget(genTarget()); // assign current topic as the target of index-see or index-see-also term
             parentTerm.addSubTerm(term);
         }
 
@@ -237,8 +231,8 @@ public final class IndexTermReader extends AbstractXMLReader {
         if (titleSpecList.contains(localName)) {
             inTitleElement = false;
             if (!topicIdStack.empty() && !titleMap.containsKey(topicIdStack.peek())) {
-                //If this is the first topic title
-                if (title == null) {  //Guard against zero-content titles
+                // If this is the first topic title
+                if (title == null) { // Guard against zero-content titles
                     title = "***";
                 }
                 if (titleMap.size() == 0) {
@@ -287,23 +281,20 @@ public final class IndexTermReader extends AbstractXMLReader {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes attributes) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+            throws SAXException {
 
-        //Skip the topic if @processing-role="resource-only"
-        final String attrValue = attributes
-                .getValue(ATTRIBUTE_NAME_PROCESSING_ROLE);
+        // Skip the topic if @processing-role="resource-only"
+        final String attrValue = attributes.getValue(ATTRIBUTE_NAME_PROCESSING_ROLE);
         if (attrValue != null) {
             processRoleStack.push(attrValue);
             processRoleLevel++;
-            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY
-                    .equals(attrValue)) {
+            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(attrValue)) {
                 return;
             }
         } else if (processRoleLevel > 0) {
             processRoleLevel++;
-            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY
-                    .equals(processRoleStack.peek())) {
+            if (ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY.equals(processRoleStack.peek())) {
                 return;
             }
         }
@@ -312,14 +303,13 @@ public final class IndexTermReader extends AbstractXMLReader {
 
         handleSpecialization(localName, classAttr);
         parseTopic(localName, attributes.getValue(ATTRIBUTE_NAME_ID));
-        //change parseIndexTerm(localName) to parseIndexTerm(localName, attributes)
+        // change parseIndexTerm(localName) to parseIndexTerm(localName, attributes)
         parseIndexTerm(localName, attributes);
         parseIndexSee(localName);
         parseIndexSeeAlso(localName);
 
         if (IndexTerm.getTermLocale() == null) {
-            final String xmlLang = attributes
-                    .getValue(ATTRIBUTE_NAME_XML_LANG);
+            final String xmlLang = attributes.getValue(ATTRIBUTE_NAME_XML_LANG);
 
             if (xmlLang != null) {
                 IndexTerm.setTermLocale(getLocale(xmlLang));
@@ -329,8 +319,7 @@ public final class IndexTermReader extends AbstractXMLReader {
         /*
          * For title info
          */
-        if (titleSpecList.contains(localName)
-                && !topicIdStack.empty() && !titleMap.containsKey(topicIdStack.peek())) {
+        if (titleSpecList.contains(localName) && !topicIdStack.empty() && !titleMap.containsKey(topicIdStack.peek())) {
             inTitleElement = true;
             title = null;
         }
@@ -434,13 +423,13 @@ public final class IndexTermReader extends AbstractXMLReader {
                 indexSortAsSpecList.add(localName);
             }
         } else if (TOPIC_TOPIC.matches(classAttr)) {
-            //add the element name to the topic specialization element
+            // add the element name to the topic specialization element
             // list if it does not already exist in that list.
             if (!topicSpecList.contains(localName)) {
                 topicSpecList.add(localName);
             }
         } else if (TOPIC_TITLE.matches(classAttr)) {
-            //add the element name to the title specailization element list
+            // add the element name to the title specailization element list
             // if it does not exist in that list.
             if (!titleSpecList.contains(localName)) {
                 titleSpecList.add(localName);
@@ -476,13 +465,12 @@ public final class IndexTermReader extends AbstractXMLReader {
         final int targetSize = indexterm.getTargetList().size();
         final int subtermSize = indexterm.getSubTerms().size();
 
-        for (int i = 0; i<targetSize; i++) {
+        for (int i = 0; i < targetSize; i++) {
             final IndexTermTarget target = indexterm.getTargetList().get(i);
             final String uri = target.getTargetURI();
             final int indexOfSharp = uri.lastIndexOf(SHARP);
-            final String fragment = (indexOfSharp == -1 || uri.endsWith(SHARP))?
-                    null:
-                        uri.substring(indexOfSharp + 1);
+            final String fragment =
+                    (indexOfSharp == -1 || uri.endsWith(SHARP)) ? null : uri.substring(indexOfSharp + 1);
             if (fragment != null && titleMap.containsKey(fragment)) {
                 target.setTargetName(titleMap.get(fragment));
             } else {
@@ -490,7 +478,7 @@ public final class IndexTermReader extends AbstractXMLReader {
             }
         }
 
-        for (int i = 0; i<subtermSize; i++) {
+        for (int i = 0; i < subtermSize; i++) {
             final IndexTerm subterm = indexterm.getSubTerms().get(i);
             updateIndexTermTargetName(subterm);
         }
@@ -510,5 +498,4 @@ public final class IndexTermReader extends AbstractXMLReader {
         }
         return temp;
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/KeydefFilter.java
+++ b/src/main/java/org/dita/dost/reader/KeydefFilter.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
 
 import static org.dita.dost.util.Constants.*;
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.util.KeyDef;
 import org.dita.dost.util.StringUtils;
@@ -88,7 +87,6 @@ public final class KeydefFilter extends AbstractXMLFilter {
         getContentHandler().startElement(uri, localName, qName, atts);
     }
 
-
     /**
      * Clean up.
      */
@@ -122,8 +120,10 @@ public final class KeydefFilter extends AbstractXMLFilter {
                     if (target != null && !target.toString().isEmpty()) {
                         final String attrScope = atts.getValue(ATTRIBUTE_NAME_SCOPE);
                         final String attrFormat = atts.getValue(ATTRIBUTE_NAME_FORMAT);
-                        if (attrScope != null && (attrScope.equals(ATTR_SCOPE_VALUE_EXTERNAL) || attrScope.equals(ATTR_SCOPE_VALUE_PEER))) {
-                            keysDefMap.put(key, new KeyDef(key, target, attrScope,  attrFormat, null, null));
+                        if (attrScope != null
+                                && (attrScope.equals(ATTR_SCOPE_VALUE_EXTERNAL)
+                                        || attrScope.equals(ATTR_SCOPE_VALUE_PEER))) {
+                            keysDefMap.put(key, new KeyDef(key, target, attrScope, attrFormat, null, null));
                         } else {
                             String tail = null;
                             if (target.getFragment() != null) {
@@ -133,7 +133,15 @@ public final class KeydefFilter extends AbstractXMLFilter {
                             if (!target.isAbsolute()) {
                                 target = currentDir.resolve(target);
                             }
-                            keysDefMap.put(key, new KeyDef(key, setFragment(target, tail), ATTR_SCOPE_VALUE_LOCAL, attrFormat, null, null));
+                            keysDefMap.put(
+                                    key,
+                                    new KeyDef(
+                                            key,
+                                            setFragment(target, tail),
+                                            ATTR_SCOPE_VALUE_LOCAL,
+                                            attrFormat,
+                                            null,
+                                            null));
                         }
                     } else if (!StringUtils.isEmptyString(keyRef)) {
                         // store multi-level keys.
@@ -144,7 +152,9 @@ public final class KeydefFilter extends AbstractXMLFilter {
                         keysDefMap.put(key, new KeyDef(key, null, null, null, null, null));
                     }
                 } else {
-                    logger.info(MessageUtils.getMessage("DOTJ045I", key).setLocation(atts).toString());
+                    logger.info(MessageUtils.getMessage("DOTJ045I", key)
+                            .setLocation(atts)
+                            .toString());
                 }
             }
         }
@@ -197,5 +207,4 @@ public final class KeydefFilter extends AbstractXMLFilter {
         // update keysDefMap.
         keysDefMap.putAll(tempMap);
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -1,28 +1,27 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.reader;
-
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLUtils;
-import org.dita.dost.writer.AbstractDomFilter;
-import org.w3c.dom.*;
-
-import java.io.File;
-import java.net.URI;
-import java.util.*;
-import java.util.Map.Entry;
 
 import static java.util.Arrays.asList;
 import static org.dita.dost.module.GenMapAndTopicListModule.ELEMENT_STUB;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.stripFragment;
+
+import java.io.File;
+import java.net.URI;
+import java.util.*;
+import java.util.Map.Entry;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.URLUtils;
+import org.dita.dost.util.XMLUtils;
+import org.dita.dost.writer.AbstractDomFilter;
+import org.w3c.dom.*;
 
 /**
  * Cascade map metadata to child topic references and collect metadata for topics.
@@ -40,8 +39,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_PUBLISHER.matcher,
             TOPIC_SOURCE.matcher,
             MAP_SEARCHTITLE.matcher,
-            TOPIC_SEARCHTITLE.matcher
-    )));
+            TOPIC_SEARCHTITLE.matcher)));
     private static final Set<String> cascadeSet = Collections.unmodifiableSet(new HashSet<>(asList(
             TOPIC_AUDIENCE.matcher,
             TOPIC_AUTHOR.matcher,
@@ -51,8 +49,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_METADATA.matcher,
             TOPIC_PERMISSIONS.matcher,
             TOPIC_PRODINFO.matcher,
-            TOPIC_PUBLISHER.matcher
-    )));
+            TOPIC_PUBLISHER.matcher)));
     private static final Set<String> metaSet = Collections.unmodifiableSet(new HashSet<>(asList(
             MAP_SEARCHTITLE.matcher,
             TOPIC_SEARCHTITLE.matcher,
@@ -71,8 +68,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             TOPIC_DATA.matcher,
             TOPIC_DATA_ABOUT.matcher,
             TOPIC_FOREIGN.matcher,
-            TOPIC_UNKNOWN.matcher
-    )));
+            TOPIC_UNKNOWN.matcher)));
     private static final List<String> metaPos = Collections.unmodifiableList(asList(
             MAP_SEARCHTITLE.matcher,
             TOPIC_SEARCHTITLE.matcher,
@@ -97,8 +93,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             MAP_SHORTDESC.matcher,
             TOPIC_SHORTDESC.matcher,
             TOPIC_NAVTITLE.matcher,
-            TOPIC_METADATA.matcher
-            ));
+            TOPIC_METADATA.matcher));
 
     private final Map<String, Element> globalMeta;
     /** Current document. */
@@ -125,7 +120,7 @@ public final class MapMetaReader extends AbstractDomFilter {
     public void read(final File filename) throws DITAOTException {
         filePath = filename;
 
-        //clear the history on global metadata table
+        // clear the history on global metadata table
         globalMeta.clear();
         super.read(filename);
     }
@@ -143,7 +138,7 @@ public final class MapMetaReader extends AbstractDomFilter {
                     // if this node is topicmeta node under root
                     if (MAP_TOPICMETA.matches(classAttr.getNodeValue())) {
                         handleGlobalMeta(elem);
-                    // if this node is topicref node under root
+                        // if this node is topicref node under root
                     } else if (MAP_TOPICREF.matches(classAttr.getNodeValue())) {
                         handleTopicref(elem, globalMeta);
                     }
@@ -152,8 +147,8 @@ public final class MapMetaReader extends AbstractDomFilter {
         }
         // Indexterm elements with either start or end attribute should not been
         // move to referenced dita file's prolog section.
-        for (final Map<String, Element> resultTableEntry: resultTable.values()) {
-            for (final Map.Entry<String, Element> mapEntry: resultTableEntry.entrySet()) {
+        for (final Map<String, Element> resultTableEntry : resultTable.values()) {
+            for (final Map.Entry<String, Element> mapEntry : resultTableEntry.entrySet()) {
                 final String key = mapEntry.getKey();
                 if (TOPIC_KEYWORDS.matcher.equals(key)) {
                     removeIndexTermRecursive(mapEntry.getValue());
@@ -178,7 +173,8 @@ public final class MapMetaReader extends AbstractDomFilter {
             if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
                 child = (Element) children.item(i);
                 final boolean isIndexTerm = TOPIC_INDEXTERM.matches(child);
-                final boolean hasStart = !child.getAttribute(ATTRIBUTE_NAME_START).isEmpty();
+                final boolean hasStart =
+                        !child.getAttribute(ATTRIBUTE_NAME_START).isEmpty();
                 final boolean hasEnd = !child.getAttribute(ATTRIBUTE_NAME_END).isEmpty();
                 if (isIndexTerm && (hasStart || hasEnd)) {
                     parent.removeChild(child);
@@ -205,11 +201,13 @@ public final class MapMetaReader extends AbstractDomFilter {
                 Attr classAttr = elem.getAttributeNode(ATTRIBUTE_NAME_CLASS);
                 if (classAttr != null) {
                     // if this node is topicmeta and the parent topicref refers to a valid dita topic
-                    if (MAP_TOPICMETA.matches(classAttr.getNodeValue()) &&
-                        hrefAttr != null && isLocalScope(scopeAttr) && isDitaFormat(formatAttr)) {
+                    if (MAP_TOPICMETA.matches(classAttr.getNodeValue())
+                            && hrefAttr != null
+                            && isLocalScope(scopeAttr)
+                            && isDitaFormat(formatAttr)) {
                         metaNode = elem;
                         current = handleMeta(elem, inheritance);
-                    // if this node is topicref node under topicref
+                        // if this node is topicref node under topicref
                     } else if (MAP_TOPICREF.matches(classAttr.getNodeValue())) {
                         handleTopicref(elem, current);
                     }
@@ -217,7 +215,7 @@ public final class MapMetaReader extends AbstractDomFilter {
             }
         }
 
-        if (!current.isEmpty() && hrefAttr != null) {// prevent the metadata is empty
+        if (!current.isEmpty() && hrefAttr != null) { // prevent the metadata is empty
             if (isDitaFormat(formatAttr) && isLocalScope(scopeAttr)) {
                 URI topicPath;
                 if (copytoAttr != null) {
@@ -228,8 +226,8 @@ public final class MapMetaReader extends AbstractDomFilter {
                     topicPath = job.tempDirURI.relativize(filePath.toURI().resolve(hrefUri));
                 }
                 if (resultTable.containsKey(topicPath)) {
-                    //if the result table already contains some result
-                    //metadata for current topic path.
+                    // if the result table already contains some result
+                    // metadata for current topic path.
                     final Map<String, Element> previous = resultTable.get(topicPath);
                     resultTable.put(topicPath, mergeMeta(previous, current, metaSet));
                 } else {
@@ -262,9 +260,9 @@ public final class MapMetaReader extends AbstractDomFilter {
     }
 
     private boolean isDitaFormat(final Attr formatAttr) {
-        return formatAttr == null ||
-            ATTR_FORMAT_VALUE_DITA.equals(formatAttr.getNodeValue()) ||
-            ATTR_FORMAT_VALUE_DITAMAP.equals(formatAttr.getNodeValue());
+        return formatAttr == null
+                || ATTR_FORMAT_VALUE_DITA.equals(formatAttr.getNodeValue())
+                || ATTR_FORMAT_VALUE_DITAMAP.equals(formatAttr.getNodeValue());
     }
 
     /**
@@ -275,12 +273,11 @@ public final class MapMetaReader extends AbstractDomFilter {
      */
     private Map<String, Element> cloneElementMap(final Map<String, Element> current) {
         final Map<String, Element> topicMetaTable = new HashMap<>(16);
-        for (final Entry<String, Element> topicMetaItem: current.entrySet()) {
+        for (final Entry<String, Element> topicMetaItem : current.entrySet()) {
             topicMetaTable.put(topicMetaItem.getKey(), (Element) resultDoc.importNode(topicMetaItem.getValue(), true));
         }
         return topicMetaTable;
     }
-
 
     private Map<String, Element> handleMeta(final Element meta, final Map<String, Element> inheritance) {
         final Map<String, Element> topicMetaTable = new HashMap<>(16);
@@ -298,18 +295,24 @@ public final class MapMetaReader extends AbstractDomFilter {
                 if (classAttr != null) {
                     final String classValue = classAttr.getNodeValue();
                     // int number 1 is used to remove the first "-" or "+" character in class attribute
-                    final String metaKey = classValue.substring(1, classValue.indexOf(STRING_BLANK, classValue.indexOf(SLASH)) + 1);
+                    final String metaKey =
+                            classValue.substring(1, classValue.indexOf(STRING_BLANK, classValue.indexOf(SLASH)) + 1);
                     if (TOPIC_METADATA.matches(classValue)) {
                         getMeta(elem, topicMetaTable);
                     } else if (topicMetaTable.containsKey(metaKey)) {
-                        //append node to the list if it exist in topic meta table
+                        // append node to the list if it exist in topic meta table
                         topicMetaTable.get(metaKey).appendChild(resultDoc.importNode(elem, true));
                     } else {
                         if (TOPIC_NAVTITLE.matches(classValue)) {
-                            //Add locktitle value to navtitle so we know whether it should be pushed to topics
-                            final String locktitleAttr =  ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE) != null ?
-                                                          ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE).getNodeValue() : "no";
-                            elem.setAttributeNS(DITA_OT_NS, DITA_OT_NS_PREFIX + ":" + ATTRIBUTE_NAME_LOCKTITLE, locktitleAttr);
+                            // Add locktitle value to navtitle so we know whether it should be pushed to topics
+                            final String locktitleAttr =
+                                    ((Element) meta.getParentNode()).getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE) != null
+                                            ? ((Element) meta.getParentNode())
+                                                    .getAttributeNode(ATTRIBUTE_NAME_LOCKTITLE)
+                                                    .getNodeValue()
+                                            : "no";
+                            elem.setAttributeNS(
+                                    DITA_OT_NS, DITA_OT_NS_PREFIX + ":" + ATTRIBUTE_NAME_LOCKTITLE, locktitleAttr);
                         }
                         final Element stub = resultDoc.createElement(ELEMENT_STUB);
                         stub.appendChild(resultDoc.importNode(elem, true));
@@ -320,8 +323,8 @@ public final class MapMetaReader extends AbstractDomFilter {
         }
     }
 
-    private Map<String, Element> mergeMeta(Map<String, Element> topicMetaTable,
-            final Map<String, Element> inheritance, final Set<String> enableSet) {
+    private Map<String, Element> mergeMeta(
+            Map<String, Element> topicMetaTable, final Map<String, Element> inheritance, final Set<String> enableSet) {
         // When inherited metadata need to be merged into current metadata
         // enableSet should be cascadeSet so that only metadata that can
         // be inherited are merged.
@@ -336,13 +339,13 @@ public final class MapMetaReader extends AbstractDomFilter {
                     if (!topicMetaTable.containsKey(key)) {
                         topicMetaTable.put(key, inheritance.get(key));
                     }
-                } else {  // not unique metadata
+                } else { // not unique metadata
                     if (!topicMetaTable.containsKey(key)) {
                         topicMetaTable.put(key, inheritance.get(key));
                     } else {
-                        //not necessary to do node type check here
-                        //because inheritStub doesn't contains any node
-                        //other than Element.
+                        // not necessary to do node type check here
+                        // because inheritStub doesn't contains any node
+                        // other than Element.
                         final Element stub = topicMetaTable.get(key);
                         final Node inheritStub = inheritance.get(key);
                         if (stub != inheritStub) {
@@ -372,12 +375,13 @@ public final class MapMetaReader extends AbstractDomFilter {
                 final Attr classAttr = elem.getAttributeNode(ATTRIBUTE_NAME_CLASS);
                 if (classAttr != null) {
                     final String classValue = classAttr.getNodeValue();
-                    final String metaKey = classValue.substring(1, classValue.indexOf(STRING_BLANK, classValue.indexOf(SLASH))+1 );
+                    final String metaKey =
+                            classValue.substring(1, classValue.indexOf(STRING_BLANK, classValue.indexOf(SLASH)) + 1);
                     if (TOPIC_METADATA.matches(classValue)) {
-                        //proceed the metadata in <metadata>
+                        // proceed the metadata in <metadata>
                         handleGlobalMeta(elem);
                     } else if (cascadeSet.contains(metaKey) && globalMeta.containsKey(metaKey)) {
-                        //append node to the list if it exist in global meta table
+                        // append node to the list if it exist in global meta table
                         globalMeta.get(metaKey).appendChild(resultDoc.importNode(elem, true));
                     } else if (cascadeSet.contains(metaKey)) {
                         final Element stub = resultDoc.createElement(ELEMENT_STUB);
@@ -397,5 +401,4 @@ public final class MapMetaReader extends AbstractDomFilter {
     public Map<URI, Map<String, Element>> getMapping() {
         return Collections.unmodifiableMap(resultTable);
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -8,6 +8,13 @@
 
 package org.dita.dost.reader;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.io.*;
+import java.net.URI;
+import java.util.*;
+import javax.xml.namespace.QName;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.util.Job;
@@ -17,14 +24,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import javax.xml.namespace.QName;
-import java.io.*;
-import java.net.URI;
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Subject scheme reader.
@@ -115,11 +114,11 @@ public class SubjectSchemeReader {
             throw new IOException("Failed to read subject scheme graph: " + e.getMessage(), e);
         }
 
-        for (final Map.Entry<Object, Object> entry: prop.entrySet()) {
+        for (final Map.Entry<Object, Object> entry : prop.entrySet()) {
             final String key = (String) entry.getKey();
             final String value = (String) entry.getValue();
             final Set<URI> r = new HashSet<>();
-            for (final String v: StringUtils.restoreSet(value, COMMA)) {
+            for (final String v : StringUtils.restoreSet(value, COMMA)) {
                 r.add(toURI(v));
             }
             graph.put(toURI(key), r);
@@ -142,7 +141,7 @@ public class SubjectSchemeReader {
             return;
         }
         final Properties prop = new Properties();
-        for (final Map.Entry<URI, Set<URI>> entry: m.entrySet()) {
+        for (final Map.Entry<URI, Set<URI>> entry : m.entrySet()) {
             final URI key = entry.getKey();
             final String value = StringUtils.join(entry.getValue(), COMMA);
             prop.setProperty(key.getPath(), value);
@@ -176,7 +175,7 @@ public class SubjectSchemeReader {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -258,7 +257,7 @@ public class SubjectSchemeReader {
             final NodeList children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                    queue.add((Element)children.item(i));
+                    queue.add((Element) children.item(i));
                 }
             }
             if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
@@ -279,7 +278,8 @@ public class SubjectSchemeReader {
      * @param attName attribute name
      * @param category enumeration category name
      */
-    private void putValuePairsIntoMap(final Element subtree, final String elementName, final QName attName, final String category) {
+    private void putValuePairsIntoMap(
+            final Element subtree, final String elementName, final QName attName, final String category) {
         if (subtree == null || attName == null) {
             return;
         }
@@ -302,7 +302,7 @@ public class SubjectSchemeReader {
             final NodeList children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                    queue.offer((Element)children.item(i));
+                    queue.offer((Element) children.item(i));
                 }
             }
             if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
@@ -315,5 +315,4 @@ public class SubjectSchemeReader {
         valueMap.put(elementName, valueSet);
         validValuesMap.put(attName, valueMap);
     }
-
 }

--- a/src/main/java/org/dita/dost/reader/SvgMetadataReader.java
+++ b/src/main/java/org/dita/dost/reader/SvgMetadataReader.java
@@ -7,14 +7,13 @@
  */
 package org.dita.dost.reader;
 
+import java.io.IOException;
+import java.io.InputStream;
 import org.dita.dost.writer.ImageMetadataFilter;
 import org.xml.sax.Attributes;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Reader for SVG dimension metadata.
@@ -34,11 +33,12 @@ public class SvgMetadataReader extends AbstractXMLReader {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-                             final Attributes atts) throws SAXException {
-        if (SVG_NS.equals(uri) &&
-                (SVG_ELEM.equals(localName) || SVG_ELEM.equals(qName) ||
-                        (qName != null && qName.startsWith(SVG_ELEM + ":")))) {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
+        if (SVG_NS.equals(uri)
+                && (SVG_ELEM.equals(localName)
+                        || SVG_ELEM.equals(qName)
+                        || (qName != null && qName.startsWith(SVG_ELEM + ":")))) {
             dimensions.width = atts.getValue(WIDTH_ATTR);
             dimensions.height = atts.getValue(HEIGHT_ATTR);
         }
@@ -50,7 +50,8 @@ public class SvgMetadataReader extends AbstractXMLReader {
 
     public static class EmptyEntityResolver implements EntityResolver {
         @Override
-        public InputSource resolveEntity(final String publicId, final String systemId) throws SAXException, IOException {
+        public InputSource resolveEntity(final String publicId, final String systemId)
+                throws SAXException, IOException {
             return new InputSource(new InputStream() {
                 @Override
                 public int read() throws IOException {

--- a/src/main/java/org/dita/dost/store/AbstractStore.java
+++ b/src/main/java/org/dita/dost/store/AbstractStore.java
@@ -8,20 +8,18 @@
 
 package org.dita.dost.store;
 
-import net.sf.saxon.s9api.XsltTransformer;
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.util.XMLUtils;
-import org.xml.sax.XMLFilter;
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
+import static org.dita.dost.util.URLUtils.setFragment;
+import static org.dita.dost.util.URLUtils.toURI;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
-
-import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
-import static org.dita.dost.util.URLUtils.setFragment;
-import static org.dita.dost.util.URLUtils.toURI;
+import net.sf.saxon.s9api.XsltTransformer;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.XMLUtils;
+import org.xml.sax.XMLFilter;
 
 /**
  * Common base class for store implementations.
@@ -34,7 +32,7 @@ public abstract class AbstractStore implements Store {
     public final File tempDir;
     public final URI tempDirUri;
 
-//    final TransformerFactory tf;
+    //    final TransformerFactory tf;
 
     public AbstractStore(final File tempDir, final XMLUtils xmlUtils) {
         if (!tempDir.isAbsolute()) {
@@ -43,20 +41,20 @@ public abstract class AbstractStore implements Store {
         this.tempDirUri = tempDir.toURI();
         this.tempDir = tempDir;
         this.xmlUtils = xmlUtils;
-//        tf = TransformerFactory.newInstance();
+        //        tf = TransformerFactory.newInstance();
     }
 
     @Override
     public URI getUri(final URI path) {
-//        if (path.isAbsolute()) {
-//            if (path.normalize().toString().startsWith(tempDirUri.toString())) {
-//                return URI.create(path.normalize().toString() + ".xxx");
-//            } else {
-//                return path.normalize();
-//            }
-//        } else {
-//            return URI.create(tempDirUri.resolve(path).normalize().toString() + ".xxx");
-//        }
+        //        if (path.isAbsolute()) {
+        //            if (path.normalize().toString().startsWith(tempDirUri.toString())) {
+        //                return URI.create(path.normalize().toString() + ".xxx");
+        //            } else {
+        //                return path.normalize();
+        //            }
+        //        } else {
+        //            return URI.create(tempDirUri.resolve(path).normalize().toString() + ".xxx");
+        //        }
         return tempDirUri.resolve(path).normalize();
     }
 
@@ -64,25 +62,25 @@ public abstract class AbstractStore implements Store {
         return f.toString().startsWith(tempDirUri.toString());
     }
 
-//    @Override
-//    public void transform(final URI src, final ContentHandler dst) throws DITAOTException {
-//        try {
-////            final Transformer serializer = tf.newTransformer();
-////            serializer.setURIResolver(this);
-//
-//            final Source source = getSource(src);
-//            final SAXDestination destination = new SAXDestination(dst);
-////            final Result result = new SAXResult(dst);
-//
-////            xmlUtils.getProcessor().se
-////            serializer.transform(source, result);
-//            xmlUtils.getProcessor().writeXdmValue(source, destination);
-//        } catch (final RuntimeException e) {
-//            throw e;
-//        } catch (final Exception e) {
-//            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
-//        }
-//    }
+    //    @Override
+    //    public void transform(final URI src, final ContentHandler dst) throws DITAOTException {
+    //        try {
+    ////            final Transformer serializer = tf.newTransformer();
+    ////            serializer.setURIResolver(this);
+    //
+    //            final Source source = getSource(src);
+    //            final SAXDestination destination = new SAXDestination(dst);
+    ////            final Result result = new SAXResult(dst);
+    //
+    ////            xmlUtils.getProcessor().se
+    ////            serializer.transform(source, result);
+    //            xmlUtils.getProcessor().writeXdmValue(source, destination);
+    //        } catch (final RuntimeException e) {
+    //            throw e;
+    //        } catch (final Exception e) {
+    //            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+    //        }
+    //    }
 
     @Override
     public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
@@ -97,10 +95,10 @@ public abstract class AbstractStore implements Store {
 
     @Override
     public void transform(URI src, final List<XMLFilter> filters) throws DITAOTException {
-//        assert input.isAbsolute();
-//        if (!input.getScheme().equals("file")) {
-//            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
-//        }
+        //        assert input.isAbsolute();
+        //        if (!input.getScheme().equals("file")) {
+        //            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+        //        }
         final URI srcFile = setFragment(src, null);
         final URI dst = toURI(srcFile.toString() + FILE_EXTENSION_TEMP).normalize();
         transformURI(srcFile, dst, filters);
@@ -115,39 +113,41 @@ public abstract class AbstractStore implements Store {
 
     abstract void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException;
 
-    abstract void transformUri(final URI input, final URI output, final XsltTransformer transformer) throws DITAOTException;
+    abstract void transformUri(final URI input, final URI output, final XsltTransformer transformer)
+            throws DITAOTException;
 
-//    @Override
-//    public void transform(final URI src, final URI outputFile, final List<XMLFilter> filters) throws DITAOTException {
-//        try {
-//            final IdentityTransformer serializer = (IdentityTransformer) tf.newTransformer();
-//            serializer.getConfiguration().setErrorListener(new ErrorGatherer(new ArrayList<>()));
-//            final URIResolver resolver = new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), this);
-//            serializer.setURIResolver(resolver);
-//
-//            final Source source = getSource(src);
-//            final Result result = getResult(outputFile);
-//
-//            ContentHandler handler;
-//            final TransformerHandler th = ((SAXTransformerFactory) tf).newTransformerHandler();
-//            th.getTransformer().setURIResolver(this);
-//            th.setResult(result);
-//            handler = th;
-//
-//            final ArrayList<XMLFilter> fs = new ArrayList<>(filters);
-//            Collections.reverse(fs);
-//            for (final XMLFilter filter : fs) {
-//                filter.setContentHandler(handler);
-//                handler = (ContentHandler) filter;
-//            }
-//
-//            final Result intermediate = new SAXResult(handler);
-//
-//            serializer.transform(source, intermediate);
-//        } catch (final RuntimeException e) {
-//            throw e;
-//        } catch (final Exception e) {
-//            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
-//        }
-//    }
+    //    @Override
+    //    public void transform(final URI src, final URI outputFile, final List<XMLFilter> filters) throws
+    // DITAOTException {
+    //        try {
+    //            final IdentityTransformer serializer = (IdentityTransformer) tf.newTransformer();
+    //            serializer.getConfiguration().setErrorListener(new ErrorGatherer(new ArrayList<>()));
+    //            final URIResolver resolver = new DelegatingURIResolver(CatalogUtils.getCatalogResolver(), this);
+    //            serializer.setURIResolver(resolver);
+    //
+    //            final Source source = getSource(src);
+    //            final Result result = getResult(outputFile);
+    //
+    //            ContentHandler handler;
+    //            final TransformerHandler th = ((SAXTransformerFactory) tf).newTransformerHandler();
+    //            th.getTransformer().setURIResolver(this);
+    //            th.setResult(result);
+    //            handler = th;
+    //
+    //            final ArrayList<XMLFilter> fs = new ArrayList<>(filters);
+    //            Collections.reverse(fs);
+    //            for (final XMLFilter filter : fs) {
+    //                filter.setContentHandler(handler);
+    //                handler = (ContentHandler) filter;
+    //            }
+    //
+    //            final Result intermediate = new SAXResult(handler);
+    //
+    //            serializer.transform(source, intermediate);
+    //        } catch (final RuntimeException e) {
+    //            throw e;
+    //        } catch (final Exception e) {
+    //            throw new DITAOTException("Failed to transform " + src + ": " + e.getMessage(), e);
+    //        }
+    //    }
 }

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -8,6 +8,17 @@
 
 package org.dita.dost.store;
 
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.io.*;
+import java.net.URI;
+import java.util.*;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.dom.NodeOverNodeInfo;
 import net.sf.saxon.event.PipelineConfiguration;
 import net.sf.saxon.event.Receiver;
@@ -30,18 +41,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
 import org.xml.sax.helpers.XMLFilterImpl;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamSource;
-import java.io.*;
-import java.net.URI;
-import java.util.*;
-
-import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
-import static org.dita.dost.util.URLUtils.stripFragment;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * DOM and memory based store, backed up by a disk store.
@@ -189,14 +188,16 @@ public class CacheStore extends AbstractStore implements Store {
                 if (entry.node != null) {
                     return entry.node;
                 } else if (entry.doc != null) {
-                    final XdmNode node = xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
+                    final XdmNode node =
+                            xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
                     put(f, new Entry(entry.doc, node, entry.bytes));
                     return node;
                 } else if (entry.bytes != null) {
                     try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
                         final StreamSource source = new StreamSource(in);
                         source.setSystemId(f.toString());
-                        final XdmNode node = xmlUtils.getProcessor().newDocumentBuilder().build(source);
+                        final XdmNode node =
+                                xmlUtils.getProcessor().newDocumentBuilder().build(source);
                         put(f, new Entry(entry.doc, node, entry.bytes));
                     } catch (SaxonApiException e) {
                         throw new IOException(e);
@@ -260,10 +261,10 @@ public class CacheStore extends AbstractStore implements Store {
     public void writeDocument(final XdmNode node, final URI path) throws IOException {
         if (isTempFile(path)) {
             if (LOG) System.err.println("writeDocument: " + path);
-//            final NodeInfo nodeInfo = node.getUnderlyingNode();
-//            if (nodeInfo.getBaseURI() == null || nodeInfo.getBaseURI().isEmpty()) {
-//                nodeInfo.setSystemId(doc.getBaseURI());
-//            }
+            //            final NodeInfo nodeInfo = node.getUnderlyingNode();
+            //            if (nodeInfo.getBaseURI() == null || nodeInfo.getBaseURI().isEmpty()) {
+            //                nodeInfo.setSystemId(doc.getBaseURI());
+            //            }
             put(path, new Entry(null, node, null));
         } else {
             fallback.writeDocument(node, path);
@@ -377,9 +378,7 @@ public class CacheStore extends AbstractStore implements Store {
     @Override
     public void transform(final URI src, final XsltTransformer transformer) throws DITAOTException {
         final boolean useTmpBuf = !isTempFile(src.normalize());
-        final URI dst = useTmpBuf
-                ? toURI(src + FILE_EXTENSION_TEMP).normalize()
-                : src;
+        final URI dst = useTmpBuf ? toURI(src + FILE_EXTENSION_TEMP).normalize() : src;
         try {
             final Source source = getSource(src);
             transformer.setSource(source);
@@ -437,7 +436,8 @@ public class CacheStore extends AbstractStore implements Store {
                     }
                 } else if (entry.doc != null) {
                     try (ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
-                        final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
+                        final XdmNode source =
+                                xmlUtils.getProcessor().newDocumentBuilder().wrap(entry.doc);
                         final Serializer serializer = xmlUtils.getProcessor().newSerializer(buf);
                         serializer.serializeNode(source);
                         final byte[] bytes = buf.toByteArray();
@@ -489,7 +489,8 @@ public class CacheStore extends AbstractStore implements Store {
 
     private Receiver getReceiver(final ContentHandler dst) {
         final SAXDestination result = new SAXDestination(dst);
-        final PipelineConfiguration pipe = xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration();
+        final PipelineConfiguration pipe =
+                xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration();
         return result.getReceiver(pipe, new SerializationProperties());
     }
 
@@ -498,15 +499,16 @@ public class CacheStore extends AbstractStore implements Store {
     }
 
     private void cacheMiss(final URI f) {
-//        System.err.println("Cache miss: " + f);
-//        throw new IllegalStateException("Cache miss: " + f);
+        //        System.err.println("Cache miss: " + f);
+        //        throw new IllegalStateException("Cache miss: " + f);
     }
 
     private Entry put(URI path, Entry entry) {
         if (entry.node != null) {
             final XdmNode node = entry.node;
             assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
-            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null
+                    && !node.getUnderlyingNode().getBaseURI().isEmpty();
         }
         if (entry.doc != null) {
             final Document doc = entry.doc;
@@ -520,7 +522,8 @@ public class CacheStore extends AbstractStore implements Store {
         if (entry.node != null) {
             final XdmNode node = entry.node;
             assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
-            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null
+                    && !node.getUnderlyingNode().getBaseURI().isEmpty();
         } else if (entry.doc != null) {
             final Document node = entry.doc;
             assert node.getBaseURI() != null && !node.getBaseURI().isEmpty();
@@ -533,7 +536,8 @@ public class CacheStore extends AbstractStore implements Store {
         if (entry.node != null) {
             final XdmNode node = entry.node;
             assert node.getBaseURI() != null && !node.getBaseURI().toString().isEmpty();
-            assert node.getUnderlyingNode().getBaseURI() != null && !node.getUnderlyingNode().getBaseURI().isEmpty();
+            assert node.getUnderlyingNode().getBaseURI() != null
+                    && !node.getUnderlyingNode().getBaseURI().isEmpty();
         } else if (entry.doc != null) {
             final Document node = entry.doc;
             assert node.getBaseURI() != null && !node.getBaseURI().isEmpty();
@@ -546,22 +550,21 @@ public class CacheStore extends AbstractStore implements Store {
         Document doc = null;
         if (remove.node != null) {
             final TreeInfo treeInfo = remove.node.getUnderlyingNode().getTreeInfo();
-//            if (treeInfo instanceof DOMNodeWrapper) {
-//                Node n = ((DOMNodeWrapper) treeInfo).getUnderlyingNode();
-//                n.getOwnerDocument().setDocumentURI(d.toString());
-//                doc = (Document) n;
-//            } else if (treeInfo instanceof DocumentWrapper) {
-//                doc = (Document) ((DocumentWrapper) treeInfo).docNode;
-//                doc.setDocumentURI(d.toString());
-//            } else {
-                final TreeInfo rebasedDocument = new RebasedDocument(treeInfo,
-                        nodeInfo -> d.toString(),
-                        nodeInfo -> d.toString());
-                rebasedDocument.setSystemId(d.toString());
-                final DocumentBuilder builder = xmlUtils.getProcessor().newDocumentBuilder();
-                builder.setBaseURI(d);
-                node = builder.wrap(rebasedDocument.getRootNode());
-//            }
+            //            if (treeInfo instanceof DOMNodeWrapper) {
+            //                Node n = ((DOMNodeWrapper) treeInfo).getUnderlyingNode();
+            //                n.getOwnerDocument().setDocumentURI(d.toString());
+            //                doc = (Document) n;
+            //            } else if (treeInfo instanceof DocumentWrapper) {
+            //                doc = (Document) ((DocumentWrapper) treeInfo).docNode;
+            //                doc.setDocumentURI(d.toString());
+            //            } else {
+            final TreeInfo rebasedDocument =
+                    new RebasedDocument(treeInfo, nodeInfo -> d.toString(), nodeInfo -> d.toString());
+            rebasedDocument.setSystemId(d.toString());
+            final DocumentBuilder builder = xmlUtils.getProcessor().newDocumentBuilder();
+            builder.setBaseURI(d);
+            node = builder.wrap(rebasedDocument.getRootNode());
+            //            }
         }
         if (remove.doc != null) {
             remove.doc.setDocumentURI(d.toString());
@@ -580,11 +583,11 @@ public class CacheStore extends AbstractStore implements Store {
             } else {
                 final Entry rebase = rebase(entry, path);
                 return rebase.node.asSource();
-//                final TreeInfo rebasedDocument = new RebasedDocument(underlyingNode.getTreeInfo(),
-//                        nodeInfo -> path.toString(),
-//                        nodeInfo -> path.toString());
-//                rebasedDocument.setSystemId(path.toString());
-//                return rebasedDocument;
+                //                final TreeInfo rebasedDocument = new RebasedDocument(underlyingNode.getTreeInfo(),
+                //                        nodeInfo -> path.toString(),
+                //                        nodeInfo -> path.toString());
+                //                rebasedDocument.setSystemId(path.toString());
+                //                return rebasedDocument;
             }
         } else if (entry.bytes != null) {
             final StreamSource source = new StreamSource(new ByteArrayInputStream(entry.bytes));

--- a/src/main/java/org/dita/dost/store/CacheStoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/CacheStoreBuilder.java
@@ -8,9 +8,8 @@
 
 package org.dita.dost.store;
 
-import org.dita.dost.util.XMLUtils;
-
 import java.io.File;
+import org.dita.dost.util.XMLUtils;
 
 /**
  * Memory store builder

--- a/src/main/java/org/dita/dost/store/Store.java
+++ b/src/main/java/org/dita/dost/store/Store.java
@@ -8,6 +8,13 @@
 
 package org.dita.dost.store;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.List;
+import javax.xml.transform.Source;
+import javax.xml.transform.URIResolver;
 import net.sf.saxon.s9api.Destination;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
@@ -17,14 +24,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.XMLFilter;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.URIResolver;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URI;
-import java.util.List;
 
 /**
  * Abstract XML I/O.

--- a/src/main/java/org/dita/dost/store/StoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/StoreBuilder.java
@@ -8,9 +8,8 @@
 
 package org.dita.dost.store;
 
-import org.dita.dost.util.XMLUtils;
-
 import java.io.File;
+import org.dita.dost.util.XMLUtils;
 
 public interface StoreBuilder {
     String getType();

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -8,12 +8,27 @@
 
 package org.dita.dost.store;
 
+import static org.apache.commons.io.FileUtils.*;
+import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
+import static org.dita.dost.util.URLUtils.toFile;
+import static org.dita.dost.util.URLUtils.toURI;
+
 import com.google.common.annotations.VisibleForTesting;
+import java.io.*;
+import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.event.PipelineConfiguration;
 import net.sf.saxon.event.Receiver;
 import net.sf.saxon.event.ReceivingContentHandler;
-import net.sf.saxon.s9api.*;
 import net.sf.saxon.lib.EmptySource;
+import net.sf.saxon.s9api.*;
 import net.sf.saxon.serialize.SerializationProperties;
 import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
@@ -22,22 +37,6 @@ import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.*;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.stream.StreamSource;
-import java.io.*;
-import java.net.URI;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Objects;
-
-import static org.apache.commons.io.FileUtils.*;
-import static org.dita.dost.util.Constants.FILE_EXTENSION_TEMP;
-import static org.dita.dost.util.URLUtils.toFile;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Stream based XML I/O
@@ -52,7 +51,7 @@ public class StreamStore extends AbstractStore implements Store {
 
     @Override
     public Document getImmutableDocument(final URI path) throws IOException {
-//        return (Document) NodeOverNodeInfo.wrap(getImmutableNode(path).getUnderlyingNode());
+        //        return (Document) NodeOverNodeInfo.wrap(getImmutableNode(path).getUnderlyingNode());
         return getDocument(path);
     }
 
@@ -136,32 +135,33 @@ public class StreamStore extends AbstractStore implements Store {
         }
     }
 
-//    @Override
-//    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
-//        assert input.isAbsolute();
-//        if (!input.getScheme().equals("file")) {
-//            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
-//        }
-//
-//        final File inputFile = new File(input);
-//        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
-//        transformURI(inputFile.toURI(), outputFile.toURI(), filters);
-//        try {
-//            deleteQuietly(inputFile);
-//            moveFile(outputFile, inputFile);
-//        } catch (final IOException e) {
-//            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
-//        }
-//    }
-//
-//    @Override
-//    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
-//        if (input.equals(output)) {
-//            transform(input, filters);
-//        } else {
-//            transformURI(input, output, filters);
-//        }
-//    }
+    //    @Override
+    //    public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
+    //        assert input.isAbsolute();
+    //        if (!input.getScheme().equals("file")) {
+    //            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
+    //        }
+    //
+    //        final File inputFile = new File(input);
+    //        final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
+    //        transformURI(inputFile.toURI(), outputFile.toURI(), filters);
+    //        try {
+    //            deleteQuietly(inputFile);
+    //            moveFile(outputFile, inputFile);
+    //        } catch (final IOException e) {
+    //            throw new DITAOTException("Failed to replace " + inputFile + ": " + e.getMessage());
+    //        }
+    //    }
+    //
+    //    @Override
+    //    public void transform(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException
+    // {
+    //        if (input.equals(output)) {
+    //            transform(input, filters);
+    //        } else {
+    //            transformURI(input, output, filters);
+    //        }
+    //    }
 
     @Override
     void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
@@ -268,13 +268,13 @@ public class StreamStore extends AbstractStore implements Store {
     @Override
     public ContentHandler getContentHandler(final URI outputFile) throws SaxonApiException, IOException {
         final net.sf.saxon.Configuration configuration = xmlUtils.getProcessor().getUnderlyingConfiguration();
-//        final SerializerFactory sf = configuration.getSerializerFactory();
+        //        final SerializerFactory sf = configuration.getSerializerFactory();
         final PipelineConfiguration pipelineConfiguration = configuration.makePipelineConfiguration();
 
         final Destination dst = getDestination(outputFile);
         final Receiver receiver = dst.getReceiver(pipelineConfiguration, new SerializationProperties());
-//        final Result out = job.getStore().getResult(outputFile);
-//        final Receiver receiver = sf.getReceiver(out, new SerializationProperties());
+        //        final Result out = job.getStore().getResult(outputFile);
+        //        final Receiver receiver = sf.getReceiver(out, new SerializationProperties());
 
         final ReceivingContentHandler receivingContentHandler = new ReceivingContentHandler();
         receivingContentHandler.setPipelineConfiguration(pipelineConfiguration);
@@ -367,7 +367,7 @@ public class StreamStore extends AbstractStore implements Store {
         } else {
             if (LOG) System.err.println("  getOutputStream:" + f);
             throw new UnsupportedOperationException("Unable to write to " + f);
-//            return f.toURL().openStream();
+            //            return f.toURL().openStream();
         }
     }
 }

--- a/src/main/java/org/dita/dost/store/StreamStoreBuilder.java
+++ b/src/main/java/org/dita/dost/store/StreamStoreBuilder.java
@@ -8,9 +8,8 @@
 
 package org.dita.dost.store;
 
-import org.dita.dost.util.XMLUtils;
-
 import java.io.File;
+import org.dita.dost.util.XMLUtils;
 
 /**
  * File store builder

--- a/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
+++ b/src/main/java/org/dita/dost/store/ant/types/StoreResource.java
@@ -7,21 +7,20 @@
  */
 package org.dita.dost.store.ant.types;
 
-import org.apache.tools.ant.types.Resource;
-import org.apache.tools.ant.util.FileUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Objects;
+import org.apache.tools.ant.types.Resource;
+import org.apache.tools.ant.util.FileUtils;
 import org.dita.dost.util.Job;
 
 public class StoreResource extends Resource
 //        implements
-        //Touchable,
-        //FileProvider,
-        //Appendable,
+// Touchable,
+// FileProvider,
+// Appendable,
 //        ResourceFactory
 {
 
@@ -36,104 +35,104 @@ public class StoreResource extends Resource
         this.file = file;
     }
 
-//    /**
-//     * Construct a new StoreResource from a File.
-//     * @param f the File represented.
-//     */
-//    public StoreResource(URI f) {
-//        setFile(f);
-//    }
+    //    /**
+    //     * Construct a new StoreResource from a File.
+    //     * @param f the File represented.
+    //     */
+    //    public StoreResource(URI f) {
+    //        setFile(f);
+    //    }
 
-//    /**
-//     * Create a new StoreResource.
-//     * @param p Project
-//     * @param f File represented
-//     * @since Ant 1.8
-//     */
-//    public StoreResource(Project p, File f) {
-//        this(f);
-//        setProject(p);
-//    }
+    //    /**
+    //     * Create a new StoreResource.
+    //     * @param p Project
+    //     * @param f File represented
+    //     * @since Ant 1.8
+    //     */
+    //    public StoreResource(Project p, File f) {
+    //        this(f);
+    //        setProject(p);
+    //    }
 
-//    /**
-//     * Constructor for Ant attribute introspection.
-//     * @param p the Project against which to resolve <code>s</code>.
-//     * @param s the absolute or Project-relative filename as a String.
-//     * @see org.apache.tools.ant.IntrospectionHelper
-//     */
-//    public StoreResource(Project p, String s) {
-//        this(p, p.resolveFile(s));
-//    }
+    //    /**
+    //     * Constructor for Ant attribute introspection.
+    //     * @param p the Project against which to resolve <code>s</code>.
+    //     * @param s the absolute or Project-relative filename as a String.
+    //     * @see org.apache.tools.ant.IntrospectionHelper
+    //     */
+    //    public StoreResource(Project p, String s) {
+    //        this(p, p.resolveFile(s));
+    //    }
 
-//    /**
-//     * Set the File for this StoreResource.
-//     * @param f the File to be represented.
-//     */
-//    public void setFile(File f) {
-//        checkAttributesAllowed();
-//        file = f;
-//        if (f != null && (getBaseDir() == null || !FILE_UTILS.isLeadingPath(getBaseDir(), f))) {
-//            setBaseDir(f.getParentFile());
-//        }
-//    }
+    //    /**
+    //     * Set the File for this StoreResource.
+    //     * @param f the File to be represented.
+    //     */
+    //    public void setFile(File f) {
+    //        checkAttributesAllowed();
+    //        file = f;
+    //        if (f != null && (getBaseDir() == null || !FILE_UTILS.isLeadingPath(getBaseDir(), f))) {
+    //            setBaseDir(f.getParentFile());
+    //        }
+    //    }
 
     // FileProvider
 
-//    /**
-//     * Get the file represented by this StoreResource.
-//     * @return the File.
-//     */
-//    @Override
-//    public File getFile() {
-//        if (isReference()) {
-//            return getRef().getFile();
-//        }
-//        dieOnCircularReference();
-//        synchronized (this) {
-//            if (file == null) {
-//                //try to resolve file set via basedir/name property setters:
-//                File d = getBaseDir();
-//                String n = super.getName();
-//                if (n != null) {
-//                    setFile(FILE_UTILS.resolveFile(d, n));
-//                }
-//            }
-//        }
-//        return file;
-//    }
+    //    /**
+    //     * Get the file represented by this StoreResource.
+    //     * @return the File.
+    //     */
+    //    @Override
+    //    public File getFile() {
+    //        if (isReference()) {
+    //            return getRef().getFile();
+    //        }
+    //        dieOnCircularReference();
+    //        synchronized (this) {
+    //            if (file == null) {
+    //                //try to resolve file set via basedir/name property setters:
+    //                File d = getBaseDir();
+    //                String n = super.getName();
+    //                if (n != null) {
+    //                    setFile(FILE_UTILS.resolveFile(d, n));
+    //                }
+    //            }
+    //        }
+    //        return file;
+    //    }
 
-//    /**
-//     * Set the basedir for this StoreResource.
-//     * @param b the basedir as File.
-//     */
-//    public void setBaseDir(File b) {
-//        checkAttributesAllowed();
-//        baseDir = b;
-//    }
+    //    /**
+    //     * Set the basedir for this StoreResource.
+    //     * @param b the basedir as File.
+    //     */
+    //    public void setBaseDir(File b) {
+    //        checkAttributesAllowed();
+    //        baseDir = b;
+    //    }
 
-//    /**
-//     * Return the basedir to which the name is relative.
-//     * @return the basedir as File.
-//     */
-//    public File getBaseDir() {
-//        if (isReference()) {
-//            return getRef().getBaseDir();
-//        }
-//        dieOnCircularReference();
-//        return baseDir;
-//    }
+    //    /**
+    //     * Return the basedir to which the name is relative.
+    //     * @return the basedir as File.
+    //     */
+    //    public File getBaseDir() {
+    //        if (isReference()) {
+    //            return getRef().getBaseDir();
+    //        }
+    //        dieOnCircularReference();
+    //        return baseDir;
+    //    }
 
-//    /**
-//     * Overrides the super version.
-//     * @param r the Reference to set.
-//     */
-//    @Override
-//    public void setRefid(Reference r) {
-//        if (file != null || baseDir != null) {
-//            throw tooManyAttributes();
-//        }
-//        super.setRefid(r);
-//    }
+    //    /**
+    //     * Overrides the super version.
+    //     * @param r the Reference to set.
+    //     */
+    //    @Override
+    //    public void setRefid(Reference r) {
+    //        if (file != null || baseDir != null) {
+    //            throw tooManyAttributes();
+    //        }
+    //        super.setRefid(r);
+    //    }
 
     /**
      * Get the name of this StoreResource.  If the basedir is set,
@@ -143,12 +142,12 @@ public class StoreResource extends Resource
      */
     @Override
     public String getName() {
-//        if (isReference()) {
-//            return getRef().getName();
-//        }
-//        File b = getBaseDir();
-//        return b == null ? getNotNullFile().getName()
-//            : FILE_UTILS.removeLeadingPath(b, getNotNullFile());
+        //        if (isReference()) {
+        //            return getRef().getName();
+        //        }
+        //        File b = getBaseDir();
+        //        return b == null ? getNotNullFile().getName()
+        //            : FILE_UTILS.removeLeadingPath(b, getNotNullFile());
         return file.getPath();
     }
 
@@ -158,8 +157,8 @@ public class StoreResource extends Resource
      */
     @Override
     public boolean isExists() {
-//        return isReference() ? getRef().isExists()
-//            : getNotNullFile().exists();
+        //        return isReference() ? getRef().isExists()
+        //            : getNotNullFile().exists();
         return job.getStore().exists(job.tempDirURI.resolve(file));
     }
 
@@ -169,9 +168,9 @@ public class StoreResource extends Resource
      */
     @Override
     public long getLastModified() {
-//        return isReference()
-//            ? getRef().getLastModified()
-//            : getNotNullFile().lastModified();
+        //        return isReference()
+        //            ? getRef().getLastModified()
+        //            : getNotNullFile().lastModified();
         // TODO: Add long lastModified entry to cache Store
         return -1;
     }
@@ -182,8 +181,8 @@ public class StoreResource extends Resource
      */
     @Override
     public boolean isDirectory() {
-//        return isReference() ? getRef().isDirectory()
-//            : getNotNullFile().isDirectory();
+        //        return isReference() ? getRef().isDirectory()
+        //            : getNotNullFile().isDirectory();
         return false;
     }
 
@@ -193,8 +192,8 @@ public class StoreResource extends Resource
      */
     @Override
     public long getSize() {
-//        return isReference() ? getRef().getSize()
-//            : getNotNullFile().length();
+        //        return isReference() ? getRef().getSize()
+        //            : getNotNullFile().length();
         return -1;
     }
 
@@ -205,8 +204,8 @@ public class StoreResource extends Resource
      */
     @Override
     public InputStream getInputStream() throws IOException {
-//        return isReference() ? getRef().getInputStream()
-//            : Files.newInputStream(getNotNullFile().toPath());
+        //        return isReference() ? getRef().getInputStream()
+        //            : Files.newInputStream(getNotNullFile().toPath());
         return job.getStore().getInputStream(job.tempDirURI.resolve(file));
     }
 
@@ -220,38 +219,38 @@ public class StoreResource extends Resource
      */
     @Override
     public OutputStream getOutputStream() throws IOException {
-//        if (isReference()) {
-//            return getRef().getOutputStream();
-//        }
-//        return getOutputStream(false);
+        //        if (isReference()) {
+        //            return getRef().getOutputStream();
+        //        }
+        //        return getOutputStream(false);
         return job.getStore().getOutputStream(job.tempDirURI.resolve(file));
     }
 
-//    /**
-//     * {@inheritDoc}
-//     */
-//    @Override
-//    public OutputStream getAppendOutputStream() throws IOException {
-//        if (isReference()) {
-//            return getRef().getAppendOutputStream();
-//        }
-//        return getOutputStream(true);
-//    }
+    //    /**
+    //     * {@inheritDoc}
+    //     */
+    //    @Override
+    //    public OutputStream getAppendOutputStream() throws IOException {
+    //        if (isReference()) {
+    //            return getRef().getAppendOutputStream();
+    //        }
+    //        return getOutputStream(true);
+    //    }
 
-//    private OutputStream getOutputStream(boolean append) throws IOException {
-//        File f = getNotNullFile();
-//        if (f.exists()) {
-//            if (f.isFile() && !append) {
-//                f.delete();
-//            }
-//        } else {
-//            File p = f.getParentFile();
-//            if (p != null && !(p.exists())) {
-//                p.mkdirs();
-//            }
-//        }
-//        return FileUtils.newOutputStream(f.toPath(), append);
-//    }
+    //    private OutputStream getOutputStream(boolean append) throws IOException {
+    //        File f = getNotNullFile();
+    //        if (f.exists()) {
+    //            if (f.isFile() && !append) {
+    //                f.delete();
+    //            }
+    //        } else {
+    //            File p = f.getParentFile();
+    //            if (p != null && !(p.exists())) {
+    //                p.mkdirs();
+    //            }
+    //        }
+    //        return FileUtils.newOutputStream(f.toPath(), append);
+    //    }
 
     /**
      * Compare this StoreResource to another Resource.
@@ -261,27 +260,27 @@ public class StoreResource extends Resource
      */
     @Override
     public int compareTo(Resource another) {
-//        if (isReference()) {
-//            return getRef().compareTo(another);
-//        }
-//        if (this.equals(another)) {
-//            return 0;
-//        }
-//        FileProvider otherFP = another.as(FileProvider.class);
-//        if (otherFP != null) {
-//            File f = getFile();
-//            if (f == null) {
-//                return -1;
-//            }
-//            File of = otherFP.getFile();
-//            if (of == null) {
-//                return 1;
-//            }
-//            int compareFiles = f.compareTo(of);
-//            return compareFiles != 0 ? compareFiles
-//                : getName().compareTo(another.getName());
-//        }
-//        return super.compareTo(another);
+        //        if (isReference()) {
+        //            return getRef().compareTo(another);
+        //        }
+        //        if (this.equals(another)) {
+        //            return 0;
+        //        }
+        //        FileProvider otherFP = another.as(FileProvider.class);
+        //        if (otherFP != null) {
+        //            File f = getFile();
+        //            if (f == null) {
+        //                return -1;
+        //            }
+        //            File of = otherFP.getFile();
+        //            if (of == null) {
+        //                return 1;
+        //            }
+        //            int compareFiles = f.compareTo(of);
+        //            return compareFiles != 0 ? compareFiles
+        //                : getName().compareTo(another.getName());
+        //        }
+        //        return super.compareTo(another);
         // TODO add a way to compare resources
         return -1;
     }
@@ -296,17 +295,17 @@ public class StoreResource extends Resource
         if (this == another) {
             return true;
         }
-//        if (isReference()) {
-//            return getRef().equals(another);
-//        }
+        //        if (isReference()) {
+        //            return getRef().equals(another);
+        //        }
         if (another == null || !(another.getClass().equals(getClass()))) {
             return false;
         }
         StoreResource otherfr = (StoreResource) another;
         return Objects.equals(file, otherfr.file);
-//                getFile() == null
-//            ? otherfr.getFile() == null
-//            : getFile().equals(otherfr.getFile()) && getName().equals(otherfr.getName());
+        //                getFile() == null
+        //            ? otherfr.getFile() == null
+        //            : getFile().equals(otherfr.getFile()) && getName().equals(otherfr.getName());
     }
 
     /**
@@ -315,10 +314,10 @@ public class StoreResource extends Resource
      */
     @Override
     public int hashCode() {
-//        if (isReference()) {
-//            return getRef().hashCode();
-//        }
-//        return MAGIC * (getFile() == null ? NULL_FILE : getFile().hashCode());
+        //        if (isReference()) {
+        //            return getRef().hashCode();
+        //        }
+        //        return MAGIC * (getFile() == null ? NULL_FILE : getFile().hashCode());
         return file.hashCode();
     }
 
@@ -328,14 +327,14 @@ public class StoreResource extends Resource
      */
     @Override
     public String toString() {
-//        if (isReference()) {
-//            return getRef().toString();
-//        }
-//        if (file == null) {
-//            return "(unbound file resource)";
-//        }
-//        String absolutePath = file.getAbsolutePath();
-//        return FILE_UTILS.normalize(absolutePath).getAbsolutePath();
+        //        if (isReference()) {
+        //            return getRef().toString();
+        //        }
+        //        if (file == null) {
+        //            return "(unbound file resource)";
+        //        }
+        //        String absolutePath = file.getAbsolutePath();
+        //        return FILE_UTILS.normalize(absolutePath).getAbsolutePath();
         return job.tempDirURI.resolve(file).toString();
     }
 
@@ -345,58 +344,58 @@ public class StoreResource extends Resource
      */
     @Override
     public boolean isFilesystemOnly() {
-//        if (isReference()) {
-//            return getRef().isFilesystemOnly();
-//        }
-//        dieOnCircularReference();
+        //        if (isReference()) {
+        //            return getRef().isFilesystemOnly();
+        //        }
+        //        dieOnCircularReference();
         return true;
     }
 
-//    /**
-//     * Implement the Touchable interface.
-//     * @param modTime new last modification time.
-//     */
-//    @Override
-//    public void touch(long modTime) {
-//        if (isReference()) {
-//            getRef().touch(modTime);
-//            return;
-//        }
-//        if (!getNotNullFile().setLastModified(modTime)) {
-//            log("Failed to change file modification time", Project.MSG_WARN);
-//        }
-//    }
+    //    /**
+    //     * Implement the Touchable interface.
+    //     * @param modTime new last modification time.
+    //     */
+    //    @Override
+    //    public void touch(long modTime) {
+    //        if (isReference()) {
+    //            getRef().touch(modTime);
+    //            return;
+    //        }
+    //        if (!getNotNullFile().setLastModified(modTime)) {
+    //            log("Failed to change file modification time", Project.MSG_WARN);
+    //        }
+    //    }
 
-//    /**
-//     * Get the file represented by this StoreResource, ensuring it is not null.
-//     * @return the not-null File.
-//     * @throws BuildException if file is null.
-//     */
-//    protected File getNotNullFile() {
-//        if (getFile() == null) {
-//            throw new BuildException("file attribute is null!");
-//        }
-//        dieOnCircularReference();
-//        return getFile();
-//    }
+    //    /**
+    //     * Get the file represented by this StoreResource, ensuring it is not null.
+    //     * @return the not-null File.
+    //     * @throws BuildException if file is null.
+    //     */
+    //    protected File getNotNullFile() {
+    //        if (getFile() == null) {
+    //            throw new BuildException("file attribute is null!");
+    //        }
+    //        dieOnCircularReference();
+    //        return getFile();
+    //    }
 
-//    /**
-//     * Create a new resource that matches a relative or absolute path.
-//     * If the current instance has a compatible baseDir attribute, it is copied.
-//     * @param path relative/absolute path to a resource
-//     * @return a new resource of type StoreResource
-//     * @throws BuildException if desired
-//     * @since Ant1.8
-//     */
-//    @Override
-//    public Resource getResource(String path) {
-//        File newfile = FILE_UTILS.resolveFile(getFile(), path);
-//        StoreResource fileResource = new StoreResource(newfile);
-//        if (FILE_UTILS.isLeadingPath(getBaseDir(), newfile)) {
-//            fileResource.setBaseDir(getBaseDir());
-//        }
-//        return fileResource;
-//    }
+    //    /**
+    //     * Create a new resource that matches a relative or absolute path.
+    //     * If the current instance has a compatible baseDir attribute, it is copied.
+    //     * @param path relative/absolute path to a resource
+    //     * @return a new resource of type StoreResource
+    //     * @throws BuildException if desired
+    //     * @since Ant1.8
+    //     */
+    //    @Override
+    //    public Resource getResource(String path) {
+    //        File newfile = FILE_UTILS.resolveFile(getFile(), path);
+    //        StoreResource fileResource = new StoreResource(newfile);
+    //        if (FILE_UTILS.isLeadingPath(getBaseDir(), newfile)) {
+    //            fileResource.setBaseDir(getBaseDir());
+    //        }
+    //        return fileResource;
+    //    }
 
     @Override
     protected StoreResource getRef() {

--- a/src/main/java/org/dita/dost/util/CatalogUtils.java
+++ b/src/main/java/org/dita/dost/util/CatalogUtils.java
@@ -1,17 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
-
 import org.apache.xml.resolver.CatalogManager;
 import org.apache.xml.resolver.tools.CatalogResolver;
 
@@ -20,7 +19,6 @@ import org.apache.xml.resolver.tools.CatalogResolver;
  * @version 1.0 2005-4-11
  * @author Zhang, Yuan Peng
  */
-
 public final class CatalogUtils {
 
     /**apache catalogResolver.*/
@@ -53,13 +51,14 @@ public final class CatalogUtils {
             manager.setIgnoreMissingProperties(true);
             manager.setUseStaticCatalog(false); // We'll use a private catalog.
             manager.setPreferPublic(true);
-            final File catalogFilePath = new File(ditaDir, Configuration.pluginResourceDirs.get("org.dita.base") + File.separator + FILE_NAME_CATALOG);
+            final File catalogFilePath = new File(
+                    ditaDir,
+                    Configuration.pluginResourceDirs.get("org.dita.base") + File.separator + FILE_NAME_CATALOG);
             manager.setCatalogFiles(catalogFilePath.toURI().toASCIIString());
-            //manager.setVerbosity(10);
+            // manager.setVerbosity(10);
             catalogResolver = new CatalogResolver(manager);
         }
 
         return catalogResolver;
     }
 }
-

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -16,9 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-
 import org.dita.dost.platform.Integrator;
-
 
 /**
  * Global configuration object for static configurations.
@@ -37,15 +35,17 @@ public final class Configuration {
      * <p>If configuration file is not found e.g. during integration, the
      * configuration will be an empty.</p>
      */
-    public final static Map<String, String> configuration;
+    public static final Map<String, String> configuration;
+
     static {
         final Map<String, String> c = new HashMap<>();
 
         final Properties applicationProperties = new Properties();
-        try (InputStream applicationInputStream = Configuration.class.getClassLoader().getResourceAsStream(APP_CONF_PROPERTIES)) {
+        try (InputStream applicationInputStream =
+                Configuration.class.getClassLoader().getResourceAsStream(APP_CONF_PROPERTIES)) {
             if (applicationInputStream != null) {
                 applicationProperties.load(applicationInputStream);
-                for (final Map.Entry<Object, Object> e: applicationProperties.entrySet()) {
+                for (final Map.Entry<Object, Object> e : applicationProperties.entrySet()) {
                     c.put(e.getKey().toString(), e.getValue().toString());
                 }
             }
@@ -57,11 +57,13 @@ public final class Configuration {
         InputStream plugingConfigurationInputStream = null;
         try {
             final ClassLoader loader = FileUtils.class.getClassLoader();
-            plugingConfigurationInputStream = loader.getResourceAsStream(Integrator.class.getPackage().getName() + "/" + GEN_CONF_PROPERTIES);
+            plugingConfigurationInputStream =
+                    loader.getResourceAsStream(Integrator.class.getPackage().getName() + "/" + GEN_CONF_PROPERTIES);
             if (plugingConfigurationInputStream != null) {
                 pluginProperties.load(plugingConfigurationInputStream);
             } else {
-                final File configurationFile = new File("config", Integrator.class.getPackage().getName() + File.separator + GEN_CONF_PROPERTIES);
+                final File configurationFile = new File(
+                        "config", Integrator.class.getPackage().getName() + File.separator + GEN_CONF_PROPERTIES);
                 if (configurationFile.exists()) {
                     plugingConfigurationInputStream = new BufferedInputStream(new FileInputStream(configurationFile));
                     pluginProperties.load(plugingConfigurationInputStream);
@@ -74,11 +76,11 @@ public final class Configuration {
                 try {
                     plugingConfigurationInputStream.close();
                 } catch (final IOException ex) {
-                    System.err.println(ex.getMessage()) ;
+                    System.err.println(ex.getMessage());
                 }
             }
         }
-        for (final Map.Entry<Object, Object> e: pluginProperties.entrySet()) {
+        for (final Map.Entry<Object, Object> e : pluginProperties.entrySet()) {
             c.put(e.getKey().toString(), e.getValue().toString());
         }
 
@@ -97,17 +99,17 @@ public final class Configuration {
                 }
             }
         } catch (final IOException e) {
-            System.err.println(e.getMessage()) ;
+            System.err.println(e.getMessage());
         } finally {
             if (configurationInputStream != null) {
                 try {
                     configurationInputStream.close();
                 } catch (final IOException ex) {
-                    System.err.println(ex.getMessage()) ;
+                    System.err.println(ex.getMessage());
                 }
             }
         }
-        for (final Map.Entry<Object, Object> e: properties.entrySet()) {
+        for (final Map.Entry<Object, Object> e : properties.entrySet()) {
             c.put(e.getKey().toString(), e.getValue().toString());
         }
 
@@ -125,17 +127,17 @@ public final class Configuration {
     }
 
     /** Private constructor to disallow instance creation. */
-    private Configuration() {
-    }
+    private Configuration() {}
 
     /** List of print-oriented transtypes. */
     public static final List<String> printTranstype;
+
     static {
         final List<String> types = new ArrayList<>();
         final String printTranstypes = Configuration.configuration.get(CONF_PRINT_TRANSTYPES);
         if (printTranstypes != null) {
             if (printTranstypes.trim().length() > 0) {
-                for (final String transtype: printTranstypes.split(CONF_LIST_SEPARATOR)) {
+                for (final String transtype : printTranstypes.split(CONF_LIST_SEPARATOR)) {
                     types.add(transtype.trim());
                 }
             }
@@ -148,12 +150,13 @@ public final class Configuration {
 
     /** List of transtypes. */
     public static final List<String> transtypes;
+
     static {
         final List<String> types = new ArrayList<>();
         final String printTranstypes = Configuration.configuration.get(CONF_TRANSTYPES);
         if (printTranstypes != null) {
             if (printTranstypes.trim().length() > 0) {
-                for (final String transtype: printTranstypes.split(CONF_LIST_SEPARATOR)) {
+                for (final String transtype : printTranstypes.split(CONF_LIST_SEPARATOR)) {
                     types.add(transtype.trim());
                 }
             }
@@ -165,9 +168,10 @@ public final class Configuration {
 
     /** Map of plug-in resource directories. */
     public static final Map<String, File> pluginResourceDirs;
+
     static {
         final Map<String, File> ps = new HashMap<>();
-        for (final Map.Entry<String, String> e: configuration.entrySet()) {
+        for (final Map.Entry<String, String> e : configuration.entrySet()) {
             final String key = e.getKey();
             if (key.startsWith("plugin.") && key.endsWith(".dir")) {
                 ps.put(key.substring(7, key.length() - 4), new File(e.getValue()));
@@ -178,10 +182,11 @@ public final class Configuration {
 
     public static final Map<String, String> parserMap;
     public static final Map<String, Map<String, Boolean>> parserFeatures;
+
     static {
         final Map<String, String> m = new HashMap<>();
         final Map<String, Map<String, Boolean>> f = new HashMap<>();
-        for (final Map.Entry<String, String> e: configuration.entrySet()) {
+        for (final Map.Entry<String, String> e : configuration.entrySet()) {
             final String key = e.getKey();
             if (key.startsWith(CONF_PARSER_FORMAT) && key.indexOf('.', CONF_PARSER_FORMAT.length()) == -1) {
                 final String format = key.substring(CONF_PARSER_FORMAT.length());
@@ -204,9 +209,10 @@ public final class Configuration {
     }
 
     public static final Set<String> ditaFormat;
+
     static {
         final Set<String> s = new HashSet<>();
-        for (final Map.Entry<String, String> e: configuration.entrySet()) {
+        for (final Map.Entry<String, String> e : configuration.entrySet()) {
             final String key = e.getKey();
             if (key.startsWith(CONF_PARSER_FORMAT) && key.indexOf('.', CONF_PARSER_FORMAT.length()) == -1) {
                 s.add(key.substring(CONF_PARSER_FORMAT.length()));
@@ -214,5 +220,4 @@ public final class Configuration {
         }
         ditaFormat = Collections.unmodifiableSet(s);
     }
-
 }

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -59,7 +59,8 @@ public final class Constants {
 
     public static final String RESOURCES_DIR = "resources";
 
-    public static final DitaClass ABBREV_D_ABBREVIATED_FORM = DitaClass.getInstance("+ topic/term abbrev-d/abbreviated-form ");
+    public static final DitaClass ABBREV_D_ABBREVIATED_FORM =
+            DitaClass.getInstance("+ topic/term abbrev-d/abbreviated-form ");
     public static final DitaClass BOOKMAP_ABBREVLIST = DitaClass.getInstance("- map/topicref bookmap/abbrevlist ");
     public static final DitaClass BOOKMAP_AMENDMENTS = DitaClass.getInstance("- map/topicref bookmap/amendments ");
     public static final DitaClass BOOKMAP_APPENDICES = DitaClass.getInstance("- map/topicref bookmap/appendices ");
@@ -68,7 +69,8 @@ public final class Constants {
     public static final DitaClass BOOKMAP_BACKMATTER = DitaClass.getInstance("- map/topicref bookmap/backmatter ");
     public static final DitaClass BOOKMAP_BIBLIOLIST = DitaClass.getInstance("- map/topicref bookmap/bibliolist ");
     public static final DitaClass BOOKMAP_BOOKABSTRACT = DitaClass.getInstance("- map/topicref bookmap/bookabstract ");
-    public static final DitaClass BOOKMAP_BOOKCHANGEHISTORY = DitaClass.getInstance("- topic/data bookmap/bookchangehistory ");
+    public static final DitaClass BOOKMAP_BOOKCHANGEHISTORY =
+            DitaClass.getInstance("- topic/data bookmap/bookchangehistory ");
     public static final DitaClass BOOKMAP_BOOKEVENT = DitaClass.getInstance("- topic/data bookmap/bookevent ");
     public static final DitaClass BOOKMAP_BOOKEVENTTYPE = DitaClass.getInstance("- topic/data bookmap/bookeventtype ");
     public static final DitaClass BOOKMAP_BOOKID = DitaClass.getInstance("- topic/data bookmap/bookid ");
@@ -80,7 +82,8 @@ public final class Constants {
     public static final DitaClass BOOKMAP_BOOKNUMBER = DitaClass.getInstance("- topic/data bookmap/booknumber ");
     public static final DitaClass BOOKMAP_BOOKOWNER = DitaClass.getInstance("- topic/data bookmap/bookowner ");
     public static final DitaClass BOOKMAP_BOOKPARTNO = DitaClass.getInstance("- topic/data bookmap/bookpartno ");
-    public static final DitaClass BOOKMAP_BOOKRESTRICTION = DitaClass.getInstance("- topic/data bookmap/bookrestriction ");
+    public static final DitaClass BOOKMAP_BOOKRESTRICTION =
+            DitaClass.getInstance("- topic/data bookmap/bookrestriction ");
     public static final DitaClass BOOKMAP_BOOKRIGHTS = DitaClass.getInstance("- topic/data bookmap/bookrights ");
     public static final DitaClass BOOKMAP_BOOKTITLE = DitaClass.getInstance("- topic/title bookmap/booktitle ");
     public static final DitaClass BOOKMAP_BOOKTITLEALT = DitaClass.getInstance("- topic/ph bookmap/booktitlealt ");
@@ -109,7 +112,8 @@ public final class Constants {
     public static final DitaClass BOOKMAP_PREFACE = DitaClass.getInstance("- map/topicref bookmap/preface ");
     public static final DitaClass BOOKMAP_PRINTLOCATION = DitaClass.getInstance("- topic/data bookmap/printlocation ");
     public static final DitaClass BOOKMAP_PUBLISHED = DitaClass.getInstance("- topic/data bookmap/published ");
-    public static final DitaClass BOOKMAP_PUBLISHERINFORMATION = DitaClass.getInstance("- topic/publisher bookmap/publisherinformation ");
+    public static final DitaClass BOOKMAP_PUBLISHERINFORMATION =
+            DitaClass.getInstance("- topic/publisher bookmap/publisherinformation ");
     public static final DitaClass BOOKMAP_PUBLISHTYPE = DitaClass.getInstance("- topic/data bookmap/publishtype ");
     public static final DitaClass BOOKMAP_REVIEWED = DitaClass.getInstance("- topic/data bookmap/reviewed ");
     public static final DitaClass BOOKMAP_REVISIONID = DitaClass.getInstance("- topic/ph bookmap/revisionid ");
@@ -118,51 +122,88 @@ public final class Constants {
     public static final DitaClass BOOKMAP_TABLELIST = DitaClass.getInstance("- map/topicref bookmap/tablelist ");
     public static final DitaClass BOOKMAP_TESTED = DitaClass.getInstance("- topic/data bookmap/tested ");
     public static final DitaClass BOOKMAP_TOC = DitaClass.getInstance("- map/topicref bookmap/toc ");
-    public static final DitaClass BOOKMAP_TRADEMARKLIST = DitaClass.getInstance("- map/topicref bookmap/trademarklist ");
+    public static final DitaClass BOOKMAP_TRADEMARKLIST =
+            DitaClass.getInstance("- map/topicref bookmap/trademarklist ");
     public static final DitaClass BOOKMAP_VOLUME = DitaClass.getInstance("- topic/data bookmap/volume ");
     public static final DitaClass BOOKMAP_YEAR = DitaClass.getInstance("- topic/ph bookmap/year ");
-    public static final DitaClass CLASSIFY_D_SUBJECTCELL = DitaClass.getInstance("+ map/relcell classify-d/subjectCell ");
-    public static final DitaClass CLASSIFY_D_SUBJECTREF = DitaClass.getInstance("+ map/topicref classify-d/subjectref ");
-    public static final DitaClass CLASSIFY_D_TOPICAPPLY = DitaClass.getInstance("+ map/topicref classify-d/topicapply ");
+    public static final DitaClass CLASSIFY_D_SUBJECTCELL =
+            DitaClass.getInstance("+ map/relcell classify-d/subjectCell ");
+    public static final DitaClass CLASSIFY_D_SUBJECTREF =
+            DitaClass.getInstance("+ map/topicref classify-d/subjectref ");
+    public static final DitaClass CLASSIFY_D_TOPICAPPLY =
+            DitaClass.getInstance("+ map/topicref classify-d/topicapply ");
     public static final DitaClass CLASSIFY_D_TOPICCELL = DitaClass.getInstance("+ map/relcell classify-d/topicCell ");
-    public static final DitaClass CLASSIFY_D_TOPICSUBJECT = DitaClass.getInstance("+ map/topicref classify-d/topicsubject ");
-    public static final DitaClass CLASSIFY_D_TOPICSUBJECTHEADER = DitaClass.getInstance("+ map/relrow classify-d/topicSubjectHeader ");
-    public static final DitaClass CLASSIFY_D_TOPICSUBJECTROW = DitaClass.getInstance("+ map/relrow classify-d/topicSubjectRow ");
-    public static final DitaClass CLASSIFY_D_TOPICSUBJECTTABLE = DitaClass.getInstance("+ map/reltable classify-d/topicSubjectTable ");
+    public static final DitaClass CLASSIFY_D_TOPICSUBJECT =
+            DitaClass.getInstance("+ map/topicref classify-d/topicsubject ");
+    public static final DitaClass CLASSIFY_D_TOPICSUBJECTHEADER =
+            DitaClass.getInstance("+ map/relrow classify-d/topicSubjectHeader ");
+    public static final DitaClass CLASSIFY_D_TOPICSUBJECTROW =
+            DitaClass.getInstance("+ map/relrow classify-d/topicSubjectRow ");
+    public static final DitaClass CLASSIFY_D_TOPICSUBJECTTABLE =
+            DitaClass.getInstance("+ map/reltable classify-d/topicSubjectTable ");
     public static final DitaClass CONCEPT_CONBODY = DitaClass.getInstance("- topic/body concept/conbody ");
     public static final DitaClass CONCEPT_CONBODYDIV = DitaClass.getInstance("- topic/bodydiv concept/conbodydiv ");
     public static final DitaClass CONCEPT_CONCEPT = DitaClass.getInstance("- topic/topic concept/concept ");
-    public static final DitaClass DITAVAREF_D_DITAVALMETA = DitaClass.getInstance("+ map/topicmeta ditavalref-d/ditavalmeta ");
-    public static final DitaClass DITAVAREF_D_DITAVALREF = DitaClass.getInstance("+ map/topicref ditavalref-d/ditavalref ");
-    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPEPREFIX = DitaClass.getInstance("+ topic/data ditavalref-d/dvrKeyscopePrefix ");
-    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPESUFFIX = DitaClass.getInstance("+ topic/data ditavalref-d/dvrKeyscopeSuffix ");
-    public static final DitaClass DITAVAREF_D_DVR_RESOURCEPREFIX = DitaClass.getInstance("+ topic/data ditavalref-d/dvrResourcePrefix ");
-    public static final DitaClass DITAVAREF_D_DVR_RESOURCESUFFIX = DitaClass.getInstance("+ topic/data ditavalref-d/dvrResourceSuffix ");
-    public static final DitaClass EQUATION_D_EQUATION_BLOCK = DitaClass.getInstance("+ topic/div equation-d/equation-block ");
-    public static final DitaClass EQUATION_D_EQUATION_FIGURE = DitaClass.getInstance("+ topic/fig equation-d/equation-figure ");
-    public static final DitaClass EQUATION_D_EQUATION_INLINE = DitaClass.getInstance("+ topic/ph equation-d/equation-inline ");
-    public static final DitaClass EQUATION_D_EQUATION_NUMBER = DitaClass.getInstance("+ topic/ph equation-d/equation-number ");
-    public static final DitaClass GLOSSENTRY_GLOSSABBREVIATION = DitaClass.getInstance("- topic/title concept/title glossentry/glossAbbreviation ");
-    public static final DitaClass GLOSSENTRY_GLOSSACRONYM = DitaClass.getInstance("- topic/title concept/title glossentry/glossAcronym ");
-    public static final DitaClass GLOSSENTRY_GLOSSALT = DitaClass.getInstance("- topic/section concept/section glossentry/glossAlt ");
-    public static final DitaClass GLOSSENTRY_GLOSSALTERNATEFOR = DitaClass.getInstance("- topic/xref concept/xref glossentry/glossAlternateFor ");
-    public static final DitaClass GLOSSENTRY_GLOSSBODY = DitaClass.getInstance("- topic/body concept/conbody glossentry/glossBody ");
-    public static final DitaClass GLOSSENTRY_GLOSSDEF = DitaClass.getInstance("- topic/abstract concept/abstract glossentry/glossdef ");
-    public static final DitaClass GLOSSENTRY_GLOSSENTRY = DitaClass.getInstance("- topic/topic concept/concept glossentry/glossentry ");
-    public static final DitaClass GLOSSENTRY_GLOSSPARTOFSPEECH = DitaClass.getInstance("- topic/data concept/data glossentry/glossPartOfSpeech ");
-    public static final DitaClass GLOSSENTRY_GLOSSPROPERTY = DitaClass.getInstance("- topic/data concept/data glossentry/glossProperty ");
-    public static final DitaClass GLOSSENTRY_GLOSSSCOPENOTE = DitaClass.getInstance("- topic/note concept/note glossentry/glossScopeNote ");
-    public static final DitaClass GLOSSENTRY_GLOSSSHORTFORM = DitaClass.getInstance("- topic/title concept/title glossentry/glossShortForm ");
-    public static final DitaClass GLOSSENTRY_GLOSSSTATUS = DitaClass.getInstance("- topic/data concept/data glossentry/glossStatus ");
-    public static final DitaClass GLOSSENTRY_GLOSSSURFACEFORM = DitaClass.getInstance("- topic/p concept/p glossentry/glossSurfaceForm ");
-    public static final DitaClass GLOSSENTRY_GLOSSSYMBOL = DitaClass.getInstance("- topic/image concept/image glossentry/glossSymbol ");
-    public static final DitaClass GLOSSENTRY_GLOSSSYNONYM = DitaClass.getInstance("- topic/title concept/title glossentry/glossSynonym ");
-    public static final DitaClass GLOSSENTRY_GLOSSTERM = DitaClass.getInstance("- topic/title concept/title glossentry/glossterm ");
-    public static final DitaClass GLOSSENTRY_GLOSSUSAGE = DitaClass.getInstance("- topic/note concept/note glossentry/glossUsage ");
-    public static final DitaClass GLOSSGROUP_GLOSSGROUP = DitaClass.getInstance("- topic/topic concept/concept glossgroup/glossgroup ");
+    public static final DitaClass DITAVAREF_D_DITAVALMETA =
+            DitaClass.getInstance("+ map/topicmeta ditavalref-d/ditavalmeta ");
+    public static final DitaClass DITAVAREF_D_DITAVALREF =
+            DitaClass.getInstance("+ map/topicref ditavalref-d/ditavalref ");
+    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPEPREFIX =
+            DitaClass.getInstance("+ topic/data ditavalref-d/dvrKeyscopePrefix ");
+    public static final DitaClass DITAVAREF_D_DVR_KEYSCOPESUFFIX =
+            DitaClass.getInstance("+ topic/data ditavalref-d/dvrKeyscopeSuffix ");
+    public static final DitaClass DITAVAREF_D_DVR_RESOURCEPREFIX =
+            DitaClass.getInstance("+ topic/data ditavalref-d/dvrResourcePrefix ");
+    public static final DitaClass DITAVAREF_D_DVR_RESOURCESUFFIX =
+            DitaClass.getInstance("+ topic/data ditavalref-d/dvrResourceSuffix ");
+    public static final DitaClass EQUATION_D_EQUATION_BLOCK =
+            DitaClass.getInstance("+ topic/div equation-d/equation-block ");
+    public static final DitaClass EQUATION_D_EQUATION_FIGURE =
+            DitaClass.getInstance("+ topic/fig equation-d/equation-figure ");
+    public static final DitaClass EQUATION_D_EQUATION_INLINE =
+            DitaClass.getInstance("+ topic/ph equation-d/equation-inline ");
+    public static final DitaClass EQUATION_D_EQUATION_NUMBER =
+            DitaClass.getInstance("+ topic/ph equation-d/equation-number ");
+    public static final DitaClass GLOSSENTRY_GLOSSABBREVIATION =
+            DitaClass.getInstance("- topic/title concept/title glossentry/glossAbbreviation ");
+    public static final DitaClass GLOSSENTRY_GLOSSACRONYM =
+            DitaClass.getInstance("- topic/title concept/title glossentry/glossAcronym ");
+    public static final DitaClass GLOSSENTRY_GLOSSALT =
+            DitaClass.getInstance("- topic/section concept/section glossentry/glossAlt ");
+    public static final DitaClass GLOSSENTRY_GLOSSALTERNATEFOR =
+            DitaClass.getInstance("- topic/xref concept/xref glossentry/glossAlternateFor ");
+    public static final DitaClass GLOSSENTRY_GLOSSBODY =
+            DitaClass.getInstance("- topic/body concept/conbody glossentry/glossBody ");
+    public static final DitaClass GLOSSENTRY_GLOSSDEF =
+            DitaClass.getInstance("- topic/abstract concept/abstract glossentry/glossdef ");
+    public static final DitaClass GLOSSENTRY_GLOSSENTRY =
+            DitaClass.getInstance("- topic/topic concept/concept glossentry/glossentry ");
+    public static final DitaClass GLOSSENTRY_GLOSSPARTOFSPEECH =
+            DitaClass.getInstance("- topic/data concept/data glossentry/glossPartOfSpeech ");
+    public static final DitaClass GLOSSENTRY_GLOSSPROPERTY =
+            DitaClass.getInstance("- topic/data concept/data glossentry/glossProperty ");
+    public static final DitaClass GLOSSENTRY_GLOSSSCOPENOTE =
+            DitaClass.getInstance("- topic/note concept/note glossentry/glossScopeNote ");
+    public static final DitaClass GLOSSENTRY_GLOSSSHORTFORM =
+            DitaClass.getInstance("- topic/title concept/title glossentry/glossShortForm ");
+    public static final DitaClass GLOSSENTRY_GLOSSSTATUS =
+            DitaClass.getInstance("- topic/data concept/data glossentry/glossStatus ");
+    public static final DitaClass GLOSSENTRY_GLOSSSURFACEFORM =
+            DitaClass.getInstance("- topic/p concept/p glossentry/glossSurfaceForm ");
+    public static final DitaClass GLOSSENTRY_GLOSSSYMBOL =
+            DitaClass.getInstance("- topic/image concept/image glossentry/glossSymbol ");
+    public static final DitaClass GLOSSENTRY_GLOSSSYNONYM =
+            DitaClass.getInstance("- topic/title concept/title glossentry/glossSynonym ");
+    public static final DitaClass GLOSSENTRY_GLOSSTERM =
+            DitaClass.getInstance("- topic/title concept/title glossentry/glossterm ");
+    public static final DitaClass GLOSSENTRY_GLOSSUSAGE =
+            DitaClass.getInstance("- topic/note concept/note glossentry/glossUsage ");
+    public static final DitaClass GLOSSGROUP_GLOSSGROUP =
+            DitaClass.getInstance("- topic/topic concept/concept glossgroup/glossgroup ");
     public static final DitaClass GLOSSREF_D_GLOSSREF = DitaClass.getInstance("+ map/topicref glossref-d/glossref ");
     public static final DitaClass HAZARD_D_CONSEQUENCE = DitaClass.getInstance("+ topic/li hazard-d/consequence ");
-    public static final DitaClass HAZARD_D_HAZARDSTATEMENT = DitaClass.getInstance("+ topic/note hazard-d/hazardstatement ");
+    public static final DitaClass HAZARD_D_HAZARDSTATEMENT =
+            DitaClass.getInstance("+ topic/note hazard-d/hazardstatement ");
     public static final DitaClass HAZARD_D_HAZARDSYMBOL = DitaClass.getInstance("+ topic/image hazard-d/hazardsymbol ");
     public static final DitaClass HAZARD_D_HOWTOAVOID = DitaClass.getInstance("+ topic/li hazard-d/howtoavoid ");
     public static final DitaClass HAZARD_D_MESSAGEPANEL = DitaClass.getInstance("+ topic/ul hazard-d/messagepanel ");
@@ -175,189 +216,370 @@ public final class Constants {
     public static final DitaClass HI_D_SUP = DitaClass.getInstance("+ topic/ph hi-d/sup ");
     public static final DitaClass HI_D_TT = DitaClass.getInstance("+ topic/ph hi-d/tt ");
     public static final DitaClass HI_D_U = DitaClass.getInstance("+ topic/ph hi-d/u ");
-    public static final DitaClass INDEXING_D_INDEX_SEE = DitaClass.getInstance("+ topic/index-base indexing-d/index-see ");
-    public static final DitaClass INDEXING_D_INDEX_SEE_ALSO = DitaClass.getInstance("+ topic/index-base indexing-d/index-see-also ");
-    public static final DitaClass INDEXING_D_INDEX_SORT_AS = DitaClass.getInstance("+ topic/index-base indexing-d/index-sort-as ");
-    public static final DitaClass LEARNING_D_LCANSWERCONTENT = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcAnswerContent ");
-    public static final DitaClass LEARNING_D_LCANSWEROPTION = DitaClass.getInstance("+ topic/li learningInteractionBase-d/li learning-d/lcAnswerOption ");
-    public static final DitaClass LEARNING_D_LCANSWEROPTIONGROUP = DitaClass.getInstance("+ topic/ul learningInteractionBase-d/ul learning-d/lcAnswerOptionGroup ");
-    public static final DitaClass LEARNING_D_LCAREA = DitaClass.getInstance("+ topic/figgroup learningInteractionBase-d/figgroup learning-d/lcArea ");
-    public static final DitaClass LEARNING_D_LCAREACOORDS = DitaClass.getInstance("+ topic/ph learningInteractionBase-d/ph learning-d/lcAreaCoords ");
-    public static final DitaClass LEARNING_D_LCAREASHAPE = DitaClass.getInstance("+ topic/keyword learningInteractionBase-d/keyword learning-d/lcAreaShape ");
-    public static final DitaClass LEARNING_D_LCASSET = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcAsset ");
-    public static final DitaClass LEARNING_D_LCCORRECTRESPONSE = DitaClass.getInstance("+ topic/data learningInteractionBase-d/data learning-d/lcCorrectResponse ");
-    public static final DitaClass LEARNING_D_LCFEEDBACK = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedback ");
-    public static final DitaClass LEARNING_D_LCFEEDBACKCORRECT = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedbackCorrect ");
-    public static final DitaClass LEARNING_D_LCFEEDBACKINCORRECT = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedbackIncorrect ");
-    public static final DitaClass LEARNING_D_LCHOTSPOT = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcHotspot ");
-    public static final DitaClass LEARNING_D_LCHOTSPOTMAP = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/figgroup learning-d/lcHotspotMap ");
-    public static final DitaClass LEARNING_D_LCINSTRUCTORNOTE = DitaClass.getInstance("+ topic/note learningInteractionBase-d/note learning-d/lcInstructornote ");
-    public static final DitaClass LEARNING_D_LCITEM = DitaClass.getInstance("+ topic/stentry learningInteractionBase-d/stentry learning-d/lcItem ");
-    public static final DitaClass LEARNING_D_LCMATCHING = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcMatching ");
-    public static final DitaClass LEARNING_D_LCMATCHINGHEADER = DitaClass.getInstance("+ topic/sthead learningInteractionBase-d/sthead learning-d/lcMatchingHeader ");
-    public static final DitaClass LEARNING_D_LCMATCHINGITEM = DitaClass.getInstance("+ topic/stentry learningInteractionBase-d/stentry learning-d/lcMatchingItem ");
-    public static final DitaClass LEARNING_D_LCMATCHINGITEMFEEDBACK = DitaClass.getInstance("+ topic/stentry learningInteractionBase-d/stentry learning-d/lcMatchingItemFeedback ");
-    public static final DitaClass LEARNING_D_LCMATCHINGPAIR = DitaClass.getInstance("+ topic/strow learningInteractionBase-d/strow learning-d/lcMatchingPair ");
-    public static final DitaClass LEARNING_D_LCMATCHTABLE = DitaClass.getInstance("+ topic/simpletable learningInteractionBase-d/simpletable learning-d/lcMatchTable ");
-    public static final DitaClass LEARNING_D_LCMULTIPLESELECT = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcMultipleSelect ");
-    public static final DitaClass LEARNING_D_LCOPENANSWER = DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcOpenAnswer ");
-    public static final DitaClass LEARNING_D_LCOPENQUESTION = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcOpenQuestion ");
-    public static final DitaClass LEARNING_D_LCQUESTION = DitaClass.getInstance("+ topic/p learningInteractionBase-d/lcQuestionBase learning-d/lcQuestion ");
-    public static final DitaClass LEARNING_D_LCSEQUENCE = DitaClass.getInstance("+ topic/data learningInteractionBase-d/data learning-d/lcSequence ");
-    public static final DitaClass LEARNING_D_LCSEQUENCEOPTION = DitaClass.getInstance("+ topic/li learningInteractionBase-d/li learning-d/lcSequenceOption ");
-    public static final DitaClass LEARNING_D_LCSEQUENCEOPTIONGROUP = DitaClass.getInstance("+ topic/ol learningInteractionBase-d/ol learning-d/lcSequenceOptionGroup ");
-    public static final DitaClass LEARNING_D_LCSEQUENCING = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcSequencing ");
-    public static final DitaClass LEARNING_D_LCSINGLESELECT = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcSingleSelect ");
-    public static final DitaClass LEARNING_D_LCTRUEFALSE = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcTrueFalse ");
-    public static final DitaClass LEARNING2_D_LCANSWERCONTENT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcAnswerContent2 ");
-    public static final DitaClass LEARNING2_D_LCANSWEROPTION2 = DitaClass.getInstance("+ topic/li learningInteractionBase2-d/li learning2-d/lcAnswerOption2 ");
-    public static final DitaClass LEARNING2_D_LCANSWEROPTIONGROUP2 = DitaClass.getInstance("+ topic/ul learningInteractionBase2-d/ul learning2-d/lcAnswerOptionGroup2 ");
-    public static final DitaClass LEARNING2_D_LCAREA2 = DitaClass.getInstance("+ topic/figgroup learningInteractionBase2-d/figgroup learning2-d/lcArea2 ");
-    public static final DitaClass LEARNING2_D_LCAREACOORDS2 = DitaClass.getInstance("+ topic/ph learningInteractionBase2-d/ph learning2-d/lcAreaCoords2 ");
-    public static final DitaClass LEARNING2_D_LCAREASHAPE2 = DitaClass.getInstance("+ topic/keyword learningInteractionBase2-d/keyword learning2-d/lcAreaShape2 ");
-    public static final DitaClass LEARNING2_D_LCASSET2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcAsset2 ");
-    public static final DitaClass LEARNING2_D_LCCORRECTRESPONSE2 = DitaClass.getInstance("+ topic/data learningInteractionBase2-d/data learning2-d/lcCorrectResponse2 ");
-    public static final DitaClass LEARNING2_D_LCFEEDBACK2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedback2 ");
-    public static final DitaClass LEARNING2_D_LCFEEDBACKCORRECT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedbackCorrect2 ");
-    public static final DitaClass LEARNING2_D_LCFEEDBACKINCORRECT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedbackIncorrect2 ");
-    public static final DitaClass LEARNING2_D_LCHOTSPOT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcHotspot2 ");
-    public static final DitaClass LEARNING2_D_LCHOTSPOTMAP2 = DitaClass.getInstance("+ topic/fig learningInteractionBase2-d/figgroup learning2-d/lcHotspotMap2 ");
-    public static final DitaClass LEARNING2_D_LCINSTRUCTORNOTE2 = DitaClass.getInstance("+ topic/note learningInteractionBase2-d/note learning2-d/lcInstructornote2 ");
-    public static final DitaClass LEARNING2_D_LCITEM2 = DitaClass.getInstance("+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcItem2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHING2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcMatching2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHINGHEADER2 = DitaClass.getInstance("+ topic/sthead learningInteractionBase2-d/sthead learning2-d/lcMatchingHeader2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHINGITEM2 = DitaClass.getInstance("+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcMatchingItem2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHINGITEMFEEDBACK2 = DitaClass.getInstance("+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcMatchingItemFeedback2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHINGPAIR2 = DitaClass.getInstance("+ topic/strow learningInteractionBase2-d/strow learning2-d/lcMatchingPair2 ");
-    public static final DitaClass LEARNING2_D_LCMATCHTABLE2 = DitaClass.getInstance("+ topic/simpletable learningInteractionBase2-d/simpletable learning2-d/lcMatchTable2 ");
-    public static final DitaClass LEARNING2_D_LCMULTIPLESELECT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcMultipleSelect2 ");
-    public static final DitaClass LEARNING2_D_LCOPENANSWER2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcOpenAnswer2 ");
-    public static final DitaClass LEARNING2_D_LCOPENQUESTION2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcOpenQuestion2 ");
-    public static final DitaClass LEARNING2_D_LCQUESTION2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcQuestionBase2 learning2-d/lcQuestion2 ");
-    public static final DitaClass LEARNING2_D_LCSEQUENCE2 = DitaClass.getInstance("+ topic/data learningInteractionBase2-d/data learning2-d/lcSequence2 ");
-    public static final DitaClass LEARNING2_D_LCSEQUENCEOPTION2 = DitaClass.getInstance("+ topic/li learningInteractionBase2-d/li learning2-d/lcSequenceOption2 ");
-    public static final DitaClass LEARNING2_D_LCSEQUENCEOPTIONGROUP2 = DitaClass.getInstance("+ topic/ol learningInteractionBase2-d/ol learning2-d/lcSequenceOptionGroup2 ");
-    public static final DitaClass LEARNING2_D_LCSEQUENCING2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcSequencing2 ");
-    public static final DitaClass LEARNING2_D_LCSINGLESELECT2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcSingleSelect2 ");
-    public static final DitaClass LEARNING2_D_LCTRUEFALSE2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcTrueFalse2 ");
-    public static final DitaClass LEARNINGASSESSMENT_LEARNINGASSESSMENT = DitaClass.getInstance("- topic/topic learningBase/learningBase learningAssessment/learningAssessment ");
-    public static final DitaClass LEARNINGASSESSMENT_LEARNINGASSESSMENTBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody learningAssessment/learningAssessmentbody ");
-    public static final DitaClass LEARNINGBASE_LCAUDIENCE = DitaClass.getInstance("- topic/section learningBase/lcAudience ");
-    public static final DitaClass LEARNINGBASE_LCCHALLENGE = DitaClass.getInstance("- topic/section learningBase/lcChallenge ");
-    public static final DitaClass LEARNINGBASE_LCDURATION = DitaClass.getInstance("- topic/section learningBase/lcDuration ");
-    public static final DitaClass LEARNINGBASE_LCINSTRUCTION = DitaClass.getInstance("- topic/section learningBase/lcInstruction ");
-    public static final DitaClass LEARNINGBASE_LCINTERACTION = DitaClass.getInstance("- topic/section learningBase/lcInteraction ");
+    public static final DitaClass INDEXING_D_INDEX_SEE =
+            DitaClass.getInstance("+ topic/index-base indexing-d/index-see ");
+    public static final DitaClass INDEXING_D_INDEX_SEE_ALSO =
+            DitaClass.getInstance("+ topic/index-base indexing-d/index-see-also ");
+    public static final DitaClass INDEXING_D_INDEX_SORT_AS =
+            DitaClass.getInstance("+ topic/index-base indexing-d/index-sort-as ");
+    public static final DitaClass LEARNING_D_LCANSWERCONTENT =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcAnswerContent ");
+    public static final DitaClass LEARNING_D_LCANSWEROPTION =
+            DitaClass.getInstance("+ topic/li learningInteractionBase-d/li learning-d/lcAnswerOption ");
+    public static final DitaClass LEARNING_D_LCANSWEROPTIONGROUP =
+            DitaClass.getInstance("+ topic/ul learningInteractionBase-d/ul learning-d/lcAnswerOptionGroup ");
+    public static final DitaClass LEARNING_D_LCAREA =
+            DitaClass.getInstance("+ topic/figgroup learningInteractionBase-d/figgroup learning-d/lcArea ");
+    public static final DitaClass LEARNING_D_LCAREACOORDS =
+            DitaClass.getInstance("+ topic/ph learningInteractionBase-d/ph learning-d/lcAreaCoords ");
+    public static final DitaClass LEARNING_D_LCAREASHAPE =
+            DitaClass.getInstance("+ topic/keyword learningInteractionBase-d/keyword learning-d/lcAreaShape ");
+    public static final DitaClass LEARNING_D_LCASSET =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcAsset ");
+    public static final DitaClass LEARNING_D_LCCORRECTRESPONSE =
+            DitaClass.getInstance("+ topic/data learningInteractionBase-d/data learning-d/lcCorrectResponse ");
+    public static final DitaClass LEARNING_D_LCFEEDBACK =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedback ");
+    public static final DitaClass LEARNING_D_LCFEEDBACKCORRECT =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedbackCorrect ");
+    public static final DitaClass LEARNING_D_LCFEEDBACKINCORRECT =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcFeedbackIncorrect ");
+    public static final DitaClass LEARNING_D_LCHOTSPOT =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcHotspot ");
+    public static final DitaClass LEARNING_D_LCHOTSPOTMAP =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/figgroup learning-d/lcHotspotMap ");
+    public static final DitaClass LEARNING_D_LCINSTRUCTORNOTE =
+            DitaClass.getInstance("+ topic/note learningInteractionBase-d/note learning-d/lcInstructornote ");
+    public static final DitaClass LEARNING_D_LCITEM =
+            DitaClass.getInstance("+ topic/stentry learningInteractionBase-d/stentry learning-d/lcItem ");
+    public static final DitaClass LEARNING_D_LCMATCHING =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcMatching ");
+    public static final DitaClass LEARNING_D_LCMATCHINGHEADER =
+            DitaClass.getInstance("+ topic/sthead learningInteractionBase-d/sthead learning-d/lcMatchingHeader ");
+    public static final DitaClass LEARNING_D_LCMATCHINGITEM =
+            DitaClass.getInstance("+ topic/stentry learningInteractionBase-d/stentry learning-d/lcMatchingItem ");
+    public static final DitaClass LEARNING_D_LCMATCHINGITEMFEEDBACK = DitaClass.getInstance(
+            "+ topic/stentry learningInteractionBase-d/stentry learning-d/lcMatchingItemFeedback ");
+    public static final DitaClass LEARNING_D_LCMATCHINGPAIR =
+            DitaClass.getInstance("+ topic/strow learningInteractionBase-d/strow learning-d/lcMatchingPair ");
+    public static final DitaClass LEARNING_D_LCMATCHTABLE =
+            DitaClass.getInstance("+ topic/simpletable learningInteractionBase-d/simpletable learning-d/lcMatchTable ");
+    public static final DitaClass LEARNING_D_LCMULTIPLESELECT = DitaClass.getInstance(
+            "+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcMultipleSelect ");
+    public static final DitaClass LEARNING_D_LCOPENANSWER =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/p learning-d/lcOpenAnswer ");
+    public static final DitaClass LEARNING_D_LCOPENQUESTION =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcOpenQuestion ");
+    public static final DitaClass LEARNING_D_LCQUESTION =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/lcQuestionBase learning-d/lcQuestion ");
+    public static final DitaClass LEARNING_D_LCSEQUENCE =
+            DitaClass.getInstance("+ topic/data learningInteractionBase-d/data learning-d/lcSequence ");
+    public static final DitaClass LEARNING_D_LCSEQUENCEOPTION =
+            DitaClass.getInstance("+ topic/li learningInteractionBase-d/li learning-d/lcSequenceOption ");
+    public static final DitaClass LEARNING_D_LCSEQUENCEOPTIONGROUP =
+            DitaClass.getInstance("+ topic/ol learningInteractionBase-d/ol learning-d/lcSequenceOptionGroup ");
+    public static final DitaClass LEARNING_D_LCSEQUENCING =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcSequencing ");
+    public static final DitaClass LEARNING_D_LCSINGLESELECT =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcSingleSelect ");
+    public static final DitaClass LEARNING_D_LCTRUEFALSE =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase learning-d/lcTrueFalse ");
+    public static final DitaClass LEARNING2_D_LCANSWERCONTENT2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcAnswerContent2 ");
+    public static final DitaClass LEARNING2_D_LCANSWEROPTION2 =
+            DitaClass.getInstance("+ topic/li learningInteractionBase2-d/li learning2-d/lcAnswerOption2 ");
+    public static final DitaClass LEARNING2_D_LCANSWEROPTIONGROUP2 =
+            DitaClass.getInstance("+ topic/ul learningInteractionBase2-d/ul learning2-d/lcAnswerOptionGroup2 ");
+    public static final DitaClass LEARNING2_D_LCAREA2 =
+            DitaClass.getInstance("+ topic/figgroup learningInteractionBase2-d/figgroup learning2-d/lcArea2 ");
+    public static final DitaClass LEARNING2_D_LCAREACOORDS2 =
+            DitaClass.getInstance("+ topic/ph learningInteractionBase2-d/ph learning2-d/lcAreaCoords2 ");
+    public static final DitaClass LEARNING2_D_LCAREASHAPE2 =
+            DitaClass.getInstance("+ topic/keyword learningInteractionBase2-d/keyword learning2-d/lcAreaShape2 ");
+    public static final DitaClass LEARNING2_D_LCASSET2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcAsset2 ");
+    public static final DitaClass LEARNING2_D_LCCORRECTRESPONSE2 =
+            DitaClass.getInstance("+ topic/data learningInteractionBase2-d/data learning2-d/lcCorrectResponse2 ");
+    public static final DitaClass LEARNING2_D_LCFEEDBACK2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedback2 ");
+    public static final DitaClass LEARNING2_D_LCFEEDBACKCORRECT2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedbackCorrect2 ");
+    public static final DitaClass LEARNING2_D_LCFEEDBACKINCORRECT2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcFeedbackIncorrect2 ");
+    public static final DitaClass LEARNING2_D_LCHOTSPOT2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcHotspot2 ");
+    public static final DitaClass LEARNING2_D_LCHOTSPOTMAP2 =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase2-d/figgroup learning2-d/lcHotspotMap2 ");
+    public static final DitaClass LEARNING2_D_LCINSTRUCTORNOTE2 =
+            DitaClass.getInstance("+ topic/note learningInteractionBase2-d/note learning2-d/lcInstructornote2 ");
+    public static final DitaClass LEARNING2_D_LCITEM2 =
+            DitaClass.getInstance("+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcItem2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHING2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcMatching2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHINGHEADER2 =
+            DitaClass.getInstance("+ topic/sthead learningInteractionBase2-d/sthead learning2-d/lcMatchingHeader2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHINGITEM2 =
+            DitaClass.getInstance("+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcMatchingItem2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHINGITEMFEEDBACK2 = DitaClass.getInstance(
+            "+ topic/stentry learningInteractionBase2-d/stentry learning2-d/lcMatchingItemFeedback2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHINGPAIR2 =
+            DitaClass.getInstance("+ topic/strow learningInteractionBase2-d/strow learning2-d/lcMatchingPair2 ");
+    public static final DitaClass LEARNING2_D_LCMATCHTABLE2 = DitaClass.getInstance(
+            "+ topic/simpletable learningInteractionBase2-d/simpletable learning2-d/lcMatchTable2 ");
+    public static final DitaClass LEARNING2_D_LCMULTIPLESELECT2 = DitaClass.getInstance(
+            "+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcMultipleSelect2 ");
+    public static final DitaClass LEARNING2_D_LCOPENANSWER2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/div learning2-d/lcOpenAnswer2 ");
+    public static final DitaClass LEARNING2_D_LCOPENQUESTION2 = DitaClass.getInstance(
+            "+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcOpenQuestion2 ");
+    public static final DitaClass LEARNING2_D_LCQUESTION2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcQuestionBase2 learning2-d/lcQuestion2 ");
+    public static final DitaClass LEARNING2_D_LCSEQUENCE2 =
+            DitaClass.getInstance("+ topic/data learningInteractionBase2-d/data learning2-d/lcSequence2 ");
+    public static final DitaClass LEARNING2_D_LCSEQUENCEOPTION2 =
+            DitaClass.getInstance("+ topic/li learningInteractionBase2-d/li learning2-d/lcSequenceOption2 ");
+    public static final DitaClass LEARNING2_D_LCSEQUENCEOPTIONGROUP2 =
+            DitaClass.getInstance("+ topic/ol learningInteractionBase2-d/ol learning2-d/lcSequenceOptionGroup2 ");
+    public static final DitaClass LEARNING2_D_LCSEQUENCING2 = DitaClass.getInstance(
+            "+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcSequencing2 ");
+    public static final DitaClass LEARNING2_D_LCSINGLESELECT2 = DitaClass.getInstance(
+            "+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcSingleSelect2 ");
+    public static final DitaClass LEARNING2_D_LCTRUEFALSE2 = DitaClass.getInstance(
+            "+ topic/div learningInteractionBase2-d/lcInteractionBase2 learning2-d/lcTrueFalse2 ");
+    public static final DitaClass LEARNINGASSESSMENT_LEARNINGASSESSMENT =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase learningAssessment/learningAssessment ");
+    public static final DitaClass LEARNINGASSESSMENT_LEARNINGASSESSMENTBODY = DitaClass.getInstance(
+            "- topic/body learningBase/learningBasebody learningAssessment/learningAssessmentbody ");
+    public static final DitaClass LEARNINGBASE_LCAUDIENCE =
+            DitaClass.getInstance("- topic/section learningBase/lcAudience ");
+    public static final DitaClass LEARNINGBASE_LCCHALLENGE =
+            DitaClass.getInstance("- topic/section learningBase/lcChallenge ");
+    public static final DitaClass LEARNINGBASE_LCDURATION =
+            DitaClass.getInstance("- topic/section learningBase/lcDuration ");
+    public static final DitaClass LEARNINGBASE_LCINSTRUCTION =
+            DitaClass.getInstance("- topic/section learningBase/lcInstruction ");
+    public static final DitaClass LEARNINGBASE_LCINTERACTION =
+            DitaClass.getInstance("- topic/section learningBase/lcInteraction ");
     public static final DitaClass LEARNINGBASE_LCINTRO = DitaClass.getInstance("- topic/section learningBase/lcIntro ");
-    public static final DitaClass LEARNINGBASE_LCNEXTSTEPS = DitaClass.getInstance("- topic/section learningBase/lcNextSteps ");
-    public static final DitaClass LEARNINGBASE_LCOBJECTIVE = DitaClass.getInstance("- topic/li learningBase/lcObjective ");
-    public static final DitaClass LEARNINGBASE_LCOBJECTIVES = DitaClass.getInstance("- topic/section learningBase/lcObjectives ");
-    public static final DitaClass LEARNINGBASE_LCOBJECTIVESGROUP = DitaClass.getInstance("- topic/ul learningBase/lcObjectivesGroup ");
-    public static final DitaClass LEARNINGBASE_LCOBJECTIVESSTEM = DitaClass.getInstance("- topic/ph learningBase/lcObjectivesStem ");
-    public static final DitaClass LEARNINGBASE_LCPREREQS = DitaClass.getInstance("- topic/section learningBase/lcPrereqs ");
-    public static final DitaClass LEARNINGBASE_LCRESOURCES = DitaClass.getInstance("- topic/section learningBase/lcResources ");
-    public static final DitaClass LEARNINGBASE_LCREVIEW = DitaClass.getInstance("- topic/section learningBase/lcReview ");
-    public static final DitaClass LEARNINGBASE_LCSUMMARY = DitaClass.getInstance("- topic/section learningBase/lcSummary ");
+    public static final DitaClass LEARNINGBASE_LCNEXTSTEPS =
+            DitaClass.getInstance("- topic/section learningBase/lcNextSteps ");
+    public static final DitaClass LEARNINGBASE_LCOBJECTIVE =
+            DitaClass.getInstance("- topic/li learningBase/lcObjective ");
+    public static final DitaClass LEARNINGBASE_LCOBJECTIVES =
+            DitaClass.getInstance("- topic/section learningBase/lcObjectives ");
+    public static final DitaClass LEARNINGBASE_LCOBJECTIVESGROUP =
+            DitaClass.getInstance("- topic/ul learningBase/lcObjectivesGroup ");
+    public static final DitaClass LEARNINGBASE_LCOBJECTIVESSTEM =
+            DitaClass.getInstance("- topic/ph learningBase/lcObjectivesStem ");
+    public static final DitaClass LEARNINGBASE_LCPREREQS =
+            DitaClass.getInstance("- topic/section learningBase/lcPrereqs ");
+    public static final DitaClass LEARNINGBASE_LCRESOURCES =
+            DitaClass.getInstance("- topic/section learningBase/lcResources ");
+    public static final DitaClass LEARNINGBASE_LCREVIEW =
+            DitaClass.getInstance("- topic/section learningBase/lcReview ");
+    public static final DitaClass LEARNINGBASE_LCSUMMARY =
+            DitaClass.getInstance("- topic/section learningBase/lcSummary ");
     public static final DitaClass LEARNINGBASE_LCTIME = DitaClass.getInstance("- topic/data learningBase/lcTime ");
-    public static final DitaClass LEARNINGBASE_LEARNINGBASE = DitaClass.getInstance("- topic/topic learningBase/learningBase ");
-    public static final DitaClass LEARNINGBASE_LEARNINGBASEBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody ");
-    public static final DitaClass LEARNINGCONTENT_LEARNINGCONTENT = DitaClass.getInstance("- topic/topic learningBase/learningBase learningContent/learningContent ");
-    public static final DitaClass LEARNINGCONTENT_LEARNINGCONTENTBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody learningContent/learningContentbody ");
-    public static final DitaClass LEARNINGGROUPMAP_LEARNINGGROUPMAP = DitaClass.getInstance("- map/map learningGroupMap/learningGroupMap ");
-    public static final DitaClass LEARNINGINTERACTIONBASE_D_LCINTERACTIONBASE = DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase ");
-    public static final DitaClass LEARNINGINTERACTIONBASE_D_LCQUESTIONBASE = DitaClass.getInstance("+ topic/p learningInteractionBase-d/lcQuestionBase ");
-    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCINTERACTIONBASE2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 ");
-    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCINTERACTIONLABEL2 = DitaClass.getInstance("+ topic/p learningInteractionBase2-d/lcInteractionLabel2 ");
-    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCQUESTIONBASE2 = DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcQuestionBase2 ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGCONTENTCOMPONENTREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningContentComponentRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGCONTENTREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningContentRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGGROUP = DitaClass.getInstance("+ map/topicref learningmap-d/learningGroup ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGGROUPMAPREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningGroupMapRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGOBJECT = DitaClass.getInstance("+ map/topicref learningmap-d/learningObject ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGOBJECTMAPREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningObjectMapRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGOVERVIEWREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningOverviewRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGPLANREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningPlanRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGPOSTASSESSMENTREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningPostAssessmentRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGPREASSESSMENTREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningPreAssessmentRef ");
-    public static final DitaClass LEARNINGMAP_D_LEARNINGSUMMARYREF = DitaClass.getInstance("+ map/topicref learningmap-d/learningSummaryRef ");
-    public static final DitaClass LEARNINGMETA_D_LCLOM = DitaClass.getInstance("+ topic/metadata learningmeta-d/lcLom ");
-    public static final DitaClass LEARNINGMETA_D_LOMAGGREGATIONLEVEL = DitaClass.getInstance("+ topic/data learningmeta-d/lomAggregationLevel ");
-    public static final DitaClass LEARNINGMETA_D_LOMCONTEXT = DitaClass.getInstance("+ topic/data learningmeta-d/lomContext ");
-    public static final DitaClass LEARNINGMETA_D_LOMCOVERAGE = DitaClass.getInstance("+ topic/data learningmeta-d/lomCoverage ");
-    public static final DitaClass LEARNINGMETA_D_LOMDIFFICULTY = DitaClass.getInstance("+ topic/data learningmeta-d/lomDifficulty ");
-    public static final DitaClass LEARNINGMETA_D_LOMINSTALLATIONREMARKS = DitaClass.getInstance("+ topic/data learningmeta-d/lomInstallationRemarks ");
-    public static final DitaClass LEARNINGMETA_D_LOMINTENDEDUSERROLE = DitaClass.getInstance("+ topic/data learningmeta-d/lomIntendedUserRole ");
-    public static final DitaClass LEARNINGMETA_D_LOMINTERACTIVITYLEVEL = DitaClass.getInstance("+ topic/data learningmeta-d/lomInteractivityLevel ");
-    public static final DitaClass LEARNINGMETA_D_LOMINTERACTIVITYTYPE = DitaClass.getInstance("+ topic/data learningmeta-d/lomInteractivityType ");
-    public static final DitaClass LEARNINGMETA_D_LOMLEARNINGRESOURCETYPE = DitaClass.getInstance("+ topic/data learningmeta-d/lomLearningResourceType ");
-    public static final DitaClass LEARNINGMETA_D_LOMOTHERPLATFORMREQUIREMENTS = DitaClass.getInstance("+ topic/data learningmeta-d/lomOtherPlatformRequirements ");
-    public static final DitaClass LEARNINGMETA_D_LOMSEMANTICDENSITY = DitaClass.getInstance("+ topic/data learningmeta-d/lomSemanticDensity ");
-    public static final DitaClass LEARNINGMETA_D_LOMSTRUCTURE = DitaClass.getInstance("+ topic/data learningmeta-d/lomStructure ");
-    public static final DitaClass LEARNINGMETA_D_LOMTECHREQUIREMENT = DitaClass.getInstance("+ topic/data learningmeta-d/lomTechRequirement ");
-    public static final DitaClass LEARNINGMETA_D_LOMTYPICALAGERANGE = DitaClass.getInstance("+ topic/data learningmeta-d/lomTypicalAgeRange ");
-    public static final DitaClass LEARNINGMETA_D_LOMTYPICALLEARNINGTIME = DitaClass.getInstance("+ topic/data learningmeta-d/lomTypicalLearningTime ");
-    public static final DitaClass LEARNINGOBJECTMAP_LEARNINGOBJECTMAP = DitaClass.getInstance("- map/map learningObjectMap/learningObjectMap ");
-    public static final DitaClass LEARNINGOVERVIEW_LEARNINGOVERVIEW = DitaClass.getInstance("- topic/topic learningBase/learningBase learningOverview/learningOverview ");
-    public static final DitaClass LEARNINGOVERVIEW_LEARNINGOVERVIEWBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody learningOverview/learningOverviewbody ");
-    public static final DitaClass LEARNINGPLAN_LCAGE = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAge ");
-    public static final DitaClass LEARNINGPLAN_LCASSESSMENT = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAssessment ");
-    public static final DitaClass LEARNINGPLAN_LCATTITUDE = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAttitude ");
-    public static final DitaClass LEARNINGPLAN_LCBACKGROUND = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcBackground ");
-    public static final DitaClass LEARNINGPLAN_LCCIN = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcCIN ");
-    public static final DitaClass LEARNINGPLAN_LCCLASSROOM = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcClassroom ");
-    public static final DitaClass LEARNINGPLAN_LCCLIENT = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcClient ");
-    public static final DitaClass LEARNINGPLAN_LCCONSTRAINTS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcConstraints ");
-    public static final DitaClass LEARNINGPLAN_LCDELIVDATE = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcDelivDate ");
-    public static final DitaClass LEARNINGPLAN_LCDELIVERY = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcDelivery ");
-    public static final DitaClass LEARNINGPLAN_LCDOWNLOADTIME = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcDownloadTime ");
-    public static final DitaClass LEARNINGPLAN_LCEDLEVEL = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcEdLevel ");
-    public static final DitaClass LEARNINGPLAN_LCFILESIZELIMITATIONS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcFileSizeLimitations ");
-    public static final DitaClass LEARNINGPLAN_LCGAPANALYSIS = DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcGapAnalysis ");
-    public static final DitaClass LEARNINGPLAN_LCGAPITEM = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcGapItem ");
-    public static final DitaClass LEARNINGPLAN_LCGAPITEMDELTA = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGapItemDelta ");
-    public static final DitaClass LEARNINGPLAN_LCGENERALDESCRIPTION = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGeneralDescription ");
-    public static final DitaClass LEARNINGPLAN_LCGOALS = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGoals ");
-    public static final DitaClass LEARNINGPLAN_LCGRAPHICS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcGraphics ");
-    public static final DitaClass LEARNINGPLAN_LCHANDOUTS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcHandouts ");
-    public static final DitaClass LEARNINGPLAN_LCINTERVENTION = DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcIntervention ");
-    public static final DitaClass LEARNINGPLAN_LCINTERVENTIONITEM = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcInterventionItem ");
-    public static final DitaClass LEARNINGPLAN_LCJTAITEM = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcJtaItem ");
-    public static final DitaClass LEARNINGPLAN_LCKNOWLEDGE = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcKnowledge ");
-    public static final DitaClass LEARNINGPLAN_LCLEARNSTRAT = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcLearnStrat ");
-    public static final DitaClass LEARNINGPLAN_LCLMS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcLMS ");
-    public static final DitaClass LEARNINGPLAN_LCMODDATE = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcModDate ");
-    public static final DitaClass LEARNINGPLAN_LCMOTIVATION = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcMotivation ");
-    public static final DitaClass LEARNINGPLAN_LCNEEDS = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcNeeds ");
-    public static final DitaClass LEARNINGPLAN_LCNEEDSANALYSIS = DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcNeedsAnalysis ");
-    public static final DitaClass LEARNINGPLAN_LCNOLMS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcNoLMS ");
-    public static final DitaClass LEARNINGPLAN_LCOJT = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcOJT ");
-    public static final DitaClass LEARNINGPLAN_LCORGANIZATIONAL = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcOrganizational ");
-    public static final DitaClass LEARNINGPLAN_LCORGCONSTRAINTS = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcOrgConstraints ");
-    public static final DitaClass LEARNINGPLAN_LCPLANAUDIENCE = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanAudience ");
-    public static final DitaClass LEARNINGPLAN_LCPLANDESCRIP = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanDescrip ");
-    public static final DitaClass LEARNINGPLAN_LCPLANOBJECTIVE = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcPlanObjective ");
-    public static final DitaClass LEARNINGPLAN_LCPLANPREREQS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanPrereqs ");
-    public static final DitaClass LEARNINGPLAN_LCPLANRESOURCES = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcPlanResources ");
-    public static final DitaClass LEARNINGPLAN_LCPLANSUBJECT = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanSubject ");
-    public static final DitaClass LEARNINGPLAN_LCPLANTITLE = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanTitle ");
-    public static final DitaClass LEARNINGPLAN_LCPLAYERS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlayers ");
-    public static final DitaClass LEARNINGPLAN_LCPROCESSES = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcProcesses ");
-    public static final DitaClass LEARNINGPLAN_LCPROJECT = DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcProject ");
-    public static final DitaClass LEARNINGPLAN_LCRESOLUTION = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcResolution ");
-    public static final DitaClass LEARNINGPLAN_LCSECURITY = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcSecurity ");
-    public static final DitaClass LEARNINGPLAN_LCSKILLS = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcSkills ");
-    public static final DitaClass LEARNINGPLAN_LCSPECCHARS = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcSpecChars ");
-    public static final DitaClass LEARNINGPLAN_LCTASK = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcTask ");
-    public static final DitaClass LEARNINGPLAN_LCTASKITEM = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcTaskItem ");
-    public static final DitaClass LEARNINGPLAN_LCTECHNICAL = DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcTechnical ");
-    public static final DitaClass LEARNINGPLAN_LCVALUES = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcValues ");
-    public static final DitaClass LEARNINGPLAN_LCVIEWERS = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcViewers ");
-    public static final DitaClass LEARNINGPLAN_LCW3C = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcW3C ");
-    public static final DitaClass LEARNINGPLAN_LCWORKENV = DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcWorkEnv ");
-    public static final DitaClass LEARNINGPLAN_LCWORKENVDESCRIPTION = DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcWorkEnvDescription ");
-    public static final DitaClass LEARNINGPLAN_LEARNINGPLAN = DitaClass.getInstance("- topic/topic learningBase/learningBase learningPlan/learningPlan ");
-    public static final DitaClass LEARNINGPLAN_LEARNINGPLANBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody learningPlan/learningPlanbody ");
-    public static final DitaClass LEARNINGSUMMARY_LEARNINGSUMMARY = DitaClass.getInstance("- topic/topic learningBase/learningBase learningSummary/learningSummary ");
-    public static final DitaClass LEARNINGSUMMARY_LEARNINGSUMMARYBODY = DitaClass.getInstance("- topic/body learningBase/learningBasebody learningSummary/learningSummarybody ");
+    public static final DitaClass LEARNINGBASE_LEARNINGBASE =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase ");
+    public static final DitaClass LEARNINGBASE_LEARNINGBASEBODY =
+            DitaClass.getInstance("- topic/body learningBase/learningBasebody ");
+    public static final DitaClass LEARNINGCONTENT_LEARNINGCONTENT =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase learningContent/learningContent ");
+    public static final DitaClass LEARNINGCONTENT_LEARNINGCONTENTBODY =
+            DitaClass.getInstance("- topic/body learningBase/learningBasebody learningContent/learningContentbody ");
+    public static final DitaClass LEARNINGGROUPMAP_LEARNINGGROUPMAP =
+            DitaClass.getInstance("- map/map learningGroupMap/learningGroupMap ");
+    public static final DitaClass LEARNINGINTERACTIONBASE_D_LCINTERACTIONBASE =
+            DitaClass.getInstance("+ topic/fig learningInteractionBase-d/lcInteractionBase ");
+    public static final DitaClass LEARNINGINTERACTIONBASE_D_LCQUESTIONBASE =
+            DitaClass.getInstance("+ topic/p learningInteractionBase-d/lcQuestionBase ");
+    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCINTERACTIONBASE2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcInteractionBase2 ");
+    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCINTERACTIONLABEL2 =
+            DitaClass.getInstance("+ topic/p learningInteractionBase2-d/lcInteractionLabel2 ");
+    public static final DitaClass LEARNINGINTERACTIONBASE2_D_LCQUESTIONBASE2 =
+            DitaClass.getInstance("+ topic/div learningInteractionBase2-d/lcQuestionBase2 ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGCONTENTCOMPONENTREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningContentComponentRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGCONTENTREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningContentRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGGROUP =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningGroup ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGGROUPMAPREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningGroupMapRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGOBJECT =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningObject ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGOBJECTMAPREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningObjectMapRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGOVERVIEWREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningOverviewRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGPLANREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningPlanRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGPOSTASSESSMENTREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningPostAssessmentRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGPREASSESSMENTREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningPreAssessmentRef ");
+    public static final DitaClass LEARNINGMAP_D_LEARNINGSUMMARYREF =
+            DitaClass.getInstance("+ map/topicref learningmap-d/learningSummaryRef ");
+    public static final DitaClass LEARNINGMETA_D_LCLOM =
+            DitaClass.getInstance("+ topic/metadata learningmeta-d/lcLom ");
+    public static final DitaClass LEARNINGMETA_D_LOMAGGREGATIONLEVEL =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomAggregationLevel ");
+    public static final DitaClass LEARNINGMETA_D_LOMCONTEXT =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomContext ");
+    public static final DitaClass LEARNINGMETA_D_LOMCOVERAGE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomCoverage ");
+    public static final DitaClass LEARNINGMETA_D_LOMDIFFICULTY =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomDifficulty ");
+    public static final DitaClass LEARNINGMETA_D_LOMINSTALLATIONREMARKS =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomInstallationRemarks ");
+    public static final DitaClass LEARNINGMETA_D_LOMINTENDEDUSERROLE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomIntendedUserRole ");
+    public static final DitaClass LEARNINGMETA_D_LOMINTERACTIVITYLEVEL =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomInteractivityLevel ");
+    public static final DitaClass LEARNINGMETA_D_LOMINTERACTIVITYTYPE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomInteractivityType ");
+    public static final DitaClass LEARNINGMETA_D_LOMLEARNINGRESOURCETYPE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomLearningResourceType ");
+    public static final DitaClass LEARNINGMETA_D_LOMOTHERPLATFORMREQUIREMENTS =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomOtherPlatformRequirements ");
+    public static final DitaClass LEARNINGMETA_D_LOMSEMANTICDENSITY =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomSemanticDensity ");
+    public static final DitaClass LEARNINGMETA_D_LOMSTRUCTURE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomStructure ");
+    public static final DitaClass LEARNINGMETA_D_LOMTECHREQUIREMENT =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomTechRequirement ");
+    public static final DitaClass LEARNINGMETA_D_LOMTYPICALAGERANGE =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomTypicalAgeRange ");
+    public static final DitaClass LEARNINGMETA_D_LOMTYPICALLEARNINGTIME =
+            DitaClass.getInstance("+ topic/data learningmeta-d/lomTypicalLearningTime ");
+    public static final DitaClass LEARNINGOBJECTMAP_LEARNINGOBJECTMAP =
+            DitaClass.getInstance("- map/map learningObjectMap/learningObjectMap ");
+    public static final DitaClass LEARNINGOVERVIEW_LEARNINGOVERVIEW =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase learningOverview/learningOverview ");
+    public static final DitaClass LEARNINGOVERVIEW_LEARNINGOVERVIEWBODY =
+            DitaClass.getInstance("- topic/body learningBase/learningBasebody learningOverview/learningOverviewbody ");
+    public static final DitaClass LEARNINGPLAN_LCAGE =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAge ");
+    public static final DitaClass LEARNINGPLAN_LCASSESSMENT =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAssessment ");
+    public static final DitaClass LEARNINGPLAN_LCATTITUDE =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcAttitude ");
+    public static final DitaClass LEARNINGPLAN_LCBACKGROUND =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcBackground ");
+    public static final DitaClass LEARNINGPLAN_LCCIN =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcCIN ");
+    public static final DitaClass LEARNINGPLAN_LCCLASSROOM =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcClassroom ");
+    public static final DitaClass LEARNINGPLAN_LCCLIENT =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcClient ");
+    public static final DitaClass LEARNINGPLAN_LCCONSTRAINTS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcConstraints ");
+    public static final DitaClass LEARNINGPLAN_LCDELIVDATE =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcDelivDate ");
+    public static final DitaClass LEARNINGPLAN_LCDELIVERY =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcDelivery ");
+    public static final DitaClass LEARNINGPLAN_LCDOWNLOADTIME =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcDownloadTime ");
+    public static final DitaClass LEARNINGPLAN_LCEDLEVEL =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcEdLevel ");
+    public static final DitaClass LEARNINGPLAN_LCFILESIZELIMITATIONS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcFileSizeLimitations ");
+    public static final DitaClass LEARNINGPLAN_LCGAPANALYSIS =
+            DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcGapAnalysis ");
+    public static final DitaClass LEARNINGPLAN_LCGAPITEM =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcGapItem ");
+    public static final DitaClass LEARNINGPLAN_LCGAPITEMDELTA =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGapItemDelta ");
+    public static final DitaClass LEARNINGPLAN_LCGENERALDESCRIPTION =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGeneralDescription ");
+    public static final DitaClass LEARNINGPLAN_LCGOALS =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcGoals ");
+    public static final DitaClass LEARNINGPLAN_LCGRAPHICS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcGraphics ");
+    public static final DitaClass LEARNINGPLAN_LCHANDOUTS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcHandouts ");
+    public static final DitaClass LEARNINGPLAN_LCINTERVENTION =
+            DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcIntervention ");
+    public static final DitaClass LEARNINGPLAN_LCINTERVENTIONITEM =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcInterventionItem ");
+    public static final DitaClass LEARNINGPLAN_LCJTAITEM =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcJtaItem ");
+    public static final DitaClass LEARNINGPLAN_LCKNOWLEDGE =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcKnowledge ");
+    public static final DitaClass LEARNINGPLAN_LCLEARNSTRAT =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcLearnStrat ");
+    public static final DitaClass LEARNINGPLAN_LCLMS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcLMS ");
+    public static final DitaClass LEARNINGPLAN_LCMODDATE =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcModDate ");
+    public static final DitaClass LEARNINGPLAN_LCMOTIVATION =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcMotivation ");
+    public static final DitaClass LEARNINGPLAN_LCNEEDS =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcNeeds ");
+    public static final DitaClass LEARNINGPLAN_LCNEEDSANALYSIS =
+            DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcNeedsAnalysis ");
+    public static final DitaClass LEARNINGPLAN_LCNOLMS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcNoLMS ");
+    public static final DitaClass LEARNINGPLAN_LCOJT =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcOJT ");
+    public static final DitaClass LEARNINGPLAN_LCORGANIZATIONAL =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcOrganizational ");
+    public static final DitaClass LEARNINGPLAN_LCORGCONSTRAINTS =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcOrgConstraints ");
+    public static final DitaClass LEARNINGPLAN_LCPLANAUDIENCE =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanAudience ");
+    public static final DitaClass LEARNINGPLAN_LCPLANDESCRIP =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanDescrip ");
+    public static final DitaClass LEARNINGPLAN_LCPLANOBJECTIVE =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcPlanObjective ");
+    public static final DitaClass LEARNINGPLAN_LCPLANPREREQS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanPrereqs ");
+    public static final DitaClass LEARNINGPLAN_LCPLANRESOURCES =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcPlanResources ");
+    public static final DitaClass LEARNINGPLAN_LCPLANSUBJECT =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanSubject ");
+    public static final DitaClass LEARNINGPLAN_LCPLANTITLE =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlanTitle ");
+    public static final DitaClass LEARNINGPLAN_LCPLAYERS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcPlayers ");
+    public static final DitaClass LEARNINGPLAN_LCPROCESSES =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcProcesses ");
+    public static final DitaClass LEARNINGPLAN_LCPROJECT =
+            DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcProject ");
+    public static final DitaClass LEARNINGPLAN_LCRESOLUTION =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcResolution ");
+    public static final DitaClass LEARNINGPLAN_LCSECURITY =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcSecurity ");
+    public static final DitaClass LEARNINGPLAN_LCSKILLS =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcSkills ");
+    public static final DitaClass LEARNINGPLAN_LCSPECCHARS =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcSpecChars ");
+    public static final DitaClass LEARNINGPLAN_LCTASK =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcTask ");
+    public static final DitaClass LEARNINGPLAN_LCTASKITEM =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcTaskItem ");
+    public static final DitaClass LEARNINGPLAN_LCTECHNICAL =
+            DitaClass.getInstance("- topic/section learningBase/section learningPlan/lcTechnical ");
+    public static final DitaClass LEARNINGPLAN_LCVALUES =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcValues ");
+    public static final DitaClass LEARNINGPLAN_LCVIEWERS =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcViewers ");
+    public static final DitaClass LEARNINGPLAN_LCW3C =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcW3C ");
+    public static final DitaClass LEARNINGPLAN_LCWORKENV =
+            DitaClass.getInstance("- topic/fig learningBase/fig learningPlan/lcWorkEnv ");
+    public static final DitaClass LEARNINGPLAN_LCWORKENVDESCRIPTION =
+            DitaClass.getInstance("- topic/p learningBase/p learningPlan/lcWorkEnvDescription ");
+    public static final DitaClass LEARNINGPLAN_LEARNINGPLAN =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase learningPlan/learningPlan ");
+    public static final DitaClass LEARNINGPLAN_LEARNINGPLANBODY =
+            DitaClass.getInstance("- topic/body learningBase/learningBasebody learningPlan/learningPlanbody ");
+    public static final DitaClass LEARNINGSUMMARY_LEARNINGSUMMARY =
+            DitaClass.getInstance("- topic/topic learningBase/learningBase learningSummary/learningSummary ");
+    public static final DitaClass LEARNINGSUMMARY_LEARNINGSUMMARYBODY =
+            DitaClass.getInstance("- topic/body learningBase/learningBasebody learningSummary/learningSummarybody ");
     public static final DitaClass MAP_ANCHOR = DitaClass.getInstance("- map/anchor ");
     public static final DitaClass MAP_LINKTEXT = DitaClass.getInstance("- map/linktext ");
     public static final DitaClass MAP_MAP = DitaClass.getInstance("- map/map ");
@@ -375,10 +597,12 @@ public final class Constants {
     public static final DitaClass MAPGROUP_D_ANCHORREF = DitaClass.getInstance("+ map/topicref mapgroup-d/anchorref ");
     public static final DitaClass MAPGROUP_D_KEYDEF = DitaClass.getInstance("+ map/topicref mapgroup-d/keydef ");
     public static final DitaClass MAPGROUP_D_MAPREF = DitaClass.getInstance("+ map/topicref mapgroup-d/mapref ");
-    public static final DitaClass MAPGROUP_D_TOPICGROUP = DitaClass.getInstance("+ map/topicref mapgroup-d/topicgroup ");
+    public static final DitaClass MAPGROUP_D_TOPICGROUP =
+            DitaClass.getInstance("+ map/topicref mapgroup-d/topicgroup ");
     public static final DitaClass MAPGROUP_D_TOPICHEAD = DitaClass.getInstance("+ map/topicref mapgroup-d/topichead ");
     public static final DitaClass MAPGROUP_D_TOPICSET = DitaClass.getInstance("+ map/topicref mapgroup-d/topicset ");
-    public static final DitaClass MAPGROUP_D_TOPICSETREF = DitaClass.getInstance("+ map/topicref mapgroup-d/topicsetref ");
+    public static final DitaClass MAPGROUP_D_TOPICSETREF =
+            DitaClass.getInstance("+ map/topicref mapgroup-d/topicsetref ");
     public static final DitaClass MARKUP_D_MARKUPNAME = DitaClass.getInstance("+ topic/keyword markup-d/markupname ");
     public static final DitaClass MATHML_D_MATHML = DitaClass.getInstance("+ topic/foreign mathml-d/mathml ");
     public static final DitaClass MATHML_D_MATHMLREF = DitaClass.getInstance("+ topic/xref mathml-d/mathmlref ");
@@ -410,47 +634,78 @@ public final class Constants {
     public static final DitaClass PR_D_VAR = DitaClass.getInstance("+ topic/ph pr-d/var ");
     public static final DitaClass REFERENCE_PROPDESC = DitaClass.getInstance("- topic/stentry reference/propdesc ");
     public static final DitaClass REFERENCE_PROPDESCHD = DitaClass.getInstance("- topic/stentry reference/propdeschd ");
-    public static final DitaClass REFERENCE_PROPERTIES = DitaClass.getInstance("- topic/simpletable reference/properties ");
+    public static final DitaClass REFERENCE_PROPERTIES =
+            DitaClass.getInstance("- topic/simpletable reference/properties ");
     public static final DitaClass REFERENCE_PROPERTY = DitaClass.getInstance("- topic/strow reference/property ");
     public static final DitaClass REFERENCE_PROPHEAD = DitaClass.getInstance("- topic/sthead reference/prophead ");
     public static final DitaClass REFERENCE_PROPTYPE = DitaClass.getInstance("- topic/stentry reference/proptype ");
     public static final DitaClass REFERENCE_PROPTYPEHD = DitaClass.getInstance("- topic/stentry reference/proptypehd ");
     public static final DitaClass REFERENCE_PROPVALUE = DitaClass.getInstance("- topic/stentry reference/propvalue ");
-    public static final DitaClass REFERENCE_PROPVALUEHD = DitaClass.getInstance("- topic/stentry reference/propvaluehd ");
+    public static final DitaClass REFERENCE_PROPVALUEHD =
+            DitaClass.getInstance("- topic/stentry reference/propvaluehd ");
     public static final DitaClass REFERENCE_REFBODY = DitaClass.getInstance("- topic/body reference/refbody ");
     public static final DitaClass REFERENCE_REFBODYDIV = DitaClass.getInstance("- topic/bodydiv reference/refbodydiv ");
     public static final DitaClass REFERENCE_REFERENCE = DitaClass.getInstance("- topic/topic reference/reference ");
     public static final DitaClass REFERENCE_REFSYN = DitaClass.getInstance("- topic/section reference/refsyn ");
-    public static final DitaClass RELMGMT_D_CHANGE_COMPLETED = DitaClass.getInstance("+ topic/data relmgmt-d/change-completed ");
-    public static final DitaClass RELMGMT_D_CHANGE_HISTORYLIST = DitaClass.getInstance("+ topic/metadata relmgmt-d/change-historylist ");
+    public static final DitaClass RELMGMT_D_CHANGE_COMPLETED =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-completed ");
+    public static final DitaClass RELMGMT_D_CHANGE_HISTORYLIST =
+            DitaClass.getInstance("+ topic/metadata relmgmt-d/change-historylist ");
     public static final DitaClass RELMGMT_D_CHANGE_ITEM = DitaClass.getInstance("+ topic/data relmgmt-d/change-item ");
-    public static final DitaClass RELMGMT_D_CHANGE_ORGANIZATION = DitaClass.getInstance("+ topic/data relmgmt-d/change-organization ");
-    public static final DitaClass RELMGMT_D_CHANGE_PERSON = DitaClass.getInstance("+ topic/data relmgmt-d/change-person ");
-    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_ID = DitaClass.getInstance("+ topic/data relmgmt-d/change-request-id ");
-    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_REFERENCE = DitaClass.getInstance("+ topic/data relmgmt-d/change-request-reference ");
-    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_SYSTEM = DitaClass.getInstance("+ topic/data relmgmt-d/change-request-system ");
-    public static final DitaClass RELMGMT_D_CHANGE_REVISIONID = DitaClass.getInstance("+ topic/data relmgmt-d/change-revisionid ");
-    public static final DitaClass RELMGMT_D_CHANGE_STARTED = DitaClass.getInstance("+ topic/data relmgmt-d/change-started ");
-    public static final DitaClass RELMGMT_D_CHANGE_SUMMARY = DitaClass.getInstance("+ topic/data relmgmt-d/change-summary ");
-    public static final DitaClass SUBJECTSCHEME_ATTRIBUTEDEF = DitaClass.getInstance("- topic/data subjectScheme/attributedef ");
-    public static final DitaClass SUBJECTSCHEME_DEFAULTSUBJECT = DitaClass.getInstance("- map/topicref subjectScheme/defaultSubject ");
-    public static final DitaClass SUBJECTSCHEME_ELEMENTDEF = DitaClass.getInstance("- topic/data subjectScheme/elementdef ");
-    public static final DitaClass SUBJECTSCHEME_ENUMERATIONDEF = DitaClass.getInstance("- map/topicref subjectScheme/enumerationdef ");
-    public static final DitaClass SUBJECTSCHEME_HASINSTANCE = DitaClass.getInstance("- map/topicref subjectScheme/hasInstance ");
-    public static final DitaClass SUBJECTSCHEME_HASKIND = DitaClass.getInstance("- map/topicref subjectScheme/hasKind ");
-    public static final DitaClass SUBJECTSCHEME_HASNARROWER = DitaClass.getInstance("- map/topicref subjectScheme/hasNarrower ");
-    public static final DitaClass SUBJECTSCHEME_HASPART = DitaClass.getInstance("- map/topicref subjectScheme/hasPart ");
-    public static final DitaClass SUBJECTSCHEME_HASRELATED = DitaClass.getInstance("- map/topicref subjectScheme/hasRelated ");
-    public static final DitaClass SUBJECTSCHEME_RELATEDSUBJECTS = DitaClass.getInstance("- map/topicref subjectScheme/relatedSubjects ");
-    public static final DitaClass SUBJECTSCHEME_SCHEMEREF = DitaClass.getInstance("- map/topicref subjectScheme/schemeref ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTDEF = DitaClass.getInstance("- map/topicref subjectScheme/subjectdef ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTHEAD = DitaClass.getInstance("- map/topicref subjectScheme/subjectHead ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTHEADMETA = DitaClass.getInstance("- map/topicmeta subjectScheme/subjectHeadMeta ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTREL = DitaClass.getInstance("- map/relrow subjectScheme/subjectRel ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTRELHEADER = DitaClass.getInstance("- map/relrow subjectScheme/subjectRelHeader ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTRELTABLE = DitaClass.getInstance("- map/reltable subjectScheme/subjectRelTable ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTROLE = DitaClass.getInstance("- map/relcell subjectScheme/subjectRole ");
-    public static final DitaClass SUBJECTSCHEME_SUBJECTSCHEME = DitaClass.getInstance("- map/map subjectScheme/subjectScheme ");
+    public static final DitaClass RELMGMT_D_CHANGE_ORGANIZATION =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-organization ");
+    public static final DitaClass RELMGMT_D_CHANGE_PERSON =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-person ");
+    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_ID =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-request-id ");
+    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_REFERENCE =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-request-reference ");
+    public static final DitaClass RELMGMT_D_CHANGE_REQUEST_SYSTEM =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-request-system ");
+    public static final DitaClass RELMGMT_D_CHANGE_REVISIONID =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-revisionid ");
+    public static final DitaClass RELMGMT_D_CHANGE_STARTED =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-started ");
+    public static final DitaClass RELMGMT_D_CHANGE_SUMMARY =
+            DitaClass.getInstance("+ topic/data relmgmt-d/change-summary ");
+    public static final DitaClass SUBJECTSCHEME_ATTRIBUTEDEF =
+            DitaClass.getInstance("- topic/data subjectScheme/attributedef ");
+    public static final DitaClass SUBJECTSCHEME_DEFAULTSUBJECT =
+            DitaClass.getInstance("- map/topicref subjectScheme/defaultSubject ");
+    public static final DitaClass SUBJECTSCHEME_ELEMENTDEF =
+            DitaClass.getInstance("- topic/data subjectScheme/elementdef ");
+    public static final DitaClass SUBJECTSCHEME_ENUMERATIONDEF =
+            DitaClass.getInstance("- map/topicref subjectScheme/enumerationdef ");
+    public static final DitaClass SUBJECTSCHEME_HASINSTANCE =
+            DitaClass.getInstance("- map/topicref subjectScheme/hasInstance ");
+    public static final DitaClass SUBJECTSCHEME_HASKIND =
+            DitaClass.getInstance("- map/topicref subjectScheme/hasKind ");
+    public static final DitaClass SUBJECTSCHEME_HASNARROWER =
+            DitaClass.getInstance("- map/topicref subjectScheme/hasNarrower ");
+    public static final DitaClass SUBJECTSCHEME_HASPART =
+            DitaClass.getInstance("- map/topicref subjectScheme/hasPart ");
+    public static final DitaClass SUBJECTSCHEME_HASRELATED =
+            DitaClass.getInstance("- map/topicref subjectScheme/hasRelated ");
+    public static final DitaClass SUBJECTSCHEME_RELATEDSUBJECTS =
+            DitaClass.getInstance("- map/topicref subjectScheme/relatedSubjects ");
+    public static final DitaClass SUBJECTSCHEME_SCHEMEREF =
+            DitaClass.getInstance("- map/topicref subjectScheme/schemeref ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTDEF =
+            DitaClass.getInstance("- map/topicref subjectScheme/subjectdef ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTHEAD =
+            DitaClass.getInstance("- map/topicref subjectScheme/subjectHead ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTHEADMETA =
+            DitaClass.getInstance("- map/topicmeta subjectScheme/subjectHeadMeta ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTREL =
+            DitaClass.getInstance("- map/relrow subjectScheme/subjectRel ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTRELHEADER =
+            DitaClass.getInstance("- map/relrow subjectScheme/subjectRelHeader ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTRELTABLE =
+            DitaClass.getInstance("- map/reltable subjectScheme/subjectRelTable ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTROLE =
+            DitaClass.getInstance("- map/relcell subjectScheme/subjectRole ");
+    public static final DitaClass SUBJECTSCHEME_SUBJECTSCHEME =
+            DitaClass.getInstance("- map/map subjectScheme/subjectScheme ");
     public static final DitaClass SVG_D_SVG_CONTAINER = DitaClass.getInstance("+ topic/foreign svg-d/svg-container ");
     public static final DitaClass SVG_D_SVGREF = DitaClass.getInstance("+ topic/xref svg-d/svgref ");
     public static final DitaClass SW_D_CMDNAME = DitaClass.getInstance("+ topic/keyword sw-d/cmdname ");
@@ -462,20 +717,26 @@ public final class Constants {
     public static final DitaClass SW_D_USERINPUT = DitaClass.getInstance("+ topic/ph sw-d/userinput ");
     public static final DitaClass SW_D_VARNAME = DitaClass.getInstance("+ topic/keyword sw-d/varname ");
     public static final DitaClass SYNTAX_D_DELIM = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/delim ");
-    public static final DitaClass SYNTAX_D_FRAGMENT = DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/fragment ");
+    public static final DitaClass SYNTAX_D_FRAGMENT =
+            DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/fragment ");
     public static final DitaClass SYNTAX_D_FRAGREF = DitaClass.getInstance("+ topic/xref syntaxdiagram-d/fragref ");
-    public static final DitaClass SYNTAX_D_GROUPCHOICE = DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupchoice ");
-    public static final DitaClass SYNTAX_D_GROUPCOMP = DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupcomp ");
-    public static final DitaClass SYNTAX_D_GROUPSEQ = DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupseq ");
+    public static final DitaClass SYNTAX_D_GROUPCHOICE =
+            DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupchoice ");
+    public static final DitaClass SYNTAX_D_GROUPCOMP =
+            DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupcomp ");
+    public static final DitaClass SYNTAX_D_GROUPSEQ =
+            DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/groupseq ");
     public static final DitaClass SYNTAX_D_KWD = DitaClass.getInstance("+ topic/keyword syntaxdiagram-d/kwd ");
     public static final DitaClass SYNTAX_D_OPER = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/oper ");
     public static final DitaClass SYNTAX_D_REPSEP = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/repsep ");
     public static final DitaClass SYNTAX_D_SEP = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/sep ");
     public static final DitaClass SYNTAX_D_SYNBLK = DitaClass.getInstance("+ topic/figgroup syntaxdiagram-d/synblk ");
     public static final DitaClass SYNTAX_D_SYNNOTE = DitaClass.getInstance("+ topic/fn syntaxdiagram-d/synnote ");
-    public static final DitaClass SYNTAX_D_SYNNOTEREF = DitaClass.getInstance("+ topic/xref syntaxdiagram-d/synnoteref ");
+    public static final DitaClass SYNTAX_D_SYNNOTEREF =
+            DitaClass.getInstance("+ topic/xref syntaxdiagram-d/synnoteref ");
     public static final DitaClass SYNTAX_D_SYNPH = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/synph ");
-    public static final DitaClass SYNTAX_D_SYNTAXDIAGRAM = DitaClass.getInstance("+ topic/fig syntaxdiagram-d/syntaxdiagram ");
+    public static final DitaClass SYNTAX_D_SYNTAXDIAGRAM =
+            DitaClass.getInstance("+ topic/fig syntaxdiagram-d/syntaxdiagram ");
     public static final DitaClass SYNTAX_D_VAR = DitaClass.getInstance("+ topic/ph syntaxdiagram-d/var ");
     public static final DitaClass TASK_CHDESC = DitaClass.getInstance("- topic/stentry task/chdesc ");
     public static final DitaClass TASK_CHDESCHD = DitaClass.getInstance("- topic/stentry task/chdeschd ");
@@ -498,25 +759,33 @@ public final class Constants {
     public static final DitaClass TASK_STEPS_INFORMAL = DitaClass.getInstance("- topic/section task/steps-informal ");
     public static final DitaClass TASK_STEPS_UNORDERED = DitaClass.getInstance("- topic/ul task/steps-unordered ");
     public static final DitaClass TASK_STEPSECTION = DitaClass.getInstance("- topic/li task/stepsection ");
-    public static final DitaClass TASK_STEPTROUBLESHOOTING = DitaClass.getInstance("- topic/itemgroup task/steptroubleshooting ");
+    public static final DitaClass TASK_STEPTROUBLESHOOTING =
+            DitaClass.getInstance("- topic/itemgroup task/steptroubleshooting ");
     public static final DitaClass TASK_STEPXMP = DitaClass.getInstance("- topic/itemgroup task/stepxmp ");
     public static final DitaClass TASK_SUBSTEP = DitaClass.getInstance("- topic/li task/substep ");
     public static final DitaClass TASK_SUBSTEPS = DitaClass.getInstance("- topic/ol task/substeps ");
     public static final DitaClass TASK_TASK = DitaClass.getInstance("- topic/topic task/task ");
     public static final DitaClass TASK_TASKBODY = DitaClass.getInstance("- topic/body task/taskbody ");
-    public static final DitaClass TASK_TASKTROUBLESHOOTING = DitaClass.getInstance("- topic/section task/tasktroubleshooting ");
+    public static final DitaClass TASK_TASKTROUBLESHOOTING =
+            DitaClass.getInstance("- topic/section task/tasktroubleshooting ");
     public static final DitaClass TASK_TUTORIALINFO = DitaClass.getInstance("- topic/itemgroup task/tutorialinfo ");
-    public static final DitaClass TASKREQ_D_CLOSEREQS = DitaClass.getInstance("+ topic/section task/postreq taskreq-d/closereqs ");
+    public static final DitaClass TASKREQ_D_CLOSEREQS =
+            DitaClass.getInstance("+ topic/section task/postreq taskreq-d/closereqs ");
     public static final DitaClass TASKREQ_D_ESTTIME = DitaClass.getInstance("+ topic/li task/li taskreq-d/esttime ");
     public static final DitaClass TASKREQ_D_NOCONDS = DitaClass.getInstance("+ topic/li task/li taskreq-d/noconds ");
     public static final DitaClass TASKREQ_D_NOSAFETY = DitaClass.getInstance("+ topic/li task/li taskreq-d/nosafety ");
-    public static final DitaClass TASKREQ_D_NOSPARES = DitaClass.getInstance("+ topic/data task/data taskreq-d/nospares ");
-    public static final DitaClass TASKREQ_D_NOSUPEQ = DitaClass.getInstance("+ topic/data task/data taskreq-d/nosupeq ");
-    public static final DitaClass TASKREQ_D_NOSUPPLY = DitaClass.getInstance("+ topic/data task/data taskreq-d/nosupply ");
+    public static final DitaClass TASKREQ_D_NOSPARES =
+            DitaClass.getInstance("+ topic/data task/data taskreq-d/nospares ");
+    public static final DitaClass TASKREQ_D_NOSUPEQ =
+            DitaClass.getInstance("+ topic/data task/data taskreq-d/nosupeq ");
+    public static final DitaClass TASKREQ_D_NOSUPPLY =
+            DitaClass.getInstance("+ topic/data task/data taskreq-d/nosupply ");
     public static final DitaClass TASKREQ_D_PERSCAT = DitaClass.getInstance("+ topic/li task/li taskreq-d/perscat ");
     public static final DitaClass TASKREQ_D_PERSKILL = DitaClass.getInstance("+ topic/li task/li taskreq-d/perskill ");
-    public static final DitaClass TASKREQ_D_PERSONNEL = DitaClass.getInstance("+ topic/li task/li taskreq-d/personnel ");
-    public static final DitaClass TASKREQ_D_PRELREQS = DitaClass.getInstance("+ topic/section task/prereq taskreq-d/prelreqs ");
+    public static final DitaClass TASKREQ_D_PERSONNEL =
+            DitaClass.getInstance("+ topic/li task/li taskreq-d/personnel ");
+    public static final DitaClass TASKREQ_D_PRELREQS =
+            DitaClass.getInstance("+ topic/section task/prereq taskreq-d/prelreqs ");
     public static final DitaClass TASKREQ_D_REQCOND = DitaClass.getInstance("+ topic/li task/li taskreq-d/reqcond ");
     public static final DitaClass TASKREQ_D_REQCONDS = DitaClass.getInstance("+ topic/ul task/ul taskreq-d/reqconds ");
     public static final DitaClass TASKREQ_D_REQCONTP = DitaClass.getInstance("+ topic/li task/li taskreq-d/reqcontp ");
@@ -639,13 +908,20 @@ public final class Constants {
     public static final DitaClass TOPIC_VRM = DitaClass.getInstance("- topic/vrm ");
     public static final DitaClass TOPIC_VRMLIST = DitaClass.getInstance("- topic/vrmlist ");
     public static final DitaClass TOPIC_XREF = DitaClass.getInstance("- topic/xref ");
-    public static final DitaClass TROUBLESHOOTING_CAUSE = DitaClass.getInstance("- topic/section troubleshooting/cause ");
-    public static final DitaClass TROUBLESHOOTING_CONDITION = DitaClass.getInstance("- topic/section troubleshooting/condition ");
-    public static final DitaClass TROUBLESHOOTING_REMEDY = DitaClass.getInstance("- topic/section troubleshooting/remedy ");
-    public static final DitaClass TROUBLESHOOTING_RESPONSIBLEPARTY = DitaClass.getInstance("- topic/p troubleshooting/responsibleParty ");
-    public static final DitaClass TROUBLESHOOTING_TROUBLEBODY = DitaClass.getInstance("- topic/body troubleshooting/troublebody ");
-    public static final DitaClass TROUBLESHOOTING_TROUBLESHOOTING = DitaClass.getInstance("- topic/topic troubleshooting/troubleshooting ");
-    public static final DitaClass TROUBLESHOOTING_TROUBLESOLUTION = DitaClass.getInstance("- topic/bodydiv troubleshooting/troubleSolution ");
+    public static final DitaClass TROUBLESHOOTING_CAUSE =
+            DitaClass.getInstance("- topic/section troubleshooting/cause ");
+    public static final DitaClass TROUBLESHOOTING_CONDITION =
+            DitaClass.getInstance("- topic/section troubleshooting/condition ");
+    public static final DitaClass TROUBLESHOOTING_REMEDY =
+            DitaClass.getInstance("- topic/section troubleshooting/remedy ");
+    public static final DitaClass TROUBLESHOOTING_RESPONSIBLEPARTY =
+            DitaClass.getInstance("- topic/p troubleshooting/responsibleParty ");
+    public static final DitaClass TROUBLESHOOTING_TROUBLEBODY =
+            DitaClass.getInstance("- topic/body troubleshooting/troublebody ");
+    public static final DitaClass TROUBLESHOOTING_TROUBLESHOOTING =
+            DitaClass.getInstance("- topic/topic troubleshooting/troubleshooting ");
+    public static final DitaClass TROUBLESHOOTING_TROUBLESOLUTION =
+            DitaClass.getInstance("- topic/bodydiv troubleshooting/troubleSolution ");
     public static final DitaClass UI_D_MENUCASCADE = DitaClass.getInstance("+ topic/ph ui-d/menucascade ");
     public static final DitaClass UI_D_SCREEN = DitaClass.getInstance("+ topic/pre ui-d/screen ");
     public static final DitaClass UI_D_SHORTCUT = DitaClass.getInstance("+ topic/keyword ui-d/shortcut ");
@@ -656,32 +932,45 @@ public final class Constants {
     public static final DitaClass UT_D_IMAGEMAP = DitaClass.getInstance("+ topic/fig ut-d/imagemap ");
     public static final DitaClass UT_D_SHAPE = DitaClass.getInstance("+ topic/keyword ut-d/shape ");
     public static final DitaClass UT_D_SORT_AS = DitaClass.getInstance("+ topic/data ut-d/sort-as ");
-    public static final DitaClass XML_D_NUMCHARREF = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/numcharref ");
-    public static final DitaClass XML_D_PARAMETERENTITY = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/parameterentity ");
-    public static final DitaClass XML_D_TEXTENTITY = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/textentity ");
-    public static final DitaClass XML_D_XMLATT = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlatt ");
-    public static final DitaClass XML_D_XMLELEMENT = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlelement ");
-    public static final DitaClass XML_D_XMLNSNAME = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlnsname ");
-    public static final DitaClass XML_D_XMLPI = DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlpi ");
+    public static final DitaClass XML_D_NUMCHARREF =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/numcharref ");
+    public static final DitaClass XML_D_PARAMETERENTITY =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/parameterentity ");
+    public static final DitaClass XML_D_TEXTENTITY =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/textentity ");
+    public static final DitaClass XML_D_XMLATT =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlatt ");
+    public static final DitaClass XML_D_XMLELEMENT =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlelement ");
+    public static final DitaClass XML_D_XMLNSNAME =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlnsname ");
+    public static final DitaClass XML_D_XMLPI =
+            DitaClass.getInstance("+ topic/keyword markup-d/markupname xml-d/xmlpi ");
     public static final DitaClass XNAL_D_ADDRESSDETAILS = DitaClass.getInstance("+ topic/ph xnal-d/addressdetails ");
-    public static final DitaClass XNAL_D_ADMINISTRATIVEAREA = DitaClass.getInstance("+ topic/ph xnal-d/administrativearea ");
-    public static final DitaClass XNAL_D_AUTHORINFORMATION = DitaClass.getInstance("+ topic/author xnal-d/authorinformation ");
+    public static final DitaClass XNAL_D_ADMINISTRATIVEAREA =
+            DitaClass.getInstance("+ topic/ph xnal-d/administrativearea ");
+    public static final DitaClass XNAL_D_AUTHORINFORMATION =
+            DitaClass.getInstance("+ topic/author xnal-d/authorinformation ");
     public static final DitaClass XNAL_D_CONTACTNUMBER = DitaClass.getInstance("+ topic/data xnal-d/contactnumber ");
     public static final DitaClass XNAL_D_CONTACTNUMBERS = DitaClass.getInstance("+ topic/data xnal-d/contactnumbers ");
     public static final DitaClass XNAL_D_COUNTRY = DitaClass.getInstance("+ topic/ph xnal-d/country ");
     public static final DitaClass XNAL_D_EMAILADDRESS = DitaClass.getInstance("+ topic/data xnal-d/emailaddress ");
     public static final DitaClass XNAL_D_EMAILADDRESSES = DitaClass.getInstance("+ topic/data xnal-d/emailaddresses ");
     public static final DitaClass XNAL_D_FIRSTNAME = DitaClass.getInstance("+ topic/data xnal-d/firstname ");
-    public static final DitaClass XNAL_D_GENERATIONIDENTIFIER = DitaClass.getInstance("+ topic/data xnal-d/generationidentifier ");
+    public static final DitaClass XNAL_D_GENERATIONIDENTIFIER =
+            DitaClass.getInstance("+ topic/data xnal-d/generationidentifier ");
     public static final DitaClass XNAL_D_HONORIFIC = DitaClass.getInstance("+ topic/data xnal-d/honorific ");
     public static final DitaClass XNAL_D_LASTNAME = DitaClass.getInstance("+ topic/data xnal-d/lastname ");
     public static final DitaClass XNAL_D_LOCALITY = DitaClass.getInstance("+ topic/ph xnal-d/locality ");
     public static final DitaClass XNAL_D_LOCALITYNAME = DitaClass.getInstance("+ topic/ph xnal-d/localityname ");
     public static final DitaClass XNAL_D_MIDDLENAME = DitaClass.getInstance("+ topic/data xnal-d/middlename ");
     public static final DitaClass XNAL_D_NAMEDETAILS = DitaClass.getInstance("+ topic/data xnal-d/namedetails ");
-    public static final DitaClass XNAL_D_ORGANIZATIONINFO = DitaClass.getInstance("+ topic/data xnal-d/organizationinfo ");
-    public static final DitaClass XNAL_D_ORGANIZATIONNAME = DitaClass.getInstance("+ topic/ph xnal-d/organizationname ");
-    public static final DitaClass XNAL_D_ORGANIZATIONNAMEDETAILS = DitaClass.getInstance("+ topic/ph xnal-d/organizationnamedetails ");
+    public static final DitaClass XNAL_D_ORGANIZATIONINFO =
+            DitaClass.getInstance("+ topic/data xnal-d/organizationinfo ");
+    public static final DitaClass XNAL_D_ORGANIZATIONNAME =
+            DitaClass.getInstance("+ topic/ph xnal-d/organizationname ");
+    public static final DitaClass XNAL_D_ORGANIZATIONNAMEDETAILS =
+            DitaClass.getInstance("+ topic/ph xnal-d/organizationnamedetails ");
     public static final DitaClass XNAL_D_OTHERINFO = DitaClass.getInstance("+ topic/data xnal-d/otherinfo ");
     public static final DitaClass XNAL_D_PERSONINFO = DitaClass.getInstance("+ topic/data xnal-d/personinfo ");
     public static final DitaClass XNAL_D_PERSONNAME = DitaClass.getInstance("+ topic/data xnal-d/personname ");
@@ -690,15 +979,20 @@ public final class Constants {
     public static final DitaClass XNAL_D_URL = DitaClass.getInstance("+ topic/data xnal-d/url ");
     public static final DitaClass XNAL_D_URLS = DitaClass.getInstance("+ topic/data xnal-d/urls ");
 
-    public static final DitaClass SUBMAP = DitaClass.getInstance("+ map/topicref mapgroup-d/topicgroup ditaot-d/submap ");
-    public static final DitaClass DITA_OT_D_KEYDEF = DitaClass.getInstance("+ map/topicref mapgroup-d/keydef ditaot-d/keydef ");
-    public static final DitaClass DITA_OT_D_DITAVAL_STARTPROP = DitaClass.getInstance("+ topic/foreign ditaot-d/ditaval-startprop ");
-    public static final DitaClass DITA_OT_D_DITAVAL_ENDPROP = DitaClass.getInstance("+ topic/foreign ditaot-d/ditaval-endprop ");
+    public static final DitaClass SUBMAP =
+            DitaClass.getInstance("+ map/topicref mapgroup-d/topicgroup ditaot-d/submap ");
+    public static final DitaClass DITA_OT_D_KEYDEF =
+            DitaClass.getInstance("+ map/topicref mapgroup-d/keydef ditaot-d/keydef ");
+    public static final DitaClass DITA_OT_D_DITAVAL_STARTPROP =
+            DitaClass.getInstance("+ topic/foreign ditaot-d/ditaval-startprop ");
+    public static final DitaClass DITA_OT_D_DITAVAL_ENDPROP =
+            DitaClass.getInstance("+ topic/foreign ditaot-d/ditaval-endprop ");
 
     /**maplinks element.*/
     public static final String ELEMENT_NAME_MAPLINKS = "maplinks";
     /**prop element.*/
     public static final String ELEMENT_NAME_PROP = "prop";
+
     public static final String ELEMENT_NAME_REVPROP = "revprop";
     /**map element.*/
     public static final String ELEMENT_NAME_ACTION = "action";
@@ -708,6 +1002,7 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_ALIGN = "align";
     /**conref attribute.*/
     public static final String ATTRIBUTE_NAME_CONREF = "conref";
+
     public static final String ATTRIBUTE_NAME_CONREFEND = "conrefend";
     /**href attribute.*/
     public static final String ATTRIBUTE_NAME_HREF = "href";
@@ -721,6 +1016,7 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_LOCKTITLE_VALUE_YES = "yes";
     /**format attribute.*/
     public static final String ATTRIBUTE_NAME_FORMAT = "format";
+
     public static final String ATTRIBUTE_NAME_ENCODING = "encoding";
     public static final String ATTRIBUTE_NAME_PARSE = "parse";
     /**charset attribute.*/
@@ -747,6 +1043,7 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_XML_LANG = "xml:lang";
     /**domains attribute.*/
     public static final String ATTRIBUTE_NAME_DOMAINS = "domains";
+
     public static final String ATTRIBUTE_NAME_SPECIALIZATIONS = "specializations";
     /**props attribute.*/
     public static final String ATTRIBUTE_NAME_PROPS = "props";
@@ -758,9 +1055,11 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_PRODUCT = "product";
     /**otherprops attribute.*/
     public static final String ATTRIBUTE_NAME_OTHERPROPS = "otherprops";
+
     public static final String ATTRIBUTE_NAME_OUTPUTCLASS = "outputclass";
     /**scope attribute.*/
     public static final String ATTRIBUTE_NAME_REV = "rev";
+
     public static final String ATTRIBUTE_NAME_SCOPE = "scope";
     /**type attribute.*/
     public static final String ATTRIBUTE_NAME_TYPE = "type";
@@ -772,6 +1071,7 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_DATA = "data";
     /**codebase attribute.*/
     public static final String ATTRIBUTE_NAME_CODEBASE = "codebase";
+
     public static final String ATTRIBUTE_NAME_ARCHIVE = "archive";
     public static final String ATTRIBUTE_NAME_CLASSID = "classid";
     /**imageref attribute.*/
@@ -787,7 +1087,8 @@ public final class Constants {
     /**keyref attribute.*/
     public static final String ATTRIBUTE_NAME_KEYREF = "keyref";
     /**conkeyref attribute.*/
-    public static final String ATTRIBUTE_NAME_CONKEYREF ="conkeyref";
+    public static final String ATTRIBUTE_NAME_CONKEYREF = "conkeyref";
+
     public static final String ATTRIBUTE_NAME_ARCHIVEKEYREFS = "archivekeyrefs";
     public static final String ATTRIBUTE_NAME_CLASSIDKEYREF = "classidkeyref";
     public static final String ATTRIBUTE_NAME_CODEBASEKEYREF = "codebasekeyref";
@@ -806,9 +1107,11 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_TOC = "toc";
     /**print attribute.*/
     public static final String ATTRIBUTE_NAME_PRINT = "print";
+
     public static final String ATTRIBUTE_NAME_DELIVERYTARGET = "deliveryTarget";
     /**cascade attribute.*/
     public static final String ATTRIBUTE_NAME_CASCADE = "cascade";
+
     public static final String ATTRIBUTE_NAME_COLS = "cols";
     public static final String ATTRIBUTE_NAME_VALUE = "value";
     public static final String ATTRIBUTE_NAME_VALUETYPE = "valuetype";
@@ -853,7 +1156,7 @@ public final class Constants {
 
     /** Constant for generated property file name(catalog-dita.xml).*/
     public static final String FILE_NAME_CATALOG = "catalog-dita.xml";
-    //store the scheme files refered by a scheme file in the form of Map<String Set<String>>
+    // store the scheme files refered by a scheme file in the form of Map<String Set<String>>
     /** Constant for generated property file name(subrelation.xml).*/
     public static final String FILE_NAME_SUBJECT_RELATION = "subrelation.xml";
     /** Constant for generated DITAVAL file name(ditaot.generated.ditaval).*/
@@ -862,12 +1165,14 @@ public final class Constants {
     /** Property name for input file system path. Deprecated since 2.2 */
     @Deprecated
     public static final String INPUT_DITAMAP = "user.input.file";
+
     public static final String INPUT_DITAMAP_URI = "user.input.file.uri";
     /** Property name for input file list file list file, i.e. file which points to a file which points to the input file */
     public static final String INPUT_DITAMAP_LIST_FILE_LIST = "user.input.file.listfile";
     /** Property name for input directory system path. Deprecated since 2.2 */
     @Deprecated
     public static final String INPUT_DIR = "user.input.dir";
+
     public static final String INPUT_DIR_URI = "user.input.dir.uri";
     /** Property name for copy-to target2sourcemap list file. Deprecated since 2.3 */
     @Deprecated
@@ -881,6 +1186,7 @@ public final class Constants {
     public static final String ANT_INVOKER_PARAM_BASEDIR = "basedir";
     /**Constants for common params used in ant invoker(inputmap).*/
     public static final String ANT_INVOKER_PARAM_INPUTMAP = "inputmap";
+
     public static final String ANT_INVOKER_PARAM_RESOURCES = "resources";
     /**Constants for common params used in ant invoker(ditaval).*/
     public static final String ANT_INVOKER_PARAM_DITAVAL = "ditaval";
@@ -919,6 +1225,7 @@ public final class Constants {
     public static final String ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP = "onlytopicinmap";
     /**Constants for extensive params used in ant invoker(crawl).*/
     public static final String ANT_INVOKER_EXT_PARAM_CRAWL = "crawl";
+
     public static final String ANT_INVOKER_EXT_PARAM_CRAWL_VALUE_MAP = "map";
     public static final String ANT_INVOKER_EXT_PARAM_CRAWL_VALUE_TOPIC = "topic";
     /**Constants for extensive params used in ant invoker(validate).*/
@@ -927,6 +1234,7 @@ public final class Constants {
     public static final String ANT_INVOKER_EXT_PARAM_OUTPUTDIR = "outputdir";
     /**Constants for extensive params used in ant invoker(gramcache).*/
     public static final String ANT_INVOKER_EXT_PARAM_GRAMCACHE = "gramcache";
+
     public static final String ANT_INVOKER_EXT_PARAN_SETSYSTEMID = "setsystemid";
     public static final String ANT_INVOKER_EXT_PARAN_FORCE_UNIQUE = "force-unique";
     public static final String ANT_INVOKER_EXT_PARAM_GENERATE_DEBUG_ATTR = "generate-debug-attributes";
@@ -939,7 +1247,7 @@ public final class Constants {
     /**OS relevant constants(windows).*/
     public static final String OS_NAME_WINDOWS = "windows";
 
-    //Misc string constants used in this toolkit.
+    // Misc string constants used in this toolkit.
 
     /**STRING_EMPTY. Deprecated since 3.0 */
     @Deprecated
@@ -972,7 +1280,7 @@ public final class Constants {
     /**COLON.*/
     public static final String COLON = ":";
     /**DOT.*/
-    public static final String DOT= ".";
+    public static final String DOT = ".";
     /**DOUBLE_BACK_SLASH. Deprecated since 3.0 */
     @Deprecated
     public static final String DOUBLE_BACK_SLASH = "\\\\";
@@ -1020,6 +1328,7 @@ public final class Constants {
     public static final String ATTR_FORMAT_VALUE_DITA = "dita";
     /**ATTR_FORMAT_VALUE_DITAMAP.*/
     public static final String ATTR_FORMAT_VALUE_DITAMAP = "ditamap";
+
     public static final String ATTR_FORMAT_VALUE_DITAVAL = "ditaval";
     public static final String ATTR_FORMAT_VALUE_IMAGE = "image";
     public static final String ATTR_FORMAT_VALUE_HTML = "html";
@@ -1030,7 +1339,9 @@ public final class Constants {
     /**ATTRIBUTE_PREFIX_DITAARCHVERSION.*/
     public static final String ATTRIBUTE_PREFIX_DITAARCHVERSION = "ditaarch";
     /**ATTRIBUTE_NAMESPACE_PREFIX_DITAARCHVERSION.*/
-    public static final String ATTRIBUTE_NAMESPACE_PREFIX_DITAARCHVERSION = XMLNS_ATTRIBUTE + ":" + ATTRIBUTE_PREFIX_DITAARCHVERSION;
+    public static final String ATTRIBUTE_NAMESPACE_PREFIX_DITAARCHVERSION =
+            XMLNS_ATTRIBUTE + ":" + ATTRIBUTE_PREFIX_DITAARCHVERSION;
+
     public static final String DITA_NAMESPACE = "http://dita.oasis-open.org/architecture/2005/";
     public static final String DITA_OT_NS_PREFIX = "dita-ot";
     public static final String DITA_OT_NAMESPACE = "http://dita-ot.sourceforge.net";
@@ -1040,7 +1351,6 @@ public final class Constants {
     public static final String ATTRIBUTE_NAME_NONAMESPACESCHEMALOCATION = XSI_NS_PREFIX + ":noNamespaceSchemaLocation";
     /**dita-ot:orig-href.*/
     public static final String ATTRIBUTE_NAME_DITA_OT_ORIG_HREF = DITA_OT_NS_PREFIX + ":" + "orig-href";
-
 
     /**ATTR_CLASS_VALUE_SUBJECT_SCHEME_BASE. Deprecated since 3.0 */
     @Deprecated
@@ -1065,7 +1375,7 @@ public final class Constants {
     public static final String ATTR_CONACTION_VALUE_PUSHBEFORE = "pushbefore";
     /** Conaction push replace value */
     public static final String ATTR_CONACTION_VALUE_PUSHREPLACE = "pushreplace";
-    
+
     /** Standard token for attribute to be ignored due to conref */
     public static final String ATTR_VALUE_DITA_USE_CONREF_TARGET = "-dita-use-conref-target";
 
@@ -1073,9 +1383,10 @@ public final class Constants {
     public static final String DEFAULT_ACTION = "default";
     /**chunk attribute.*/
     public static final String ATTRIBUTE_NAME_CHUNK = "chunk";
-    
+
     /** constants for args.draft argument value. **/
     public static final String ARGS_DRAFT_YES = "yes";
+
     public static final String ARGS_DRAFT_NO = "no";
 
     /**constants for indexterm prefix(See).
@@ -1117,6 +1428,7 @@ public final class Constants {
     public static final String CONF_SUPPORTED_RESOURCE_EXTENSIONS = "supported_resource_extensions";
     /** Property name for print transtypes. */
     public static final String CONF_PRINT_TRANSTYPES = "print_transtypes";
+
     public static final String CONF_TRANSTYPES = "transtypes";
     /** Property name for template files. */
     public static final String CONF_TEMPLATES = "templates";
@@ -1127,26 +1439,28 @@ public final class Constants {
     public static final String ANT_REFERENCE_JOB = "job";
     /** Project reference name for XML utils object. */
     public static final String ANT_REFERENCE_XML_UTILS = "xmlutils";
+
     public static final String ANT_REFERENCE_STORE = "store";
     /** Temporary directory Ant property name. */
     public static final String ANT_TEMP_DIR = "dita.temp.dir";
 
     /** OASIS catalog file namespace. */
     public static final String OASIS_CATALOG_NAMESPACE = "urn:oasis:names:tc:entity:xmlns:xml:catalog";
-    
+
     /** Deprecated since 2.3 */
     @Deprecated
     public static final String PI_PATH2PROJ_TARGET = "path2project";
+
     public static final String PI_PATH2PROJ_TARGET_URI = "path2project-uri";
     public static final String PI_PATH2ROOTMAP_TARGET_URI = "path2rootmap-uri";
     /** Deprecated since 2.3 */
     @Deprecated
     public static final String PI_WORKDIR_TARGET = "workdir";
+
     public static final String PI_WORKDIR_TARGET_URI = "workdir-uri";
 
     /**
      * Instances should NOT be constructed in standard programming.
      */
-    private Constants() {
-    }
+    private Constants() {}
 }

--- a/src/main/java/org/dita/dost/util/DITAOTCollator.java
+++ b/src/main/java/org/dita/dost/util/DITAOTCollator.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import java.lang.reflect.Method;
@@ -87,13 +87,11 @@ public final class DITAOTCollator implements Comparator<Object> {
         }
 
         try {
-            final Method m = c.getDeclaredMethod("getInstance",
-                    Locale.class);
+            final Method m = c.getDeclaredMethod("getInstance", Locale.class);
             collatorInstance = m.invoke(null, locale);
             compareMethod = c.getDeclaredMethod("compare", Object.class, Object.class);
         } catch (final Exception e) {
             throw new RuntimeException("Failed to initialize collator: " + e.getMessage(), e);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/util/DelegatingURIResolver.java
+++ b/src/main/java/org/dita/dost/util/DelegatingURIResolver.java
@@ -25,7 +25,7 @@ public class DelegatingURIResolver implements URIResolver {
 
     @Override
     public Source resolve(String href, String base) throws TransformerException {
-//        System.out.println(" DelegatingURIResolver resolve: " + href);
+        //        System.out.println(" DelegatingURIResolver resolve: " + href);
         Source src = null;
         for (final URIResolver resolver : resolvers) {
             // XXX: This will create a redundant XMLReader for each call to resolve

--- a/src/main/java/org/dita/dost/util/DitaClass.java
+++ b/src/main/java/org/dita/dost/util/DitaClass.java
@@ -9,12 +9,11 @@ package org.dita.dost.util;
 
 import static org.dita.dost.util.Constants.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-
-import com.google.common.annotations.VisibleForTesting;
 import net.sf.saxon.s9api.XdmNode;
 import net.sf.saxon.s9api.XdmNodeKind;
 import org.w3c.dom.Attr;
@@ -35,8 +34,8 @@ public final class DitaClass {
     // Variables
 
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
-    private static final Pattern VALID_DITA_CLASS = Pattern.compile("(\\+|-)\\s+(topic|map)/\\S+\\s+" +
-                                                         "([\\S[^/]]+/\\S+\\s+)*");
+    private static final Pattern VALID_DITA_CLASS =
+            Pattern.compile("(\\+|-)\\s+(topic|map)/\\S+\\s+" + "([\\S[^/]]+/\\S+\\s+)*");
 
     private static final Map<String, DitaClass> cache = new ConcurrentHashMap<>();
 
@@ -63,7 +62,7 @@ public final class DitaClass {
         matcher = ' ' + last + ' ';
         localName = last.substring(last.indexOf('/') + 1);
         final StringBuilder sb = new StringBuilder();
-        for (final String s: tokens) {
+        for (final String s : tokens) {
             sb.append(s).append(' ');
         }
         stringValue = sb.toString();
@@ -208,8 +207,7 @@ public final class DitaClass {
      * otherwise {@code false}
      */
     public Predicate<XdmNode> matcher() {
-        return item -> item.getNodeKind() == XdmNodeKind.ELEMENT
-                && matches(item.attribute(ATTRIBUTE_NAME_CLASS));
+        return item -> item.getNodeKind() == XdmNodeKind.ELEMENT && matches(item.attribute(ATTRIBUTE_NAME_CLASS));
     }
 
     /**
@@ -220,5 +218,4 @@ public final class DitaClass {
     public boolean isValid() {
         return validDitaClass;
     }
-
 }

--- a/src/main/java/org/dita/dost/util/DitaUtils.java
+++ b/src/main/java/org/dita/dost/util/DitaUtils.java
@@ -8,9 +8,9 @@
 
 package org.dita.dost.util;
 
-import org.w3c.dom.Element;
-
 import static org.dita.dost.util.Constants.*;
+
+import org.w3c.dom.Element;
 
 public class DitaUtils {
     public static boolean isDitaFormat(final Element elem) {

--- a/src/main/java/org/dita/dost/util/FilePathToURI.java
+++ b/src/main/java/org/dita/dost/util/FilePathToURI.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import java.nio.charset.StandardCharsets;
@@ -18,8 +18,7 @@ final class FilePathToURI {
     /**
      * Private default constructor to make class uninstantiable.
      */
-    private FilePathToURI() {
-    }
+    private FilePathToURI() {}
 
     // Which ASCII characters need to be escaped
     private static final boolean[] gNeedEscaping = new boolean[128];
@@ -27,8 +26,9 @@ final class FilePathToURI {
     private static final char[] gAfterEscaping1 = new char[128];
     // The second hex character if a character needs to be escaped
     private static final char[] gAfterEscaping2 = new char[128];
-    private static final char[] gHexChs = {'0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    private static final char[] gHexChs = {
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
     // Initialize the above 3 arrays
     static {
         for (int i = 0; i <= 0x1f; i++) {
@@ -39,8 +39,9 @@ final class FilePathToURI {
         gNeedEscaping[0x7f] = true;
         gAfterEscaping1[0x7f] = '7';
         gAfterEscaping2[0x7f] = 'F';
-        final char[] escChs = {' ', '<', '>', '#', '%', '"', '{', '}', '?',
-                '|', '\\', '^', '~', '[', ']', '`', '\'', '&'};
+        final char[] escChs = {
+            ' ', '<', '>', '#', '%', '"', '{', '}', '?', '|', '\\', '^', '~', '[', ']', '`', '\'', '&'
+        };
         char ch;
         for (char escCh : escChs) {
             ch = escCh;
@@ -79,7 +80,7 @@ final class FilePathToURI {
      */
     private static String escapeSpecialAsciiAndNonAscii(final String path) {
         int len = path.length(), ch;
-        final StringBuilder buffer = new StringBuilder(len*3);
+        final StringBuilder buffer = new StringBuilder(len * 3);
         // Change C:/something to /C:/something
         if (len >= 2 && path.charAt(1) == ':') {
             ch = Character.toUpperCase(path.charAt(0));
@@ -102,7 +103,7 @@ final class FilePathToURI {
                 buffer.append(gAfterEscaping2[ch]);
                 // Record the fact that it's escaped
             } else {
-                buffer.append((char)ch);
+                buffer.append((char) ch);
             }
         }
 
@@ -128,7 +129,7 @@ final class FilePathToURI {
                     buffer.append(gAfterEscaping1[b]);
                     buffer.append(gAfterEscaping2[b]);
                 } else {
-                    buffer.append((char)b);
+                    buffer.append((char) b);
                 }
             }
         }

--- a/src/main/java/org/dita/dost/util/FileUtils.java
+++ b/src/main/java/org/dita/dost/util/FileUtils.java
@@ -1,19 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
+
+import static org.apache.commons.io.FilenameUtils.normalize;
+import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 import java.net.URI;
 import java.util.*;
-
-import static org.apache.commons.io.FilenameUtils.normalize;
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Static file utilities.
@@ -25,18 +25,18 @@ public final class FileUtils {
     /**
      * Private default constructor to make class uninstantiable.
      */
-    private FileUtils() {
-    }
+    private FileUtils() {}
 
     /**
      * Supported image extensions. File extensions contain a leading dot.
      */
     @Deprecated
-    public final static List<String> supportedImageExtensions;
+    public static final List<String> supportedImageExtensions;
+
     static {
         final List<String> sie = new ArrayList<>();
         final String imageExtensions = Configuration.configuration.get(CONF_SUPPORTED_IMAGE_EXTENSIONS);
-        if (imageExtensions != null && imageExtensions.length()>0) {
+        if (imageExtensions != null && imageExtensions.length() > 0) {
             Collections.addAll(sie, imageExtensions.split(CONF_LIST_SEPARATOR));
         } else {
             System.err.println("Failed to read supported image extensions from configuration, using defaults.");
@@ -56,11 +56,12 @@ public final class FileUtils {
      * Supported HTML extensions. File extensions contain a leading dot.
      */
     @Deprecated
-    private final static List<String> supportedHTMLExtensions;
+    private static final List<String> supportedHTMLExtensions;
+
     static {
         final List<String> she = new ArrayList<>();
         final String extensions = Configuration.configuration.get(CONF_SUPPORTED_HTML_EXTENSIONS);
-        if (extensions != null && extensions.length()>0) {
+        if (extensions != null && extensions.length() > 0) {
             Collections.addAll(she, extensions.split(CONF_LIST_SEPARATOR));
         } else {
             System.err.println("Failed to read supported HTML extensions from configuration, using defaults.");
@@ -74,11 +75,12 @@ public final class FileUtils {
      * Supported resource file extensions. File extensions contain a leading dot.
      */
     @Deprecated
-    private final static List<String> supportedResourceExtensions;
+    private static final List<String> supportedResourceExtensions;
+
     static {
         final List<String> sre = new ArrayList<>();
         final String extensions = Configuration.configuration.get(CONF_SUPPORTED_RESOURCE_EXTENSIONS);
-        if (extensions != null && extensions.length()>0) {
+        if (extensions != null && extensions.length() > 0) {
             Collections.addAll(sre, extensions.split(CONF_LIST_SEPARATOR));
         } else {
             System.err.println("Failed to read supported resource file extensions from configuration, using defaults.");
@@ -95,7 +97,7 @@ public final class FileUtils {
      */
     @Deprecated
     public static boolean isHTMLFile(final String lcasefn) {
-        for (final String ext: supportedHTMLExtensions) {
+        for (final String ext : supportedHTMLExtensions) {
             if (lcasefn.endsWith(ext)) {
                 return true;
             }
@@ -135,7 +137,7 @@ public final class FileUtils {
      */
     @Deprecated
     public static boolean isResourceFile(final String lcasefn) {
-        for (final String ext: supportedResourceExtensions) {
+        for (final String ext : supportedResourceExtensions) {
             if (lcasefn.endsWith(ext)) {
                 return true;
             }
@@ -150,7 +152,7 @@ public final class FileUtils {
      */
     @Deprecated
     public static boolean isSupportedImageFile(final String lcasefn) {
-        for (final String ext: supportedImageExtensions) {
+        for (final String ext : supportedImageExtensions) {
             if (lcasefn.endsWith(ext)) {
                 return true;
             }
@@ -166,7 +168,8 @@ public final class FileUtils {
      * @return relative path, or refPath if different root means no relative path is possible
      */
     public static File getRelativePath(final File basePath, final File refPath) {
-        if (basePath.toPath().getRoot() == null || !basePath.toPath().getRoot().equals(refPath.toPath().getRoot())) {
+        if (basePath.toPath().getRoot() == null
+                || !basePath.toPath().getRoot().equals(refPath.toPath().getRoot())) {
             return refPath;
         }
         return basePath.toPath().getParent().relativize(refPath.toPath()).toFile();
@@ -195,25 +198,25 @@ public final class FileUtils {
     private static String getRelativePath(final String basePath, final String refPath, final String sep) {
         final StringBuilder upPathBuffer = new StringBuilder(128);
         final StringBuilder downPathBuffer = new StringBuilder(128);
-        final StringTokenizer mapTokenizer = new StringTokenizer(normalizePath(basePath, File.separator), File.separator);
-        final StringTokenizer topicTokenizer = new StringTokenizer(normalizePath(refPath, File.separator), File.separator);
+        final StringTokenizer mapTokenizer =
+                new StringTokenizer(normalizePath(basePath, File.separator), File.separator);
+        final StringTokenizer topicTokenizer =
+                new StringTokenizer(normalizePath(refPath, File.separator), File.separator);
 
-        while (mapTokenizer.countTokens() > 1
-                && topicTokenizer.countTokens() > 1) {
+        while (mapTokenizer.countTokens() > 1 && topicTokenizer.countTokens() > 1) {
             final String mapToken = mapTokenizer.nextToken();
             final String topicToken = topicTokenizer.nextToken();
             boolean equals;
             if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-                //if OS is Windows, we need to ignore case when comparing path names.
+                // if OS is Windows, we need to ignore case when comparing path names.
                 equals = mapToken.equalsIgnoreCase(topicToken);
             } else {
                 equals = mapToken.equals(topicToken);
             }
 
             if (!equals) {
-                if (mapToken.endsWith(COLON) ||
-                        topicToken.endsWith(COLON)) {
-                    //the two files are in different disks under Windows
+                if (mapToken.endsWith(COLON) || topicToken.endsWith(COLON)) {
+                    // the two files are in different disks under Windows
                     return refPath;
                 }
                 upPathBuffer.append("..");
@@ -277,12 +280,13 @@ public final class FileUtils {
      * @return relative path to base path, {@code null} if reference path was a single file
      */
     private static String getRelativePathForPath(final String relativePath, final String sep) {
-        final StringTokenizer tokenizer = new StringTokenizer(relativePath.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR), UNIX_SEPARATOR);
+        final StringTokenizer tokenizer =
+                new StringTokenizer(relativePath.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR), UNIX_SEPARATOR);
         final StringBuilder buffer = new StringBuilder();
         if (tokenizer.countTokens() == 1) {
             return null;
         } else {
-            while(tokenizer.countTokens() > 1) {
+            while (tokenizer.countTokens() > 1) {
                 tokenizer.nextToken();
                 buffer.append("..");
                 buffer.append(sep);
@@ -412,22 +416,19 @@ public final class FileUtils {
         return buff.toString();
     }
 
-
     /**
      * Return if the path is absolute.
      * @param path test path
      * @return true if path is absolute and false otherwise.
      */
-    public static boolean isAbsolutePath (final String path) {
+    public static boolean isAbsolutePath(final String path) {
         if (path == null || path.trim().length() == 0) {
             return false;
         }
 
         if (File.separator.equals(UNIX_SEPARATOR)) {
             return path.startsWith(UNIX_SEPARATOR);
-        } else
-
-        if (File.separator.equals(WINDOWS_SEPARATOR) && path.length() > 2) {
+        } else if (File.separator.equals(WINDOWS_SEPARATOR) && path.length() > 2) {
             return path.matches("([a-zA-Z]:|\\\\)\\\\.*");
         }
 
@@ -454,12 +455,10 @@ public final class FileUtils {
             fileExtIndex = fileName.lastIndexOf(DOT);
             return (fileExtIndex != -1)
                     ? fileName.substring(0, fileExtIndex) + extName + attValue.substring(index)
-                            : attValue;
+                    : attValue;
         } else {
             fileExtIndex = attValue.lastIndexOf(DOT);
-            return (fileExtIndex != -1)
-                    ? (attValue.substring(0, fileExtIndex) + extName)
-                            : attValue;
+            return (fileExtIndex != -1) ? (attValue.substring(0, fileExtIndex) + extName) : attValue;
         }
     }
 
@@ -526,7 +525,6 @@ public final class FileUtils {
     private static boolean isWindows() {
         final String osName = System.getProperty("os.name");
         return osName.startsWith("Win");
-
     }
 
     /**
@@ -552,9 +550,9 @@ public final class FileUtils {
     public static String stripFragment(final String path) {
         final int i = path.indexOf(SHARP);
         if (i != -1) {
-           return path.substring(0, i);
+            return path.substring(0, i);
         } else {
-           return path;
+            return path;
         }
     }
 
@@ -593,9 +591,9 @@ public final class FileUtils {
     public static String getFragment(final String path, final String defaultValue) {
         final int i = path.indexOf(SHARP);
         if (i != -1) {
-           return path.substring(i + 1);
+            return path.substring(i + 1);
         } else {
-           return defaultValue;
+            return defaultValue;
         }
     }
 
@@ -615,5 +613,4 @@ public final class FileUtils {
             return c.getPath().startsWith(d.getPath());
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -1,29 +1,21 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.module.filter.SubjectScheme;
-import org.w3c.dom.*;
-import org.xml.sax.*;
-
-import javax.xml.namespace.QName;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXSource;
 import java.io.IOException;
 import java.net.URI;
 import java.util.*;
@@ -32,11 +24,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXSource;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.module.filter.SubjectScheme;
+import org.w3c.dom.*;
+import org.xml.sax.*;
 
 /**
  * Utility class used for flagging and filtering.
@@ -47,6 +46,7 @@ public final class FilterUtils {
 
     /** Subject scheme file extension */
     public static final String SUBJECT_SCHEME_EXTENSION = ".subm";
+
     public static final FilterKey DEFAULT = new FilterKey(QName.valueOf(DEFAULT_ACTION), null);
 
     private static final String FLAG_STYLE_PREFIX = "flag__style--";
@@ -56,14 +56,15 @@ public final class FilterUtils {
     private final Map<FilterKey, Action> filterMap;
     /** Set of filter keys for which an error has already been thrown. */
     private final Set<FilterKey> notMappingRules = new HashSet<>();
+
     private boolean logMissingAction;
     private final String foregroundConflictColor;
     private final String backgroundConflictColor;
     private Set<QName> filterAttributes;
     private Set<QName> flagAttributes;
 
-    public FilterUtils(final Map<FilterKey, Action> filterMap, String foregroundConflictColor,
-                       String backgroundConflictColor) {
+    public FilterUtils(
+            final Map<FilterKey, Action> filterMap, String foregroundConflictColor, String backgroundConflictColor) {
         this.logMissingAction = !filterMap.isEmpty();
         this.filterMap = new HashMap<>(filterMap);
         this.foregroundConflictColor = foregroundConflictColor;
@@ -86,8 +87,11 @@ public final class FilterUtils {
      *
      * @param isPrintType transformation output is print-oriented
      */
-    public FilterUtils(final boolean isPrintType, final Map<FilterKey, Action> filterMap,
-                       String foregroundConflictColor, String backgroundConflictColor) {
+    public FilterUtils(
+            final boolean isPrintType,
+            final Map<FilterKey, Action> filterMap,
+            String foregroundConflictColor,
+            String backgroundConflictColor) {
         final Map<FilterKey, Action> dfm = new HashMap<>();
         dfm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_PRINT), ATTR_PRINT_VALUE_YES), Action.INCLUDE);
         if (isPrintType) {
@@ -108,9 +112,13 @@ public final class FilterUtils {
     }
 
     @VisibleForTesting
-    public FilterUtils(boolean isPrintType, Map<FilterKey, Action> filterMap,
-                       String foregroundConflictColor, String backgroundConflictColor,
-                       Set<QName> filterAttributes, Set<QName> flagAttributes) {
+    public FilterUtils(
+            boolean isPrintType,
+            Map<FilterKey, Action> filterMap,
+            String foregroundConflictColor,
+            String backgroundConflictColor,
+            Set<QName> filterAttributes,
+            Set<QName> flagAttributes) {
         this(isPrintType, filterMap, foregroundConflictColor, backgroundConflictColor);
         this.filterAttributes = Sets.union(this.filterAttributes, filterAttributes);
         this.flagAttributes = Sets.union(this.flagAttributes, flagAttributes);
@@ -127,7 +135,8 @@ public final class FilterUtils {
 
     private static Set<QName> getProfileAttributes(final String conf) {
         final ImmutableSet.Builder<QName> res = ImmutableSet.<QName>builder()
-                .add(QName.valueOf(ATTRIBUTE_NAME_AUDIENCE),
+                .add(
+                        QName.valueOf(ATTRIBUTE_NAME_AUDIENCE),
                         QName.valueOf(ATTRIBUTE_NAME_PLATFORM),
                         QName.valueOf(ATTRIBUTE_NAME_PRODUCT),
                         QName.valueOf(ATTRIBUTE_NAME_OTHERPROPS),
@@ -135,28 +144,24 @@ public final class FilterUtils {
                         QName.valueOf(ATTRIBUTE_NAME_PRINT),
                         QName.valueOf(ATTRIBUTE_NAME_DELIVERYTARGET));
         if (conf != null) {
-            Stream.of(conf.trim().split("\\s*,\\s*"))
-                    .map(QName::valueOf)
-                    .forEach(res::add);
+            Stream.of(conf.trim().split("\\s*,\\s*")).map(QName::valueOf).forEach(res::add);
         }
         return res.build();
     }
 
     private static Set<QName> getFlaggingAttributes(final String conf) {
         final ImmutableSet.Builder<QName> res = ImmutableSet.<QName>builder()
-                .add(QName.valueOf(ATTRIBUTE_NAME_AUDIENCE),
+                .add(
+                        QName.valueOf(ATTRIBUTE_NAME_AUDIENCE),
                         QName.valueOf(ATTRIBUTE_NAME_PLATFORM),
                         QName.valueOf(ATTRIBUTE_NAME_PRODUCT),
                         QName.valueOf(ATTRIBUTE_NAME_OTHERPROPS),
                         QName.valueOf(ATTRIBUTE_NAME_PROPS),
                         QName.valueOf(ATTRIBUTE_NAME_PRINT),
                         QName.valueOf(ATTRIBUTE_NAME_DELIVERYTARGET),
-                        QName.valueOf(ATTRIBUTE_NAME_REV)
-        );
+                        QName.valueOf(ATTRIBUTE_NAME_REV));
         if (conf != null) {
-            Stream.of(conf.trim().split("\\s*,\\s*"))
-                    .map(QName::valueOf)
-                    .forEach(res::add);
+            Stream.of(conf.trim().split("\\s*,\\s*")).map(QName::valueOf).forEach(res::add);
         }
         return res.build();
     }
@@ -167,15 +172,13 @@ public final class FilterUtils {
         }
 
         final Set<Flag> res = new HashSet<>();
-        for (final QName attr: flagAttributes) {
+        for (final QName attr : flagAttributes) {
             final String value = atts.getValue(attr.getNamespaceURI(), attr.getLocalPart());
             if (value != null) {
                 final Map<QName, List<String>> groups = getGroups(value);
-                for (Map.Entry<QName, List<String>> group: groups.entrySet()) {
+                for (Map.Entry<QName, List<String>> group : groups.entrySet()) {
                     final QName[] propList =
-                            group.getKey() != null
-                                    ? new QName[]{attr, group.getKey()}
-                                    : new QName[]{attr};
+                            group.getKey() != null ? new QName[] {attr, group.getKey()} : new QName[] {attr};
                     res.addAll(extCheckFlag(propList, group.getValue()));
                 }
             }
@@ -189,7 +192,8 @@ public final class FilterUtils {
                 while ((propValue == null || propValue.trim().isEmpty()) && propListIndex > 0) {
                     propListIndex--;
                     final QName current = propList[propListIndex];
-                    propValue = getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
+                    propValue =
+                            getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
                 }
                 if (propValue != null) {
                     res.addAll(extCheckFlag(propList, Arrays.asList(propValue.split("\\s+"))));
@@ -219,9 +223,15 @@ public final class FilterUtils {
         if ((conflictColor && foregroundConflictColor != null)
                 || (conflictBackcolor && backgroundConflictColor != null)) {
             return res.stream()
-                    .map(f -> new Flag(ELEMENT_NAME_PROP, conflictColor ? foregroundConflictColor : f.color,
+                    .map(f -> new Flag(
+                            ELEMENT_NAME_PROP,
+                            conflictColor ? foregroundConflictColor : f.color,
                             conflictBackcolor ? backgroundConflictColor : f.backcolor,
-                            f.style, f.changebar, f.startflag, f.endflag, f.outputClass))
+                            f.style,
+                            f.changebar,
+                            f.startflag,
+                            f.endflag,
+                            f.outputClass))
                     .collect(Collectors.toSet());
         } else {
             return res;
@@ -231,7 +241,7 @@ public final class FilterUtils {
     public Set<Flag> getFlags(final Element element, final QName[][] props) {
         final XMLUtils.AttributesBuilder buf = new XMLUtils.AttributesBuilder();
         final NamedNodeMap attrs = element.getAttributes();
-        for (int i = 0; i < attrs.getLength() ; i++) {
+        for (int i = 0; i < attrs.getLength(); i++) {
             final Node attr = attrs.item(i);
             if (attr.getNodeType() == Node.ATTRIBUTE_NODE) {
                 buf.add((Attr) attr);
@@ -268,7 +278,7 @@ public final class FilterUtils {
     public boolean needExclude(final Element element, final QName[][] props) {
         final XMLUtils.AttributesBuilder buf = new XMLUtils.AttributesBuilder();
         final NamedNodeMap attrs = element.getAttributes();
-        for (int i = 0; i < attrs.getLength() ; i++) {
+        for (int i = 0; i < attrs.getLength(); i++) {
             final Node attr = attrs.item(i);
             if (attr.getNodeType() == Node.ATTRIBUTE_NODE) {
                 buf.add((Attr) attr);
@@ -289,15 +299,13 @@ public final class FilterUtils {
             return false;
         }
 
-        for (final QName attr: filterAttributes) {
+        for (final QName attr : filterAttributes) {
             final String value = atts.getValue(attr.getNamespaceURI(), attr.getLocalPart());
             if (value != null) {
                 final Map<QName, List<String>> groups = getGroups(value);
-                for (Map.Entry<QName, List<String>> group: groups.entrySet()) {
+                for (Map.Entry<QName, List<String>> group : groups.entrySet()) {
                     final QName[] propList =
-                            group.getKey() != null
-                                    ? new QName[]{attr, group.getKey()}
-                                    : new QName[]{attr};
+                            group.getKey() != null ? new QName[] {attr, group.getKey()} : new QName[] {attr};
                     if (extCheckExclude(propList, group.getValue())) {
                         return true;
                     }
@@ -306,7 +314,7 @@ public final class FilterUtils {
         }
 
         if (extProps != null && extProps.length != 0) {
-            for (final QName[] propList: extProps) {
+            for (final QName[] propList : extProps) {
                 int propListIndex = propList.length - 1;
                 final QName propName = propList[propListIndex];
                 String propValue = atts.getValue(propName.getNamespaceURI(), propName.getLocalPart());
@@ -314,7 +322,8 @@ public final class FilterUtils {
                 while ((propValue == null || propValue.trim().isEmpty()) && propListIndex > 0) {
                     propListIndex--;
                     final QName current = propList[propListIndex];
-                    propValue = getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
+                    propValue =
+                            getLabelValue(propName, atts.getValue(current.getNamespaceURI(), current.getLocalPart()));
                 }
                 if (propValue != null && extCheckExclude(propList, Arrays.asList(propValue.split("\\s+")))) {
                     return true;
@@ -339,7 +348,7 @@ public final class FilterUtils {
         final StringBuilder buf = new StringBuilder();
         int previousEnd = 0;
         final Matcher m = groupPattern.matcher(value);
-        while(m.find()) {
+        while (m.find()) {
             buf.append(value.subSequence(previousEnd, m.start()));
             final String v = m.group(2);
             if (!v.trim().isEmpty()) {
@@ -399,7 +408,7 @@ public final class FilterUtils {
             checkRuleMapping(attName, attValue);
             boolean hasNonExcludeAction = false;
             boolean hasExcludeAction = false;
-            for (final String attSubValue: attValue) {
+            for (final String attSubValue : attValue) {
                 final FilterKey filterKey = new FilterKey(attName, attSubValue);
                 final Action filterAction = filterMap.get(filterKey);
                 // no action will be considered as 'not exclude'
@@ -442,7 +451,7 @@ public final class FilterUtils {
                     // the ancient parent on the top level
                     return isDefaultExclude();
                 }
-            // if all of the value should be excluded
+                // if all of the value should be excluded
             } else if (hasExcludeAction) {
                 return true;
             }
@@ -466,15 +475,16 @@ public final class FilterUtils {
         if (attValue == null || attValue.isEmpty()) {
             return;
         }
-        for (final String attSubValue: attValue) {
+        for (final String attSubValue : attValue) {
             final FilterKey filterKey = new FilterKey(attName, attSubValue);
             final Action filterAction = filterMap.get(filterKey);
-            if (filterAction == null 
+            if (filterAction == null
                     && logMissingAction
                     && filterMap.get(DEFAULT) == null
                     && filterMap.get(new FilterKey(attName, null)) == null) {
                 if (!alreadyShowed(filterKey)) {
-                    logger.info(MessageUtils.getMessage("DOTJ031I", filterKey.toString()).toString());
+                    logger.info(MessageUtils.getMessage("DOTJ031I", filterKey.toString())
+                            .toString());
                 }
             }
         }
@@ -495,7 +505,7 @@ public final class FilterUtils {
      * @param value     Attribute value, may be {@code null}
      * @since 1.6
      */
-     public record FilterKey(QName attribute, String value) {
+    public record FilterKey(QName attribute, String value) {
         public FilterKey {
             Objects.requireNonNull(attribute, "Attribute may not be null");
         }
@@ -527,7 +537,7 @@ public final class FilterUtils {
     private FilterUtils refine(final Map<QName, Map<String, Set<Element>>> bindingMap) {
         if (bindingMap != null && !bindingMap.isEmpty()) {
             final Map<FilterKey, Action> buf = new HashMap<>(filterMap);
-            for (final Map.Entry<FilterKey, Action> e: filterMap.entrySet()) {
+            for (final Map.Entry<FilterKey, Action> e : filterMap.entrySet()) {
                 refineAction(e.getValue(), e.getKey(), bindingMap, buf);
             }
             final FilterUtils filterUtils = new FilterUtils(buf, foregroundConflictColor, backgroundConflictColor);
@@ -541,13 +551,16 @@ public final class FilterUtils {
     /**
      * Refine action key with information from subject schemes.
      */
-    private void refineAction(final Action action, final FilterKey key, final Map<QName, Map<String, Set<Element>>> bindingMap,
-                              final Map<FilterKey, Action> destFilterMap) {
+    private void refineAction(
+            final Action action,
+            final FilterKey key,
+            final Map<QName, Map<String, Set<Element>>> bindingMap,
+            final Map<FilterKey, Action> destFilterMap) {
         if (key.value != null) {
             final Map<String, Set<Element>> schemeMap = bindingMap.get(key.attribute);
             if (schemeMap != null && !schemeMap.isEmpty()) {
-                for (final Set<Element> submap: schemeMap.values()) {
-                    for (final Element e: submap) {
+                for (final Set<Element> submap : schemeMap.values()) {
+                    for (final Element e : submap) {
                         final Element subRoot = searchForKey(e, key.value);
                         if (subRoot != null) {
                             insertAction(subRoot, key.attribute, action, destFilterMap);
@@ -574,7 +587,7 @@ public final class FilterUtils {
             final NodeList children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                    queue.add((Element)children.item(i));
+                    queue.add((Element) children.item(i));
                 }
             }
             if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
@@ -593,7 +606,11 @@ public final class FilterUtils {
      * @param attName attribute name
      * @param action action to insert
      */
-    private void insertAction(final Element subTree, final QName attName, final Action action, final Map<FilterKey, Action> destFilterMap) {
+    private void insertAction(
+            final Element subTree,
+            final QName attName,
+            final Action action,
+            final Map<FilterKey, Action> destFilterMap) {
         if (subTree == null || action == null) {
             return;
         }
@@ -604,7 +621,7 @@ public final class FilterUtils {
         NodeList children = subTree.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                queue.offer((Element)children.item(i));
+                queue.offer((Element) children.item(i));
             }
         }
 
@@ -613,7 +630,7 @@ public final class FilterUtils {
             children = node.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                    queue.offer((Element)children.item(i));
+                    queue.offer((Element) children.item(i));
                 }
             }
             if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
@@ -627,7 +644,6 @@ public final class FilterUtils {
             }
         }
     }
-
 
     public interface Action {
         Action INCLUDE = new Include();
@@ -656,224 +672,300 @@ public final class FilterUtils {
         }
     }
 
-    public record Flag(String proptype,
-                       String color,
-                       String backcolor,
-                       String[] style, String changebar,
-                       FilterUtils.Flag.FlagImage startflag,
-                       FilterUtils.Flag.FlagImage endflag,
-                       String outputClass) implements Action {
+    public record Flag(
+            String proptype,
+            String color,
+            String backcolor,
+            String[] style,
+            String changebar,
+            FilterUtils.Flag.FlagImage startflag,
+            FilterUtils.Flag.FlagImage endflag,
+            String outputClass)
+            implements Action {
 
         public Flag adjustPath(final URI currentFile, final Job job) {
-                return new Flag(proptype, color, backcolor, style, changebar,
-                        adjustPath(startflag, currentFile, job),
-                        adjustPath(endflag, currentFile, job),
-                        outputClass);
+            return new Flag(
+                    proptype,
+                    color,
+                    backcolor,
+                    style,
+                    changebar,
+                    adjustPath(startflag, currentFile, job),
+                    adjustPath(endflag, currentFile, job),
+                    outputClass);
+        }
+
+        private FlagImage adjustPath(final FlagImage img, final URI currentFile, final Job job) {
+            if (img == null) {
+                return img;
+            }
+            final URI rel;
+            final Job.FileInfo flagFi = job.getFileInfo(img.href);
+            if (flagFi != null) {
+                final Job.FileInfo current = job.getFileInfo(currentFile);
+                final URI flag = job.tempDirURI.resolve(flagFi.uri);
+                final URI curr = job.tempDirURI.resolve(current.uri);
+                rel = URLUtils.getRelativePath(curr, flag);
+            } else {
+                rel = img.href;
+            }
+            return new FlagImage(rel, img.alt);
+        }
+
+        public void writeStartFlag(final ContentHandler contentHandler) throws SAXException {
+            final StringJoiner outputClassAttr = new StringJoiner(" ");
+            final StringBuilder styleAttr = new StringBuilder();
+            if (color != null) {
+                styleAttr.append("color:").append(color).append(";");
+            }
+            if (backcolor != null) {
+                styleAttr.append("background-color:").append(backcolor).append(";");
+            }
+            if (outputClass != null) {
+                outputClassAttr.add(outputClass);
+            }
+            if (style != null) {
+                for (final String style : style) {
+                    outputClassAttr.add(FLAG_STYLE_PREFIX + style);
+                }
             }
 
-            private FlagImage adjustPath(final FlagImage img, final URI currentFile, final Job job) {
-                if (img == null) {
-                    return img;
-                }
-                final URI rel;
-                final Job.FileInfo flagFi = job.getFileInfo(img.href);
-                if (flagFi != null) {
-                    final Job.FileInfo current = job.getFileInfo(currentFile);
-                    final URI flag = job.tempDirURI.resolve(flagFi.uri);
-                    final URI curr = job.tempDirURI.resolve(current.uri);
-                    rel = URLUtils.getRelativePath(curr, flag);
-                } else {
-                    rel = img.href;
-                }
-                return new FlagImage(rel, img.alt);
+            final XMLUtils.AttributesBuilder atts =
+                    new XMLUtils.AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, DITA_OT_D_DITAVAL_STARTPROP.toString());
+            if (outputClassAttr.length() != 0) {
+                atts.add(ATTRIBUTE_NAME_OUTPUTCLASS, outputClassAttr.toString());
             }
-
-            public void writeStartFlag(final ContentHandler contentHandler) throws SAXException {
-                final StringJoiner outputClassAttr = new StringJoiner(" ");
-                final StringBuilder styleAttr = new StringBuilder();
-                if (color != null) {
-                    styleAttr.append("color:").append(color).append(";");
-                }
-                if (backcolor != null) {
-                    styleAttr.append("background-color:").append(backcolor).append(";");
-                }
-                if (outputClass != null) {
-                    outputClassAttr.add(outputClass);
-                }
-                if (style != null) {
-                    for (final String style : style) {
-                        outputClassAttr.add(FLAG_STYLE_PREFIX + style);
-                    }
-                }
-
-                final XMLUtils.AttributesBuilder atts = new XMLUtils.AttributesBuilder()
-                        .add(ATTRIBUTE_NAME_CLASS, DITA_OT_D_DITAVAL_STARTPROP.toString());
-                if (outputClassAttr.length() != 0) {
-                    atts.add(ATTRIBUTE_NAME_OUTPUTCLASS, outputClassAttr.toString());
-                }
-                if (styleAttr.length() != 0) {
-                    atts.add(ATTRIBUTE_NAME_STYLE, styleAttr.toString());
-                }
-                contentHandler.startElement(NULL_NS_URI, DITA_OT_D_DITAVAL_STARTPROP.localName, DITA_OT_D_DITAVAL_STARTPROP.localName,
-                        atts.build());
-                writeProp(contentHandler, true);
-                contentHandler.endElement(NULL_NS_URI, DITA_OT_D_DITAVAL_STARTPROP.localName, DITA_OT_D_DITAVAL_STARTPROP.localName);
+            if (styleAttr.length() != 0) {
+                atts.add(ATTRIBUTE_NAME_STYLE, styleAttr.toString());
             }
+            contentHandler.startElement(
+                    NULL_NS_URI,
+                    DITA_OT_D_DITAVAL_STARTPROP.localName,
+                    DITA_OT_D_DITAVAL_STARTPROP.localName,
+                    atts.build());
+            writeProp(contentHandler, true);
+            contentHandler.endElement(
+                    NULL_NS_URI, DITA_OT_D_DITAVAL_STARTPROP.localName, DITA_OT_D_DITAVAL_STARTPROP.localName);
+        }
 
-            public void writeEndFlag(final ContentHandler contentHandler) throws SAXException {
-                contentHandler.startElement(NULL_NS_URI, DITA_OT_D_DITAVAL_ENDPROP.localName, DITA_OT_D_DITAVAL_ENDPROP.localName,
-                        new XMLUtils.AttributesBuilder()
-                                .add(ATTRIBUTE_NAME_CLASS, DITA_OT_D_DITAVAL_ENDPROP.toString())
-                                .build());
-                writeProp(contentHandler, false);
-                contentHandler.endElement(NULL_NS_URI, DITA_OT_D_DITAVAL_ENDPROP.localName, DITA_OT_D_DITAVAL_ENDPROP.localName);
+        public void writeEndFlag(final ContentHandler contentHandler) throws SAXException {
+            contentHandler.startElement(
+                    NULL_NS_URI,
+                    DITA_OT_D_DITAVAL_ENDPROP.localName,
+                    DITA_OT_D_DITAVAL_ENDPROP.localName,
+                    new XMLUtils.AttributesBuilder()
+                            .add(ATTRIBUTE_NAME_CLASS, DITA_OT_D_DITAVAL_ENDPROP.toString())
+                            .build());
+            writeProp(contentHandler, false);
+            contentHandler.endElement(
+                    NULL_NS_URI, DITA_OT_D_DITAVAL_ENDPROP.localName, DITA_OT_D_DITAVAL_ENDPROP.localName);
+        }
+
+        private void writeProp(final ContentHandler contentHandler, final boolean isStart) throws SAXException {
+            final XMLUtils.AttributesBuilder propAtts = new XMLUtils.AttributesBuilder().add("action", "flag");
+            if (color != null) {
+                propAtts.add("color", color);
             }
+            if (backcolor != null) {
+                propAtts.add("backcolor", backcolor);
+            }
+            if (style != null) {
+                propAtts.add("style", String.join(" ", style));
+            }
+            if (outputClass != null) {
+                propAtts.add("outputclass", outputClass);
+            }
+            if (changebar != null) {
+                propAtts.add("changebar", changebar);
+            }
+            contentHandler.startElement(NULL_NS_URI, proptype, proptype, propAtts.build());
+            if (isStart && startflag != null) {
+                startflag.writeFlag(contentHandler, "startflag");
+            }
+            if (!isStart && endflag != null) {
+                endflag.writeFlag(contentHandler, "endflag");
+            }
+            contentHandler.endElement(NULL_NS_URI, proptype, proptype);
+        }
 
-            private void writeProp(final ContentHandler contentHandler, final boolean isStart) throws SAXException {
+        public Element getStartFlag() {
+            return writeToElement((ContentHandler contentHandler) -> {
+                try {
+                    writeStartFlag(contentHandler);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        public Element getEndFlag() {
+            return writeToElement((ContentHandler contentHandler) -> {
+                try {
+                    writeEndFlag(contentHandler);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        private static Element writeToElement(final Consumer<ContentHandler> writer) {
+            final TransformerFactory factory = TransformerFactory.newInstance();
+            final Transformer transformer;
+            try {
+                transformer = factory.newTransformer();
+            } catch (TransformerConfigurationException e) {
+                throw new RuntimeException(e);
+            }
+            final SAXSource xmlSource = new SAXSource(
+                    new XMLReader() {
+                        @Override
+                        public boolean getFeature(String name)
+                                throws SAXNotRecognizedException, SAXNotSupportedException {
+                            return false;
+                        }
+
+                        @Override
+                        public void setFeature(String name, boolean value)
+                                throws SAXNotRecognizedException, SAXNotSupportedException {}
+
+                        @Override
+                        public Object getProperty(String name)
+                                throws SAXNotRecognizedException, SAXNotSupportedException {
+                            return null;
+                        }
+
+                        @Override
+                        public void setProperty(String name, Object value)
+                                throws SAXNotRecognizedException, SAXNotSupportedException {}
+
+                        @Override
+                        public void setEntityResolver(EntityResolver resolver) {}
+
+                        @Override
+                        public EntityResolver getEntityResolver() {
+                            return null;
+                        }
+
+                        @Override
+                        public void setDTDHandler(DTDHandler handler) {}
+
+                        @Override
+                        public DTDHandler getDTDHandler() {
+                            return null;
+                        }
+
+                        private ContentHandler contentHandler;
+
+                        @Override
+                        public void setContentHandler(ContentHandler handler) {
+                            this.contentHandler = handler;
+                        }
+
+                        @Override
+                        public ContentHandler getContentHandler() {
+                            return contentHandler;
+                        }
+
+                        @Override
+                        public void setErrorHandler(ErrorHandler handler) {}
+
+                        @Override
+                        public ErrorHandler getErrorHandler() {
+                            return null;
+                        }
+
+                        @Override
+                        public void parse(InputSource input) throws IOException, SAXException {
+                            parse((String) null);
+                        }
+
+                        @Override
+                        public void parse(String input) throws IOException, SAXException {
+                            getContentHandler().startDocument();
+                            writer.accept(getContentHandler());
+                            getContentHandler().endDocument();
+                        }
+                    },
+                    null);
+            final DOMResult outputTarget = new DOMResult();
+            try {
+                transformer.transform(xmlSource, outputTarget);
+            } catch (TransformerException e) {
+                throw new RuntimeException(e);
+            }
+            return ((Document) outputTarget.getNode()).getDocumentElement();
+        }
+
+        @Override
+        public String toString() {
+            return "Flag{" + "color='"
+                    + color + '\'' + ", backcolor='"
+                    + backcolor + '\'' + ", style="
+                    + Arrays.toString(style) + ", outputclass="
+                    + outputClass + ", changebar='"
+                    + changebar + '\'' + ", startflag="
+                    + startflag + ", endflag="
+                    + endflag + '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Flag flag = (Flag) o;
+
+            if (!Objects.equals(color, flag.color)) return false;
+            if (!Objects.equals(backcolor, flag.backcolor)) return false;
+            // Probably incorrect - comparing Object[] arrays with Arrays.equals
+            if (!Arrays.equals(style, flag.style)) return false;
+            if (!Objects.equals(outputClass, flag.outputClass)) return false;
+            if (!Objects.equals(changebar, flag.changebar)) return false;
+            if (!Objects.equals(startflag, flag.startflag)) return false;
+            return Objects.equals(endflag, flag.endflag);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = color != null ? color.hashCode() : 0;
+            result = 31 * result + (backcolor != null ? backcolor.hashCode() : 0);
+            result = 31 * result + Arrays.hashCode(style);
+            result = 31 * result + (changebar != null ? changebar.hashCode() : 0);
+            result = 31 * result + (outputClass != null ? outputClass.hashCode() : 0);
+            result = 31 * result + (startflag != null ? startflag.hashCode() : 0);
+            result = 31 * result + (endflag != null ? endflag.hashCode() : 0);
+            return result;
+        }
+
+        public record FlagImage(URI href, String alt) {
+
+            private void writeFlag(final ContentHandler contentHandler, final String tag) throws SAXException {
                 final XMLUtils.AttributesBuilder propAtts = new XMLUtils.AttributesBuilder().add("action", "flag");
-                if (color != null) {
-                    propAtts.add("color", color);
+                final URI abs = href;
+                if (abs != null) {
+                    propAtts.add(
+                            DITA_OT_NS,
+                            ATTRIBUTE_NAME_IMAGEREF_URI,
+                            "dita-ot:" + ATTRIBUTE_NAME_IMAGEREF_URI,
+                            "CDATA",
+                            abs.toString());
+                    final URI rel = abs;
+                    propAtts.add(
+                            DITA_OT_NS,
+                            "original-" + ATTRIBUTE_NAME_IMAGEREF,
+                            "dita-ot:original-" + ATTRIBUTE_NAME_IMAGEREF,
+                            "CDATA",
+                            rel.toString());
+                    propAtts.add(ATTRIBUTE_NAME_IMAGEREF, rel.toString());
                 }
-                if (backcolor != null) {
-                    propAtts.add("backcolor", backcolor);
+                contentHandler.startElement(NULL_NS_URI, tag, tag, propAtts.build());
+                if (alt != null) {
+                    contentHandler.startElement(NULL_NS_URI, "alt-text", "alt-text", XMLUtils.EMPTY_ATTRIBUTES);
+                    final char[] chars = alt.toCharArray();
+                    contentHandler.characters(chars, 0, chars.length);
+                    contentHandler.endElement(NULL_NS_URI, "alt-text", "alt-text");
                 }
-                if (style != null) {
-                    propAtts.add("style", String.join(" ", style));
-                }
-                if (outputClass != null) {
-                    propAtts.add("outputclass", outputClass);
-                }
-                if (changebar != null) {
-                    propAtts.add("changebar", changebar);
-                }
-                contentHandler.startElement(NULL_NS_URI, proptype, proptype, propAtts.build());
-                if (isStart && startflag != null) {
-                    startflag.writeFlag(contentHandler, "startflag");
-                }
-                if (!isStart && endflag != null) {
-                    endflag.writeFlag(contentHandler, "endflag");
-                }
-                contentHandler.endElement(NULL_NS_URI, proptype, proptype);
-            }
-
-            public Element getStartFlag() {
-                return writeToElement((ContentHandler contentHandler) -> {
-                    try {
-                        writeStartFlag(contentHandler);
-                    } catch (SAXException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-            }
-
-            public Element getEndFlag() {
-                return writeToElement((ContentHandler contentHandler) -> {
-                    try {
-                        writeEndFlag(contentHandler);
-                    } catch (SAXException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-            }
-
-            private static Element writeToElement(final Consumer<ContentHandler> writer) {
-                final TransformerFactory factory = TransformerFactory.newInstance();
-                final Transformer transformer;
-                try {
-                    transformer = factory.newTransformer();
-                } catch (TransformerConfigurationException e) {
-                    throw new RuntimeException(e);
-                }
-                final SAXSource xmlSource = new SAXSource(new XMLReader() {
-                    @Override
-                    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
-                        return false;
-                    }
-
-                    @Override
-                    public void setFeature(String name, boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
-                    }
-
-                    @Override
-                    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
-                        return null;
-                    }
-
-                    @Override
-                    public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
-                    }
-
-                    @Override
-                    public void setEntityResolver(EntityResolver resolver) {
-                    }
-
-                    @Override
-                    public EntityResolver getEntityResolver() {
-                        return null;
-                    }
-
-                    @Override
-                    public void setDTDHandler(DTDHandler handler) {
-                    }
-
-                    @Override
-                    public DTDHandler getDTDHandler() {
-                        return null;
-                    }
-
-                    private ContentHandler contentHandler;
-
-                    @Override
-                    public void setContentHandler(ContentHandler handler) {
-                        this.contentHandler = handler;
-                    }
-
-                    @Override
-                    public ContentHandler getContentHandler() {
-                        return contentHandler;
-                    }
-
-                    @Override
-                    public void setErrorHandler(ErrorHandler handler) {
-                    }
-
-                    @Override
-                    public ErrorHandler getErrorHandler() {
-                        return null;
-                    }
-
-                    @Override
-                    public void parse(InputSource input) throws IOException, SAXException {
-                        parse((String) null);
-                    }
-
-                    @Override
-                    public void parse(String input) throws IOException, SAXException {
-                        getContentHandler().startDocument();
-                        writer.accept(getContentHandler());
-                        getContentHandler().endDocument();
-                    }
-                }, null);
-                final DOMResult outputTarget = new DOMResult();
-                try {
-                    transformer.transform(xmlSource, outputTarget);
-                } catch (TransformerException e) {
-                    throw new RuntimeException(e);
-                }
-                return ((Document) outputTarget.getNode()).getDocumentElement();
-            }
-
-            @Override
-            public String toString() {
-                return "Flag{" +
-                        "color='" + color + '\'' +
-                        ", backcolor='" + backcolor + '\'' +
-                        ", style=" + Arrays.toString(style) +
-                        ", outputclass=" + outputClass +
-                        ", changebar='" + changebar + '\'' +
-                        ", startflag=" + startflag +
-                        ", endflag=" + endflag +
-                        '}';
+                contentHandler.endElement(NULL_NS_URI, tag, tag);
             }
 
             @Override
@@ -881,70 +973,16 @@ public final class FilterUtils {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
 
-                Flag flag = (Flag) o;
+                FlagImage flagImage = (FlagImage) o;
 
-                if (!Objects.equals(color, flag.color)) return false;
-                if (!Objects.equals(backcolor, flag.backcolor)) return false;
-                // Probably incorrect - comparing Object[] arrays with Arrays.equals
-                if (!Arrays.equals(style, flag.style)) return false;
-                if (!Objects.equals(outputClass, flag.outputClass)) return false;
-                if (!Objects.equals(changebar, flag.changebar)) return false;
-                if (!Objects.equals(startflag, flag.startflag)) return false;
-                return Objects.equals(endflag, flag.endflag);
+                if (!Objects.equals(href, flagImage.href)) return false;
+                return Objects.equals(alt, flagImage.alt);
             }
 
             @Override
-            public int hashCode() {
-                int result = color != null ? color.hashCode() : 0;
-                result = 31 * result + (backcolor != null ? backcolor.hashCode() : 0);
-                result = 31 * result + Arrays.hashCode(style);
-                result = 31 * result + (changebar != null ? changebar.hashCode() : 0);
-                result = 31 * result + (outputClass != null ? outputClass.hashCode() : 0);
-                result = 31 * result + (startflag != null ? startflag.hashCode() : 0);
-                result = 31 * result + (endflag != null ? endflag.hashCode() : 0);
-                return result;
-            }
-
-            public record FlagImage(URI href, String alt) {
-
-                private void writeFlag(final ContentHandler contentHandler, final String tag) throws SAXException {
-                    final XMLUtils.AttributesBuilder propAtts = new XMLUtils.AttributesBuilder().add("action", "flag");
-                    final URI abs = href;
-                    if (abs != null) {
-                        propAtts.add(DITA_OT_NS, ATTRIBUTE_NAME_IMAGEREF_URI, "dita-ot:" + ATTRIBUTE_NAME_IMAGEREF_URI, "CDATA", abs.toString());
-                        final URI rel = abs;
-                        propAtts.add(DITA_OT_NS, "original-" + ATTRIBUTE_NAME_IMAGEREF, "dita-ot:original-" + ATTRIBUTE_NAME_IMAGEREF, "CDATA", rel.toString());
-                        propAtts.add(ATTRIBUTE_NAME_IMAGEREF, rel.toString());
-                    }
-                    contentHandler.startElement(NULL_NS_URI, tag, tag, propAtts.build());
-                    if (alt != null) {
-                        contentHandler.startElement(NULL_NS_URI, "alt-text", "alt-text", XMLUtils.EMPTY_ATTRIBUTES);
-                        final char[] chars = alt.toCharArray();
-                        contentHandler.characters(chars, 0, chars.length);
-                        contentHandler.endElement(NULL_NS_URI, "alt-text", "alt-text");
-                    }
-                    contentHandler.endElement(NULL_NS_URI, tag, tag);
-                }
-
-                @Override
-                public boolean equals(Object o) {
-                    if (this == o) return true;
-                    if (o == null || getClass() != o.getClass()) return false;
-
-                    FlagImage flagImage = (FlagImage) o;
-
-                    if (!Objects.equals(href, flagImage.href)) return false;
-                    return Objects.equals(alt, flagImage.alt);
-                }
-
-                @Override
-                public String toString() {
-                    return "FlagImage{" +
-                            "href=" + href +
-                            ", alt='" + alt + '\'' +
-                            '}';
-                }
+            public String toString() {
+                return "FlagImage{" + "href=" + href + ", alt='" + alt + '\'' + '}';
             }
         }
-
+    }
 }

--- a/src/main/java/org/dita/dost/util/KeyDef.java
+++ b/src/main/java/org/dita/dost/util/KeyDef.java
@@ -7,11 +7,10 @@
  */
 package org.dita.dost.util;
 
-import net.sf.saxon.s9api.XdmNode;
+import static org.dita.dost.util.Constants.*;
 
 import java.net.URI;
-
-import static org.dita.dost.util.Constants.*;
+import net.sf.saxon.s9api.XdmNode;
 
 /**
  * Key definition.
@@ -20,6 +19,7 @@ public class KeyDef {
 
     /** Space delimited list of key names */
     public final String keys;
+
     public URI href;
     public final String scope;
     public final URI source;
@@ -34,8 +34,14 @@ public class KeyDef {
      * @param scope link scope, may be {@code null}
      * @param source key definition source, may be {@code null}
      */
-    public KeyDef(final String keys, final URI href, final String scope, final String format, final URI source, final XdmNode element) {
-        //assert href.isAbsolute();
+    public KeyDef(
+            final String keys,
+            final URI href,
+            final String scope,
+            final String format,
+            final URI source,
+            final XdmNode element) {
+        // assert href.isAbsolute();
         this.keys = keys;
         this.href = href == null || href.toString().isEmpty() ? null : href;
         this.scope = scope == null ? ATTR_SCOPE_VALUE_LOCAL : scope;
@@ -119,5 +125,4 @@ public class KeyDef {
         }
         return true;
     }
-
 }

--- a/src/main/java/org/dita/dost/util/KeyScope.java
+++ b/src/main/java/org/dita/dost/util/KeyScope.java
@@ -7,26 +7,26 @@
  */
 package org.dita.dost.util;
 
-import com.google.common.collect.ImmutableList;
-
-import java.util.*;
-
 import static java.util.Collections.unmodifiableMap;
+
+import com.google.common.collect.ImmutableList;
+import java.util.*;
 
 /**
  * Immutable key store for keys and child key scopes.
  *
  * @since 2.2
  */
-public record KeyScope(String id,
-                       String name,
-                       Map<String, KeyDef> keyDefinition,
-                       List<KeyScope> childScopes) {
+public record KeyScope(String id, String name, Map<String, KeyDef> keyDefinition, List<KeyScope> childScopes) {
 
     public static final String ROOT_ID = "#root";
     public static final KeyScope EMPTY = new KeyScope(ROOT_ID, null, Collections.emptyMap(), Collections.emptyList());
 
-    public KeyScope(final String id, final String name, final Map<String, KeyDef> keyDefinition, final List<KeyScope> childScopes) {
+    public KeyScope(
+            final String id,
+            final String name,
+            final Map<String, KeyDef> keyDefinition,
+            final List<KeyScope> childScopes) {
         this.id = id;
         this.name = name;
         this.keyDefinition = unmodifiableMap(keyDefinition);
@@ -42,7 +42,10 @@ public record KeyScope(String id,
     }
 
     public KeyScope getChildScope(final String scope) {
-        return childScopes.stream().filter(s -> s.name.equals(scope)).findFirst().orElse(null);
+        return childScopes.stream()
+                .filter(s -> s.name.equals(scope))
+                .findFirst()
+                .orElse(null);
     }
 
     @Override
@@ -67,7 +70,8 @@ public record KeyScope(String id,
 
     public static KeyScope merge(final KeyScope scope1, final KeyScope scope2) {
         if (!Objects.equals(scope1.id, scope2.id)) {
-            throw new IllegalArgumentException(String.format("Scopes should have the same ID: %s != %s", scope1.id, scope2.id));
+            throw new IllegalArgumentException(
+                    String.format("Scopes should have the same ID: %s != %s", scope1.id, scope2.id));
         }
         final Map<String, KeyDef> keyDefinition = new HashMap<>();
         scope1.keyDefinition.forEach(keyDefinition::putIfAbsent);
@@ -79,7 +83,6 @@ public record KeyScope(String id,
                 ImmutableList.<KeyScope>builder()
                         .addAll(scope1.childScopes)
                         .addAll(scope2.childScopes)
-                        .build()
-        );
+                        .build());
     }
 }

--- a/src/main/java/org/dita/dost/util/LangUtils.java
+++ b/src/main/java/org/dita/dost/util/LangUtils.java
@@ -25,8 +25,6 @@ public class LangUtils {
      * @return stream of value-index pairs
      */
     public static <T> Stream<Map.Entry<T, Integer>> zipWithIndex(List<T> src) {
-        return IntStream
-                .range(0, src.size())
-                .mapToObj(i -> pair(src.get(i), i));
+        return IntStream.range(0, src.size()).mapToObj(i -> pair(src.get(i), i));
     }
 }

--- a/src/main/java/org/dita/dost/util/MergeUtils.java
+++ b/src/main/java/org/dita/dost/util/MergeUtils.java
@@ -1,23 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import static org.dita.dost.util.URLUtils.*;
 
-import java.io.File;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.dita.dost.log.DITAOTLogger;
-
-import org.xml.sax.XMLReader;
 
 /**
  * Utility that topic merge utilize. An instance can be reused by calling
@@ -30,6 +26,7 @@ public final class MergeUtils {
     private int index;
     /** Set of visited topic files. */
     private final Set<URI> visitSet;
+
     private DITAOTLogger logger;
     private Job job;
 
@@ -79,7 +76,7 @@ public final class MergeUtils {
             return null;
         }
         final URI localId = id.normalize();
-        index ++;
+        index++;
         final String newId = PREFIX + Integer.toString(index);
         idMap.put(localId, newId);
         return newId;
@@ -148,9 +145,8 @@ public final class MergeUtils {
         try {
             job.getStore().transform(file, parser);
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
         return firstTopicId.toString();
     }
-
 }

--- a/src/main/java/org/dita/dost/util/StringUtils.java
+++ b/src/main/java/org/dita/dost/util/StringUtils.java
@@ -1,14 +1,12 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
-
-import javax.xml.namespace.QName;
 
 import static java.util.Arrays.asList;
 import static org.dita.dost.util.Constants.*;
@@ -16,6 +14,7 @@ import static org.dita.dost.util.Constants.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.xml.namespace.QName;
 
 /**
  * String relevant utilities.
@@ -27,8 +26,7 @@ public final class StringUtils {
     /**
      * Private default constructor to make class uninstantiable.
      */
-    private StringUtils() {
-    }
+    private StringUtils() {}
 
     /**
      * Assemble all elements in collection to a string.
@@ -67,13 +65,13 @@ public final class StringUtils {
      * @param delim entry delimiter
      * @return concatenated map
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static String join(final Map value, final String delim) {
         if (value == null || value.isEmpty()) {
             return "";
         }
         final StringBuilder buf = new StringBuilder();
-        for (final Iterator<Map.Entry<String, String>> i = value.entrySet().iterator(); i.hasNext();) {
+        for (final Iterator<Map.Entry<String, String>> i = value.entrySet().iterator(); i.hasNext(); ) {
             final Map.Entry<String, String> e = i.next();
             buf.append(e.getKey()).append(EQUAL).append(e.getValue());
             if (i.hasNext()) {
@@ -95,8 +93,7 @@ public final class StringUtils {
      * @return replaced string
      *
      */
-    public static String replaceAll(final String input,
-            final String pattern, final String replacement) {
+    public static String replaceAll(final String input, final String pattern, final String replacement) {
         final StringBuilder result = new StringBuilder();
         int startIndex = 0;
         int newIndex;
@@ -122,15 +119,14 @@ public final class StringUtils {
         // FIXME Dont' mix arrays and collections
         final List<QName[]> propsBuffer = new ArrayList<>();
         int propsStart = domains.indexOf("a(" + ATTRIBUTE_NAME_PROPS);
-        int propsEnd = domains.indexOf(")",propsStart);
+        int propsEnd = domains.indexOf(")", propsStart);
         while (propsStart != -1 && propsEnd != -1) {
             final String propPath = domains.substring(propsStart + 2, propsEnd).trim();
-            final List<QName> propList = Stream.of(propPath.split("\\s+"))
-                    .map(QName::valueOf)
-                    .collect(Collectors.toList());
+            final List<QName> propList =
+                    Stream.of(propPath.split("\\s+")).map(QName::valueOf).collect(Collectors.toList());
             propsBuffer.add(propList.toArray(new QName[0]));
             propsStart = domains.indexOf("a(" + ATTRIBUTE_NAME_PROPS, propsEnd);
-            propsEnd = domains.indexOf(")",propsStart);
+            propsEnd = domains.indexOf(")", propsStart);
         }
         return propsBuffer.toArray(new QName[propsBuffer.size()][]);
     }
@@ -145,10 +141,9 @@ public final class StringUtils {
         // FIXME Dont' mix arrays and collections
         return Arrays.stream(specializations.trim().split("\\s+"))
                 .map(token -> Arrays.stream(token.substring(1).split("/"))
-                            .map(QName::valueOf)
-                            .collect(Collectors.toList())
-                            .toArray(new QName[0])
-                )
+                        .map(QName::valueOf)
+                        .collect(Collectors.toList())
+                        .toArray(new QName[0]))
                 .collect(Collectors.toList())
                 .toArray(new QName[0][]);
     }
@@ -197,7 +192,8 @@ public final class StringUtils {
     public static String setOrAppend(final String target, final String value, final boolean withSpace) {
         if (target == null) {
             return value;
-        }if(value == null) {
+        }
+        if (value == null) {
             return target;
         } else {
             if (withSpace && !target.endsWith(STRING_BLANK)) {
@@ -214,35 +210,34 @@ public final class StringUtils {
      * @return locale
      * @throws NullPointerException when anEncoding parameter is {@code null}
      */
-
     public static Locale getLocale(final String anEncoding) {
         Locale aLocale = null;
         String country = null;
         String language = null;
         String variant;
 
-        //Tokenize the string using "-" as the token string as per IETF RFC4646 (superceeds RFC3066).
+        // Tokenize the string using "-" as the token string as per IETF RFC4646 (superceeds RFC3066).
 
         final StringTokenizer tokenizer = new StringTokenizer(anEncoding, "-");
 
-        //We need to know how many tokens we have so we can create a Locale object with the proper constructor.
+        // We need to know how many tokens we have so we can create a Locale object with the proper constructor.
         final int numberOfTokens = tokenizer.countTokens();
 
         if (numberOfTokens == 1) {
             final String tempString = tokenizer.nextToken().toLowerCase();
 
-            //Note: Newer XML parsers should throw an error if the xml:lang value contains
-            //underscore. But this is not guaranteed.
+            // Note: Newer XML parsers should throw an error if the xml:lang value contains
+            // underscore. But this is not guaranteed.
 
-            //Check to see if some one used "en_US" instead of "en-US".
-            //If so, the first token will contain "en_US" or "xxx_YYYYYYYY". In this case,
-            //we will only grab the value for xxx.
+            // Check to see if some one used "en_US" instead of "en-US".
+            // If so, the first token will contain "en_US" or "xxx_YYYYYYYY". In this case,
+            // we will only grab the value for xxx.
             final int underscoreIndex = tempString.indexOf("_");
 
             if (underscoreIndex == -1) {
                 language = tempString;
             } else if (underscoreIndex == 2 || underscoreIndex == 3) {
-                //check is first subtag is two or three characters in length.
+                // check is first subtag is two or three characters in length.
                 language = tempString.substring(0, underscoreIndex);
             }
 
@@ -252,9 +247,9 @@ public final class StringUtils {
             language = tokenizer.nextToken().toLowerCase();
 
             final String subtag2 = tokenizer.nextToken();
-            //All country tags should be three characters or less.
-            //If the subtag is longer than three characters, it assumes that
-            //is a dialect or variant.
+            // All country tags should be three characters or less.
+            // If the subtag is longer than three characters, it assumes that
+            // is a dialect or variant.
             if (subtag2.length() <= 3) {
                 country = subtag2.toUpperCase();
                 aLocale = new Locale(language, country);
@@ -262,10 +257,8 @@ public final class StringUtils {
                 variant = subtag2;
                 aLocale = new Locale(language, "", variant);
             } else if (subtag2.length() > 8) {
-                //return an error!
+                // return an error!
             }
-
-
 
         } else if (numberOfTokens >= 3) {
 
@@ -275,18 +268,16 @@ public final class StringUtils {
                 country = subtag2.toUpperCase();
             } else if (subtag2.length() > 3 && subtag2.length() <= 8) {
             } else if (subtag2.length() > 8) {
-                //return an error!
+                // return an error!
             }
             variant = tokenizer.nextToken();
 
             aLocale = new Locale(language, country, variant);
 
         } else {
-            //return an warning or do nothing.
-            //The xml:lang attribute is empty.
-            aLocale = new Locale(LANGUAGE_EN,
-                    COUNTRY_US);
-
+            // return an warning or do nothing.
+            // The xml:lang attribute is empty.
+            aLocale = new Locale(LANGUAGE_EN, COUNTRY_US);
         }
 
         return aLocale;
@@ -310,8 +301,8 @@ public final class StringUtils {
             switch (current) {
                 case '.' -> buff.append("\\.");
 
-                // case '/':
-                // case '|':
+                    // case '/':
+                    // case '|':
                 case '\\' -> buff.append("[\\\\|/]");
                 case '(' -> buff.append("\\(");
                 case ')' -> buff.append("\\)");
@@ -330,7 +321,10 @@ public final class StringUtils {
     }
 
     /** Whitespace normalization state. */
-    private enum WhiteSpaceState { WORD, SPACE }
+    private enum WhiteSpaceState {
+        WORD,
+        SPACE
+    }
 
     /**
      * Normalize and collapse whitespaces from string buffer.
@@ -367,5 +361,4 @@ public final class StringUtils {
         final String[] tokens = value.trim().split("\\s+");
         return asList(tokens);
     }
-
 }

--- a/src/main/java/org/dita/dost/util/TopicIdParser.java
+++ b/src/main/java/org/dita/dost/util/TopicIdParser.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import static org.dita.dost.util.Constants.*;
@@ -57,8 +57,7 @@ public final class TopicIdParser implements ContentHandler {
     }
 
     @Override
-    public void startPrefixMapping(final String prefix, final String uri)
-            throws SAXException {
+    public void startPrefixMapping(final String prefix, final String uri) throws SAXException {
         // NOOP
     }
 
@@ -68,8 +67,8 @@ public final class TopicIdParser implements ContentHandler {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
         if (isFirstId) {
             if (atts.getValue(ATTRIBUTE_NAME_ID) != null) {
                 isFirstId = false;
@@ -79,26 +78,22 @@ public final class TopicIdParser implements ContentHandler {
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         // NOOP
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         // NOOP
     }
 
     @Override
-    public void ignorableWhitespace(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
         // NOOP
     }
 
     @Override
-    public void processingInstruction(final String target, final String data)
-            throws SAXException {
+    public void processingInstruction(final String target, final String data) throws SAXException {
         // NOOP
     }
 
@@ -106,5 +101,4 @@ public final class TopicIdParser implements ContentHandler {
     public void skippedEntity(final String name) throws SAXException {
         // NOOP
     }
-
 }

--- a/src/main/java/org/dita/dost/util/URLUtils.java
+++ b/src/main/java/org/dita/dost/util/URLUtils.java
@@ -1,12 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
+
+import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,8 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Corrects the URLs.
@@ -29,8 +29,7 @@ public final class URLUtils {
     /**
      * Private default constructor to make class uninstantiable.
      */
-    private URLUtils() {
-    }
+    private URLUtils() {}
 
     /**
      * Corrects the file to URL.
@@ -109,22 +108,24 @@ public final class URLUtils {
             final char current = s.charAt(i);
             ch = current;
             switch (ch) {
-            case '%':
-                if (i + 2 < s.length()) {
-                    // Avoid java.lang.StringIndexOutOfBoundsException...
-                    ch = s.charAt(++i);
-                    final int hb = (Character.isDigit((char) ch) ? ch - '0'
-                            : 10 + Character.toLowerCase((char) ch) - 'a') & 0xF;
-                    ch = s.charAt(++i);
-                    final int lb = (Character.isDigit((char) ch) ? ch - '0'
-                            : 10 + Character.toLowerCase((char) ch) - 'a') & 0xF;
-                    b = (hb << 4) | lb;
-                    applyUTF8dec = true;
-                }
-                break;
-            default:
-                b = ch;
-                applyUTF8dec = false;
+                case '%':
+                    if (i + 2 < s.length()) {
+                        // Avoid java.lang.StringIndexOutOfBoundsException...
+                        ch = s.charAt(++i);
+                        final int hb =
+                                (Character.isDigit((char) ch) ? ch - '0' : 10 + Character.toLowerCase((char) ch) - 'a')
+                                        & 0xF;
+                        ch = s.charAt(++i);
+                        final int lb =
+                                (Character.isDigit((char) ch) ? ch - '0' : 10 + Character.toLowerCase((char) ch) - 'a')
+                                        & 0xF;
+                        b = (hb << 4) | lb;
+                        applyUTF8dec = true;
+                    }
+                    break;
+                default:
+                    b = ch;
+                    applyUTF8dec = false;
             }
             // Decode byte b as UTF-8, sumb collects incomplete chars
             if (applyUTF8dec) {
@@ -192,7 +193,6 @@ public final class URLUtils {
                 // Does not exist.
                 file = file.getAbsoluteFile();
             }
-
         }
         return file;
     }
@@ -287,7 +287,6 @@ public final class URLUtils {
             final File file = new File(fileName);
             return file.toURI().toString();
         }
-
     }
 
     // Which ASCII characters need to be escaped
@@ -296,8 +295,9 @@ public final class URLUtils {
     private static final char[] gAfterEscaping1 = new char[128];
     // The second hex character if a character needs to be escaped
     private static final char[] gAfterEscaping2 = new char[128];
-    private static final char[] gHexChs = {'0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    private static final char[] gHexChs = {
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
     // Initialize the above 3 arrays
     static {
         for (int i = 0; i <= 0x1f; i++) {
@@ -308,17 +308,26 @@ public final class URLUtils {
         gNeedEscaping[0x7f] = true;
         gAfterEscaping1[0x7f] = '7';
         gAfterEscaping2[0x7f] = 'F';
-        final char[] escChs = {' ', '<', '>',
-                //'#',
-                //'%',
-                '"', '{', '}',
-                //'?',
-                '|', '\\', '^',
-                //'~',
-                '[', ']', '`',
-                //'\'',
-                //'&'
-                };
+        final char[] escChs = {
+            ' ',
+            '<',
+            '>',
+            // '#',
+            // '%',
+            '"',
+            '{',
+            '}',
+            // '?',
+            '|',
+            '\\',
+            '^',
+            // '~',
+            '[',
+            ']',
+            '`',
+            // '\'',
+            // '&'
+        };
         char ch;
         for (char escCh : escChs) {
             ch = escCh;
@@ -347,7 +356,7 @@ public final class URLUtils {
      */
     public static String clean(final String path, final boolean ascii) {
         int len = path.length(), ch;
-        final StringBuilder buffer = new StringBuilder(len*3);
+        final StringBuilder buffer = new StringBuilder(len * 3);
         // Change C:/something to /C:/something
         if (len >= 2 && path.charAt(1) == ':') {
             ch = Character.toUpperCase(path.charAt(0));
@@ -368,13 +377,13 @@ public final class URLUtils {
             if (ch >= 128 && ascii) {
                 break;
             }
-            if (ch <  gNeedEscaping.length && gNeedEscaping[ch]) {
+            if (ch < gNeedEscaping.length && gNeedEscaping[ch]) {
                 buffer.append('%');
                 buffer.append(gAfterEscaping1[ch]);
                 buffer.append(gAfterEscaping2[ch]);
                 // Record the fact that it's escaped
             } else {
-                buffer.append((char)ch);
+                buffer.append((char) ch);
             }
         }
 
@@ -400,7 +409,7 @@ public final class URLUtils {
                     buffer.append(gAfterEscaping1[b]);
                     buffer.append(gAfterEscaping2[b]);
                 } else {
-                    buffer.append((char)b);
+                    buffer.append((char) b);
                 }
             }
         }
@@ -416,9 +425,7 @@ public final class URLUtils {
             return false;
         }
         final char c2 = seq.charAt(1);
-        if (!(c2 >= '0' && c2 <= '9'
-                || c2 >= 'a' && c2 <= 'f'
-                || c2 >= 'A' && c2 <= 'F')) {
+        if (!(c2 >= '0' && c2 <= '9' || c2 >= 'a' && c2 <= 'f' || c2 >= 'A' && c2 <= 'F')) {
             return false;
         }
         return true;
@@ -486,7 +493,8 @@ public final class URLUtils {
             return file.toURI();
         } else {
             try {
-                return new URI(clean(file.getPath().replace(WINDOWS_SEPARATOR, URI_SEPARATOR).trim(), false));
+                return new URI(clean(
+                        file.getPath().replace(WINDOWS_SEPARATOR, URI_SEPARATOR).trim(), false));
             } catch (final URISyntaxException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
@@ -510,7 +518,8 @@ public final class URLUtils {
             return new URI(file);
         } catch (final URISyntaxException e) {
             try {
-                return new URI(clean(file.replace(WINDOWS_SEPARATOR, URI_SEPARATOR).trim(), false));
+                return new URI(
+                        clean(file.replace(WINDOWS_SEPARATOR, URI_SEPARATOR).trim(), false));
             } catch (final URISyntaxException ex) {
                 throw new IllegalArgumentException(ex.getMessage(), ex);
             }
@@ -554,7 +563,14 @@ public final class URLUtils {
     public static URI setFragment(final URI path, final String fragment) {
         try {
             if (path.getPath() != null) {
-                return new URI(path.getScheme(), path.getUserInfo(), path.getHost(), path.getPort(), path.getPath(), path.getQuery(), fragment);
+                return new URI(
+                        path.getScheme(),
+                        path.getUserInfo(),
+                        path.getHost(),
+                        path.getPort(),
+                        path.getPath(),
+                        path.getQuery(),
+                        fragment);
             } else {
                 return new URI(path.getScheme(), path.getSchemeSpecificPart(), fragment);
             }
@@ -573,7 +589,14 @@ public final class URLUtils {
     public static URI setQuery(final URI path, final String query) {
         try {
             if (path.getPath() != null) {
-                return new URI(path.getScheme(), path.getUserInfo(), path.getHost(), path.getPort(), path.getPath(), query, path.getFragment());
+                return new URI(
+                        path.getScheme(),
+                        path.getUserInfo(),
+                        path.getHost(),
+                        path.getPort(),
+                        path.getPath(),
+                        query,
+                        path.getFragment());
             } else {
                 return new URI(path.getScheme(), path.getSchemeSpecificPart(), path.getFragment());
             }
@@ -601,7 +624,14 @@ public final class URLUtils {
      */
     public static URI setPath(final URI orig, final String path) {
         try {
-            return new URI(orig.getScheme(), orig.getUserInfo(), orig.getHost(), orig.getPort(), path, orig.getQuery(), orig.getFragment());
+            return new URI(
+                    orig.getScheme(),
+                    orig.getUserInfo(),
+                    orig.getHost(),
+                    orig.getPort(),
+                    path,
+                    orig.getQuery(),
+                    orig.getFragment());
         } catch (final URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -616,7 +646,14 @@ public final class URLUtils {
      */
     public static URI setScheme(final URI orig, final String scheme) {
         try {
-            return new URI(scheme, orig.getUserInfo(), orig.getHost(), orig.getPort(), orig.getPath(), orig.getQuery(), orig.getFragment());
+            return new URI(
+                    scheme,
+                    orig.getUserInfo(),
+                    orig.getHost(),
+                    orig.getPort(),
+                    orig.getPath(),
+                    orig.getQuery(),
+                    orig.getFragment());
         } catch (final URISyntaxException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -634,8 +671,10 @@ public final class URLUtils {
         final String refScheme = ref.getScheme();
         final String baseAuth = base.getAuthority();
         final String refAuth = ref.getAuthority();
-        if (!(((baseScheme == null && refScheme == null) || (baseScheme != null && refScheme != null && baseScheme.equals(refScheme))) &&
-                ((baseAuth == null && refAuth == null) || (baseAuth != null && refAuth != null && baseAuth.equals(refAuth))))) {
+        if (!(((baseScheme == null && refScheme == null)
+                        || (baseScheme != null && refScheme != null && baseScheme.equals(refScheme)))
+                && ((baseAuth == null && refAuth == null)
+                        || (baseAuth != null && refAuth != null && baseAuth.equals(refAuth))))) {
             return ref;
         }
 
@@ -656,13 +695,13 @@ public final class URLUtils {
             while (baseTokenizer.countTokens() > 1 && refTokenizer.countTokens() > 1) {
                 final String baseToken = baseTokenizer.nextToken();
                 final String refToken = refTokenizer.nextToken();
-                //if OS is Windows, we need to ignore case when comparing path names.
+                // if OS is Windows, we need to ignore case when comparing path names.
                 final boolean equals = OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)
-                                       ? baseToken.equalsIgnoreCase(refToken)
-                                       : baseToken.equals(refToken);
+                        ? baseToken.equalsIgnoreCase(refToken)
+                        : baseToken.equals(refToken);
                 if (!equals) {
                     if (baseToken.endsWith(COLON) || refToken.endsWith(COLON)) {
-                        //the two files are in different disks under Windows
+                        // the two files are in different disks under Windows
                         return ref;
                     }
                     upPathBuffer.append("..");
@@ -711,7 +750,7 @@ public final class URLUtils {
         if (tokenizer.countTokens() == 1) {
             return null;
         } else {
-            while(tokenizer.countTokens() > 1) {
+            while (tokenizer.countTokens() > 1) {
                 tokenizer.nextToken();
                 buffer.append("..");
                 buffer.append(URI_SEPARATOR);
@@ -789,9 +828,8 @@ public final class URLUtils {
     public static String getTopicID(final URI relativePath) {
         final String fragment = relativePath.getFragment();
         if (fragment != null) {
-            final String id = fragment.lastIndexOf(SLASH) != -1
-                              ? fragment.substring(0, fragment.lastIndexOf(SLASH))
-                              : fragment;
+            final String id =
+                    fragment.lastIndexOf(SLASH) != -1 ? fragment.substring(0, fragment.lastIndexOf(SLASH)) : fragment;
             return id.isEmpty() ? null : id;
         }
         return null;

--- a/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLGrammarPoolImplUtils.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005, 2006 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005, 2006 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.util;
 
 import org.apache.xerces.impl.xs.XSDDescription;
@@ -21,7 +21,6 @@ import org.apache.xerces.xni.grammars.XMLGrammarDescription;
 public class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
 
     private static final Grammar[] INITIAL_GRAMMAR_SET = new Grammar[0];
-
 
     /** Constructs a grammar pool with a default number of buckets. */
     public XMLGrammarPoolImplUtils() {
@@ -46,11 +45,11 @@ public class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
      */
     @Override
     public void putGrammar(Grammar grammar) {
-     //Avoid caching any type of XSD grammar
-     if (grammar instanceof org.apache.xerces.impl.xs.SchemaGrammar) {
-      return;
-     }
-     super.putGrammar(grammar);
+        // Avoid caching any type of XSD grammar
+        if (grammar instanceof org.apache.xerces.impl.xs.SchemaGrammar) {
+            return;
+        }
+        super.putGrammar(grammar);
     }
 
     /**
@@ -63,8 +62,8 @@ public class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
     @Override
     public int hashCode(final XMLGrammarDescription desc) {
         if (desc instanceof XSDDescription) {
-//            final String systemId = ((XSDDescription) desc).getLiteralSystemId();
-//            return systemId == null ? 0 : systemId.hashCode();
+            //            final String systemId = ((XSDDescription) desc).getLiteralSystemId();
+            //            return systemId == null ? 0 : systemId.hashCode();
             // return -1 for XSD grammar hashcode because we want to disable XSD grammar caching
             return -1;
         } else {
@@ -89,12 +88,10 @@ public class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
      * @return True if the grammars are equal, otherwise false
      */
     @Override
-    public boolean equals(final XMLGrammarDescription desc1,
-            final XMLGrammarDescription desc2) {
-        if (desc1 instanceof XSDDescription
-                && desc2 instanceof XSDDescription) {
-//                return desc1.getLiteralSystemId().equals(
-//                        desc2.getLiteralSystemId());
+    public boolean equals(final XMLGrammarDescription desc1, final XMLGrammarDescription desc2) {
+        if (desc1 instanceof XSDDescription && desc2 instanceof XSDDescription) {
+            //                return desc1.getLiteralSystemId().equals(
+            //                        desc2.getLiteralSystemId());
             // always return false for XSD grammar to disable XSD grammar caching
             return false;
         } else {
@@ -105,5 +102,4 @@ public class XMLGrammarPoolImplUtils extends XMLGrammarPoolImpl {
             }
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/util/XMLSerializer.java
+++ b/src/main/java/org/dita/dost/util/XMLSerializer.java
@@ -7,25 +7,24 @@
  */
 package org.dita.dost.util;
 
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
+import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
+import static javax.xml.XMLConstants.NULL_NS_URI;
 
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
-import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-
-import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
-import static javax.xml.XMLConstants.NULL_NS_URI;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * XML serializer. Users a {@link javax.xml.transform.sax.TransformerHandler
@@ -187,7 +186,7 @@ public class XMLSerializer {
             throw new IllegalStateException("Current state does not allow Namespace writing");
         }
         final QName qName = elementStack.getFirst(); // peek
-        for (final NamespaceMapping p: qName.mappings) {
+        for (final NamespaceMapping p : qName.mappings) {
             if (p.prefix.equals(prefix) && p.uri.equals(uri)) {
                 return;
             } else if (p.prefix.equals(prefix)) {
@@ -237,7 +236,7 @@ public class XMLSerializer {
         processStartElement();
         final QName qName = elementStack.remove(); // pop
         transformer.endElement(qName.uri, qName.localName, qName.qName);
-        for (final NamespaceMapping p: qName.mappings) {
+        for (final NamespaceMapping p : qName.mappings) {
             if (p.newMapping) {
                 transformer.endPrefixMapping(p.prefix);
             }
@@ -300,13 +299,12 @@ public class XMLSerializer {
         transformer.comment(ch, 0, ch.length);
     }
 
-
     // Private methods ---------------------------------------------------------
 
     private void processStartElement() throws SAXException {
         if (openStartElement) {
             final QName qName = elementStack.getFirst(); // peek
-            for (final NamespaceMapping p: qName.mappings) {
+            for (final NamespaceMapping p : qName.mappings) {
                 if (p.newMapping) {
                     transformer.startPrefixMapping(p.prefix, p.uri);
                 }
@@ -325,8 +323,9 @@ public class XMLSerializer {
         if (uri != null) {
             // attempt to find apping in stack
             boolean found = false;
-            stack: for (final QName e: elementStack) {
-                for (final NamespaceMapping m: e.mappings) {
+            stack:
+            for (final QName e : elementStack) {
+                for (final NamespaceMapping m : e.mappings) {
                     if (m.uri.equals(uri) && m.prefix.equals(prefix)) {
                         found = true;
                         break stack;
@@ -361,10 +360,7 @@ public class XMLSerializer {
             this.qName = qName;
             mappings = new ArrayList<>(5);
         }
-
     }
 
-    private record NamespaceMapping(String prefix, String uri, boolean newMapping) {
-    }
-
+    private record NamespaceMapping(String prefix, String uri, boolean newMapping) {}
 }

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -1,13 +1,24 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
+import static javax.xml.XMLConstants.*;
+import static org.dita.dost.reader.ChunkMapReader.*;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.util.*;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.module.ChunkModule.ChunkFilenameGenerator;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -24,18 +35,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.NamespaceSupport;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.net.URI;
-import java.util.*;
-
-import static javax.xml.XMLConstants.*;
-import static org.dita.dost.reader.ChunkMapReader.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.*;
 
 /**
  * ChunkTopicParser class, writing chunking content into relative topic files
@@ -92,14 +91,15 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     public void setJob(final Job job) {
         super.setJob(job);
         try {
-            tempFileNameScheme = (TempFileNameScheme) Class.forName(job.getProperty("temp-file-name-scheme")).newInstance();
+            tempFileNameScheme = (TempFileNameScheme)
+                    Class.forName(job.getProperty("temp-file-name-scheme")).newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
         tempFileNameScheme.setBaseDir(job.getInputDir());
     }
 
-    abstract public void write(final URI filename);
+    public abstract void write(final URI filename);
 
     @Override
     public void write(final File fileDir) throws DITAOTException {
@@ -113,9 +113,11 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
      * @param conflictTable conflictTable
      * @param rootTopicref  chunking topicref
      */
-    public void setup(final LinkedHashMap<URI, URI> changeTable, final Map<URI, URI> conflictTable,
-                      final Element rootTopicref,
-                      final ChunkFilenameGenerator chunkFilenameGenerator) {
+    public void setup(
+            final LinkedHashMap<URI, URI> changeTable,
+            final Map<URI, URI> conflictTable,
+            final Element rootTopicref,
+            final ChunkFilenameGenerator chunkFilenameGenerator) {
         this.changeTable = changeTable;
         this.rootTopicref = rootTopicref;
         this.conflictTable = conflictTable;
@@ -192,8 +194,8 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     }
 
     @Override
-    public abstract void startElement(final String uri, final String localName, final String qName, final Attributes atts)
-            throws SAXException;
+    public abstract void startElement(
+            final String uri, final String localName, final String qName, final Attributes atts) throws SAXException;
 
     void processSelect(String id) {
         if (include) {
@@ -234,14 +236,12 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final URI t = job.tempDirURI.relativize(output);
         final URI result = job.getInputDir().resolve(t);
         final URI temp = tempFileNameScheme.generateTempFileName(result);
-        final FileInfo.Builder b = (currentParsingFile != null && job.getFileInfo(stripFragment(currentParsingFile)) != null)
-                ? new FileInfo.Builder(job.getFileInfo(stripFragment(currentParsingFile)))
-                : new FileInfo.Builder();
-        final FileInfo fi = b
-                .uri(temp)
-                .result(result)
-                .format(ATTR_FORMAT_VALUE_DITA)
-                .build();
+        final FileInfo.Builder b =
+                (currentParsingFile != null && job.getFileInfo(stripFragment(currentParsingFile)) != null)
+                        ? new FileInfo.Builder(job.getFileInfo(stripFragment(currentParsingFile)))
+                        : new FileInfo.Builder();
+        final FileInfo fi =
+                b.uri(temp).result(result).format(ATTR_FORMAT_VALUE_DITA).build();
         return fi;
     }
 
@@ -249,18 +249,15 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final FileInfo cfi = job.getFileInfo(stripFragment(currentParsingFile));
         URI result = cfi.result.resolve(id + FILE_EXTENSION_DITA);
         URI temp = tempFileNameScheme.generateTempFileName(result);
-        if (id == null || job.getStore().exists(job.tempDirURI.resolve(temp))) { //job.getFileInfo(result) != null
+        if (id == null || job.getStore().exists(job.tempDirURI.resolve(temp))) { // job.getFileInfo(result) != null
             final URI t = temp;
 
             result = cfi.result.resolve(generateFilename());
             temp = tempFileNameScheme.generateTempFileName(result);
 
             final FileInfo.Builder b = new FileInfo.Builder(cfi);
-            final FileInfo fi = b
-                    .uri(temp)
-                    .result(result)
-                    .format(ATTR_FORMAT_VALUE_DITA)
-                    .build();
+            final FileInfo fi =
+                    b.uri(temp).result(result).format(ATTR_FORMAT_VALUE_DITA).build();
             job.add(fi);
 
             conflictTable.put(job.tempDirURI.resolve(temp), job.tempDirURI.resolve(t));
@@ -313,7 +310,8 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
             } else if (relative.toString().contains(SLASH)) {
                 // if new file is not under the same directory with current file
                 // add path information to the @href value
-                XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_HREF, relative.resolve(href).toString());
+                XMLUtils.addOrSetAttribute(
+                        resAtts, ATTRIBUTE_NAME_HREF, relative.resolve(href).toString());
             }
         }
         if (TOPIC_TOPIC.matches(cls) && resAtts.getValue(ATTRIBUTE_NAMESPACE_PREFIX_DITAARCHVERSION) == null) {
@@ -322,7 +320,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         if (TOPIC_TOPIC.matches(cls) && resAtts.getValue(XMLNS_ATTRIBUTE + ":" + DITA_OT_NS_PREFIX) == null) {
             addOrSetAttribute(resAtts, XMLNS_ATTRIBUTE + ":" + DITA_OT_NS_PREFIX, DITA_OT_NS);
         }
-        //Need to add a check to see if root element of the topic uses schema validation or not.
+        // Need to add a check to see if root element of the topic uses schema validation or not.
         if (TOPIC_TOPIC.matches(cls) && resAtts.getValue(ATTRIBUTE_NAME_NONAMESPACESCHEMALOCATION) != null) {
             addOrSetAttribute(resAtts, ATTRIBUTE_NAMESPACE_PREFIX_XSI, W3C_XML_SCHEMA_INSTANCE_NS_URI);
         }
@@ -341,13 +339,13 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     Attributes processAttributesNS(Attributes atts, String uri) {
         final AttributesImpl resAtts = new AttributesImpl(processAttributes(atts));
 
-        //Check to see we are at the root element to be processed is the start of the namespaced element
+        // Check to see we are at the root element to be processed is the start of the namespaced element
         if (namespaceMap.get(uri) == 1) {
             String prefix = namespaces.getPrefix(uri);
             if (prefix != null) {
-                if (!prefix.equals(DEFAULT_NS_PREFIX)){
+                if (!prefix.equals(DEFAULT_NS_PREFIX)) {
                     addOrSetAttribute(resAtts, XMLNS_ATTRIBUTE + ":" + prefix, uri);
-                }else {
+                } else {
                     addOrSetAttribute(resAtts, XMLNS_ATTRIBUTE, uri);
                 }
             }
@@ -376,10 +374,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
         final URI tmp = tempFileNameScheme.generateTempFileName(newSrc);
 
         if (job.getFileInfo(tmp) == null) {
-            job.add(new FileInfo.Builder()
-                    .result(newSrc)
-                    .uri(tmp)
-                    .build());
+            job.add(new FileInfo.Builder().result(newSrc).uri(tmp).build());
         }
 
         return job.tempDirURI.resolve(tmp);
@@ -530,8 +525,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
      * @param name  PI name
      * @param value PI value, may be {@code null}
      */
-    void writeProcessingInstruction(final Writer output, final String name, final String value)
-            throws SAXException {
+    void writeProcessingInstruction(final Writer output, final String name, final String value) throws SAXException {
         try {
             output.write(LESS_THAN);
             output.write(QUESTION);
@@ -551,7 +545,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
      * start of namespace associated with Element
      */
     public void startPrefixMapping(String prefix, String uri) {
-    	namespaces.pushContext();        
+        namespaces.pushContext();
         namespaces.declarePrefix(prefix, uri);
     }
 
@@ -561,5 +555,4 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
     public void endPrefixMapping(String prefix) {
         namespaces.popContext();
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDitaMetaWriter.java
@@ -1,13 +1,16 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.util.*;
 import org.dita.dost.util.DitaClass;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Document;
@@ -15,23 +18,13 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
-
 /**
  * Base class for metadata filter that reads dita files and inserts metadata.
  */
 public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
 
     private static final Set<DitaClass> uniqueSet = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            TOPIC_CRITDATES,
-            TOPIC_PERMISSIONS,
-            TOPIC_PUBLISHER,
-            TOPIC_SOURCE,
-            MAP_SEARCHTITLE,
-            TOPIC_SEARCHTITLE
-    )));
+            TOPIC_CRITDATES, TOPIC_PERMISSIONS, TOPIC_PUBLISHER, TOPIC_SOURCE, MAP_SEARCHTITLE, TOPIC_SEARCHTITLE)));
 
     private Map<String, Element> metaTable;
     private String topicid = null;
@@ -39,7 +32,7 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
     public void setMetaTable(final Map<String, Element> metaTable) {
         this.metaTable = metaTable;
     }
-    
+
     public void setTopicId(final String topicid) {
         this.topicid = topicid;
     }
@@ -52,9 +45,9 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
             final List<Element> newChildren = getNewChildren(cls, metadataContainer.getOwnerDocument());
             if (!newChildren.isEmpty()) {
                 final Element insertPoint = getInsertionRef(metadataContainer, order.subList(i, order.size()));
-                for (final Element newChild: newChildren) {
+                for (final Element newChild : newChildren) {
                     if (skipUnlockedNavtitle(metadataContainer, newChild)) {
-                        //Navtitle element without locktitle="yes", do not push into topic
+                        // Navtitle element without locktitle="yes", do not push into topic
                     } else if (insertPoint != null) {
                         if (uniqueSet.contains(cls) && cls.matches(insertPoint)) {
                             metadataContainer.replaceChild(newChild, insertPoint);
@@ -70,14 +63,14 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
     }
 
     boolean hasMetadata(final List<DitaClass> order) {
-        for (final DitaClass cls: order) {
+        for (final DitaClass cls : order) {
             if (metaTable.containsKey(cls.matcher)) {
                 return true;
             }
         }
         return false;
     }
-    
+
     /**
      * Check if an element is an unlocked navtitle, which should not be pushed into topics.
      *
@@ -85,12 +78,13 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
      * @param checkForNavtitle title element
      */
     boolean skipUnlockedNavtitle(final Element metadataContainer, final Element checkForNavtitle) {
-        if (!TOPIC_TITLEALTS.matches(metadataContainer) ||
-                !TOPIC_NAVTITLE.matches(checkForNavtitle)) {
+        if (!TOPIC_TITLEALTS.matches(metadataContainer) || !TOPIC_NAVTITLE.matches(checkForNavtitle)) {
             return false;
         } else if (checkForNavtitle.getAttributeNodeNS(DITA_OT_NS, ATTRIBUTE_NAME_LOCKTITLE) == null) {
             return false;
-        } else if (ATTRIBUTE_NAME_LOCKTITLE_VALUE_YES.matches(checkForNavtitle.getAttributeNodeNS(DITA_OT_NS, ATTRIBUTE_NAME_LOCKTITLE).getValue())) {
+        } else if (ATTRIBUTE_NAME_LOCKTITLE_VALUE_YES.matches(checkForNavtitle
+                .getAttributeNodeNS(DITA_OT_NS, ATTRIBUTE_NAME_LOCKTITLE)
+                .getValue())) {
             return false;
         }
         return true;
@@ -182,7 +176,7 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
         }
         return res;
     }
- 
+
     public Element getMatchingTopicElement(Element root) {
         if (this.topicid != null) {
             final Element res = matchTopicElementById(root);
@@ -200,7 +194,7 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
             return root;
         }
     }
- 
+
     private Element matchTopicElementById(Element topic) {
         if (topic.getAttribute(ATTRIBUTE_NAME_ID).equals(topicid)) {
             return topic;
@@ -224,5 +218,4 @@ public abstract class AbstractDitaMetaWriter extends AbstractDomFilter {
             parent.appendChild(newChild);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractDomFilter.java
@@ -7,14 +7,13 @@
  */
 package org.dita.dost.writer;
 
+import java.io.File;
+import java.io.IOException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.reader.AbstractReader;
 import org.dita.dost.util.Job;
 import org.w3c.dom.Document;
-
-import java.io.File;
-import java.io.IOException;
 
 /**
  * Reads XML into DOM, modifies it, and serializes back into XML.
@@ -45,7 +44,8 @@ public abstract class AbstractDomFilter implements AbstractReader {
                 resDoc.setDocumentURI(filename.toURI().toString());
                 job.getStore().writeDocument(resDoc, filename.toURI());
             } catch (final IOException e) {
-                throw new DITAOTException("Failed to serialize " + filename.getAbsolutePath() + ": " + e.getMessage(), e);
+                throw new DITAOTException(
+                        "Failed to serialize " + filename.getAbsolutePath() + ": " + e.getMessage(), e);
             }
         }
     }
@@ -67,5 +67,4 @@ public abstract class AbstractDomFilter implements AbstractReader {
      * @return modified document, may be argument document; if {@code null}, document is not serialized
      */
     protected abstract Document process(final Document doc);
-
 }

--- a/src/main/java/org/dita/dost/writer/AbstractExtendDitaWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractExtendDitaWriter.java
@@ -1,21 +1,20 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import java.util.List;
-
 import org.dita.dost.index.IndexTerm;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Job;
 
-//RFE 2987769 Eclipse index-see
+// RFE 2987769 Eclipse index-see
 
 public abstract class AbstractExtendDitaWriter implements AbstractWriter, IExtendDitaWriter, IDitaTranstypeIndexWriter {
 
@@ -52,5 +51,4 @@ public abstract class AbstractExtendDitaWriter implements AbstractWriter, IExten
     public final void setPipelineHashIO(final PipelineHashIO hashIO) {
         pipelineHashMap = hashIO;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/AbstractWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractWriter.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import java.io.File;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
@@ -43,5 +42,4 @@ public interface AbstractWriter {
      * @param job Job configuration to use for processing
      */
     void setJob(Job job);
-
 }

--- a/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLFilter.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
@@ -30,6 +29,7 @@ public abstract class AbstractXMLFilter extends XMLFilterImpl implements Abstrac
     protected Job job;
     /** Absolute temporary directory URI to file being processed */
     protected URI currentFile;
+
     protected final Map<String, String> params = new HashMap<>();
 
     @Override

--- a/src/main/java/org/dita/dost/writer/AbstractXMLWriter.java
+++ b/src/main/java/org/dita/dost/writer/AbstractXMLWriter.java
@@ -1,16 +1,15 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
@@ -27,67 +26,47 @@ import org.xml.sax.SAXException;
  * @version 1.0 2005-6-28
  * @author Zhang, Yuan Peng
  */
-
-abstract class AbstractXMLWriter implements AbstractWriter,
-ContentHandler, EntityResolver {
+abstract class AbstractXMLWriter implements AbstractWriter, ContentHandler, EntityResolver {
 
     DITAOTLogger logger;
     Job job;
 
+    @Override
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {}
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
-    }
+    public void endDocument() throws SAXException {}
 
     @Override
-    public void endDocument() throws SAXException {
-    }
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {}
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
-    }
+    public void endPrefixMapping(final String prefix) throws SAXException {}
 
     @Override
-    public void endPrefixMapping(final String prefix) throws SAXException {
-    }
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {}
 
     @Override
-    public void ignorableWhitespace(final char[] ch, final int start, final int length)
-            throws SAXException {
-    }
+    public void processingInstruction(final String target, final String data) throws SAXException {}
 
     @Override
-    public void processingInstruction(final String target, final String data)
-            throws SAXException {
-    }
+    public void setDocumentLocator(final Locator locator) {}
 
     @Override
-    public void setDocumentLocator(final Locator locator) {
-    }
+    public void skippedEntity(final String name) throws SAXException {}
 
     @Override
-    public void skippedEntity(final String name) throws SAXException {
-    }
+    public void startDocument() throws SAXException {}
 
     @Override
-    public void startDocument() throws SAXException {
-    }
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {}
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes atts) throws SAXException {
-    }
+    public void startPrefixMapping(final String prefix, final String uri) throws SAXException {}
 
     @Override
-    public void startPrefixMapping(final String prefix, final String uri)
-            throws SAXException {
-    }
-
-    @Override
-    public InputSource resolveEntity(final String publicId, final String systemId)
-            throws SAXException, IOException {
+    public InputSource resolveEntity(final String publicId, final String systemId) throws SAXException, IOException {
         return null;
     }
 
@@ -103,5 +82,4 @@ ContentHandler, EntityResolver {
     public void setJob(final Job job) {
         this.job = job;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/ChunkTopicParser.java
@@ -1,26 +1,12 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
-
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.Job.FileInfo;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
-
-import java.io.*;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
 
 import static javax.xml.XMLConstants.NULL_NS_URI;
 import static org.dita.dost.reader.ChunkMapReader.*;
@@ -30,6 +16,19 @@ import static org.dita.dost.util.FileUtils.getRelativeUnixPath;
 import static org.dita.dost.util.StringUtils.split;
 import static org.dita.dost.util.URLUtils.*;
 import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.*;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.Job.FileInfo;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * Combine topic into a single file for {@code to-content} chunking.
@@ -42,13 +41,13 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
      */
     public ChunkTopicParser() {
         super();
-//        try {
-//            reader = getXMLReader();
-//            reader.setContentHandler(this);
-//            reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
-//        } catch (final Exception e) {
-//            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
-//        }
+        //        try {
+        //            reader = getXMLReader();
+        //            reader.setContentHandler(this);
+        //            reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
+        //        } catch (final Exception e) {
+        //            throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
+        //        }
     }
 
     @Override
@@ -120,14 +119,14 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                         outputFileName = currentFile.resolve(copytoValue);
                     } else if (hrefValue != null) {
                         // try to use href value as the new file name
-                        if (chunkValue.contains(CHUNK_SELECT_TOPIC)
-                                || chunkValue.contains(CHUNK_SELECT_BRANCH)) {
+                        if (chunkValue.contains(CHUNK_SELECT_TOPIC) || chunkValue.contains(CHUNK_SELECT_BRANCH)) {
                             if (hrefValue.getFragment() != null) {
                                 // if we have an ID here, use it.
                                 outputFileName = currentFile.resolve(hrefValue.getFragment() + FILE_EXTENSION_DITA);
                             } else {
                                 // Find the first topic id in target file if any.
-                                final String firstTopic = getFirstTopicId(new File(stripFragment(currentFile.resolve(hrefValue))));
+                                final String firstTopic =
+                                        getFirstTopicId(new File(stripFragment(currentFile.resolve(hrefValue))));
                                 if (firstTopic != null) {
                                     outputFileName = currentFile.resolve(firstTopic + FILE_EXTENSION_DITA);
                                 } else {
@@ -176,7 +175,10 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                 // TopicRefWriter's updateHref method, very important!!!
                 changeTable.put(path, newpath);
                 // update current element's @href value
-                topicref.setAttribute(ATTRIBUTE_NAME_HREF, getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), newpath).toString());
+                topicref.setAttribute(
+                        ATTRIBUTE_NAME_HREF,
+                        getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), newpath)
+                                .toString());
 
                 if (parseFilePath.getFragment() != null) {
                     targetTopicId = parseFilePath.getFragment();
@@ -199,19 +201,19 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                     // TODO recursive point
                     logger.info("Processing " + currentParsingFile);
                     job.getStore().transform(currentParsingFile, this);
-//                    reader.parse(currentParsingFile.toString());
+                    //                    reader.parse(currentParsingFile.toString());
                     if (currentParsingFileTopicIDChangeTable.size() > 0) {
                         final URI href = toURI(topicref.getAttribute(ATTRIBUTE_NAME_HREF));
-                        final String pathtoElem = href.getFragment() != null
-                                ? href.getFragment()
-                                : "";
+                        final String pathtoElem = href.getFragment() != null ? href.getFragment() : "";
                         final String old_elementid = pathtoElem.contains(SLASH)
                                 ? pathtoElem.substring(0, pathtoElem.indexOf(SLASH))
                                 : pathtoElem;
                         if (!old_elementid.isEmpty()) {
                             final String new_elementid = currentParsingFileTopicIDChangeTable.get(old_elementid);
                             if (new_elementid != null && !new_elementid.isEmpty()) {
-                                topicref.setAttribute(ATTRIBUTE_NAME_HREF, setFragment(href, new_elementid).toString());
+                                topicref.setAttribute(
+                                        ATTRIBUTE_NAME_HREF,
+                                        setFragment(href, new_elementid).toString());
                             }
                         }
                     }
@@ -277,9 +279,11 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
         final int end = parentResult.indexOf(">", insertpoint);
 
         if (insertpoint == -1 || end == -1) {
-            logger.error(MessageUtils.getMessage("DOTJ033E", hrefValue.toString()).toString());
+            logger.error(
+                    MessageUtils.getMessage("DOTJ033E", hrefValue.toString()).toString());
         } else {
-            if (ELEMENT_NAME_DITA.equals(parentResult.substring(insertpoint, end).trim())) {
+            if (ELEMENT_NAME_DITA.equals(
+                    parentResult.substring(insertpoint, end).trim())) {
                 insertpoint = parentResult.lastIndexOf("</", insertpoint - 1);
             }
             parentResult.insert(insertpoint, tmpContent);
@@ -287,10 +291,12 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
     }
 
     // flush the buffer to file after processing is finished
-    private void writeToContentChunk(final String tmpContent, final URI outputFileName, final boolean needWriteDitaTag) throws IOException {
+    private void writeToContentChunk(final String tmpContent, final URI outputFileName, final boolean needWriteDitaTag)
+            throws IOException {
         assert outputFileName.isAbsolute();
         logger.info("Writing " + outputFileName);
-        try (Writer ditaFileOutput = new OutputStreamWriter(job.getStore().getOutputStream(outputFileName), StandardCharsets.UTF_8)) {
+        try (Writer ditaFileOutput =
+                new OutputStreamWriter(job.getStore().getOutputStream(outputFileName), StandardCharsets.UTF_8)) {
             if (outputFileName.equals(changeTable.get(outputFileName))) {
                 // if the output file is newly generated file
                 // write the xml header and workdir PI into new file
@@ -299,28 +305,38 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
                 if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
                     writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET, new File(workDir).getAbsolutePath());
                 } else {
-                    writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET, UNIX_SEPARATOR + new File(workDir).getAbsolutePath());
+                    writeProcessingInstruction(
+                            ditaFileOutput, PI_WORKDIR_TARGET, UNIX_SEPARATOR + new File(workDir).getAbsolutePath());
                 }
                 writeProcessingInstruction(ditaFileOutput, PI_WORKDIR_TARGET_URI, workDir.toString());
 
-                final File path2rootmap = toFile(getRelativePath(outputFileName, job.getInputMap())).getParentFile();
-                writeProcessingInstruction(ditaFileOutput, PI_PATH2ROOTMAP_TARGET_URI, path2rootmap == null ? "./" : toURI(path2rootmap).toString());
+                final File path2rootmap = toFile(getRelativePath(outputFileName, job.getInputMap()))
+                        .getParentFile();
+                writeProcessingInstruction(
+                        ditaFileOutput,
+                        PI_PATH2ROOTMAP_TARGET_URI,
+                        path2rootmap == null ? "./" : toURI(path2rootmap).toString());
 
                 if (conflictTable.get(outputFileName) != null) {
-                    final String relativePath = getRelativeUnixPath(new File(currentFile.resolve(".")) + UNIX_SEPARATOR + FILE_NAME_STUB_DITAMAP,
+                    final String relativePath = getRelativeUnixPath(
+                            new File(currentFile.resolve(".")) + UNIX_SEPARATOR + FILE_NAME_STUB_DITAMAP,
                             new File(conflictTable.get(outputFileName)).getAbsolutePath());
                     String path2project = getRelativeUnixPath(relativePath);
                     if (null == path2project) {
                         path2project = "";
                     }
                     writeProcessingInstruction(ditaFileOutput, PI_PATH2PROJ_TARGET, path2project);
-                    writeProcessingInstruction(ditaFileOutput, PI_PATH2PROJ_TARGET_URI, path2project.isEmpty() ? "./" : toURI(path2project).toString());
+                    writeProcessingInstruction(
+                            ditaFileOutput,
+                            PI_PATH2PROJ_TARGET_URI,
+                            path2project.isEmpty() ? "./" : toURI(path2project).toString());
                 }
             }
             if (needWriteDitaTag) {
                 final AttributesImpl atts = new AttributesImpl();
                 addOrSetAttribute(atts, ATTRIBUTE_NAMESPACE_PREFIX_DITAARCHVERSION, DITA_NAMESPACE);
-                addOrSetAttribute(atts, ATTRIBUTE_PREFIX_DITAARCHVERSION + COLON + ATTRIBUTE_NAME_DITAARCHVERSION, "1.3");
+                addOrSetAttribute(
+                        atts, ATTRIBUTE_PREFIX_DITAARCHVERSION + COLON + ATTRIBUTE_NAME_DITAARCHVERSION, "1.3");
                 writeStartElement(ditaFileOutput, ELEMENT_NAME_DITA, atts);
             }
             // write the final result to the output file
@@ -355,7 +371,7 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
         if (include) {
             includelevel++;
 
-            AttributesImpl resAtts = new AttributesImpl(checkForNSDeclaration(atts,uri));
+            AttributesImpl resAtts = new AttributesImpl(checkForNSDeclaration(atts, uri));
             writeStartElement(output, qName, resAtts);
         }
     }
@@ -363,9 +379,9 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
     @Override
     public void endElement(final String uri, final String localName, final String qName) throws SAXException {
 
-        //pop the namespace level
+        // pop the namespace level
         if (!Objects.equals(uri, NULL_NS_URI)) {
-            if (namespaceMap.containsKey(uri)){
+            if (namespaceMap.containsKey(uri)) {
                 decreaseNamespaceLevel(uri);
             }
         }
@@ -390,13 +406,11 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
         }
     }
 
-
-    private void increaseNamespaceLevel (String uri){
+    private void increaseNamespaceLevel(String uri) {
         namespaceMap.put(uri, namespaceMap.get(uri) + 1);
-
     }
 
-    private void decreaseNamespaceLevel (String uri){
+    private void decreaseNamespaceLevel(String uri) {
         namespaceMap.put(uri, namespaceMap.get(uri) - 1);
     }
 
@@ -405,21 +419,21 @@ public final class ChunkTopicParser extends AbstractChunkTopicParser {
      *
      * @return updated attributes
      */
-    private Attributes checkForNSDeclaration (Attributes atts, String uri){
+    private Attributes checkForNSDeclaration(Attributes atts, String uri) {
         AttributesImpl resAtts = null;
 
-        //This part is to handle namespace declaration in the content.
+        // This part is to handle namespace declaration in the content.
         if (!Objects.equals(uri, NULL_NS_URI)) {
-            if (namespaceMap.containsKey(uri)){
+            if (namespaceMap.containsKey(uri)) {
                 increaseNamespaceLevel(uri);
-            }else {
+            } else {
                 namespaceMap.put(uri, 1);
             }
-            resAtts =  new AttributesImpl(processAttributesNS(atts,uri));
-        }else {
-            resAtts = new AttributesImpl(processAttributes(atts));        }
+            resAtts = new AttributesImpl(processAttributesNS(atts, uri));
+        } else {
+            resAtts = new AttributesImpl(processAttributes(atts));
+        }
 
         return resAtts;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/CoderefResolver.java
+++ b/src/main/java/org/dita/dost/writer/CoderefResolver.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import org.dita.dost.writer.include.IncludeResolver;
 
 @Deprecated
-public final class CoderefResolver extends IncludeResolver {
-}
+public final class CoderefResolver extends IncludeResolver {}

--- a/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
+++ b/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
@@ -12,7 +12,6 @@ import static org.dita.dost.util.URLUtils.*;
 
 import java.net.URI;
 import java.util.Optional;
-
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.util.*;
 import org.xml.sax.Attributes;
@@ -31,7 +30,6 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
         this.keys = keys;
     }
 
-
     // XML filter methods ------------------------------------------------------
 
     @Override
@@ -39,7 +37,8 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
             throws SAXException {
         AttributesImpl resAtts = null;
         final String conkeyref = atts.getValue(ATTRIBUTE_NAME_CONKEYREF);
-        conkeyref: if (conkeyref != null) {
+        conkeyref:
+        if (conkeyref != null) {
             final int keyIndex = conkeyref.indexOf(SLASH);
             final String key = keyIndex != -1 ? conkeyref.substring(0, keyIndex) : conkeyref;
             final KeyDef keyDef = keys.get(key);
@@ -60,10 +59,14 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
                     }
                     XMLUtils.addOrSetAttribute(resAtts, ATTRIBUTE_NAME_CONREF, target.toString());
                 } else {
-                    logger.warn(MessageUtils.getMessage("DOTJ060W", key, conkeyref).setLocation(atts).toString());
+                    logger.warn(MessageUtils.getMessage("DOTJ060W", key, conkeyref)
+                            .setLocation(atts)
+                            .toString());
                 }
             } else {
-                logger.error(MessageUtils.getMessage("DOTJ046E", conkeyref).setLocation(atts).toString());
+                logger.error(MessageUtils.getMessage("DOTJ046E", conkeyref)
+                        .setLocation(atts)
+                        .toString());
             }
         }
         getContentHandler().startElement(uri, localName, name, resAtts != null ? resAtts : atts);
@@ -77,9 +80,8 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
      * @return updated href URI
      */
     private URI getRelativePath(final URI keyMap, final URI href) {
-        final URI inputMap = Optional.ofNullable(job.getFileInfo(keyMap))
-                .map(fi -> fi.uri)
-                .orElse(null);
+        final URI inputMap =
+                Optional.ofNullable(job.getFileInfo(keyMap)).map(fi -> fi.uri).orElse(null);
         final URI keyValue;
         if (inputMap != null) {
             final URI tmpMap = job.tempDirURI.resolve(inputMap);
@@ -89,5 +91,4 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
         }
         return URLUtils.getRelativePath(currentFile, keyValue);
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/ConrefPushParser.java
+++ b/src/main/java/org/dita/dost/writer/ConrefPushParser.java
@@ -1,28 +1,27 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
-
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.DitaClass;
-import org.dita.dost.util.Job.FileInfo;
-import org.w3c.dom.*;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Map;
 
 import static org.apache.commons.io.FilenameUtils.normalize;
 import static org.dita.dost.reader.ConrefPushReader.MoveKey;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toURI;
 import static org.dita.dost.util.XMLUtils.*;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.DitaClass;
+import org.dita.dost.util.Job.FileInfo;
+import org.w3c.dom.*;
 
 /**
  * This class is for writing conref push contents into
@@ -51,7 +50,8 @@ public final class ConrefPushParser extends AbstractDomFilter {
         super.read(filename);
 
         for (final MoveKey key : movetable.keySet()) {
-            logger.warn(MessageUtils.getMessage("DOTJ043W", key.idPath(), filename.getPath()).toString());
+            logger.warn(MessageUtils.getMessage("DOTJ043W", key.idPath(), filename.getPath())
+                    .toString());
         }
         if (hasConref || hasKeyref) {
             updateList(filename);
@@ -71,7 +71,8 @@ public final class ConrefPushParser extends AbstractDomFilter {
      */
     private void updateList(final File filename) {
         try {
-            final URI relativePath = toURI(filename.getAbsolutePath().substring(new File(normalize(tempDir.toString())).getPath().length() + 1));
+            final URI relativePath = toURI(filename.getAbsolutePath()
+                    .substring(new File(normalize(tempDir.toString())).getPath().length() + 1));
             final FileInfo f = job.getOrCreateFileInfo(relativePath);
             if (hasConref) {
                 f.hasConref = true;
@@ -120,11 +121,17 @@ public final class ConrefPushParser extends AbstractDomFilter {
                     final Element elem = (Element) node;
                     final DitaClass cls = DitaClass.getInstance(elem);
                     // get type of the target element
-                    final String type = targetClassAttribute.toString().substring(1, targetClassAttribute.toString().indexOf("/")).trim();
+                    final String type = targetClassAttribute
+                            .toString()
+                            .substring(1, targetClassAttribute.toString().indexOf("/"))
+                            .trim();
                     if (!cls.equals(targetClassAttribute) && targetClassAttribute.matches(cls)) {
                         // Specializing the pushing content is not handled here
                         // but we can catch such a situation to emit a warning by comparing the class values.
-                        final String targetElementName = targetClassAttribute.toString().substring(targetClassAttribute.toString().indexOf("/") + 1).trim();
+                        final String targetElementName = targetClassAttribute
+                                .toString()
+                                .substring(targetClassAttribute.toString().indexOf("/") + 1)
+                                .trim();
                         if (elem.getAttributeNode(ATTRIBUTE_NAME_CONREF) != null) {
                             hasConref = true;
                         }
@@ -137,7 +144,7 @@ public final class ConrefPushParser extends AbstractDomFilter {
                         for (int j = 0; j < nList.getLength(); j++) {
                             final Node subNode = nList.item(j);
                             if (subNode.getNodeType() == Node.ELEMENT_NODE) {
-                                //replace the subElement Name
+                                // replace the subElement Name
                                 replaceSubElementName(type, (Element) subNode);
                             }
                         }
@@ -162,7 +169,9 @@ public final class ConrefPushParser extends AbstractDomFilter {
         if (cls != null) {
             if (cls.toString().contains(type) && !type.equals(STRING_BLANK)) {
                 final int index = cls.toString().indexOf("/");
-                generalizedElemName = cls.toString().substring(index + 1, cls.toString().indexOf(STRING_BLANK, index)).trim();
+                generalizedElemName = cls.toString()
+                        .substring(index + 1, cls.toString().indexOf(STRING_BLANK, index))
+                        .trim();
             }
         }
         elem.getOwnerDocument().renameNode(elem, elem.getNamespaceURI(), generalizedElemName);
@@ -175,8 +184,8 @@ public final class ConrefPushParser extends AbstractDomFilter {
         }
     }
 
-    private MoveKey hasAction(final DitaClass classValue, final String idPath, final String defaultIdPath,
-                              final String action) {
+    private MoveKey hasAction(
+            final DitaClass classValue, final String idPath, final String defaultIdPath, final String action) {
         if (movetable.containsKey(new MoveKey(idPath, action))) {
             final MoveKey containkey = new MoveKey(idPath, action);
             if (isPushedTypeMatch(classValue, movetable.get(containkey))) {

--- a/src/main/java/org/dita/dost/writer/DebugFilter.java
+++ b/src/main/java/org/dita/dost/writer/DebugFilter.java
@@ -7,17 +7,16 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.util.HashMap;
+import java.util.Map;
 import org.dita.dost.util.DitaClass;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Add debug attributes.
@@ -68,14 +67,10 @@ public final class DebugFilter extends AbstractXMLFilter {
             counterMap.put(qName, nextValue);
             final StringBuilder xtrc = new StringBuilder(qName).append(COLON).append(nextValue);
             if (locator != null) {
-                xtrc.append(';')
-                    .append(locator.getLineNumber())
-                    .append(COLON)
-                    .append(locator.getColumnNumber());
+                xtrc.append(';').append(locator.getLineNumber()).append(COLON).append(locator.getColumnNumber());
             }
             XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_XTRC, xtrc.toString());
         }
         super.startElement(uri, localName, qName, res);
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaIndexWriter.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import static org.apache.commons.io.FileUtils.*;
@@ -22,7 +22,6 @@ import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-
 
 /*
  * Created on 2004-12-17
@@ -43,15 +42,16 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
     private String indexEntries;
     /** topic path that topicIdList need to match */
     private List<String> matchList;
+
     private OutputStreamWriter output;
     private final XMLReader reader;
     /** whether to insert links at this topic */
     private boolean startTopic;
     /** array list that is used to keep the hierarchy of topic id */
     private final List<String> topicIdList;
+
     private boolean hasWritten;
     private int topicLevel = -1;
-
 
     /**
      * Default constructor of DitaIndexWriter class.
@@ -74,17 +74,14 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         } catch (final Exception e) {
             throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
         }
-
     }
 
-
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         try {
             writeCharacters(ch, start, length);
         } catch (final IOException e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -107,20 +104,23 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         try {
             output.flush();
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (!startTopic) {
             topicIdList.remove(topicIdList.size() - 1);
         }
         try {
             if (!hasMetadataTillNow && TOPIC_PROLOG.localName.equals(qName) && startTopic && !hasWritten) {
 
-                writeStartElement(TOPIC_METADATA.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString()).build());
+                writeStartElement(
+                        TOPIC_METADATA.localName,
+                        new AttributesBuilder()
+                                .add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString())
+                                .build());
                 output.write(indexEntries);
                 writeEndElement(TOPIC_METADATA.localName);
                 hasMetadataTillNow = true;
@@ -129,8 +129,16 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
             writeEndElement(qName);
             if (!hasPrologTillNow && startTopic && !hasWritten) {
                 // if <prolog> don't exist
-                writeStartElement(TOPIC_PROLOG.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_PROLOG.toString()).build());
-                writeStartElement(TOPIC_METADATA.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString()).build());
+                writeStartElement(
+                        TOPIC_PROLOG.localName,
+                        new AttributesBuilder()
+                                .add(ATTRIBUTE_NAME_CLASS, TOPIC_PROLOG.toString())
+                                .build());
+                writeStartElement(
+                        TOPIC_METADATA.localName,
+                        new AttributesBuilder()
+                                .add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString())
+                                .build());
                 output.write(indexEntries);
                 writeEndElement(TOPIC_METADATA.localName);
                 writeEndElement(TOPIC_PROLOG.localName);
@@ -140,22 +148,22 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
     private boolean hasMetadata(final String qName) {
-        //check whether there is <metadata> in <prolog> element
-        //if there is <prolog> element and there is no <metadata> element before
-        //and current element is <resourceid>, then there is no <metadata> in current
-        //<prolog> element. return false.
+        // check whether there is <metadata> in <prolog> element
+        // if there is <prolog> element and there is no <metadata> element before
+        // and current element is <resourceid>, then there is no <metadata> in current
+        // <prolog> element. return false.
         return !(hasPrologTillNow && !hasMetadataTillNow && TOPIC_RESOURCEID.localName.equals(qName));
     }
 
     private boolean hasProlog(final Attributes atts) {
-        //check whether there is <prolog> in the current topic
-        //if current element is <body> and there is no <prolog> before
-        //then this topic has no <prolog> and return false
+        // check whether there is <prolog> in the current topic
+        // if current element is <body> and there is no <prolog> before
+        // then this topic has no <prolog> and return false
 
         if (atts.getValue(ATTRIBUTE_NAME_CLASS) != null) {
             if (!hasPrologTillNow) {
@@ -172,8 +180,7 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
                     } else {
                         return false;
                     }
-                    return false;  //Eric
-
+                    return false; // Eric
                 }
             }
         }
@@ -181,22 +188,20 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
     }
 
     @Override
-    public void ignorableWhitespace(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
         try {
             writeCharacters(ch, start, length);
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
     @Override
-    public void processingInstruction(final String target, final String data)
-            throws SAXException {
+    public void processingInstruction(final String target, final String data) throws SAXException {
         try {
             writeProcessingInstruction(target, data);
         } catch (final IOException e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -221,15 +226,23 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-            final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
 
         try {
             if (topicLevel != -1) {
                 if (!hasProlog(atts) && startTopic && !hasWritten) {
                     // if <prolog> don't exist
-                    writeStartElement(TOPIC_PROLOG.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_PROLOG.toString()).build());
-                    writeStartElement(TOPIC_METADATA.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString()).build());
+                    writeStartElement(
+                            TOPIC_PROLOG.localName,
+                            new AttributesBuilder()
+                                    .add(ATTRIBUTE_NAME_CLASS, TOPIC_PROLOG.toString())
+                                    .build());
+                    writeStartElement(
+                            TOPIC_METADATA.localName,
+                            new AttributesBuilder()
+                                    .add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString())
+                                    .build());
                     output.write(indexEntries);
                     writeEndElement(TOPIC_METADATA.localName);
                     writeEndElement(TOPIC_PROLOG.localName);
@@ -244,13 +257,17 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
                     topicIdList.add("null");
                 }
                 if (topicIdList.size() >= matchList.size()) {
-                    //To access topic by id globally
+                    // To access topic by id globally
                     startTopic = checkMatch();
                 }
             }
 
             if (!hasMetadata(qName) && startTopic && !hasWritten) {
-                writeStartElement(TOPIC_METADATA.localName, new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString()).build());
+                writeStartElement(
+                        TOPIC_METADATA.localName,
+                        new AttributesBuilder()
+                                .add(ATTRIBUTE_NAME_CLASS, TOPIC_METADATA.toString())
+                                .build());
                 output.write(indexEntries);
                 writeEndElement(TOPIC_METADATA.localName);
                 hasMetadataTillNow = true;
@@ -273,7 +290,7 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -287,12 +304,12 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
 
         try {
             if (filename.endsWith(SHARP)) {
-                filename = filename.substring(0, filename.length()-1);
+                filename = filename.substring(0, filename.length() - 1);
             }
 
             if (filename.lastIndexOf(SHARP) != -1) {
                 file = filename.substring(0, filename.lastIndexOf(SHARP));
-                topic = filename.substring(filename.lastIndexOf(SHARP)+1);
+                topic = filename.substring(filename.lastIndexOf(SHARP) + 1);
                 setMatch(topic);
                 startTopic = false;
             } else {
@@ -313,13 +330,13 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         } catch (final RuntimeException e) {
             throw e;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e) ;
-        }finally {
+            logger.error(e.getMessage(), e);
+        } finally {
             if (output != null) {
                 try {
                     output.close();
                 } catch (final Exception e) {
-                    logger.error(e.getMessage(), e) ;
+                    logger.error(e.getMessage(), e);
                 }
             }
         }
@@ -358,5 +375,4 @@ public final class DitaIndexWriter extends AbstractXMLWriter {
         final String pi = data != null ? target + STRING_BLANK + data : target;
         output.write(LESS_THAN + QUESTION + pi + QUESTION + GREATER_THAN);
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
@@ -1,13 +1,26 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.getRelativePath;
+import static org.dita.dost.util.XMLUtils.AttributesBuilder;
+import static org.dita.dost.util.XMLUtils.getChildElements;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Map;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.StringUtils;
@@ -20,20 +33,6 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.XMLFilterImpl;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Map;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.getRelativePath;
-import static org.dita.dost.util.XMLUtils.AttributesBuilder;
-import static org.dita.dost.util.XMLUtils.getChildElements;
-
 /**
  * Read DITA topic file and insert map links information into it.
  */
@@ -45,6 +44,7 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
     private Map<String, Element> indexEntries;
     /** Stack of topic IDs. */
     private Deque<String> topicIdStack;
+
     private final ArrayList<String> topicSpecList;
     private static final Attributes relatedLinksAtts = new AttributesBuilder()
             .add(ATTRIBUTE_NAME_CLASS, TOPIC_RELATED_LINKS.toString())
@@ -106,9 +106,15 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
             topicIdStack.addFirst(atts.getValue(ATTRIBUTE_NAME_ID));
             if (curMatchTopic != null && !firstTopic) {
                 try {
-                    getContentHandler().startElement(NULL_NS_URI, TOPIC_RELATED_LINKS.localName, TOPIC_RELATED_LINKS.localName, relatedLinksAtts);
+                    getContentHandler()
+                            .startElement(
+                                    NULL_NS_URI,
+                                    TOPIC_RELATED_LINKS.localName,
+                                    TOPIC_RELATED_LINKS.localName,
+                                    relatedLinksAtts);
                     domToSax(indexEntries.get(curMatchTopic));
-                    getContentHandler().endElement(NULL_NS_URI, TOPIC_RELATED_LINKS.localName, TOPIC_RELATED_LINKS.localName);
+                    getContentHandler()
+                            .endElement(NULL_NS_URI, TOPIC_RELATED_LINKS.localName, TOPIC_RELATED_LINKS.localName);
                     curMatchTopic = null;
                 } catch (final RuntimeException e) {
                     throw e;
@@ -146,7 +152,12 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
         }
         if (curMatchTopic != null && topicSpecList.contains(localName)) {
             // if <TOPIC_RELATED_LINKS> doesn't exist
-            getContentHandler().startElement(NULL_NS_URI, TOPIC_RELATED_LINKS.localName, TOPIC_RELATED_LINKS.localName, relatedLinksAtts);
+            getContentHandler()
+                    .startElement(
+                            NULL_NS_URI,
+                            TOPIC_RELATED_LINKS.localName,
+                            TOPIC_RELATED_LINKS.localName,
+                            relatedLinksAtts);
             domToSax(indexEntries.get(curMatchTopic));
             getContentHandler().endElement(NULL_NS_URI, TOPIC_RELATED_LINKS.localName, TOPIC_RELATED_LINKS.localName);
             curMatchTopic = null;
@@ -172,8 +183,8 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
     /** Relativize links */
     private Element rewriteLinks(final Element src) {
         final Element dst = (Element) src.cloneNode(true);
-        for (final Element desc: getChildElements(dst, TOPIC_DESC, true)) {
-            for (final Element elem: getChildElements(desc, true)) {
+        for (final Element desc : getChildElements(dst, TOPIC_DESC, true)) {
+            for (final Element elem : getChildElements(desc, true)) {
                 final Attr href = elem.getAttributeNode(ATTRIBUTE_NAME_HREF);
                 final String scope = elem.getAttribute(ATTRIBUTE_NAME_SCOPE);
                 if (href != null && !scope.equals(ATTR_SCOPE_VALUE_EXTERNAL)) {
@@ -202,7 +213,5 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
         public void endDocument() throws SAXException {
             // ignore
         }
-
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMapMetaWriter.java
@@ -7,22 +7,19 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.util.*;
 import org.dita.dost.util.DitaClass;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Reads map files and inserts the metadata.
  */
 public final class DitaMapMetaWriter extends AbstractDitaMetaWriter {
 
-    private static final List<DitaClass> topicmetaPosition = Collections.singletonList(
-            TOPIC_TITLE
-    );
+    private static final List<DitaClass> topicmetaPosition = Collections.singletonList(TOPIC_TITLE);
     private static final List<DitaClass> topicmetaOrder = Collections.unmodifiableList(Arrays.asList(
             TOPIC_NAVTITLE,
             MAP_LINKTEXT,
@@ -47,8 +44,7 @@ public final class DitaMapMetaWriter extends AbstractDitaMetaWriter {
             TOPIC_DATA,
             TOPIC_DATA_ABOUT,
             TOPIC_FOREIGN,
-            TOPIC_UNKNOWN
-    ));
+            TOPIC_UNKNOWN));
 
     public Document process(final Document doc) {
         Element root = getMatchingTopicElement(doc.getDocumentElement());
@@ -58,5 +54,4 @@ public final class DitaMapMetaWriter extends AbstractDitaMetaWriter {
         }
         return doc;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaMetaWriter.java
@@ -7,33 +7,24 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.util.*;
 import org.dita.dost.util.DitaClass;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
-import java.util.*;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Reads topic files and inserts the metadata.
  */
 public final class DitaMetaWriter extends AbstractDitaMetaWriter {
 
-    private static final List<DitaClass> titlealtsPosition = Collections.unmodifiableList(Collections.singletonList(
-            TOPIC_TITLE
-    ));
-    private static final List<DitaClass> titlealtsOrder = Collections.unmodifiableList(Arrays.asList(
-            TOPIC_NAVTITLE,
-            MAP_SEARCHTITLE,
-            TOPIC_SEARCHTITLE
-    ));
-    private static final List<DitaClass> prologPosition = Collections.unmodifiableList(Arrays.asList(
-            TOPIC_TITLE,
-            TOPIC_TITLEALTS,
-            TOPIC_SHORTDESC,
-            TOPIC_ABSTRACT
-    ));
+    private static final List<DitaClass> titlealtsPosition =
+            Collections.unmodifiableList(Collections.singletonList(TOPIC_TITLE));
+    private static final List<DitaClass> titlealtsOrder =
+            Collections.unmodifiableList(Arrays.asList(TOPIC_NAVTITLE, MAP_SEARCHTITLE, TOPIC_SEARCHTITLE));
+    private static final List<DitaClass> prologPosition =
+            Collections.unmodifiableList(Arrays.asList(TOPIC_TITLE, TOPIC_TITLEALTS, TOPIC_SHORTDESC, TOPIC_ABSTRACT));
     private static final List<DitaClass> prologOrder = Collections.unmodifiableList(Arrays.asList(
             TOPIC_AUTHOR,
             TOPIC_SOURCE,
@@ -46,23 +37,11 @@ public final class DitaMetaWriter extends AbstractDitaMetaWriter {
             TOPIC_DATA,
             TOPIC_DATA_ABOUT,
             TOPIC_FOREIGN,
-            TOPIC_UNKNOWN
-    ));
+            TOPIC_UNKNOWN));
     private static final List<DitaClass> metadataPosition = Collections.unmodifiableList(Arrays.asList(
-            TOPIC_AUTHOR,
-            TOPIC_SOURCE,
-            TOPIC_PUBLISHER,
-            TOPIC_COPYRIGHT,
-            TOPIC_CRITDATES,
-            TOPIC_PERMISSIONS
-    ));
-    private static final List<DitaClass> metadataOrder = Collections.unmodifiableList(Arrays.asList(
-            TOPIC_AUDIENCE,
-            TOPIC_CATEGORY,
-            TOPIC_KEYWORDS,
-            TOPIC_PRODINFO,
-            TOPIC_OTHERMETA
-    ));
+            TOPIC_AUTHOR, TOPIC_SOURCE, TOPIC_PUBLISHER, TOPIC_COPYRIGHT, TOPIC_CRITDATES, TOPIC_PERMISSIONS));
+    private static final List<DitaClass> metadataOrder = Collections.unmodifiableList(
+            Arrays.asList(TOPIC_AUDIENCE, TOPIC_CATEGORY, TOPIC_KEYWORDS, TOPIC_PRODINFO, TOPIC_OTHERMETA));
 
     public Document process(final Document doc) {
         final Element root = getMatchingTopicElement(doc.getDocumentElement());
@@ -83,5 +62,4 @@ public final class DitaMetaWriter extends AbstractDitaMetaWriter {
         }
         return doc;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -1,31 +1,29 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2004, 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2004, 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
+import static org.dita.dost.reader.GenListModuleReader.*;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.DitaUtils.isLocalScope;
+import static org.dita.dost.util.URLUtils.*;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import org.dita.dost.module.DebugAndFilterModule;
 import org.dita.dost.module.reader.TempFileNameScheme;
 import org.dita.dost.util.*;
 import org.dita.dost.util.Job.FileInfo;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
-import org.dita.dost.module.DebugAndFilterModule;
-
-import javax.xml.namespace.QName;
-import java.io.File;
-import java.net.URI;
-import java.util.Map;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.DitaUtils.isLocalScope;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.reader.GenListModuleReader.*;
-
 
 /**
  * Insert document PIs and normalize attributes.
@@ -60,10 +58,10 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
     private File outputFile;
     /** File infos by src. */
     private Map<URI, FileInfo> fileInfoMap;
+
     private TempFileNameScheme tempFileNameScheme;
 
-    public DitaWriterFilter() {
-    }
+    public DitaWriterFilter() {}
 
     public void setTempFileNameScheme(TempFileNameScheme tempFileNameScheme) {
         this.tempFileNameScheme = tempFileNameScheme;
@@ -74,7 +72,7 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
      * @param defaultMap default value map
      */
     public void setDefaultValueMap(final Map<QName, Map<String, String>> defaultMap) {
-        defaultValueMap  = defaultMap;
+        defaultValueMap = defaultMap;
     }
 
     public void setOutputFile(final File outputFile) {
@@ -84,8 +82,7 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
     // ContentHandler methods
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         getContentHandler().endElement(uri, localName, qName);
     }
 
@@ -93,38 +90,48 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
     public void startDocument() throws SAXException {
         // XXX May be require fixup
         final URI relativeToMap = URLUtils.getRelativePath(job.getInputFile(), currentFile);
-        final File path2Project = DebugAndFilterModule.getPathtoProject(toFile(relativeToMap),
-                toFile(currentFile),
-                toFile(job.getInputFile()),
-                job);
-        final File path2rootmap = toFile(getRelativePath(currentFile, job.getInputFile())).getParentFile();
+        final File path2Project = DebugAndFilterModule.getPathtoProject(
+                toFile(relativeToMap), toFile(currentFile), toFile(job.getInputFile()), job);
+        final File path2rootmap =
+                toFile(getRelativePath(currentFile, job.getInputFile())).getParentFile();
         getContentHandler().startDocument();
         if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-            getContentHandler().processingInstruction(PI_WORKDIR_TARGET, outputFile.getParentFile().getAbsolutePath());
+            getContentHandler()
+                    .processingInstruction(
+                            PI_WORKDIR_TARGET, outputFile.getParentFile().getAbsolutePath());
         } else {
-            getContentHandler().processingInstruction(PI_WORKDIR_TARGET, UNIX_SEPARATOR + outputFile.getParentFile().getAbsolutePath());
+            getContentHandler()
+                    .processingInstruction(
+                            PI_WORKDIR_TARGET,
+                            UNIX_SEPARATOR + outputFile.getParentFile().getAbsolutePath());
         }
-        getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
-        getContentHandler().processingInstruction(PI_WORKDIR_TARGET_URI, outputFile.toURI().resolve(".").toString());
-        getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
+        getContentHandler().ignorableWhitespace(new char[] {'\n'}, 0, 1);
+        getContentHandler()
+                .processingInstruction(
+                        PI_WORKDIR_TARGET_URI, outputFile.toURI().resolve(".").toString());
+        getContentHandler().ignorableWhitespace(new char[] {'\n'}, 0, 1);
         if (path2Project != null) {
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET, path2Project.getPath() + File.separator);
-            getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET_URI, toURI(path2Project).toString() + URI_SEPARATOR);
+            getContentHandler()
+                    .processingInstruction(
+                            PI_PATH2PROJ_TARGET_URI, toURI(path2Project).toString() + URI_SEPARATOR);
         } else {
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET, "");
             getContentHandler().processingInstruction(PI_PATH2PROJ_TARGET_URI, "." + URI_SEPARATOR);
         }
         if (path2rootmap != null) {
-            getContentHandler().processingInstruction(PI_PATH2ROOTMAP_TARGET_URI, toURI(path2rootmap).toString() + URI_SEPARATOR);
+            getContentHandler()
+                    .processingInstruction(
+                            PI_PATH2ROOTMAP_TARGET_URI, toURI(path2rootmap).toString() + URI_SEPARATOR);
         } else {
             getContentHandler().processingInstruction(PI_PATH2ROOTMAP_TARGET_URI, "." + URI_SEPARATOR);
         }
-        getContentHandler().ignorableWhitespace(new char[]{'\n'}, 0, 1);
+        getContentHandler().ignorableWhitespace(new char[] {'\n'}, 0, 1);
     }
 
     @Override
-    public void startElement(final String uri, final String localName, final String qName,
-                             final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
         final AttributesImpl res = new AttributesImpl();
         processAttributes(qName, atts, res);
 
@@ -145,8 +152,10 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
             final String origValue = atts.getValue(i);
             String attValue = origValue;
             if (ATTRIBUTE_NAME_CONREF.equals(attQName.getLocalPart())) {
-                attValue = replaceHREF(QName.valueOf(ATTRIBUTE_NAME_CONREF), atts).toString();
-            } else if (ATTRIBUTE_NAME_HREF.equals(attQName.getLocalPart()) || ATTRIBUTE_NAME_COPY_TO.equals(attQName.getLocalPart())) {
+                attValue =
+                        replaceHREF(QName.valueOf(ATTRIBUTE_NAME_CONREF), atts).toString();
+            } else if (ATTRIBUTE_NAME_HREF.equals(attQName.getLocalPart())
+                    || ATTRIBUTE_NAME_COPY_TO.equals(attQName.getLocalPart())) {
                 if (isLocalScope(atts.getValue(ATTRIBUTE_NAME_SCOPE))) {
                     attValue = replaceHREF(attQName, atts).toString();
                 }
@@ -157,13 +166,20 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
                 if (isFormatDita(format) && isLocalScope(scope)) {
                     attValue = ATTR_FORMAT_VALUE_DITA;
                     if (!format.equals(ATTR_FORMAT_VALUE_DITA)) {
-                        XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTRIBUTE_NAME_ORIG_FORMAT, DITA_OT_NS_PREFIX + ":" + ATTRIBUTE_NAME_ORIG_FORMAT, "CDATA", format);
+                        XMLUtils.addOrSetAttribute(
+                                res,
+                                DITA_OT_NS,
+                                ATTRIBUTE_NAME_ORIG_FORMAT,
+                                DITA_OT_NS_PREFIX + ":" + ATTRIBUTE_NAME_ORIG_FORMAT,
+                                "CDATA",
+                                format);
                     }
                 }
             } else {
                 attValue = getAttributeValue(qName, attQName, attValue);
             }
-            XMLUtils.addOrSetAttribute(res, atts.getURI(i), atts.getLocalName(i), atts.getQName(i), atts.getType(i), attValue);
+            XMLUtils.addOrSetAttribute(
+                    res, atts.getURI(i), atts.getLocalName(i), atts.getQName(i), atts.getType(i), attValue);
         }
     }
 
@@ -211,7 +227,8 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
                     final URI targetTemp = job.tempDirURI.resolve(f.uri);
                     attValue = getRelativePath(currrentFileTemp, targetTemp);
                 } else if (tempFileNameScheme != null) {
-                    final URI currrentFileTemp = job.tempDirURI.resolve(tempFileNameScheme.generateTempFileName(currentFile));
+                    final URI currrentFileTemp =
+                            job.tempDirURI.resolve(tempFileNameScheme.generateTempFileName(currentFile));
                     final URI targetTemp = job.tempDirURI.resolve(tempFileNameScheme.generateTempFileName(current));
                     final URI relativePath = getRelativePath(currrentFileTemp, targetTemp);
                     attValue = relativePath;
@@ -227,5 +244,4 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
         }
         return attValue;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/HTMLIndexWriter.java
+++ b/src/main/java/org/dita/dost/writer/HTMLIndexWriter.java
@@ -1,11 +1,11 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2005 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2005 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import static javax.xml.transform.OutputKeys.*;
@@ -15,14 +15,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-
 import javax.xml.transform.Transformer;
-
-import org.xml.sax.SAXException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.index.IndexTerm;
 import org.dita.dost.index.IndexTermTarget;
 import org.dita.dost.util.XMLSerializer;
+import org.xml.sax.SAXException;
 
 /**
  * This class extends AbstractWriter, used to output IndexTerm list to CHM index
@@ -61,7 +59,7 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
             final int termNum = termList.size();
             for (int i = 0; i < termNum; i++) {
                 final IndexTerm term = termList.get(i);
-                //Add alphabetical headings:
+                // Add alphabetical headings:
                 if (i == 0) {
                     printLetter = term.getTermFullName().substring(0, 1);
                     serializer.writeCharacters(printLetter);
@@ -71,7 +69,7 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
                     printLetter = firstLetter;
                     serializer.writeCharacters(printLetter);
                 }
-                //End alphabetical heading.
+                // End alphabetical heading.
                 outputIndexTerm(term, serializer);
             }
             serializer.writeEndElement(); // ul
@@ -85,7 +83,7 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
                 try {
                     out.close();
                 } catch (final IOException e) {
-                    logger.error(e.getMessage(), e) ;
+                    logger.error(e.getMessage(), e);
                 }
             }
         }
@@ -103,8 +101,8 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
 
         serializer.writeStartElement("li");
 
-        //if term doesn't have target to link to, it won't appear in the index tab
-        //we need to create links for such terms
+        // if term doesn't have target to link to, it won't appear in the index tab
+        // we need to create links for such terms
         if (targets.isEmpty()) {
             findTargets(term);
             targets = term.getTargetList();
@@ -137,7 +135,7 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
     private void findTargets(final IndexTerm term) {
         final List<IndexTerm> subTerms = term.getSubTerms();
         List<IndexTermTarget> subTargets;
-        if (subTerms != null && ! subTerms.isEmpty()) {
+        if (subTerms != null && !subTerms.isEmpty()) {
             for (final IndexTerm subTerm : subTerms) {
                 subTargets = subTerm.getTargetList();
                 if (subTargets != null && !subTargets.isEmpty()) {
@@ -157,5 +155,4 @@ public final class HTMLIndexWriter extends AbstractExtendDitaWriter {
     public String getIndexFileName(final String outputFileRoot) {
         return outputFileRoot + ".hhk";
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/IDitaTranstypeIndexWriter.java
+++ b/src/main/java/org/dita/dost/writer/IDitaTranstypeIndexWriter.java
@@ -1,15 +1,14 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import java.util.List;
-
 import org.dita.dost.index.IndexTerm;
 
 /**
@@ -26,5 +25,4 @@ public interface IDitaTranstypeIndexWriter {
     String getIndexFileName(String outputFileRoot);
 
     void setTermList(final List<IndexTerm> termList);
-
 }

--- a/src/main/java/org/dita/dost/writer/IExtendDitaWriter.java
+++ b/src/main/java/org/dita/dost/writer/IExtendDitaWriter.java
@@ -1,20 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2010 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2010 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
 import org.dita.dost.pipeline.PipelineHashIO;
 
-//RFE 2987769 Eclipse index-see
+// RFE 2987769 Eclipse index-see
 interface IExtendDitaWriter {
 
     PipelineHashIO getPipelineHashIO();
 
     void setPipelineHashIO(PipelineHashIO pipelineHashIO);
-
 }

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -7,8 +7,23 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.exists;
+import static org.dita.dost.util.URLUtils.toURI;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.reader.SvgMetadataReader;
 import org.dita.dost.util.Job;
@@ -18,23 +33,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.*;
 import org.xml.sax.helpers.AttributesImpl;
-
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.exists;
-import static org.dita.dost.util.URLUtils.toURI;
 
 /**
  * Image metadata filter.
@@ -111,8 +109,8 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     // XMLFilter methods -------------------------------------------------------
 
     @Override
-    public void startElement(final String uri, final String localName, final String name,
-            final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String name, final Attributes atts)
+            throws SAXException {
         if (TOPIC_IMAGE.matches(atts) || SVG_D_SVGREF.matches(atts)) {
             final XMLUtils.AttributesBuilder a = new XMLUtils.AttributesBuilder(atts);
             final URI href = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
@@ -164,7 +162,12 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
                 a.add(DITA_OT_NS, ATTR_IMAGE_HEIGHT, DITA_OT_NS_PREFIX + ":" + ATTR_IMAGE_HEIGHT, "CDATA", height);
             }
             if (horizontalDpi != null) {
-                a.add(DITA_OT_NS, ATTR_HORIZONTAL_DPI, DITA_OT_NS_PREFIX + ":" + ATTR_HORIZONTAL_DPI, "CDATA", horizontalDpi);
+                a.add(
+                        DITA_OT_NS,
+                        ATTR_HORIZONTAL_DPI,
+                        DITA_OT_NS_PREFIX + ":" + ATTR_HORIZONTAL_DPI,
+                        "CDATA",
+                        horizontalDpi);
             }
             if (verticalDpi != null) {
                 a.add(DITA_OT_NS, ATTR_VERTICAL_DPI, DITA_OT_NS_PREFIX + ":" + ATTR_VERTICAL_DPI, "CDATA", verticalDpi);
@@ -317,5 +320,4 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
 
         return null;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/LinkFilter.java
+++ b/src/main/java/org/dita/dost/writer/LinkFilter.java
@@ -8,7 +8,12 @@
 
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.addOrSetAttribute;
+
 import com.google.common.annotations.VisibleForTesting;
+import java.net.URI;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
@@ -16,18 +21,13 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
-import java.net.URI;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.addOrSetAttribute;
-
 public class LinkFilter extends AbstractXMLFilter {
 
     /**
      * Destination temporary file
      */
     private URI destFile;
+
     private URI base;
 
     @Override
@@ -73,7 +73,8 @@ public class LinkFilter extends AbstractXMLFilter {
 
     @VisibleForTesting
     URI getHref(final URI target) {
-        if (target.getFragment() != null && (target.getPath() == null || target.getPath().equals(""))) {
+        if (target.getFragment() != null
+                && (target.getPath() == null || target.getPath().equals(""))) {
             return target;
         }
         final URI targetAbs = stripFragment(currentFile.resolve(target));

--- a/src/main/java/org/dita/dost/writer/MapCleanFilter.java
+++ b/src/main/java/org/dita/dost/writer/MapCleanFilter.java
@@ -8,18 +8,19 @@
 
 package org.dita.dost.writer;
 
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
+import static org.dita.dost.util.Constants.*;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-
-import static org.dita.dost.util.Constants.*;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
 
 public class MapCleanFilter extends AbstractXMLFilter {
 
     private enum Keep {
-        RETAIN, DISCARD, DISCARD_BRANCH
+        RETAIN,
+        DISCARD,
+        DISCARD_BRANCH
     }
 
     private final Deque<Keep> stack = new ArrayDeque<>();
@@ -56,49 +57,45 @@ public class MapCleanFilter extends AbstractXMLFilter {
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (stack.removeFirst() == Keep.RETAIN) {
             getContentHandler().endElement(uri, localName, qName);
         }
     }
 
     @Override
-    public void characters(char[] ch, int start, int length)
-            throws SAXException {
+    public void characters(char[] ch, int start, int length) throws SAXException {
         if (stack.peekFirst() != Keep.DISCARD_BRANCH) {
             getContentHandler().characters(ch, start, length);
         }
     }
 
     @Override
-    public void ignorableWhitespace(char[] ch, int start, int length)
-            throws SAXException {
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
         if (stack.peekFirst() != Keep.DISCARD_BRANCH) {
             getContentHandler().ignorableWhitespace(ch, start, length);
         }
     }
 
     @Override
-    public void processingInstruction(String target, String data)
-            throws SAXException {
+    public void processingInstruction(String target, String data) throws SAXException {
         if (stack.isEmpty() || stack.peekFirst() != Keep.DISCARD_BRANCH) {
             getContentHandler().processingInstruction(target, data);
         }
     }
 
     @Override
-    public void skippedEntity(String name)
-            throws SAXException {
+    public void skippedEntity(String name) throws SAXException {
         if (stack.peekFirst() != Keep.DISCARD_BRANCH) {
             getContentHandler().skippedEntity(name);
         }
     }
 
-//    <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle ')]">
-//      <xsl:call-template name="output-message">
-//        <xsl:with-param name="id" select="'DOTX072I'"/>
-//      </xsl:call-template>
-//    </xsl:template>
+    //    <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle
+    // ')]">
+    //      <xsl:call-template name="output-message">
+    //        <xsl:with-param name="id" select="'DOTX072I'"/>
+    //      </xsl:call-template>
+    //    </xsl:template>
 
 }

--- a/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeCodeblock.java
@@ -7,14 +7,13 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_OUTPUTCLASS;
+import static org.dita.dost.util.Constants.PR_D_CODEBLOCK;
+
+import java.util.*;
 import org.dita.dost.util.SaxCache.*;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-
-import java.util.*;
-
-import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_OUTPUTCLASS;
-import static org.dita.dost.util.Constants.PR_D_CODEBLOCK;
 
 /**
  * Trim whitespace in codeblock elements.
@@ -28,8 +27,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     private final Collection<SaxEvent> buf = new ArrayList<>();
 
     @Override
-    public void startPrefixMapping(String prefix, String uri)
-            throws SAXException {
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
         if (depth > 0) {
             buf.add(new StartPrefixMappingEvent(prefix, uri));
         } else {
@@ -38,8 +36,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void endPrefixMapping(String prefix)
-            throws SAXException {
+    public void endPrefixMapping(String prefix) throws SAXException {
         if (depth > 0) {
             buf.add(new EndPrefixMappingEvent(prefix));
         } else {
@@ -48,9 +45,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void startElement(String uri, String localName, String qName,
-                             Attributes atts)
-            throws SAXException {
+    public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
         if (depth > 0) {
             depth++;
             buf.add(new StartElementEvent(uri, localName, qName, atts));
@@ -67,8 +62,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void endElement(String uri, String localName, String qName)
-            throws SAXException {
+    public void endElement(String uri, String localName, String qName) throws SAXException {
         if (depth > 0) {
             depth--;
             if (depth == 0) {
@@ -159,12 +153,8 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     private char[] stripLeadingSpace(boolean first, int prefix, char[] ch, int start, int length) {
-        final String str = first
-                ? new String(ch, start + prefix, length - prefix)
-                : new String(ch, start, length);
-        return str
-                .replaceAll("\n {" + prefix + "}", "\n")
-                .toCharArray();
+        final String str = first ? new String(ch, start + prefix, length - prefix) : new String(ch, start, length);
+        return str.replaceAll("\n {" + prefix + "}", "\n").toCharArray();
     }
 
     int countLeadingSpace(String ch) {
@@ -177,8 +167,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void characters(char[] ch, int start, int length)
-            throws SAXException {
+    public void characters(char[] ch, int start, int length) throws SAXException {
         if (depth > 0) {
             buf.add(new CharactersEvent(ch, start, length));
         } else {
@@ -187,8 +176,7 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void ignorableWhitespace(char[] ch, int start, int length)
-            throws SAXException {
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
         if (depth > 0) {
             buf.add(new CharactersEvent(ch, start, length));
         } else {
@@ -197,13 +185,11 @@ public final class NormalizeCodeblock extends AbstractXMLFilter {
     }
 
     @Override
-    public void processingInstruction(String target, String data)
-            throws SAXException {
+    public void processingInstruction(String target, String data) throws SAXException {
         if (depth > 0) {
             buf.add(new ProcessingInstructionEvent(target, data));
         } else {
             super.processingInstruction(target, data);
         }
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/NormalizeFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeFilter.java
@@ -7,18 +7,17 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Configuration.configuration;
+import static org.dita.dost.util.Constants.*;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.dita.dost.util.Configuration;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
-
-import java.util.Arrays;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Configuration.configuration;
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Normalize content.
@@ -60,7 +59,9 @@ public final class NormalizeFilter extends AbstractXMLFilter {
                 if (res == null) {
                     res = new AttributesImpl(atts);
                 }
-                XMLUtils.addOrSetAttribute(res, ATTRIBUTE_NAME_CASCADE,
+                XMLUtils.addOrSetAttribute(
+                        res,
+                        ATTRIBUTE_NAME_CASCADE,
                         configuration.getOrDefault("default.cascade", ATTRIBUTE_CASCADE_VALUE_MERGE));
             }
         }
@@ -76,7 +77,8 @@ public final class NormalizeFilter extends AbstractXMLFilter {
             }
             final String specializations = atts.getValue(ATTRIBUTE_NAME_SPECIALIZATIONS);
             if (specializations != null) {
-                final String normalized = whitespace.matcher(specializations.trim()).replaceAll(" ");
+                final String normalized =
+                        whitespace.matcher(specializations.trim()).replaceAll(" ");
                 if (res == null) {
                     res = new AttributesImpl(atts);
                 }
@@ -89,7 +91,8 @@ public final class NormalizeFilter extends AbstractXMLFilter {
     }
 
     private String domainsToSpecializations(final String domains) {
-        return Arrays.stream(domains.trim().replaceAll("(\\))\\s+(a?\\()", "$1\n$2").split("\n"))
+        return Arrays.stream(
+                        domains.trim().replaceAll("(\\))\\s+(a?\\()", "$1\n$2").split("\n"))
                 .filter(token -> token.startsWith("a("))
                 .map(token -> "@" + token.substring(2, token.length() - 1).replace(' ', '/'))
                 .collect(Collectors.joining(" "));
@@ -110,5 +113,4 @@ public final class NormalizeFilter extends AbstractXMLFilter {
         }
         depth--;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
+++ b/src/main/java/org/dita/dost/writer/NormalizeSimpleTableFilter.java
@@ -7,15 +7,14 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.util.Constants.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
 import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Normalize simpletable content.
@@ -33,6 +32,7 @@ public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
 
     /** DITA class stack */
     private final Deque<String> classStack = new LinkedList<>();
+
     private int depth;
     private final Map<String, String> ns = new HashMap<>();
 
@@ -100,9 +100,11 @@ public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
         final int rowspan = getRowSpan(res);
         Span prev;
         if (tableState.previousRow != null) {
-            for (prev = tableState.previousRow.get(tableState.currentColumn); prev != null && prev.y > 1; prev = tableState.previousRow.get(tableState.currentColumn)) {
+            for (prev = tableState.previousRow.get(tableState.currentColumn);
+                    prev != null && prev.y > 1;
+                    prev = tableState.previousRow.get(tableState.currentColumn)) {
                 for (int i = 0; i < prev.x; i++) {
-                    tableState.currentColumn = tableState.currentColumn + 1; //prev.x - 1;
+                    tableState.currentColumn = tableState.currentColumn + 1; // prev.x - 1;
                     grow(tableState.currentRow, tableState.currentColumn + 1);
                 }
             }
@@ -114,8 +116,20 @@ public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
 
         tableState.currentRow.set(tableState.currentColumn, span);
 
-        XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_X, DITA_OT_NS_PREFIX + ":" + ATTR_X, "CDATA", Integer.toString(tableState.currentColumn + 1));
-        XMLUtils.addOrSetAttribute(res, DITA_OT_NS, ATTR_Y, DITA_OT_NS_PREFIX + ":" + ATTR_Y, "CDATA", Integer.toString(tableState.rowNumber));
+        XMLUtils.addOrSetAttribute(
+                res,
+                DITA_OT_NS,
+                ATTR_X,
+                DITA_OT_NS_PREFIX + ":" + ATTR_X,
+                "CDATA",
+                Integer.toString(tableState.currentColumn + 1));
+        XMLUtils.addOrSetAttribute(
+                res,
+                DITA_OT_NS,
+                ATTR_Y,
+                DITA_OT_NS_PREFIX + ":" + ATTR_Y,
+                "CDATA",
+                Integer.toString(tableState.rowNumber));
 
         tableState.currentColumn = tableState.currentColumn + colspan;
     }
@@ -163,12 +177,12 @@ public final class NormalizeSimpleTableFilter extends AbstractXMLFilter {
         }
     }
 
-    private record Span(int x, int y) {
-    }
+    private record Span(int x, int y) {}
 
     private static class TableState {
         /** Store row number */
         public int rowNumber = 0;
+
         public ArrayList<Span> previousRow;
         public ArrayList<Span> currentRow;
         public int currentColumn;

--- a/src/main/java/org/dita/dost/writer/ProfilingFilter.java
+++ b/src/main/java/org/dita/dost/writer/ProfilingFilter.java
@@ -7,19 +7,17 @@
  */
 package org.dita.dost.writer;
 
-import org.dita.dost.log.MessageUtils;
+import static org.dita.dost.util.Constants.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.xml.namespace.QName;
 import org.dita.dost.util.DitaClass;
 import org.dita.dost.util.FilterUtils;
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-
-import javax.xml.namespace.QName;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Constants.*;
 
 /**
  * Profiling filter strips out the content that is not necessary in the output.
@@ -40,6 +38,7 @@ public final class ProfilingFilter extends AbstractXMLFilter {
     private final Map<String, String> prefixes = new HashMap<>();
     /** Flag that last element was excluded. */
     private boolean lastElementExcluded = false;
+
     private final Deque<Set<Flag>> flagStack = new LinkedList<>();
     private final boolean doFlag;
 
@@ -92,7 +91,8 @@ public final class ProfilingFilter extends AbstractXMLFilter {
             throws SAXException {
         Set<Flag> flags = null;
 
-        final DitaClass cls = atts.getValue(ATTRIBUTE_NAME_CLASS) != null ? DitaClass.getInstance(atts) : DitaClass.getInstance("");
+        final DitaClass cls =
+                atts.getValue(ATTRIBUTE_NAME_CLASS) != null ? DitaClass.getInstance(atts) : DitaClass.getInstance("");
         if (cls.isValid() && (TOPIC_TOPIC.matches(cls) || MAP_MAP.matches(cls))) {
             final String domains = atts.getValue(ATTRIBUTE_NAME_DOMAINS);
             if (domains != null) {
@@ -114,7 +114,7 @@ public final class ProfilingFilter extends AbstractXMLFilter {
                 level = 0;
             } else {
                 elementOutput = true;
-                for (final Map.Entry<String, String> prefix: prefixes.entrySet()) {
+                for (final Map.Entry<String, String> prefix : prefixes.entrySet()) {
                     getContentHandler().startPrefixMapping(prefix.getKey(), prefix.getValue());
                 }
                 prefixes.clear();
@@ -124,7 +124,7 @@ public final class ProfilingFilter extends AbstractXMLFilter {
                             .flatMap(f -> f.getFlags(atts, props).stream())
                             .map(f -> f.adjustPath(currentFile, job))
                             .collect(Collectors.toSet());
-                    for (final Flag flag: flags) {
+                    for (final Flag flag : flags) {
                         flag.writeStartFlag(getContentHandler());
                     }
                 }
@@ -137,8 +137,7 @@ public final class ProfilingFilter extends AbstractXMLFilter {
     }
 
     @Override
-    public void endElement(final String uri, final String localName, final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         if (doFlag) {
             final Set<Flag> flags = flagStack.pop();
             if (flags != null) {
@@ -160,12 +159,10 @@ public final class ProfilingFilter extends AbstractXMLFilter {
         } else { // exclude shows whether it's excluded by filtering
             getContentHandler().endElement(uri, localName, qName);
         }
-
     }
 
     @Override
-    public void characters(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
         if (!exclude) {
             getContentHandler().characters(ch, start, length);
         }
@@ -186,16 +183,14 @@ public final class ProfilingFilter extends AbstractXMLFilter {
     }
 
     @Override
-    public void ignorableWhitespace(final char[] ch, final int start, final int length)
-            throws SAXException {
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
         if (!exclude) {
             getContentHandler().characters(ch, start, length);
         }
     }
 
     @Override
-    public void processingInstruction(final String target, final String data)
-            throws SAXException {
+    public void processingInstruction(final String target, final String data) throws SAXException {
         if (!exclude) {
             getContentHandler().processingInstruction(target, data);
         }
@@ -220,5 +215,4 @@ public final class ProfilingFilter extends AbstractXMLFilter {
     public void startPrefixMapping(final String prefix, final String uri) throws SAXException {
         prefixes.put(prefix, uri);
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/ResourceInsertFilter.java
+++ b/src/main/java/org/dita/dost/writer/ResourceInsertFilter.java
@@ -7,15 +7,14 @@
  */
 package org.dita.dost.writer;
 
-import org.dita.dost.util.XMLUtils.AttributesBuilder;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
 
 import java.net.URI;
 import java.util.List;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
+import org.dita.dost.util.XMLUtils.AttributesBuilder;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
 
 public final class ResourceInsertFilter extends AbstractXMLFilter {
 
@@ -35,11 +34,19 @@ public final class ResourceInsertFilter extends AbstractXMLFilter {
         if (!added) {
             for (URI resource : resources) {
                 logger.info("add resource " + resource);
-                super.startElement(NULL_NS_URI, MAP_TOPICREF.localName, MAP_TOPICREF.localName,
+                super.startElement(
+                        NULL_NS_URI,
+                        MAP_TOPICREF.localName,
+                        MAP_TOPICREF.localName,
                         getAttributes()
-                                .add(ATTRIBUTE_NAME_HREF, currentFile.resolve(".").relativize(resource).toString())
+                                .add(
+                                        ATTRIBUTE_NAME_HREF,
+                                        currentFile
+                                                .resolve(".")
+                                                .relativize(resource)
+                                                .toString())
                                 .add(ATTRIBUTE_NAME_PROCESSING_ROLE, ATTR_PROCESSING_ROLE_VALUE_RESOURCE_ONLY)
-//                                .add(ATTRIBUTE_NAME_FORMAT, FIXME)
+                                //                                .add(ATTRIBUTE_NAME_FORMAT, FIXME)
                                 .build());
                 super.endElement(NULL_NS_URI, MAP_TOPICREF.localName, MAP_TOPICREF.localName);
             }
@@ -50,5 +57,4 @@ public final class ResourceInsertFilter extends AbstractXMLFilter {
     private AttributesBuilder getAttributes() {
         return new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, MAP_TOPICREF.toString());
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -1,21 +1,19 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
 
-import org.dita.dost.util.Job.FileInfo;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
+import static org.dita.dost.module.GenMapAndTopicListModule.ELEMENT_STUB;
+import static org.dita.dost.reader.ChunkMapReader.*;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.StringUtils.split;
+import static org.dita.dost.util.URLUtils.*;
+import static org.dita.dost.util.XMLUtils.*;
 
 import java.io.*;
 import java.net.URI;
@@ -24,13 +22,14 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
-
-import static org.dita.dost.module.GenMapAndTopicListModule.ELEMENT_STUB;
-import static org.dita.dost.reader.ChunkMapReader.*;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.StringUtils.split;
-import static org.dita.dost.util.URLUtils.*;
-import static org.dita.dost.util.XMLUtils.*;
+import org.dita.dost.util.Job.FileInfo;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * Split topic into multiple files for {@code by-topic} chunking.
@@ -148,15 +147,15 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                 final FileInfo fi = generateFileInfo(outputFile);
                 job.add(fi);
 
-                changeTable.put(currentFile.resolve(parseFilePath),
-                        setFragment(outputFileName, id));
+                changeTable.put(currentFile.resolve(parseFilePath), setFragment(outputFileName, id));
                 // new generated file
                 changeTable.put(outputFileName, outputFileName);
             }
 
             // change the href value
-            final URI newHref = setFragment(getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), outputFileName),
-                                            firstTopicID != null ? firstTopicID : id);
+            final URI newHref = setFragment(
+                    getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), outputFileName),
+                    firstTopicID != null ? firstTopicID : id);
             rootTopicref.setAttribute(ATTRIBUTE_NAME_HREF, newHref.toString());
 
             include = false;
@@ -262,12 +261,8 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
         final URI tmp = tempFileNameScheme.generateTempFileName(dst);
 
         if (job.getFileInfo(tmp) == null) {
-            job.add(new FileInfo.Builder(srcFi)
-                    .result(dst)
-                    .uri(tmp)
-                    .build());
+            job.add(new FileInfo.Builder(srcFi).result(dst).uri(tmp).build());
         }
-
 
         return job.tempDirURI.resolve(tmp);
     }
@@ -282,7 +277,6 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
         final AttributesImpl attsMod = new AttributesImpl(atts);
         final String xmlLang = atts.getValue(ATTRIBUTE_NAME_XML_LANG);
         final String currentLang;
-
 
         if (skip && skipLevel > 0) {
             skipLevel++;
@@ -311,10 +305,10 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     output = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 
                     if (atts.getIndex(ATTRIBUTE_NAME_XML_LANG) < 0 && currentLang != null) {
-                        attsMod.addAttribute("", ATTRIBUTE_NAME_LANG, ATTRIBUTE_NAME_XML_LANG, "CDATA", currentLang );
+                        attsMod.addAttribute("", ATTRIBUTE_NAME_LANG, ATTRIBUTE_NAME_XML_LANG, "CDATA", currentLang);
                     }
-//                    final FileInfo fi = generateFileInfo(outputFile);
-//                    job.add(fi);
+                    //                    final FileInfo fi = generateFileInfo(outputFile);
+                    //                    job.add(fi);
 
                     changeTable.put(outputFile, outputFile);
                     if (id != null) {
@@ -326,18 +320,28 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
                     // write xml header and workdir PI to the new generated file
                     writeStartDocument(output);
                     if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-                        writeProcessingInstruction(output, PI_WORKDIR_TARGET, new File(currentFile).getParentFile().getAbsolutePath());
+                        writeProcessingInstruction(
+                                output,
+                                PI_WORKDIR_TARGET,
+                                new File(currentFile).getParentFile().getAbsolutePath());
                     } else {
-                        writeProcessingInstruction(output, PI_WORKDIR_TARGET, UNIX_SEPARATOR + currentFile.resolve("."));
+                        writeProcessingInstruction(
+                                output, PI_WORKDIR_TARGET, UNIX_SEPARATOR + currentFile.resolve("."));
                     }
-                    writeProcessingInstruction(output, PI_WORKDIR_TARGET_URI, currentFile.resolve(".").toString());
+                    writeProcessingInstruction(
+                            output,
+                            PI_WORKDIR_TARGET_URI,
+                            currentFile.resolve(".").toString());
 
                     // create a new child element in separate case topicref is equals to parameter
                     // element in separateChunk(Element element)
                     final Element newTopicref = rootTopicref.getOwnerDocument().createElement(MAP_TOPICREF.localName);
                     newTopicref.setAttribute(ATTRIBUTE_NAME_CLASS, MAP_TOPICREF.toString());
                     newTopicref.setAttribute(ATTRIBUTE_NAME_XTRF, ATTR_XTRF_VALUE_GENERATED);
-                    newTopicref.setAttribute(ATTRIBUTE_NAME_HREF, getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), outputFile).toString());
+                    newTopicref.setAttribute(
+                            ATTRIBUTE_NAME_HREF,
+                            getRelativePath(currentFile.resolve(FILE_NAME_STUB_DITAMAP), outputFile)
+                                    .toString());
 
                     final Element topic = searchForNode(topicDoc, id, ATTRIBUTE_NAME_ID, TOPIC_TOPIC);
                     final Element topicmeta = createTopicMeta(topic);
@@ -406,5 +410,4 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
 
         lang.pop();
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/TopicFragmentFilter.java
+++ b/src/main/java/org/dita/dost/writer/TopicFragmentFilter.java
@@ -13,7 +13,6 @@ import static org.dita.dost.util.XMLUtils.*;
 
 import java.net.URI;
 import java.util.*;
-
 import org.dita.dost.util.DitaClass;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -53,10 +52,7 @@ public final class TopicFragmentFilter extends AbstractXMLFilter {
     }
 
     @Override
-    public void startElement(final String uri,
-            final String localName,
-            final String qName,
-            final Attributes atts)
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
             throws SAXException {
         Attributes res = atts;
         final DitaClass cls = DitaClass.getInstance(atts);
@@ -64,7 +60,7 @@ public final class TopicFragmentFilter extends AbstractXMLFilter {
         if (TOPIC_TOPIC.matches(cls)) {
             topics.addFirst(atts.getValue(ATTRIBUTE_NAME_ID));
         } else {
-            for (final String attrName: attrNames) {
+            for (final String attrName : attrNames) {
                 URI href = toURI(atts.getValue(attrName));
                 if (href != null && isLocalDitaReference(atts, attrName)) {
                     final String fragment = href.getFragment();
@@ -92,15 +88,11 @@ public final class TopicFragmentFilter extends AbstractXMLFilter {
     }
 
     @Override
-    public void endElement(final String uri,
-            final String localName,
-            final String qName)
-            throws SAXException {
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
         final DitaClass cls = classes.removeFirst();
         if (TOPIC_TOPIC.matches(cls)) {
             topics.removeFirst();
         }
         super.endElement(uri, localName, qName);
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/TopicRefWriter.java
+++ b/src/main/java/org/dita/dost/writer/TopicRefWriter.java
@@ -1,27 +1,26 @@
 /*
- * This file is part of the DITA Open Toolkit project.
- *
- * Copyright 2007 IBM Corporation
- *
- * See the accompanying LICENSE file for applicable license.
+* This file is part of the DITA Open Toolkit project.
+*
+* Copyright 2007 IBM Corporation
+*
+* See the accompanying LICENSE file for applicable license.
 
- */
+*/
 package org.dita.dost.writer;
-
-import org.dita.dost.exception.DITAOTException;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.AttributesImpl;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Map;
 
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.DitaUtils.isLocalScope;
 import static org.dita.dost.util.FileUtils.getFragment;
 import static org.dita.dost.util.URLUtils.*;
 import static org.dita.dost.util.XMLUtils.addOrSetAttribute;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import org.dita.dost.exception.DITAOTException;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * TopicRefWriter which updates the linking elements' value according to the
@@ -47,7 +46,7 @@ public final class TopicRefWriter extends AbstractXMLFilter {
      * @param conflictTable conflictTable
      */
     public void setup(final Map<URI, URI> conflictTable) {
-        for (final Map.Entry<URI, URI> e: conflictTable.entrySet()) {
+        for (final Map.Entry<URI, URI> e : conflictTable.entrySet()) {
             assert e.getKey().isAbsolute();
             assert e.getValue().isAbsolute();
         }
@@ -56,7 +55,7 @@ public final class TopicRefWriter extends AbstractXMLFilter {
 
     public void setChangeTable(final Map<URI, URI> changeTable) {
         assert changeTable != null && !changeTable.isEmpty();
-        for (final Map.Entry<URI, URI> e: changeTable.entrySet()) {
+        for (final Map.Entry<URI, URI> e : changeTable.entrySet()) {
             assert e.getKey().isAbsolute();
             assert e.getValue().isAbsolute();
         }
@@ -116,8 +115,7 @@ public final class TopicRefWriter extends AbstractXMLFilter {
      */
     private boolean isLocalDita(final Attributes atts) {
         final String classValue = atts.getValue(ATTRIBUTE_NAME_CLASS);
-        if (classValue == null
-                || (TOPIC_IMAGE.matches(classValue))) {
+        if (classValue == null || (TOPIC_IMAGE.matches(classValue))) {
             return false;
         }
 
@@ -128,7 +126,6 @@ public final class TopicRefWriter extends AbstractXMLFilter {
         }
 
         return isLocalScope(scopeValue) && formatValue.equals(ATTR_FORMAT_VALUE_DITA);
-
     }
 
     private String updateData(final String origValue) {
@@ -179,14 +176,15 @@ public final class TopicRefWriter extends AbstractXMLFilter {
             }
 
             if (changeTarget == null) {
-                return hrefValue;// no change
+                return hrefValue; // no change
             } else {
                 final URI conTarget = conflictTable.get(stripFragment(changeTarget));
                 logger.debug("Update " + changeTarget + " to " + conTarget);
                 if (conTarget != null && !conTarget.toString().isEmpty()) {
                     final URI p = getRelativePath(rootPathName, conTarget);
                     if (elementID == null) {
-                        return setFragment(p, getElementID(changeTarget.toString())).toString();
+                        return setFragment(p, getElementID(changeTarget.toString()))
+                                .toString();
                     } else {
                         if (conTarget.getFragment() != null) {
                             if (!pathtoElem.contains(SLASH)) {
@@ -234,5 +232,4 @@ public final class TopicRefWriter extends AbstractXMLFilter {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/dita/dost/writer/include/AllRange.java
+++ b/src/main/java/org/dita/dost/writer/include/AllRange.java
@@ -8,12 +8,11 @@
 
 package org.dita.dost.writer.include;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import org.dita.dost.writer.CoderefResolver;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
-
-import java.io.BufferedReader;
-import java.io.IOException;
 
 public class AllRange implements Range {
 

--- a/src/main/java/org/dita/dost/writer/include/AnchorRange.java
+++ b/src/main/java/org/dita/dost/writer/include/AnchorRange.java
@@ -8,11 +8,10 @@
 
 package org.dita.dost.writer.include;
 
-import org.dita.dost.writer.CoderefResolver;
-import org.xml.sax.SAXException;
-
 import java.io.BufferedReader;
 import java.io.IOException;
+import org.dita.dost.writer.CoderefResolver;
+import org.xml.sax.SAXException;
 
 public class AnchorRange extends AllRange implements Range {
 

--- a/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeResolver.java
@@ -8,19 +8,18 @@
 
 package org.dita.dost.writer.include;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.util.Configuration;
-import org.dita.dost.writer.AbstractXMLFilter;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toURI;
 
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Deque;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toURI;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.util.Configuration;
+import org.dita.dost.writer.AbstractXMLFilter;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
 
 /**
  * Include element resolver filter.
@@ -61,16 +60,14 @@ public class IncludeResolver extends AbstractXMLFilter {
     private final Deque<Deque<StackItem>> includeStack = new ArrayDeque<>();
     private Configuration.Mode processingMode;
 
-    private record StackItem(String cls, boolean include) {
-    }
+    private record StackItem(String cls, boolean include) {}
 
     // Constructors ------------------------------------------------------------
 
     /**
      * Constructor.
      */
-    public IncludeResolver() {
-    }
+    public IncludeResolver() {}
 
     // AbstractWriter methods --------------------------------------------------
 
@@ -84,8 +81,7 @@ public class IncludeResolver extends AbstractXMLFilter {
     // XMLFilter methods -------------------------------------------------------
 
     @Override
-    public void startDocument()
-            throws SAXException {
+    public void startDocument() throws SAXException {
         final String mode = params.get(ANT_INVOKER_EXT_PARAM_PROCESSING_MODE);
         processingMode = mode != null ? Configuration.Mode.valueOf(mode.toUpperCase()) : Configuration.Mode.LAX;
         final ArrayDeque<StackItem> elementStack = new ArrayDeque<>();
@@ -94,31 +90,30 @@ public class IncludeResolver extends AbstractXMLFilter {
         super.startDocument();
     }
 
-    public void endDocument()
-            throws SAXException {
+    public void endDocument() throws SAXException {
         super.endDocument();
         final Deque<StackItem> elementStack = includeStack.pop();
         assert elementStack.size() == 1;
         assert includeStack.isEmpty();
     }
 
-//    public void startPrefixMapping(String prefix, String uri)
-//            throws SAXException {
-//        if (contentHandler != null) {
-//            contentHandler.startPrefixMapping(prefix, uri);
-//        }
-//    }
-//
-//    public void endPrefixMapping(String prefix)
-//            throws SAXException {
-//        if (contentHandler != null) {
-//            contentHandler.endPrefixMapping(prefix);
-//        }
-//    }
+    //    public void startPrefixMapping(String prefix, String uri)
+    //            throws SAXException {
+    //        if (contentHandler != null) {
+    //            contentHandler.startPrefixMapping(prefix, uri);
+    //        }
+    //    }
+    //
+    //    public void endPrefixMapping(String prefix)
+    //            throws SAXException {
+    //        if (contentHandler != null) {
+    //            contentHandler.endPrefixMapping(prefix);
+    //        }
+    //    }
 
     @Override
-    public void startElement(final String uri, final String localName, final String name,
-                             final Attributes atts) throws SAXException {
+    public void startElement(final String uri, final String localName, final String name, final Attributes atts)
+            throws SAXException {
         final Deque<StackItem> elementStack = includeStack.peek();
         final StackItem stackItem = elementStack.peek();
         final String cls = atts.getValue(ATTRIBUTE_NAME_CLASS);
@@ -132,10 +127,11 @@ public class IncludeResolver extends AbstractXMLFilter {
                         logger.debug("Resolve " + localName + " " + currentFile.resolve(hrefValue));
                         final String parse = getParse(atts.getValue(ATTRIBUTE_NAME_PARSE));
                         switch (parse) {
-                            case "text" ->
-                                    include = new IncludeText(job, currentFile, getContentHandler(), logger, processingMode).include(atts);
-                            case "xml" ->
-                                    include = new IncludeXml(job, currentFile, getContentHandler(), logger).include(atts);
+                            case "text" -> include = new IncludeText(
+                                            job, currentFile, getContentHandler(), logger, processingMode)
+                                    .include(atts);
+                            case "xml" -> include =
+                                    new IncludeXml(job, currentFile, getContentHandler(), logger).include(atts);
                             default -> logger.error("Unsupported include parse " + parse);
                         }
                     }
@@ -217,9 +213,6 @@ public class IncludeResolver extends AbstractXMLFilter {
     }
 
     // Private methods ---------------------------------------------------------
-
-
-
 
     private String getParse(final String value) {
         if (value == null) {

--- a/src/main/java/org/dita/dost/writer/include/IncludeText.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeText.java
@@ -8,14 +8,8 @@
 
 package org.dita.dost.writer.include;
 
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.exception.UncheckedDITAOTException;
-import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.log.MessageUtils;
-import org.dita.dost.util.Configuration;
-import org.dita.dost.util.Job;
-import org.xml.sax.Attributes;
-import org.xml.sax.ContentHandler;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.*;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -25,9 +19,14 @@ import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.*;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.exception.UncheckedDITAOTException;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.Configuration;
+import org.dita.dost.util.Job;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
 
 final class IncludeText {
 
@@ -37,7 +36,12 @@ final class IncludeText {
     private final DITAOTLogger logger;
     private final Configuration.Mode processingMode;
 
-    IncludeText(Job job, URI currentFile, ContentHandler contentHandler, DITAOTLogger logger, Configuration.Mode processingMode) {
+    IncludeText(
+            Job job,
+            URI currentFile,
+            ContentHandler contentHandler,
+            DITAOTLogger logger,
+            Configuration.Mode processingMode) {
         this.job = job;
         this.currentFile = currentFile;
         this.contentHandler = contentHandler;
@@ -54,7 +58,8 @@ final class IncludeText {
             try (BufferedReader codeReader = Files.newBufferedReader(codeFile.toPath(), charset)) {
                 range.copyLines(codeReader);
             } catch (final MalformedInputException e) {
-                final String msg = MessageUtils.getMessage("DOTJ084E", codeFile.toURI().toString(), charset.toString())
+                final String msg = MessageUtils.getMessage(
+                                "DOTJ084E", codeFile.toURI().toString(), charset.toString())
                         .setLocation(atts)
                         .toString();
                 if (processingMode.equals(Configuration.Mode.STRICT)) {
@@ -71,13 +76,14 @@ final class IncludeText {
     }
 
     private File getFile(URI hrefValue) {
-        final File tempFile = toFile(stripFragment(currentFile.resolve(hrefValue))).getAbsoluteFile();
+        final File tempFile =
+                toFile(stripFragment(currentFile.resolve(hrefValue))).getAbsoluteFile();
         final URI rel = job.tempDirURI.relativize(tempFile.toURI());
         final Job.FileInfo fi = job.getFileInfo(rel);
 
-//        if (tempFile.exists() && fi != null && PR_D_CODEREF.localName.equals(fi.format)) {
-//            return tempFile;
-//        }
+        //        if (tempFile.exists() && fi != null && PR_D_CODEREF.localName.equals(fi.format)) {
+        //            return tempFile;
+        //        }
         if (fi != null && "file".equals(fi.src.getScheme())) {
             return new File(fi.src);
         }
@@ -96,7 +102,8 @@ final class IncludeText {
         final String fragment = uri.getFragment();
         if (fragment != null) {
             // RFC 5147
-            final Matcher m = Pattern.compile("^line=(?:(\\d+)|(\\d+)?,(\\d+)?)$").matcher(fragment);
+            final Matcher m =
+                    Pattern.compile("^line=(?:(\\d+)|(\\d+)?,(\\d+)?)$").matcher(fragment);
             if (m.matches()) {
                 if (m.group(1) != null) {
                     start = Integer.parseInt(m.group(1));
@@ -111,7 +118,8 @@ final class IncludeText {
                 }
                 return new LineNumberRange(start, end).handler(contentHandler);
             } else {
-                final Matcher mc = Pattern.compile("^line-range\\((\\d+)(?:,\\s*(\\d+))?\\)$").matcher(fragment);
+                final Matcher mc = Pattern.compile("^line-range\\((\\d+)(?:,\\s*(\\d+))?\\)$")
+                        .matcher(fragment);
                 if (mc.matches()) {
                     start = Integer.parseInt(mc.group(1)) - 1;
                     if (mc.group(2) != null) {
@@ -119,7 +127,8 @@ final class IncludeText {
                     }
                     return new LineNumberRange(start, end).handler(contentHandler);
                 } else {
-                    final Matcher mi = Pattern.compile("^token=([^,\\s)]*)(?:,\\s*([^,\\s)]+))?$").matcher(fragment);
+                    final Matcher mi = Pattern.compile("^token=([^,\\s)]*)(?:,\\s*([^,\\s)]+))?$")
+                            .matcher(fragment);
                     if (mi.matches()) {
                         if (mi.group(1) != null && mi.group(1).length() != 0) {
                             startId = mi.group(1);
@@ -141,7 +150,6 @@ final class IncludeText {
      *
      * @return charset if set, otherwise default charset
      */
-
     private Charset getCharset(Attributes atts) {
         final String format = atts.getValue(ATTRIBUTE_NAME_FORMAT);
         final String encoding = atts.getValue(ATTRIBUTE_NAME_ENCODING);
@@ -156,7 +164,9 @@ final class IncludeText {
                 }
             }
         } catch (final RuntimeException e) {
-            logger.error(MessageUtils.getMessage("DOTJ052E", encoding).setLocation(atts).toString());
+            logger.error(MessageUtils.getMessage("DOTJ052E", encoding)
+                    .setLocation(atts)
+                    .toString());
         }
         if (c == null) {
             final String defaultCharset = Configuration.configuration.get("default.coderef-charset");

--- a/src/main/java/org/dita/dost/writer/include/IncludeXml.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeXml.java
@@ -8,23 +8,21 @@
 
 package org.dita.dost.writer.include;
 
+import static net.sf.saxon.s9api.streams.Steps.id;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.dita.dost.util.URLUtils.toURI;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.stream.Stream;
 import net.sf.saxon.s9api.XdmAtomicValue;
 import net.sf.saxon.s9api.XdmItem;
 import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.Job;
-import org.dita.dost.util.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.stream.Stream;
-
-import static net.sf.saxon.s9api.streams.Steps.id;
-import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
-import static org.dita.dost.util.URLUtils.stripFragment;
-import static org.dita.dost.util.URLUtils.toURI;
 
 final class IncludeXml {
     private final Job job;

--- a/src/main/java/org/dita/dost/writer/include/LineNumberRange.java
+++ b/src/main/java/org/dita/dost/writer/include/LineNumberRange.java
@@ -8,11 +8,10 @@
 
 package org.dita.dost.writer.include;
 
-import org.dita.dost.writer.CoderefResolver;
-import org.xml.sax.SAXException;
-
 import java.io.BufferedReader;
 import java.io.IOException;
+import org.dita.dost.writer.CoderefResolver;
+import org.xml.sax.SAXException;
 
 public class LineNumberRange extends AllRange implements Range {
 

--- a/src/main/java/org/dita/dost/writer/include/Range.java
+++ b/src/main/java/org/dita/dost/writer/include/Range.java
@@ -8,11 +8,10 @@
 
 package org.dita.dost.writer.include;
 
-import org.xml.sax.ContentHandler;
-import org.xml.sax.SAXException;
-
 import java.io.BufferedReader;
 import java.io.IOException;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
 
 public interface Range {
     /**

--- a/src/main/java/org/ditang/relaxng/defaults/OxygenRelaxNGSchemaReader.java
+++ b/src/main/java/org/ditang/relaxng/defaults/OxygenRelaxNGSchemaReader.java
@@ -7,15 +7,6 @@
  */
 package org.ditang.relaxng.defaults;
 
-import java.io.IOException;
-
-import javax.xml.transform.sax.SAXSource;
-
-import org.relaxng.datatype.DatatypeLibraryFactory;
-import org.relaxng.datatype.helpers.DatatypeLibraryLoader;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.SAXException;
-
 import com.thaiopensource.relaxng.parse.IllegalSchemaException;
 import com.thaiopensource.relaxng.pattern.FeasibleTransform;
 import com.thaiopensource.relaxng.pattern.IdTypeMap;
@@ -39,167 +30,176 @@ import com.thaiopensource.validate.rng.impl.FeasibleIdTypeMapSchema;
 import com.thaiopensource.validate.rng.impl.IdTypeMapSchema;
 import com.thaiopensource.validate.rng.impl.PatternSchema;
 import com.thaiopensource.validate.rng.impl.SchemaReaderImpl;
+import java.io.IOException;
+import javax.xml.transform.sax.SAXSource;
+import org.relaxng.datatype.DatatypeLibraryFactory;
+import org.relaxng.datatype.helpers.DatatypeLibraryLoader;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
 
 /**
  * Schema Reader for RelaxNG
  * @author george@oxygenxml.com
  */
 public abstract class OxygenRelaxNGSchemaReader extends SchemaReaderImpl {
-	  /**
-	   * The Schema Wrapper.
-	   */
-	  public static class SchemaWrapper implements Schema {
-	    /**
-	     * The wrapped schema.
-	     */
-	    private final Schema schema;
-	    
-	    /**
-	     * The start pattern.
-	     */
-	    private Pattern start;
-	    
-	    /**
-	     * The ID Type map.
-	     */
-	    private IdTypeMap idTypeMap;
+    /**
+     * The Schema Wrapper.
+     */
+    public static class SchemaWrapper implements Schema {
+        /**
+         * The wrapped schema.
+         */
+        private final Schema schema;
 
-	    /**
-	     * Get start Pattern.
-	     * 
-	     * @return start pattern.
-	     */
-	    public Pattern getStart() {
-	      return start;
-	    }
+        /**
+         * The start pattern.
+         */
+        private Pattern start;
 
-	    /**
-	     * Set start pattern.
-	     * 
-	     * @param start The start pattern.
-	     */
-	    public void setStart(Pattern start) {
-	      this.start = start;
-	    }
+        /**
+         * The ID Type map.
+         */
+        private IdTypeMap idTypeMap;
 
-	    /**
-	     * Constructor.
-	     * 
-	     * @param wrapped The wrapped schema.
-	     */
-	    public SchemaWrapper(Schema wrapped) {
-	      schema = wrapped;
-	    }
+        /**
+         * Get start Pattern.
+         *
+         * @return start pattern.
+         */
+        public Pattern getStart() {
+            return start;
+        }
 
-	    /**
-	     * @see com.thaiopensource.validate.Schema#createValidator(com.thaiopensource.util.PropertyMap)
-	     */
-	    public Validator createValidator(PropertyMap properties) {
-	      return schema.createValidator(properties);
-	    }
+        /**
+         * Set start pattern.
+         *
+         * @param start The start pattern.
+         */
+        public void setStart(Pattern start) {
+            this.start = start;
+        }
 
-	    /**
-	     * @see com.thaiopensource.validate.Schema#getProperties()
-	     */
-	    public PropertyMap getProperties() {
-	      return schema.getProperties();
-	    }
-	    /**
-	     * Get the ID Type map.
-	     * 
-	     * @return Returns the idTypeMap.
-	     */
-	    private IdTypeMap getIdTypeMap() {
-	      return idTypeMap;
-	    }
-	    	    
-	    /**
-	     * Set the ID Type map.
-	     * 
-	     * @param idTypeMap The idTypeMap to set.
-	     */
-	    public void setIdTypeMap(IdTypeMap idTypeMap) {
-	      this.idTypeMap = idTypeMap;
-	    }
-	  }
-	
-	
-  /**
-   * Supported property ids.
-   */
-  private static final PropertyId<?>[] supportedPropertyIds = {
-    ValidateProperty.XML_READER_CREATOR,
-    ValidateProperty.ERROR_HANDLER,
-    ValidateProperty.ENTITY_RESOLVER,
-    ValidateProperty.URI_RESOLVER,
-    ValidateProperty.RESOLVER,
-    RngProperty.DATATYPE_LIBRARY_FACTORY,
-    RngProperty.CHECK_ID_IDREF,
-    RngProperty.FEASIBLE,
-    WrapProperty.ATTRIBUTE_OWNER,
-  };
-  
-  /***
-   * Create a schema from an input source and a property map.
-   */
-  public Schema createSchema(SAXSource source, PropertyMap properties) throws IOException, SAXException, IncorrectSchemaException {
-    SchemaPatternBuilder spb = new SchemaPatternBuilder();
-    SAXResolver resolver = ResolverFactory.createResolver(properties);
-    ErrorHandler eh = properties.get(ValidateProperty.ERROR_HANDLER);
-    DatatypeLibraryFactory dlf = properties.get(RngProperty.DATATYPE_LIBRARY_FACTORY);
-    if (dlf == null) {
-      //Create a new Data Type Library Loader
-      dlf = new DatatypeLibraryLoader();
+        /**
+         * Constructor.
+         *
+         * @param wrapped The wrapped schema.
+         */
+        public SchemaWrapper(Schema wrapped) {
+            schema = wrapped;
+        }
+
+        /**
+         * @see com.thaiopensource.validate.Schema#createValidator(com.thaiopensource.util.PropertyMap)
+         */
+        public Validator createValidator(PropertyMap properties) {
+            return schema.createValidator(properties);
+        }
+
+        /**
+         * @see com.thaiopensource.validate.Schema#getProperties()
+         */
+        public PropertyMap getProperties() {
+            return schema.getProperties();
+        }
+        /**
+         * Get the ID Type map.
+         *
+         * @return Returns the idTypeMap.
+         */
+        private IdTypeMap getIdTypeMap() {
+            return idTypeMap;
+        }
+
+        /**
+         * Set the ID Type map.
+         *
+         * @param idTypeMap The idTypeMap to set.
+         */
+        public void setIdTypeMap(IdTypeMap idTypeMap) {
+            this.idTypeMap = idTypeMap;
+        }
     }
-    try {
-      Pattern start = SchemaBuilderImpl.parse(createParseable(source, resolver, eh, properties), eh, dlf, spb,
-          properties.contains(WrapProperty.ATTRIBUTE_OWNER));
-      //Wrap the pattern
-      return wrapPattern2(start, spb, properties);
-    }
-    catch (IllegalSchemaException e) {
-      throw new IncorrectSchemaException();
-    }
-  }
 
-  /**
-   * Make a schema wrapper.
-   * 
-   * @param start Start pattern.
-   * @param spb The schema pattern builder.
-   * @param properties The properties map.
-   * @return The schema wrapper.
-   */
-  private static SchemaWrapper wrapPattern2(Pattern start, SchemaPatternBuilder spb, PropertyMap properties)
-    throws SAXException, IncorrectSchemaException {
-    
-    if (properties.contains(RngProperty.FEASIBLE)) {
-      //Use a feasible transform
-      start = FeasibleTransform.transform(spb, start);
+    /**
+     * Supported property ids.
+     */
+    private static final PropertyId<?>[] supportedPropertyIds = {
+        ValidateProperty.XML_READER_CREATOR,
+        ValidateProperty.ERROR_HANDLER,
+        ValidateProperty.ENTITY_RESOLVER,
+        ValidateProperty.URI_RESOLVER,
+        ValidateProperty.RESOLVER,
+        RngProperty.DATATYPE_LIBRARY_FACTORY,
+        RngProperty.CHECK_ID_IDREF,
+        RngProperty.FEASIBLE,
+        WrapProperty.ATTRIBUTE_OWNER,
+    };
+
+    /***
+     * Create a schema from an input source and a property map.
+     */
+    public Schema createSchema(SAXSource source, PropertyMap properties)
+            throws IOException, SAXException, IncorrectSchemaException {
+        SchemaPatternBuilder spb = new SchemaPatternBuilder();
+        SAXResolver resolver = ResolverFactory.createResolver(properties);
+        ErrorHandler eh = properties.get(ValidateProperty.ERROR_HANDLER);
+        DatatypeLibraryFactory dlf = properties.get(RngProperty.DATATYPE_LIBRARY_FACTORY);
+        if (dlf == null) {
+            // Create a new Data Type Library Loader
+            dlf = new DatatypeLibraryLoader();
+        }
+        try {
+            Pattern start = SchemaBuilderImpl.parse(
+                    createParseable(source, resolver, eh, properties),
+                    eh,
+                    dlf,
+                    spb,
+                    properties.contains(WrapProperty.ATTRIBUTE_OWNER));
+            // Wrap the pattern
+            return wrapPattern2(start, spb, properties);
+        } catch (IllegalSchemaException e) {
+            throw new IncorrectSchemaException();
+        }
     }
-    //Get properties for supported IDs
-    properties = AbstractSchema.filterProperties(properties, supportedPropertyIds);
-    Schema schema = new PatternSchema(spb, start, properties);
-    IdTypeMap idTypeMap = null;
-    if (spb.hasIdTypes() && properties.contains(RngProperty.CHECK_ID_IDREF)) {
-      //Check ID/IDREF
-      ErrorHandler eh = properties.get(ValidateProperty.ERROR_HANDLER);
-      idTypeMap = new IdTypeMapBuilder(eh, start).getIdTypeMap();
-      if (idTypeMap == null) {
-        throw new IncorrectSchemaException();
-      }
-      Schema idSchema;
-      if (properties.contains(RngProperty.FEASIBLE)) {
-        idSchema = new FeasibleIdTypeMapSchema(idTypeMap, properties);
-      } else {
-        idSchema = new IdTypeMapSchema(idTypeMap, properties);
-      }
-      schema = new CombineSchema(schema, idSchema, properties);
+
+    /**
+     * Make a schema wrapper.
+     *
+     * @param start Start pattern.
+     * @param spb The schema pattern builder.
+     * @param properties The properties map.
+     * @return The schema wrapper.
+     */
+    private static SchemaWrapper wrapPattern2(Pattern start, SchemaPatternBuilder spb, PropertyMap properties)
+            throws SAXException, IncorrectSchemaException {
+
+        if (properties.contains(RngProperty.FEASIBLE)) {
+            // Use a feasible transform
+            start = FeasibleTransform.transform(spb, start);
+        }
+        // Get properties for supported IDs
+        properties = AbstractSchema.filterProperties(properties, supportedPropertyIds);
+        Schema schema = new PatternSchema(spb, start, properties);
+        IdTypeMap idTypeMap = null;
+        if (spb.hasIdTypes() && properties.contains(RngProperty.CHECK_ID_IDREF)) {
+            // Check ID/IDREF
+            ErrorHandler eh = properties.get(ValidateProperty.ERROR_HANDLER);
+            idTypeMap = new IdTypeMapBuilder(eh, start).getIdTypeMap();
+            if (idTypeMap == null) {
+                throw new IncorrectSchemaException();
+            }
+            Schema idSchema;
+            if (properties.contains(RngProperty.FEASIBLE)) {
+                idSchema = new FeasibleIdTypeMapSchema(idTypeMap, properties);
+            } else {
+                idSchema = new IdTypeMapSchema(idTypeMap, properties);
+            }
+            schema = new CombineSchema(schema, idSchema, properties);
+        }
+        // Wrap the schema
+        SchemaWrapper sw = new SchemaWrapper(schema);
+        sw.setStart(start);
+        sw.setIdTypeMap(idTypeMap);
+        return sw;
     }
-    //Wrap the schema
-    SchemaWrapper sw = new SchemaWrapper(schema);
-    sw.setStart(start);
-    sw.setIdTypeMap(idTypeMap);      
-    return sw;
-  }
 }

--- a/src/main/java/org/ditang/relaxng/defaults/RNCDefaultValues.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RNCDefaultValues.java
@@ -7,12 +7,6 @@
  */
 package org.ditang.relaxng.defaults;
 
-import javax.xml.transform.sax.SAXSource;
-
-import org.xml.sax.EntityResolver;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.Locator;
-
 import com.thaiopensource.relaxng.parse.Parseable;
 import com.thaiopensource.relaxng.parse.compact.CompactParseable;
 import com.thaiopensource.relaxng.pattern.AnnotationsImpl;
@@ -25,11 +19,14 @@ import com.thaiopensource.resolver.xml.sax.SAXResolver;
 import com.thaiopensource.util.PropertyMap;
 import com.thaiopensource.util.VoidValue;
 import com.thaiopensource.validate.SchemaReader;
+import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.Locator;
 
 /**
  * RNC default values gatherer
  * <p>
- * 
+ *
  * @author george@oxygenxml.com
  */
 public class RNCDefaultValues extends RelaxNGDefaultValues {
@@ -54,8 +51,7 @@ public class RNCDefaultValues extends RelaxNGDefaultValues {
     /**
      * class OxygenCompactSchemaReader extends SchemaReaderImpl
      */
-    private static class OxygenCompactSchemaReader extends
-    OxygenRelaxNGSchemaReader {
+    private static class OxygenCompactSchemaReader extends OxygenRelaxNGSchemaReader {
         /**
          * The instance of schema reader.
          */
@@ -70,7 +66,7 @@ public class RNCDefaultValues extends RelaxNGDefaultValues {
 
         /**
          * Get the reader singleton.
-         * 
+         *
          * @return The current Schema Reader instance.
          */
         private static SchemaReader getInstance() {
@@ -80,16 +76,13 @@ public class RNCDefaultValues extends RelaxNGDefaultValues {
         /**
          * Creates a parseable object from a catalog resolved input source
          * associated to a RNG schema.
-         * 
+         *
          * @return the parseable object
          */
         @Override
         protected Parseable<Pattern, NameClass, Locator, VoidValue, CommentListImpl, AnnotationsImpl> createParseable(
-                SAXSource source, SAXResolver saxResolver, ErrorHandler eh,
-                PropertyMap properties) {
-            return new CompactParseable<>(
-                    SAX.createInput(source.getInputSource()), saxResolver.getResolver(),
-                    eh);
+                SAXSource source, SAXResolver saxResolver, ErrorHandler eh, PropertyMap properties) {
+            return new CompactParseable<>(SAX.createInput(source.getInputSource()), saxResolver.getResolver(), eh);
         }
     }
 

--- a/src/main/java/org/ditang/relaxng/defaults/RNGDefaultValues.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RNGDefaultValues.java
@@ -7,12 +7,6 @@
  */
 package org.ditang.relaxng.defaults;
 
-import javax.xml.transform.sax.SAXSource;
-
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.Locator;
-import org.xml.sax.SAXException;
-
 import com.thaiopensource.relaxng.parse.Parseable;
 import com.thaiopensource.relaxng.parse.sax.SAXParseable;
 import com.thaiopensource.relaxng.pattern.AnnotationsImpl;
@@ -24,10 +18,14 @@ import com.thaiopensource.resolver.xml.sax.SAXResolver;
 import com.thaiopensource.util.PropertyMap;
 import com.thaiopensource.util.VoidValue;
 import com.thaiopensource.validate.SchemaReader;
+import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
 
 /**
  * @author george@oxygenxml.com
- * 
+ *
  */
 public class RNGDefaultValues extends RelaxNGDefaultValues {
     /**
@@ -48,7 +46,7 @@ public class RNGDefaultValues extends RelaxNGDefaultValues {
 
         /**
          * Get the singleton instance.
-         * 
+         *
          * @return The instance.
          */
         public static SchemaReader getInstance() {
@@ -58,21 +56,17 @@ public class RNGDefaultValues extends RelaxNGDefaultValues {
         /**
          * Creates a parseable object from a catalog resolved input source
          * associated to a RNG schema.
-         * 
+         *
          * @return the parseable object
          */
         @Override
         protected Parseable<Pattern, NameClass, Locator, VoidValue, CommentListImpl, AnnotationsImpl> createParseable(
-                SAXSource source, SAXResolver resolver, ErrorHandler eh,
-                PropertyMap properties) throws SAXException {
+                SAXSource source, SAXResolver resolver, ErrorHandler eh, PropertyMap properties) throws SAXException {
             if (source.getXMLReader() == null) {
-                source = new SAXSource(resolver.createXMLReader(),
-                        source.getInputSource());
+                source = new SAXSource(resolver.createXMLReader(), source.getInputSource());
             }
-            return new SAXParseable<>(
-                    source, resolver, eh);
+            return new SAXParseable<>(source, resolver, eh);
         }
-
     }
 
     /**

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxDefaultsParserConfiguration.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxDefaultsParserConfiguration.java
@@ -7,8 +7,8 @@
  */
 package org.ditang.relaxng.defaults;
 
+import com.thaiopensource.resolver.Resolver;
 import java.io.IOException;
-
 import org.apache.xerces.impl.Constants;
 import org.apache.xerces.parsers.XIncludeAwareParserConfiguration;
 import org.apache.xerces.util.SymbolTable;
@@ -19,23 +19,19 @@ import org.apache.xerces.xni.parser.XMLComponentManager;
 import org.apache.xerces.xni.parser.XMLConfigurationException;
 import org.apache.xerces.xni.parser.XMLDocumentSource;
 
-import com.thaiopensource.resolver.Resolver;
-
 /**
  * @author george@oxygenxml.com
  * A parser configuration that adds in a module to add Relax NG specified default values.
  */
-public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfiguration  {
+public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfiguration {
 
     /** Feature identifier: dynamic validation. */
     protected static final String DYNAMIC_VALIDATION =
             Constants.XERCES_FEATURE_PREFIX + Constants.DYNAMIC_VALIDATION_FEATURE;
     /** Feature identifier: validation. */
-    protected static final String VALIDATION =
-            Constants.SAX_FEATURE_PREFIX + Constants.VALIDATION_FEATURE;
+    protected static final String VALIDATION = Constants.SAX_FEATURE_PREFIX + Constants.VALIDATION_FEATURE;
     /**Schema validation**/
-    protected static final String XERCES_SCHEMA_VALIDATION =
-            "http://apache.org/xml/features/validation/schema";
+    protected static final String XERCES_SCHEMA_VALIDATION = "http://apache.org/xml/features/validation/schema";
 
     /**
      * An XML component that adds default attribute values by looking into a Relax NG schema
@@ -45,7 +41,7 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
     protected RelaxNGDefaultsComponent fRelaxDefaults = null;
 
     /**
-     * The special RNG resolver 
+     * The special RNG resolver
      */
     protected final Resolver resolver;
 
@@ -61,8 +57,8 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
         this(null, null, null);
     }
 
-    /** 
-     * Constructs a parser configuration using the specified symbol table. 
+    /**
+     * Constructs a parser configuration using the specified symbol table.
      *
      * @param symbolTable The symbol table to use.
      */
@@ -79,9 +75,7 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
      * @param grammarPool The grammar pool to use.
      * @param resolver The JING resolver
      */
-    public RelaxDefaultsParserConfiguration(
-            SymbolTable symbolTable,
-            XMLGrammarPool grammarPool, Resolver resolver) {
+    public RelaxDefaultsParserConfiguration(SymbolTable symbolTable, XMLGrammarPool grammarPool, Resolver resolver) {
         this(symbolTable, grammarPool, null, resolver);
     }
 
@@ -98,7 +92,8 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
     public RelaxDefaultsParserConfiguration(
             SymbolTable symbolTable,
             XMLGrammarPool grammarPool,
-            XMLComponentManager parentSettings, Resolver resolver) {
+            XMLComponentManager parentSettings,
+            Resolver resolver) {
         super(symbolTable, grammarPool, parentSettings);
         this.resolver = resolver;
     }
@@ -107,18 +102,17 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
     public boolean parse(boolean complete) throws XNIException, IOException {
         if (fInputSource != null) {
             try {
-                setFeature(DYNAMIC_VALIDATION, getFeature(VALIDATION) 
-                        || getFeature(XERCES_SCHEMA_VALIDATION));
-            } catch(Exception ex) {
-                //Could happen if the parser is not Xerces, most probably not.
+                setFeature(DYNAMIC_VALIDATION, getFeature(VALIDATION) || getFeature(XERCES_SCHEMA_VALIDATION));
+            } catch (Exception ex) {
+                // Could happen if the parser is not Xerces, most probably not.
                 ex.printStackTrace();
             }
         }
         return super.parse(complete);
     }
 
-    /** 
-     * Configures the pipeline. 
+    /**
+     * Configures the pipeline.
      */
     @Override
     protected void configurePipeline() {
@@ -143,7 +137,8 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
             fRelaxDefaults = new RelaxNGDefaultsComponent(resolver, fGrammarPool);
             addCommonComponent(fRelaxDefaults);
             fRelaxDefaults.setValidate(relaxNGValidation);
-            fRelaxDefaults.setProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_HANDLER_PROPERTY, 
+            fRelaxDefaults.setProperty(
+                    Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_HANDLER_PROPERTY,
                     getProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_HANDLER_PROPERTY));
             fRelaxDefaults.reset(this);
         }
@@ -163,7 +158,7 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
      */
     @Override
     public void setFeature(String featureId, boolean state) throws XMLConfigurationException {
-        if(XERCES_SCHEMA_VALIDATION.equals(featureId)) {
+        if (XERCES_SCHEMA_VALIDATION.equals(featureId)) {
             relaxNGValidation = state;
         } else {
             super.setFeature(featureId, state);
@@ -172,7 +167,7 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
 
     @Override
     public void setProperty(String propertyId, Object value) throws XMLConfigurationException {
-        if("http://apache.org/xml/properties/internal/grammar-pool".equals(propertyId)) {
+        if ("http://apache.org/xml/properties/internal/grammar-pool".equals(propertyId)) {
             fGrammarPool = (XMLGrammarPool) value;
         }
         super.setProperty(propertyId, value);

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultParserConfigurationWrapper.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultParserConfigurationWrapper.java
@@ -9,7 +9,6 @@ package org.ditang.relaxng.defaults;
 
 import java.io.IOException;
 import java.util.Locale;
-
 import org.apache.xerces.parsers.XIncludeAwareParserConfiguration;
 import org.apache.xerces.xni.XMLDTDContentModelHandler;
 import org.apache.xerces.xni.XMLDTDHandler;
@@ -26,181 +25,176 @@ import org.apache.xerces.xni.parser.XMLParserConfiguration;
  * RelaxNG schema
  */
 public class RelaxNGDefaultParserConfigurationWrapper implements XMLParserConfiguration {
-  /**
-   * The wrapped configuration
-   */
-  private final XMLParserConfiguration config;
+    /**
+     * The wrapped configuration
+     */
+    private final XMLParserConfiguration config;
 
-  /**
-   * Default constructor
-   */
-  public RelaxNGDefaultParserConfigurationWrapper() {
-    XIncludeAwareParserConfiguration c = new XIncludeAwareParserConfiguration();
-    this.config = c;
-  }
-  
-  /**
-   * Constructor
-   * @param config The wrapped configuration.
-   */
-  public RelaxNGDefaultParserConfigurationWrapper(XMLParserConfiguration config) {
-    this.config = config;
-  }
-  
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#parse(org.apache.xerces.xni.parser.XMLInputSource)
-   */
-  @Override
-  public void parse(XMLInputSource inputSource) throws XNIException,
-      IOException {
-    config.parse(inputSource);
-  }
+    /**
+     * Default constructor
+     */
+    public RelaxNGDefaultParserConfigurationWrapper() {
+        XIncludeAwareParserConfiguration c = new XIncludeAwareParserConfiguration();
+        this.config = c;
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#addRecognizedFeatures(java.lang.String[])
-   */
-  @Override
-  public void addRecognizedFeatures(String[] featureIds) {
-    config.addRecognizedFeatures(featureIds);
-  }
+    /**
+     * Constructor
+     * @param config The wrapped configuration.
+     */
+    public RelaxNGDefaultParserConfigurationWrapper(XMLParserConfiguration config) {
+        this.config = config;
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setFeature(java.lang.String, boolean)
-   */
-  @Override
-  public void setFeature(String featureId, boolean state)
-      throws XMLConfigurationException {
-    config.setFeature(featureId, state);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#parse(org.apache.xerces.xni.parser.XMLInputSource)
+     */
+    @Override
+    public void parse(XMLInputSource inputSource) throws XNIException, IOException {
+        config.parse(inputSource);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getFeature(java.lang.String)
-   */
-  @Override
-  public boolean getFeature(String featureId) throws XMLConfigurationException {
-    return config.getFeature(featureId);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#addRecognizedFeatures(java.lang.String[])
+     */
+    @Override
+    public void addRecognizedFeatures(String[] featureIds) {
+        config.addRecognizedFeatures(featureIds);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#addRecognizedProperties(java.lang.String[])
-   */
-  @Override
-  public void addRecognizedProperties(String[] propertyIds) {
-    config.addRecognizedProperties(propertyIds);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setFeature(java.lang.String, boolean)
+     */
+    @Override
+    public void setFeature(String featureId, boolean state) throws XMLConfigurationException {
+        config.setFeature(featureId, state);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setProperty(java.lang.String, java.lang.Object)
-   */
-  @Override
-  public void setProperty(String propertyId, Object value)
-      throws XMLConfigurationException {
-    config.setProperty(propertyId, value);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getFeature(java.lang.String)
+     */
+    @Override
+    public boolean getFeature(String featureId) throws XMLConfigurationException {
+        return config.getFeature(featureId);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getProperty(java.lang.String)
-   */
-  @Override
-  public Object getProperty(String propertyId) throws XMLConfigurationException {
-    return config.getProperty(propertyId);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#addRecognizedProperties(java.lang.String[])
+     */
+    @Override
+    public void addRecognizedProperties(String[] propertyIds) {
+        config.addRecognizedProperties(propertyIds);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setErrorHandler(org.apache.xerces.xni.parser.XMLErrorHandler)
-   */
-  @Override
-  public void setErrorHandler(XMLErrorHandler errorHandler) {
-    config.setErrorHandler(errorHandler);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setProperty(java.lang.String, java.lang.Object)
+     */
+    @Override
+    public void setProperty(String propertyId, Object value) throws XMLConfigurationException {
+        config.setProperty(propertyId, value);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getErrorHandler()
-   */
-  @Override
-  public XMLErrorHandler getErrorHandler() {
-    return config.getErrorHandler();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getProperty(java.lang.String)
+     */
+    @Override
+    public Object getProperty(String propertyId) throws XMLConfigurationException {
+        return config.getProperty(propertyId);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDocumentHandler(org.apache.xerces.xni.XMLDocumentHandler)
-   */
-  @Override
-  public void setDocumentHandler(XMLDocumentHandler documentHandler) {
-    config.setDocumentHandler(documentHandler);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setErrorHandler(org.apache.xerces.xni.parser.XMLErrorHandler)
+     */
+    @Override
+    public void setErrorHandler(XMLErrorHandler errorHandler) {
+        config.setErrorHandler(errorHandler);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDocumentHandler()
-   */
-  @Override
-  public XMLDocumentHandler getDocumentHandler() {
-    return config.getDocumentHandler();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getErrorHandler()
+     */
+    @Override
+    public XMLErrorHandler getErrorHandler() {
+        return config.getErrorHandler();
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDTDHandler(org.apache.xerces.xni.XMLDTDHandler)
-   */
-  @Override
-  public void setDTDHandler(XMLDTDHandler dtdHandler) {
-    config.setDTDHandler(dtdHandler);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDocumentHandler(org.apache.xerces.xni.XMLDocumentHandler)
+     */
+    @Override
+    public void setDocumentHandler(XMLDocumentHandler documentHandler) {
+        config.setDocumentHandler(documentHandler);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDTDHandler()
-   */
-  @Override
-  public XMLDTDHandler getDTDHandler() {
-    return config.getDTDHandler();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDocumentHandler()
+     */
+    @Override
+    public XMLDocumentHandler getDocumentHandler() {
+        return config.getDocumentHandler();
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDTDContentModelHandler(org.apache.xerces.xni.XMLDTDContentModelHandler)
-   */
-  @Override
-  public void setDTDContentModelHandler(
-      XMLDTDContentModelHandler dtdContentModelHandler) {
-    config.setDTDContentModelHandler(dtdContentModelHandler);
-    
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDTDHandler(org.apache.xerces.xni.XMLDTDHandler)
+     */
+    @Override
+    public void setDTDHandler(XMLDTDHandler dtdHandler) {
+        config.setDTDHandler(dtdHandler);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDTDContentModelHandler()
-   */
-  @Override
-  public XMLDTDContentModelHandler getDTDContentModelHandler() {
-    return config.getDTDContentModelHandler();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDTDHandler()
+     */
+    @Override
+    public XMLDTDHandler getDTDHandler() {
+        return config.getDTDHandler();
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setEntityResolver(org.apache.xerces.xni.parser.XMLEntityResolver)
-   */
-  @Override
-  public void setEntityResolver(XMLEntityResolver entityResolver) {
-    config.setEntityResolver(entityResolver);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setDTDContentModelHandler(org.apache.xerces.xni.XMLDTDContentModelHandler)
+     */
+    @Override
+    public void setDTDContentModelHandler(XMLDTDContentModelHandler dtdContentModelHandler) {
+        config.setDTDContentModelHandler(dtdContentModelHandler);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getEntityResolver()
-   */
-  @Override
-  public XMLEntityResolver getEntityResolver() {
-    return config.getEntityResolver();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getDTDContentModelHandler()
+     */
+    @Override
+    public XMLDTDContentModelHandler getDTDContentModelHandler() {
+        return config.getDTDContentModelHandler();
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setLocale(java.util.Locale)
-   */
-  @Override
-  public void setLocale(Locale locale) throws XNIException {
-    config.setLocale(locale);
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setEntityResolver(org.apache.xerces.xni.parser.XMLEntityResolver)
+     */
+    @Override
+    public void setEntityResolver(XMLEntityResolver entityResolver) {
+        config.setEntityResolver(entityResolver);
+    }
 
-  /**
-   * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getLocale()
-   */
-  @Override
-  public Locale getLocale() {
-    return config.getLocale();
-  }
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getEntityResolver()
+     */
+    @Override
+    public XMLEntityResolver getEntityResolver() {
+        return config.getEntityResolver();
+    }
+
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#setLocale(java.util.Locale)
+     */
+    @Override
+    public void setLocale(Locale locale) throws XNIException {
+        config.setLocale(locale);
+    }
+
+    /**
+     * @see org.apache.xerces.xni.parser.XMLParserConfiguration#getLocale()
+     */
+    @Override
+    public Locale getLocale() {
+        return config.getLocale();
+    }
 }

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultValues.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultValues.java
@@ -15,19 +15,18 @@ import com.thaiopensource.util.PropertyMapBuilder;
 import com.thaiopensource.validate.SchemaReader;
 import com.thaiopensource.validate.ValidateProperty;
 import com.thaiopensource.validate.Validator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import org.ditang.relaxng.defaults.OxygenRelaxNGSchemaReader.SchemaWrapper;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 /**
  * Relax NG default values gatherer.
- * 
+ *
  * @author george@oxygenxml.com
  */
 public abstract class RelaxNGDefaultValues {
@@ -86,8 +85,7 @@ public abstract class RelaxNGDefaultValues {
     /**
      * Collects default values. Listener for the default values extractor.
      */
-    class DefaultValuesCollector implements
-    DefaultValuesExtractor.DefaultValuesListener {
+    class DefaultValuesCollector implements DefaultValuesExtractor.DefaultValuesListener {
         /**
          * Stores the default attributes as a hash map with the element info as key.
          */
@@ -95,7 +93,7 @@ public abstract class RelaxNGDefaultValues {
 
         /**
          * Constructor.
-         * 
+         *
          * @param start
          *          The Relax NG schema pattern.
          */
@@ -105,38 +103,40 @@ public abstract class RelaxNGDefaultValues {
 
         /**
          * Get a key for an element.
-         * 
+         *
          * @return A string formed from the element local name and its namespace.
          */
         private String getKey(String elementLocalName, String elementNamespace) {
-            return elementLocalName + "#"
-                    + (elementNamespace == null ? "" : elementNamespace);
+            return elementLocalName + "#" + (elementNamespace == null ? "" : elementNamespace);
         }
 
         /**
          * Get the default attributes for an element.
-         * 
+         *
          * @param elementLocalName
          *          The element local name.
          * @param elementNamespace
          *          The element namespace. Use null or empty for no namespace.
          * @return A list of Attribute objects or null if no defaults.
          */
-        private List<Attribute> getDefaultAttributes(String elementLocalName,
-                String elementNamespace) {
+        private List<Attribute> getDefaultAttributes(String elementLocalName, String elementNamespace) {
             return defaults.get(getKey(elementLocalName, elementNamespace));
         }
 
         /**
          * Default attribute notification.
-         * 
+         *
          * @see com.thaiopensource.relaxng.pattern.DefaultValuesExtractor.DefaultValuesListener#defaultValue(java.lang.String,
          *      java.lang.String, java.lang.String, java.lang.String,
          *      java.lang.String)
          */
         @Override
-        public void defaultValue(String elementLocalName, String elementNamespace,
-                String attributeLocalName, String attributeNamepsace, String value) {
+        public void defaultValue(
+                String elementLocalName,
+                String elementNamespace,
+                String attributeLocalName,
+                String attributeNamepsace,
+                String value) {
             String key = getKey(elementLocalName, elementNamespace);
             List<Attribute> list = defaults.computeIfAbsent(key, k -> new ArrayList<>());
             list.add(new Attribute(attributeLocalName, attributeNamepsace, value));
@@ -163,19 +163,19 @@ public abstract class RelaxNGDefaultValues {
 
     /**
      * Updates the annotation model.
-     * 
+     *
      * @param in The schema input source.
      */
     public void update(InputSource in) throws SAXException {
         defaultValuesCollector = null;
         PropertyMapBuilder builder = new PropertyMapBuilder();
-        //Set the resolver
-        builder.put(ValidateProperty.RESOLVER, resolver);  
+        // Set the resolver
+        builder.put(ValidateProperty.RESOLVER, resolver);
         builder.put(ValidateProperty.ERROR_HANDLER, eh);
         PropertyMap properties = builder.toPropertyMap();
         try {
             SchemaWrapper sw = (SchemaWrapper) getSchemaReader().createSchema(in, properties);
-            if(keepSchema) {
+            if (keepSchema) {
                 schema = sw;
             }
             Pattern start = sw.getStart();
@@ -196,7 +196,7 @@ public abstract class RelaxNGDefaultValues {
 
     /**
      * Get the default attributes for an element.
-     * 
+     *
      * @param localName
      *          The element local name.
      * @param namespace

--- a/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxNGDefaultsComponent.java
@@ -11,6 +11,12 @@ import com.thaiopensource.resolver.*;
 import com.thaiopensource.util.PropertyMapBuilder;
 import com.thaiopensource.validate.ValidateProperty;
 import com.thaiopensource.validate.Validator;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
 import org.apache.xerces.impl.Constants;
 import org.apache.xerces.util.SymbolTable;
 import org.apache.xerces.util.XMLResourceIdentifierImpl;
@@ -21,64 +27,40 @@ import org.ditang.relaxng.defaults.pool.RNGDefaultsEnabledGrammarPool;
 import org.xml.sax.*;
 import org.xml.sax.helpers.AttributesImpl;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.Stack;
-
 /**
  * XNI component that adds Relax NG default values.
- * 
+ *
  * @author george@oxygenxml.com
  */
-public class RelaxNGDefaultsComponent implements XMLDocumentHandler,
-XMLComponent, XMLDocumentSource {
-
+public class RelaxNGDefaultsComponent implements XMLDocumentHandler, XMLComponent, XMLDocumentSource {
 
     /** Property identifier: entity resolver. */
-    public static final String ENTITY_RESOLVER = Constants.XERCES_PROPERTY_PREFIX
-            + Constants.ENTITY_RESOLVER_PROPERTY;
+    public static final String ENTITY_RESOLVER = Constants.XERCES_PROPERTY_PREFIX + Constants.ENTITY_RESOLVER_PROPERTY;
 
     /** Property identifier: error reporter. */
-    private static final String ERROR_REPORTER = Constants.XERCES_PROPERTY_PREFIX
-            + Constants.ERROR_REPORTER_PROPERTY;
+    private static final String ERROR_REPORTER = Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_REPORTER_PROPERTY;
 
     /** Property identifier: error reporter. */
-    private static final String ERROR_HANDLER = Constants.XERCES_PROPERTY_PREFIX
-            + Constants.ERROR_HANDLER_PROPERTY;
+    private static final String ERROR_HANDLER = Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_HANDLER_PROPERTY;
 
     /** Property identifier: symbol table. */
-    private static final String SYMBOL_TABLE = Constants.XERCES_PROPERTY_PREFIX
-            + Constants.SYMBOL_TABLE_PROPERTY;
-
+    private static final String SYMBOL_TABLE = Constants.XERCES_PROPERTY_PREFIX + Constants.SYMBOL_TABLE_PROPERTY;
 
     // recognized features and properties
 
     /** Recognized features. */
-    private static final String[] RECOGNIZED_FEATURES = {
-    };
+    private static final String[] RECOGNIZED_FEATURES = {};
 
     /** Feature defaults. */
-    private static final Boolean[] FEATURE_DEFAULTS = {
-    };
+    private static final Boolean[] FEATURE_DEFAULTS = {};
 
     /** Recognized properties. */
     private static final String[] RECOGNIZED_PROPERTIES = {
-            SYMBOL_TABLE,       
-            ERROR_REPORTER,
-            ERROR_HANDLER,
-            ENTITY_RESOLVER,
+        SYMBOL_TABLE, ERROR_REPORTER, ERROR_HANDLER, ENTITY_RESOLVER,
     };
 
     /** Property defaults. */
-    private static final Object[] PROPERTY_DEFAULTS = {
-            null,
-            null,
-            null,
-            null
-    };
+    private static final Object[] PROPERTY_DEFAULTS = {null, null, null, null};
 
     private XMLDocumentHandler documentHandler;
     private XMLDocumentSource documentSource;
@@ -142,36 +124,36 @@ XMLComponent, XMLDocumentSource {
     public RelaxNGDefaultsComponent(Resolver resolver, XMLGrammarPool grammarPool) {
         this.resolver = resolver;
         this.grammarPool = grammarPool;
-        if(this.resolver == null) {
-            //Wrap a resolver over an XMLEntityResolver
+        if (this.resolver == null) {
+            // Wrap a resolver over an XMLEntityResolver
             this.resolver = new Resolver() {
                 @Override
                 public void resolve(Identifier id, Input input) throws IOException, ResolverException {
-                    if(fResolver != null) {
+                    if (fResolver != null) {
                         String expanded = id.getUriReference();
-                        //Compute the expanded system ID
+                        // Compute the expanded system ID
                         try {
-                            expanded  = new URL(new URL(id.getBase()), id.getUriReference()).toString();
+                            expanded = new URL(new URL(id.getBase()), id.getUriReference()).toString();
                         } catch (Exception e) {
                         }
 
-                        XMLResourceIdentifier identifier = new XMLResourceIdentifierImpl(
-                                null, id.getUriReference(), id.getBase(), expanded);
+                        XMLResourceIdentifier identifier =
+                                new XMLResourceIdentifierImpl(null, id.getUriReference(), id.getBase(), expanded);
                         XMLInputSource resolved = fResolver.resolveEntity(identifier);
-                        if(resolved != null) {
+                        if (resolved != null) {
                             input.setUri(resolved.getSystemId());
                             input.setByteStream(resolved.getByteStream());
                             input.setCharacterStream(resolved.getCharacterStream());
                             input.setEncoding(resolved.getEncoding());
                         } else {
-                            //Just set the URI
-                            //input.setUri(expanded);
+                            // Just set the URI
+                            // input.setUri(expanded);
                         }
                     }
                 }
                 /**
                  * Delegate to usual open mechanism.
-                 * 
+                 *
                  * @see com.thaiopensource.resolver.Resolver#open(com.thaiopensource.resolver.Input)
                  */
                 @Override
@@ -182,12 +164,10 @@ XMLComponent, XMLDocumentSource {
         }
     }
 
-
     /**
      * @see org.apache.xerces.xni.parser.XMLComponent#reset(org.apache.xerces.xni.parser.XMLComponentManager)
      */
-    public void reset(XMLComponentManager componentManager)
-            throws XMLConfigurationException {
+    public void reset(XMLComponentManager componentManager) throws XMLConfigurationException {
         baseSystemId = null;
         detecting = false;
         schema = null;
@@ -206,8 +186,8 @@ XMLComponent, XMLDocumentSource {
      *      java.lang.String, org.apache.xerces.xni.NamespaceContext,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void startDocument(XMLLocator locator, String enc,
-            NamespaceContext nc, Augmentations aug) throws XNIException {
+    public void startDocument(XMLLocator locator, String enc, NamespaceContext nc, Augmentations aug)
+            throws XNIException {
         this.locator = locator;
         context = nc;
         baseSystemId = locator.getBaseSystemId();
@@ -225,16 +205,15 @@ XMLComponent, XMLDocumentSource {
      *      org.apache.xerces.xni.Augmentations)
      */
     @Override
-    public void startElement(QName name, XMLAttributes atts, Augmentations aug)
-            throws XNIException {
+    public void startElement(QName name, XMLAttributes atts, Augmentations aug) throws XNIException {
         boolean oldDetecting = detecting;
         onStartElement(name, atts);
         if (documentHandler != null) {
             documentHandler.startElement(name, atts, aug);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
-                if(detecting != oldDetecting) {
+                if (detecting != oldDetecting) {
                     triggerStartDocumentToValidator();
                 }
                 startElementToValidator(name, atts);
@@ -264,35 +243,41 @@ XMLComponent, XMLDocumentSource {
         int len = atts.getLength();
         for (int i = 0; i < len; i++) {
             String qName = atts.getQName(i);
-            if(qName.startsWith(NS_MAPPING_PREFIX) || qName.equals(NS_MAPPING_DEFAULT)) {
-                if(prefixes == null) {
+            if (qName.startsWith(NS_MAPPING_PREFIX) || qName.equals(NS_MAPPING_DEFAULT)) {
+                if (prefixes == null) {
                     prefixes = new HashSet<>();
                 }
                 String value = atts.getValue(i);
-                if(value == null) {
+                if (value == null) {
                     value = "";
                 }
                 String prefix = "";
-                if(qName.startsWith(NS_MAPPING_PREFIX)) {
+                if (qName.startsWith(NS_MAPPING_PREFIX)) {
                     prefix = qName.substring(NS_MAPPING_PREFIX.length());
                 }
                 validator.getContentHandler().startPrefixMapping(prefix, value);
                 prefixes.add(prefix);
             } else {
-                attrs.addAttribute(atts.getURI(i) != null ? atts.getURI(i) : "", atts.getLocalName(i), atts.getQName(i), atts.getType(i), atts.getValue(i));
+                attrs.addAttribute(
+                        atts.getURI(i) != null ? atts.getURI(i) : "",
+                        atts.getLocalName(i),
+                        atts.getQName(i),
+                        atts.getType(i),
+                        atts.getValue(i));
             }
         }
         prefixMappingStack.push(prefixes);
-        validator.getContentHandler().startElement(name.uri != null ? name.uri : "", name.localpart, name.rawname, attrs);
+        validator
+                .getContentHandler()
+                .startElement(name.uri != null ? name.uri : "", name.localpart, name.rawname, attrs);
     }
-
 
     /**
      * Trigger the start document method.
      */
     private void triggerStartDocumentToValidator() throws SAXException {
-        //Set the document locator and start document before handling the first element
-        if(locator != null) {
+        // Set the document locator and start document before handling the first element
+        if (locator != null) {
             validator.getContentHandler().setDocumentLocator(new Locator() {
                 @Override
                 public String getSystemId() {
@@ -320,14 +305,14 @@ XMLComponent, XMLDocumentSource {
 
     /**
      * On start element
-     * 
+     *
      * @param name The element name
      * @param atts The attributes
      */
     private void onStartElement(QName name, XMLAttributes atts) {
         if (detecting) {
-            if("http://relaxng.org/ns/structure/1.0".equals(name.uri)) {
-                //Avoid loading defaults when validating RNG schemas.
+            if ("http://relaxng.org/ns/structure/1.0".equals(name.uri)) {
+                // Avoid loading defaults when validating RNG schemas.
                 defaults = null;
             } else {
                 loadDefaults();
@@ -340,15 +325,15 @@ XMLComponent, XMLDocumentSource {
     }
 
     /**
-     * 
+     *
      */
     private void loadDefaults() {
         defaults = null;
         ErrorHandler eh = new ErrorHandler() {
             @Override
             public void warning(SAXParseException exception) throws SAXException {
-                if(validate) {
-                    if(errorHandler != null) {
+                if (validate) {
+                    if (errorHandler != null) {
                         errorHandler.warning("", "", new XMLParseException(locator, exception.getMessage(), exception));
                     } else {
                         throw exception;
@@ -361,8 +346,8 @@ XMLComponent, XMLDocumentSource {
 
             @Override
             public void error(SAXParseException exception) throws SAXException {
-                if(validate) {
-                    if(errorHandler != null) {
+                if (validate) {
+                    if (errorHandler != null) {
                         errorHandler.error("", "", new XMLParseException(locator, exception.getMessage(), exception));
                     } else {
                         throw exception;
@@ -375,9 +360,10 @@ XMLComponent, XMLDocumentSource {
 
             @Override
             public void fatalError(SAXParseException exception) throws SAXException {
-                if(validate) {
-                    if(errorHandler != null) {
-                        errorHandler.fatalError("", "", new XMLParseException(locator, exception.getMessage(), exception));
+                if (validate) {
+                    if (errorHandler != null) {
+                        errorHandler.fatalError(
+                                "", "", new XMLParseException(locator, exception.getMessage(), exception));
                     } else {
                         throw exception;
                     }
@@ -388,7 +374,7 @@ XMLComponent, XMLDocumentSource {
             }
         };
 
-        if(schema != null) {
+        if (schema != null) {
             if ("xml".equals(type) || "compact".equals(type)) {
                 Identifier id = new Identifier(schema, baseSystemId);
                 Input input = new Input();
@@ -400,9 +386,8 @@ XMLComponent, XMLDocumentSource {
                     }
                 }
 
-
                 InputSource in = null;
-                if(input.isResolved()) {
+                if (input.isResolved()) {
                     in = new InputSource(input.getUri());
                     in.setByteStream(input.getByteStream());
                     in.setCharacterStream(input.getCharacterStream());
@@ -410,24 +395,26 @@ XMLComponent, XMLDocumentSource {
                 } else {
                     String expanded = schema;
                     try {
-                        expanded  = new URL(new URL(baseSystemId), schema).toString();
+                        expanded = new URL(new URL(baseSystemId), schema).toString();
                     } catch (Exception e) {
-                    }        
+                    }
                     in = new InputSource(expanded);
                 }
                 try {
-                    //Use caching grammar pool
+                    // Use caching grammar pool
                     RNGDefaultsEnabledGrammarPool pool = null;
-                    if(grammarPool instanceof RNGDefaultsEnabledGrammarPool) {
+                    if (grammarPool instanceof RNGDefaultsEnabledGrammarPool) {
                         pool = (RNGDefaultsEnabledGrammarPool) grammarPool;
                     }
-                    RelaxNGDefaultValues cachedDefaults = pool != null ? pool.getRngDefaultValues(in.getSystemId()) : null;
-                    if(cachedDefaults != null && 
-                            //Either the cached defaults has a schema reference
+                    RelaxNGDefaultValues cachedDefaults =
+                            pool != null ? pool.getRngDefaultValues(in.getSystemId()) : null;
+                    if (cachedDefaults != null
+                            &&
+                            // Either the cached defaults has a schema reference
                             (cachedDefaults.isKeepSchema()
-                                    //Or we do not want to validate.
-                                    || ! validate)) {
-                        //Retrieve defaults from pool
+                                    // Or we do not want to validate.
+                                    || !validate)) {
+                        // Retrieve defaults from pool
                         defaults = cachedDefaults;
                     } else {
                         if ("xml".equals(type)) {
@@ -438,14 +425,14 @@ XMLComponent, XMLDocumentSource {
 
                         defaults.update(in);
 
-                        if(pool != null && ! defaults.hasUpdateErrors()){
+                        if (pool != null && !defaults.hasUpdateErrors()) {
                             pool.putRngDefaultValues(in.getSystemId(), defaults);
                         }
                     }
-                    if(validate && defaults != null) {
+                    if (validate && defaults != null) {
                         PropertyMapBuilder builder = new PropertyMapBuilder();
-                        //Set the resolver
-                        builder.put(ValidateProperty.RESOLVER, resolver);  
+                        // Set the resolver
+                        builder.put(ValidateProperty.RESOLVER, resolver);
                         builder.put(ValidateProperty.ERROR_HANDLER, eh);
                         validator = defaults.createValidator(builder.toPropertyMap());
                     }
@@ -460,27 +447,26 @@ XMLComponent, XMLDocumentSource {
 
     /**
      * Check and add defaults
-     * 
+     *
      * @param name The element name
      * @param atts The attributes
      */
     private void checkAndAddDefaults(QName name, XMLAttributes atts) {
-        List<RelaxNGDefaultValues.Attribute> def = defaults.getDefaultAttributes(
-                name.localpart, name.uri);
+        List<RelaxNGDefaultValues.Attribute> def = defaults.getDefaultAttributes(name.localpart, name.uri);
         if (def != null) {
             for (RelaxNGDefaultValues.Attribute a : def) {
-                //EXM-24143 it is possible that the namespace of the default attribute is empty
-                //and the namespace of the attribute declared in the XMLAttributes is NULL.
+                // EXM-24143 it is possible that the namespace of the default attribute is empty
+                // and the namespace of the attribute declared in the XMLAttributes is NULL.
                 boolean alreadyDeclared = false;
                 alreadyDeclared = atts.getIndex(a.namespace, a.localName) >= 0;
-                if(! alreadyDeclared) {
-                    if("".equals(a.namespace)) {
-                        //Extra check with NULL Namespace
-                        alreadyDeclared = atts.getIndex(null, a.localName) >= 0;    
+                if (!alreadyDeclared) {
+                    if ("".equals(a.namespace)) {
+                        // Extra check with NULL Namespace
+                        alreadyDeclared = atts.getIndex(null, a.localName) >= 0;
                     }
                 }
 
-                if (! alreadyDeclared) {
+                if (!alreadyDeclared) {
                     String prefix = null;
                     String rawname = a.localName;
                     if (a.namespace != null && a.namespace.length() > 0) {
@@ -502,8 +488,10 @@ XMLComponent, XMLDocumentSource {
                             // if we want to fully handle this case we may need further
                             // processing.
                             if (atts.getIndex(rawname) < 0) {
-                                QName attName = new QName(fSymbolTable.addSymbol(prefix),
-                                        fSymbolTable.addSymbol(a.localName), fSymbolTable.addSymbol(rawname),
+                                QName attName = new QName(
+                                        fSymbolTable.addSymbol(prefix),
+                                        fSymbolTable.addSymbol(a.localName),
+                                        fSymbolTable.addSymbol(rawname),
                                         fSymbolTable.addSymbol(a.namespace));
                                 atts.addAttribute(attName, "CDATA", a.value);
                                 int attrIndex = atts.getIndex(attName.uri, attName.localpart);
@@ -511,30 +499,34 @@ XMLComponent, XMLDocumentSource {
                             }
                         } else {
                             int k = 1;
-                            if(
-                                    //EXM-24494 Prefer this prefix
-                                    //See the implementation in: org.dita.dost.reader.MergeTopicParser.startElement(String, String, String, Attributes)
-                                    //If the file is a composite no attributes are copied from the root element.
-                                    "http://dita.oasis-open.org/architecture/2005/".equals(a.namespace)) {
+                            if (
+                            // EXM-24494 Prefer this prefix
+                            // See the implementation in: org.dita.dost.reader.MergeTopicParser.startElement(String,
+                            // String, String, Attributes)
+                            // If the file is a composite no attributes are copied from the root element.
+                            "http://dita.oasis-open.org/architecture/2005/".equals(a.namespace)) {
                                 prefix = "ditaarch";
                             } else {
                                 prefix = "ns" + k;
                             }
-                            while (context.getURI(prefix) != null
-                                    || atts.getValue("xmlns:" + prefix) != null) {
+                            while (context.getURI(prefix) != null || atts.getValue("xmlns:" + prefix) != null) {
                                 k++;
                                 prefix = "ns" + k;
                             }
                             rawname = prefix + ":" + a.localName;
 
-                            QName attNs = new QName(fSymbolTable.addSymbol("xmlns"),
-                                    fSymbolTable.addSymbol(prefix), fSymbolTable.addSymbol("xmlns:" + prefix),
+                            QName attNs = new QName(
+                                    fSymbolTable.addSymbol("xmlns"),
+                                    fSymbolTable.addSymbol(prefix),
+                                    fSymbolTable.addSymbol("xmlns:" + prefix),
                                     fSymbolTable.addSymbol("http://www.w3.org/2000/xmlns/"));
                             atts.addAttribute(attNs, "CDATA", a.namespace);
                             context.declarePrefix(prefix, a.namespace);
 
-                            QName attName = new QName(fSymbolTable.addSymbol(prefix),
-                                    fSymbolTable.addSymbol(a.localName), fSymbolTable.addSymbol(rawname),
+                            QName attName = new QName(
+                                    fSymbolTable.addSymbol(prefix),
+                                    fSymbolTable.addSymbol(a.localName),
+                                    fSymbolTable.addSymbol(rawname),
                                     fSymbolTable.addSymbol(a.namespace));
                             atts.addAttribute(attName, "CDATA", a.value);
                             int attrIndex = atts.getIndex(attName.uri, attName.localpart);
@@ -557,8 +549,7 @@ XMLComponent, XMLDocumentSource {
      *      java.lang.String, java.lang.String,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void xmlDecl(String arg0, String arg1, String arg2, Augmentations arg3)
-            throws XNIException {
+    public void xmlDecl(String arg0, String arg1, String arg2, Augmentations arg3) throws XNIException {
         if (documentHandler != null) {
             documentHandler.xmlDecl(arg0, arg1, arg2, arg3);
         }
@@ -569,8 +560,7 @@ XMLComponent, XMLDocumentSource {
      *      java.lang.String, java.lang.String,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void doctypeDecl(String arg0, String arg1, String arg2,
-            Augmentations arg3) throws XNIException {
+    public void doctypeDecl(String arg0, String arg1, String arg2, Augmentations arg3) throws XNIException {
         if (documentHandler != null) {
             documentHandler.doctypeDecl(arg0, arg1, arg2, arg3);
         }
@@ -590,8 +580,7 @@ XMLComponent, XMLDocumentSource {
      * @see org.apache.xerces.xni.XMLDocumentHandler#processingInstruction(java.lang.String,
      *      org.apache.xerces.xni.XMLString, org.apache.xerces.xni.Augmentations)
      */
-    public void processingInstruction(String name, XMLString content,
-            Augmentations arg2) throws XNIException {
+    public void processingInstruction(String name, XMLString content, Augmentations arg2) throws XNIException {
         boolean detectedSchema = false;
         if (detecting && schema == null && "oxygen".equals(name)) {
             String data = content.toString();
@@ -604,8 +593,7 @@ XMLComponent, XMLDocumentSource {
             String data = content.toString();
             schema = getFromPIDataPseudoAttribute(data, "href", true);
             type = getFromPIDataPseudoAttribute(data, "type", true);
-            String schemaTypeNs = getFromPIDataPseudoAttribute(data, "schematypens",
-                    true);
+            String schemaTypeNs = getFromPIDataPseudoAttribute(data, "schematypens", true);
             if (schema != null) {
                 if (schema.toLowerCase().endsWith(".rng")) {
                     if (nullOrValue(schemaTypeNs, "http://relaxng.org/ns/structure/1.0")
@@ -626,8 +614,7 @@ XMLComponent, XMLDocumentSource {
                             && nullOrValue(type, "application/xml")) {
                         type = "xml";
                     } else if ("application/relax-ng-compact-syntax".equals(type)
-                            && nullOrValue(schemaTypeNs,
-                                    "http://relaxng.org/ns/structure/1.0")) {
+                            && nullOrValue(schemaTypeNs, "http://relaxng.org/ns/structure/1.0")) {
                         type = "compact";
                     } else {
                         schema = null;
@@ -637,8 +624,7 @@ XMLComponent, XMLDocumentSource {
             detectedSchema = true;
         }
 
-        if (documentHandler != null
-                && ! detectedSchema) {
+        if (documentHandler != null && !detectedSchema) {
             documentHandler.processingInstruction(name, content, arg2);
         }
     }
@@ -646,14 +632,12 @@ XMLComponent, XMLDocumentSource {
     /**
      * Test if a string is either null or equal to a certain value
      * @param test The string to test
-     * @param value The value to compare to 
+     * @param value The value to compare to
      * @return <code>true</code> if a string is either null or equal to a certain value
      */
     private boolean nullOrValue(String test, String value) {
-        if (test == null)
-            return true;
-        if (test.equals(value))
-            return true;
+        if (test == null) return true;
+        if (test.equals(value)) return true;
         return false;
     }
 
@@ -665,7 +649,7 @@ XMLComponent, XMLDocumentSource {
      * data part uses pseudo-attribute syntax, which it does not have to. This
      * syntax is as described in the W3C Recommendation
      * "Associating Style Sheets with XML Documents".
-     * 
+     *
      * @param data
      *          The PI Data.
      * @param name
@@ -674,8 +658,7 @@ XMLComponent, XMLDocumentSource {
      *          True to unescape value before return
      * @return the value of the pseudo-attribute if present, or null if not
      */
-    private String getFromPIDataPseudoAttribute(String data, String name,
-            boolean unescapeValue) {
+    private String getFromPIDataPseudoAttribute(String data, String name, boolean unescapeValue) {
         int pos = 0;
         while (pos <= data.length() - 4) { // minimum length of x=""
             int nextQuote = -1;
@@ -796,13 +779,12 @@ XMLComponent, XMLDocumentSource {
      *      org.apache.xerces.xni.XMLAttributes,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void emptyElement(QName name, XMLAttributes atts, Augmentations arg2)
-            throws XNIException {
+    public void emptyElement(QName name, XMLAttributes atts, Augmentations arg2) throws XNIException {
         onStartElement(name, atts);
         if (documentHandler != null) {
             documentHandler.emptyElement(name, atts, arg2);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
                 startElementToValidator(name, atts);
                 endElementToValidator(name);
@@ -812,15 +794,14 @@ XMLComponent, XMLDocumentSource {
         }
     }
 
-
     /**
      * @param name The element name
      */
     private void endElementToValidator(QName name) throws SAXException {
         validator.getContentHandler().endElement(name.uri != null ? name.uri : "", name.localpart, name.rawname);
-        if(!prefixMappingStack.isEmpty()) {
+        if (!prefixMappingStack.isEmpty()) {
             Set<String> prefixes = prefixMappingStack.pop();
-            if(prefixes != null) {
+            if (prefixes != null) {
                 for (String prefix : prefixes) {
                     validator.getContentHandler().endPrefixMapping(prefix);
                 }
@@ -833,8 +814,8 @@ XMLComponent, XMLDocumentSource {
      *      org.apache.xerces.xni.XMLResourceIdentifier, java.lang.String,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void startGeneralEntity(String arg0, XMLResourceIdentifier arg1,
-            String arg2, Augmentations arg3) throws XNIException {
+    public void startGeneralEntity(String arg0, XMLResourceIdentifier arg1, String arg2, Augmentations arg3)
+            throws XNIException {
         if (documentHandler != null) {
             documentHandler.startGeneralEntity(arg0, arg1, arg2, arg3);
         }
@@ -844,8 +825,7 @@ XMLComponent, XMLDocumentSource {
      * @see org.apache.xerces.xni.XMLDocumentHandler#textDecl(java.lang.String,
      *      java.lang.String, org.apache.xerces.xni.Augmentations)
      */
-    public void textDecl(String arg0, String arg1, Augmentations arg2)
-            throws XNIException {
+    public void textDecl(String arg0, String arg1, Augmentations arg2) throws XNIException {
         if (documentHandler != null) {
             documentHandler.textDecl(arg0, arg1, arg2);
         }
@@ -855,8 +835,7 @@ XMLComponent, XMLDocumentSource {
      * @see org.apache.xerces.xni.XMLDocumentHandler#endGeneralEntity(java.lang.String,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void endGeneralEntity(String arg0, Augmentations arg1)
-            throws XNIException {
+    public void endGeneralEntity(String arg0, Augmentations arg1) throws XNIException {
         if (documentHandler != null) {
             documentHandler.endGeneralEntity(arg0, arg1);
         }
@@ -866,12 +845,11 @@ XMLComponent, XMLDocumentSource {
      * @see org.apache.xerces.xni.XMLDocumentHandler#characters(org.apache.xerces.xni.XMLString,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void characters(XMLString arg0, Augmentations arg1)
-            throws XNIException {
+    public void characters(XMLString arg0, Augmentations arg1) throws XNIException {
         if (documentHandler != null) {
             documentHandler.characters(arg0, arg1);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
                 validator.getContentHandler().characters(arg0.ch, arg0.offset, arg0.length);
             } catch (SAXException e) {
@@ -884,12 +862,11 @@ XMLComponent, XMLDocumentSource {
      * @see org.apache.xerces.xni.XMLDocumentHandler#ignorableWhitespace(org.apache.xerces.xni.XMLString,
      *      org.apache.xerces.xni.Augmentations)
      */
-    public void ignorableWhitespace(XMLString arg0, Augmentations arg1)
-            throws XNIException {
+    public void ignorableWhitespace(XMLString arg0, Augmentations arg1) throws XNIException {
         if (documentHandler != null) {
             documentHandler.ignorableWhitespace(arg0, arg1);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
                 validator.getContentHandler().ignorableWhitespace(arg0.ch, arg0.offset, arg0.length);
             } catch (SAXException e) {
@@ -906,7 +883,7 @@ XMLComponent, XMLDocumentSource {
         if (documentHandler != null) {
             documentHandler.endElement(arg0, arg1);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
                 endElementToValidator(arg0);
             } catch (SAXException e) {
@@ -940,7 +917,7 @@ XMLComponent, XMLDocumentSource {
         if (documentHandler != null) {
             documentHandler.endDocument(arg0);
         }
-        if(validator != null) {
+        if (validator != null) {
             try {
                 validator.getContentHandler().endDocument();
             } catch (SAXException e) {
@@ -973,8 +950,7 @@ XMLComponent, XMLDocumentSource {
     /**
      * @see org.apache.xerces.xni.parser.XMLComponent#setFeature(java.lang.String, boolean)
      */
-    public void setFeature(String feature, boolean value)
-            throws XMLConfigurationException {
+    public void setFeature(String feature, boolean value) throws XMLConfigurationException {
         // Do nothing
     }
 
@@ -987,17 +963,15 @@ XMLComponent, XMLDocumentSource {
 
     /**
      * Sets the value of a property during parsing.
-     * 
+     *
      * @param propertyId Property ID
      * @param value      Property value
      */
     @Override
-    public void setProperty(String propertyId, Object value)
-            throws XMLConfigurationException {
+    public void setProperty(String propertyId, Object value) throws XMLConfigurationException {
         // Xerces properties
         if (propertyId.startsWith(Constants.XERCES_PROPERTY_PREFIX)) {
-            final int suffixLength = propertyId.length()
-                    - Constants.XERCES_PROPERTY_PREFIX.length();
+            final int suffixLength = propertyId.length() - Constants.XERCES_PROPERTY_PREFIX.length();
 
             if (suffixLength == Constants.SYMBOL_TABLE_PROPERTY.length()
                     && propertyId.endsWith(Constants.SYMBOL_TABLE_PROPERTY)) {
@@ -1005,9 +979,9 @@ XMLComponent, XMLDocumentSource {
             } else if (suffixLength == Constants.ENTITY_RESOLVER_PROPERTY.length()
                     && propertyId.endsWith(Constants.ENTITY_RESOLVER_PROPERTY)) {
                 fResolver = (XMLEntityResolver) value;
-            } else if(suffixLength == Constants.ERROR_HANDLER_PROPERTY.length()
+            } else if (suffixLength == Constants.ERROR_HANDLER_PROPERTY.length()
                     && propertyId.endsWith(Constants.ERROR_HANDLER_PROPERTY)) {
-                errorHandler = (XMLErrorHandler)value;
+                errorHandler = (XMLErrorHandler) value;
             }
         }
     } // setProperty(String,Object)

--- a/src/main/java/org/ditang/relaxng/defaults/Util.java
+++ b/src/main/java/org/ditang/relaxng/defaults/Util.java
@@ -16,22 +16,22 @@ import java.util.StringTokenizer;
  * Corrects the urls.
  */
 public class Util {
-  /**
-   * Windows platform flag.
-   */
-  private static Boolean windows = null;
+    /**
+     * Windows platform flag.
+     */
+    private static Boolean windows = null;
 
-  /**
-   * Checks for a Windows platform.
-   * 
-   * @return True if it is a win 32 platform.
-   */
-  private static boolean isWindows() {
-    if (windows == null) {
-      windows = System.getProperty("os.name").toUpperCase().startsWith("WIN");
+    /**
+     * Checks for a Windows platform.
+     *
+     * @return True if it is a win 32 platform.
+     */
+    private static boolean isWindows() {
+        if (windows == null) {
+            windows = System.getProperty("os.name").toUpperCase().startsWith("WIN");
+        }
+        return windows;
     }
-    return windows;
-  }
 
     // which ASCII characters need to be escaped
     private static final boolean[] gNeedEscaping = new boolean[128];
@@ -39,454 +39,450 @@ public class Util {
     private static final char[] gAfterEscaping1 = new char[128];
     // the second hex character if a character needs to be escaped
     private static final char[] gAfterEscaping2 = new char[128];
-  private static final char[] gHexChs = { '0', '1', '2', '3', '4', '5', '6', '7',
-      '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-  // initialize the above 3 arrays
-  static {
-    for (int i = 0; i <= 0x1f; i++) {
-      gNeedEscaping[i] = true;
-      gAfterEscaping1[i] = gHexChs[i >> 4];
-      gAfterEscaping2[i] = gHexChs[i & 0xf];
+    private static final char[] gHexChs = {
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+    // initialize the above 3 arrays
+    static {
+        for (int i = 0; i <= 0x1f; i++) {
+            gNeedEscaping[i] = true;
+            gAfterEscaping1[i] = gHexChs[i >> 4];
+            gAfterEscaping2[i] = gHexChs[i & 0xf];
+        }
+        gNeedEscaping[0x7f] = true;
+        gAfterEscaping1[0x7f] = '7';
+        gAfterEscaping2[0x7f] = 'F';
+        char[] escChs = {' ', '<', '>', '#', '%', '"', '{', '}', '?', '|', '\\', '^', '~', '[', ']', '`', '\'', '&'};
+        int len = escChs.length;
+        char ch;
+        for (char escCh : escChs) {
+            ch = escCh;
+            gNeedEscaping[ch] = true;
+            gAfterEscaping1[ch] = gHexChs[ch >> 4];
+            gAfterEscaping2[ch] = gHexChs[ch & 0xf];
+        }
     }
-    gNeedEscaping[0x7f] = true;
-    gAfterEscaping1[0x7f] = '7';
-    gAfterEscaping2[0x7f] = 'F';
-    char[] escChs = { ' ', '<', '>', '#', '%', '"', '{', '}', '?', '|', '\\',
-        '^', '~', '[', ']', '`', '\'', '&' };
-    int len = escChs.length;
-    char ch;
-    for (char escCh : escChs) {
-      ch = escCh;
-      gNeedEscaping[ch] = true;
-      gAfterEscaping1[ch] = gHexChs[ch >> 4];
-      gAfterEscaping2[ch] = gHexChs[ch & 0xf];
-    }
-  }
 
-/** 
-   * To escape a file path to a URI, by using %HH to represent
-   * special ASCII characters: 0x00~0x1F, 0x7F, ' ', '<', '>', '#', '%'
-   * and '"' and non-ASCII characters (whose value >= 128).
-   * <p>
-   * '\' character will also be escaped.
-   * 
-   * @param path The path to be escaped.
-   * @return The escaped uri.
-   */
-  private static String filepath2URI(String path) {
-    // return null if path is null.
-    if (path == null) {
-      return null;
+    /**
+     * To escape a file path to a URI, by using %HH to represent
+     * special ASCII characters: 0x00~0x1F, 0x7F, ' ', '<', '>', '#', '%'
+     * and '"' and non-ASCII characters (whose value >= 128).
+     * <p>
+     * '\' character will also be escaped.
+     *
+     * @param path The path to be escaped.
+     * @return The escaped uri.
+     */
+    private static String filepath2URI(String path) {
+        // return null if path is null.
+        if (path == null) {
+            return null;
+        }
+        path = escapeSpecialAsciiAndNonAscii(path);
+        return path;
     }
-    path = escapeSpecialAsciiAndNonAscii(path);
-    return path;
-  }
 
-/**
-   * To escape a file path to a URI, by using %HH to represent
-   * special ASCII characters: 0x00~0x1F, 0x7F, ' ', '<', '>', '#', '%'
-   * and '"' and non-ASCII characters (whose value >= 128).
-   * 
-   * @param path The path to be escaped.
-   * @return The escaped path.
-   */
-  private static String escapeSpecialAsciiAndNonAscii(String path) {
-    int len = path.length(), ch;
-    StringBuilder buffer = new StringBuilder(len * 3);
-    // change C:/blah to /C:/blah
-    if (len >= 2 && path.charAt(1) == ':') {
-      ch = Character.toUpperCase(path.charAt(0));
-      if (ch >= 'A' && ch <= 'Z') {
-        buffer.append('/');
-      }
+    /**
+     * To escape a file path to a URI, by using %HH to represent
+     * special ASCII characters: 0x00~0x1F, 0x7F, ' ', '<', '>', '#', '%'
+     * and '"' and non-ASCII characters (whose value >= 128).
+     *
+     * @param path The path to be escaped.
+     * @return The escaped path.
+     */
+    private static String escapeSpecialAsciiAndNonAscii(String path) {
+        int len = path.length(), ch;
+        StringBuilder buffer = new StringBuilder(len * 3);
+        // change C:/blah to /C:/blah
+        if (len >= 2 && path.charAt(1) == ':') {
+            ch = Character.toUpperCase(path.charAt(0));
+            if (ch >= 'A' && ch <= 'Z') {
+                buffer.append('/');
+            }
+        }
+        // for each character in the path
+        int i = 0;
+        for (i = 0; i < len; i++) {
+            ch = path.charAt(i);
+            // if it's not an ASCII character, break here, and use UTF-8 encoding
+            if (ch >= 128) {
+                break;
+            }
+            if (gNeedEscaping[ch]) {
+                buffer.append('%');
+                buffer.append(gAfterEscaping1[ch]);
+                buffer.append(gAfterEscaping2[ch]);
+            } else {
+                buffer.append((char) ch);
+            }
+        }
+        // we saw some non-ascii character
+        if (i < len) {
+            // get UTF-8 bytes for the remaining sub-string
+            byte[] bytes = null;
+            byte b;
+            bytes = path.substring(i).getBytes(StandardCharsets.UTF_8);
+            len = bytes.length;
+            // for each byte
+            for (i = 0; i < len; i++) {
+                b = bytes[i];
+                // for non-ascii character: make it positive, then escape
+                if (b < 0) {
+                    ch = b + 256;
+                    buffer.append('%');
+                    buffer.append(gHexChs[ch >> 4]);
+                    buffer.append(gHexChs[ch & 0xf]);
+                } else if (gNeedEscaping[b]) {
+                    buffer.append('%');
+                    buffer.append(gAfterEscaping1[b]);
+                    buffer.append(gAfterEscaping2[b]);
+                } else {
+                    buffer.append((char) b);
+                }
+            }
+        }
+        return buffer.toString();
     }
-    // for each character in the path
-    int i = 0;
-    for (i = 0; i < len; i++) {
-      ch = path.charAt(i);
-      // if it's not an ASCII character, break here, and use UTF-8 encoding
-      if (ch >= 128) {
-        break;
-      }
-      if (gNeedEscaping[ch]) {
-        buffer.append('%');
-        buffer.append(gAfterEscaping1[ch]);
-        buffer.append(gAfterEscaping2[ch]);
-      } else {
-        buffer.append((char) ch);
-      }
+
+    /**
+     * Corrects an URL.
+     *
+     * @param url
+     *          The url to be corrected. If null will throw MalformedURLException.
+     * @return a corrected URL. Never null.
+     * @exception MalformedURLException
+     *              when the argument is null.
+     */
+    public static URL correct(URL url) throws MalformedURLException {
+        if (url == null) {
+            throw new MalformedURLException("The url is null");
+        }
+        return new URL(correct(url.toString()));
     }
-    // we saw some non-ascii character
-    if (i < len) {
-      // get UTF-8 bytes for the remaining sub-string
-      byte[] bytes = null;
-      byte b;
-      bytes = path.substring(i).getBytes(StandardCharsets.UTF_8);
-      len = bytes.length;
-      // for each byte
-      for (i = 0; i < len; i++) {
-        b = bytes[i];
-        // for non-ascii character: make it positive, then escape
-        if (b < 0) {
-          ch = b + 256;
-          buffer.append('%');
-          buffer.append(gHexChs[ch >> 4]);
-          buffer.append(gHexChs[ch & 0xf]);
-        } else if (gNeedEscaping[b]) {
-          buffer.append('%');
-          buffer.append(gAfterEscaping1[b]);
-          buffer.append(gAfterEscaping2[b]);
+
+    /**
+     * Method introduced to correct the URLs in the default machine encoding. This
+     * was needed by the xsltproc, the catalogs URLs must be encoded in the
+     * machine encoding.
+     *
+     * @param url
+     *          The URL to be corrected. If it contains a % char, it means it
+     *          already was corrected, so it will be returned. Take care at
+     *          composing URLs from a corrected part and an uncorrected part.
+     *          Correcting the result will not work. Try to correct first the
+     *          relative part.
+     * @return The corrected URL.
+     */
+    private static String correct(String url) {
+        // Fix for bad URLs containing UNC paths
+        // If the url is a UNC file url it must be specified like:
+        // file:////<PATH>...
+        if (url.startsWith("file://")
+                // A url like file:///<PATH> refers to a local file so it must not be
+                // modified.
+                && !url.startsWith("file:///")
+                && isWindows()) {
+            url = "file:////" + url.substring("file://".length());
+        }
+
+        String userInfo = getUserInfo(url);
+        String user = extractUser(userInfo);
+        String pass = extractPassword(userInfo);
+
+        String initialUrl = url;
+        // See if the url contains user and password. If so we remove them and
+        // attach them back after the correction is performed.
+        if (user != null || pass != null) {
+            URL urlWithoutUserInfo = clearUserInfo(url);
+            if (urlWithoutUserInfo != null) {
+                url = clearUserInfo(url).toString();
+            } else {
+                // Possible a malformed URL
+            }
+        }
+
+        // If there is a % that means the url was already corrected.
+        if (url.contains("%")) {
+            return initialUrl;
+        }
+
+        // Extract the reference (anchor) part from the url. The '#' char
+        // identifying the anchor must not be corrected.
+        String reference = null;
+        int refIndex = url.lastIndexOf('#');
+        if (refIndex != -1) {
+            reference = filepath2URI(url.substring(refIndex + 1));
+            url = url.substring(0, refIndex);
+        }
+
+        // Buffer where eventual query string will be processed.
+        StringBuilder queryBuffer = null;
+
+        int queryIndex = url.indexOf('?');
+        if (queryIndex != -1) {
+            // We have a query
+            String query = url.substring(queryIndex + 1);
+            url = url.substring(0, queryIndex);
+            queryBuffer = new StringBuilder(query.length());
+            // Tokenize by &
+            StringTokenizer st = new StringTokenizer(query, "&");
+            while (st.hasMoreElements()) {
+                String token = st.nextToken();
+                token = filepath2URI(token);
+                // Correct token
+                queryBuffer.append(token);
+                if (st.hasMoreElements()) {
+                    queryBuffer.append("&");
+                }
+            }
+        }
+
+        String toReturn = filepath2URI(url);
+
+        if (queryBuffer != null) {
+            // Append to the end the corrected query.
+            toReturn += "?" + queryBuffer.toString();
+        }
+
+        if (reference != null) {
+            // Append the reference to the end the corrected query.
+            toReturn += "#" + reference;
+        }
+
+        // Re-attach the user and password.
+        if (user != null || pass != null) {
+            try {
+                if (user == null) {
+                    user = "";
+                }
+                if (pass == null) {
+                    pass = "";
+                }
+                // Re-attach user info.
+                toReturn = attachUserInfo(new URL(toReturn), user, pass.toCharArray())
+                        .toString();
+            } catch (MalformedURLException e) {
+                // Shoudn't happen.
+            }
+        }
+        return toReturn;
+    }
+
+    /**
+     * Extract the user info from an URL.
+     *
+     * @param url
+     *          The string representing the URL.
+     * @return The userinfo or null if cannot extract it.
+     */
+    private static String getUserInfo(String url) {
+        String userInfo = null;
+        int startIndex = Integer.MIN_VALUE;
+        int nextSlashIndex = Integer.MIN_VALUE;
+        int endIndex = Integer.MIN_VALUE;
+        try {
+            // The user info start index should be the first index of "//".
+            startIndex = url.indexOf("//");
+            if (startIndex != -1) {
+                startIndex += 2;
+                // The user info should be found before the next '/' index.
+                nextSlashIndex = url.indexOf('/', startIndex);
+                if (nextSlashIndex == -1) {
+                    nextSlashIndex = url.length();
+                }
+                // The user info ends at the last index of '@' from the previously
+                // computed subsequence.
+                endIndex = url.substring(startIndex, nextSlashIndex).lastIndexOf('@');
+                if (endIndex != -1) {
+                    userInfo = url.substring(startIndex, startIndex + endIndex);
+                }
+            }
+        } catch (StringIndexOutOfBoundsException ex) {
+            System.err.println("String index out of bounds for:|" + url + "|");
+            System.err.println("Start index: " + startIndex);
+            System.err.println("Next slash index " + nextSlashIndex);
+            System.err.println("End index :" + endIndex);
+            System.err.println("User info :|" + userInfo + "|");
+            ex.printStackTrace();
+        }
+        return userInfo;
+    }
+
+    /**
+     * Gets the user from an userInfo string obtained from the starting URL. Used
+     * only by the constructor.
+     *
+     * @param userInfo
+     *          userInfo, taken from the URL.
+     * @return The user.
+     */
+    private static String extractUser(String userInfo) {
+        if (userInfo == null) {
+            return null;
+        }
+
+        int index = userInfo.lastIndexOf(':');
+        if (index == -1) {
+            return userInfo;
         } else {
-          buffer.append((char) b);
+            return userInfo.substring(0, index);
         }
-      }
-    }
-    return buffer.toString();
-  }
-
-  /**
-   * Corrects an URL.
-   * 
-   * @param url
-   *          The url to be corrected. If null will throw MalformedURLException.
-   * @return a corrected URL. Never null.
-   * @exception MalformedURLException
-   *              when the argument is null.
-   */
-  public static URL correct(URL url) throws MalformedURLException {
-    if (url == null) {
-      throw new MalformedURLException("The url is null");
-    }
-    return new URL(correct(url.toString()));
-  }
-
-  /**
-   * Method introduced to correct the URLs in the default machine encoding. This
-   * was needed by the xsltproc, the catalogs URLs must be encoded in the
-   * machine encoding.
-   * 
-   * @param url
-   *          The URL to be corrected. If it contains a % char, it means it
-   *          already was corrected, so it will be returned. Take care at
-   *          composing URLs from a corrected part and an uncorrected part.
-   *          Correcting the result will not work. Try to correct first the
-   *          relative part.
-   * @return The corrected URL.
-   */
-  private static String correct(String url) {
-    // Fix for bad URLs containing UNC paths
-    // If the url is a UNC file url it must be specified like:
-    // file:////<PATH>...
-    if (url.startsWith("file://")
-    // A url like file:///<PATH> refers to a local file so it must not be
-    // modified.
-        && !url.startsWith("file:///") && isWindows()) {
-      url = "file:////" + url.substring("file://".length());
     }
 
-    String userInfo = getUserInfo(url);
-    String user = extractUser(userInfo);
-    String pass = extractPassword(userInfo);
-
-    String initialUrl = url;
-    // See if the url contains user and password. If so we remove them and
-    // attach them back after the correction is performed.
-    if (user != null || pass != null) {
-      URL urlWithoutUserInfo = clearUserInfo(url);
-      if (urlWithoutUserInfo != null) {
-        url = clearUserInfo(url).toString();
-      } else {
-        // Possible a malformed URL
-      }
-    }
-
-    // If there is a % that means the url was already corrected.
-    if (url.contains("%")) {
-      return initialUrl;
-    }
-
-    // Extract the reference (anchor) part from the url. The '#' char
-    // identifying the anchor must not be corrected.
-    String reference = null;
-    int refIndex = url.lastIndexOf('#');
-    if (refIndex != -1) {
-      reference = filepath2URI(url.substring(refIndex + 1));
-      url = url.substring(0, refIndex);
-    }
-
-    // Buffer where eventual query string will be processed.
-    StringBuilder queryBuffer = null;
-
-    int queryIndex = url.indexOf('?');
-    if (queryIndex != -1) {
-      // We have a query
-      String query = url.substring(queryIndex + 1);
-      url = url.substring(0, queryIndex);
-      queryBuffer = new StringBuilder(query.length());
-      // Tokenize by &
-      StringTokenizer st = new StringTokenizer(query, "&");
-      while (st.hasMoreElements()) {
-        String token = st.nextToken();
-        token = filepath2URI(token);
-        // Correct token
-        queryBuffer.append(token);
-        if (st.hasMoreElements()) {
-          queryBuffer.append("&");
+    /**
+     * Gets the password from an user info string obtained from the starting URL.
+     *
+     * @param userInfo
+     *          userInfo, taken from the URL. If no user info specified returning
+     *          null. If user info not null but no password after ":" then
+     *          returning empty, (we have a user so the default pass for him is
+     *          empty string). See bug 6086.
+     *
+     * @return The password.
+     */
+    private static String extractPassword(String userInfo) {
+        if (userInfo == null) {
+            return null;
         }
-      }
-    }
-
-    String toReturn = filepath2URI(url);
-
-    if (queryBuffer != null) {
-      // Append to the end the corrected query.
-      toReturn += "?" + queryBuffer.toString();
-    }
-
-    if (reference != null) {
-      // Append the reference to the end the corrected query.
-      toReturn += "#" + reference;
-    }
-
-    // Re-attach the user and password.
-    if (user != null || pass != null) {
-      try {
-        if (user == null) {
-          user = "";
+        String password = "";
+        int index = userInfo.lastIndexOf(':');
+        if (index != -1 && index < userInfo.length() - 1) {
+            // Extract password from the URL.
+            password = userInfo.substring(index + 1);
         }
-        if (pass == null) {
-          pass = "";
+        return password;
+    }
+
+    /**
+     * Clears the user info from an url.
+     *
+     * @param systemID
+     *          the url to be cleaned.
+     * @return the cleaned url, or null if the argument is not an URL.
+     */
+    private static URL clearUserInfo(String systemID) {
+        try {
+            URL url = new URL(systemID);
+            // Do not clear user info on "file" urls 'cause on Windows the drive will
+            // have no ":"...
+            if (!"file".equals(url.getProtocol())) {
+                return attachUserInfo(url, null, null);
+            }
+            return url;
+        } catch (MalformedURLException e) {
+            return null;
         }
-        // Re-attach user info.
-        toReturn = attachUserInfo(new URL(toReturn), user, pass.toCharArray())
-            .toString();
-      } catch (MalformedURLException e) {
-        // Shoudn't happen.
-      }
     }
-    return toReturn;
-  }
 
-  /**
-   * Extract the user info from an URL.
-   * 
-   * @param url
-   *          The string representing the URL.
-   * @return The userinfo or null if cannot extract it.
-   */
-  private static String getUserInfo(String url) {
-    String userInfo = null;
-    int startIndex = Integer.MIN_VALUE;
-    int nextSlashIndex = Integer.MIN_VALUE;
-    int endIndex = Integer.MIN_VALUE;
-    try {
-      // The user info start index should be the first index of "//".
-      startIndex = url.indexOf("//");
-      if (startIndex != -1) {
-        startIndex += 2;
-        // The user info should be found before the next '/' index.
-        nextSlashIndex = url.indexOf('/', startIndex);
-        if (nextSlashIndex == -1) {
-          nextSlashIndex = url.length();
+    /**
+     * Build the URL from the data obtained from the user.
+     *
+     * @param url
+     *          The URL to be transformed.
+     * @param user
+     *          The user name.
+     * @param password
+     *          The password.
+     * @return The URL with userInfo.
+     * @exception MalformedURLException
+     *              Exception thrown if the URL is malformed.
+     */
+    private static URL attachUserInfo(URL url, String user, char[] password) throws MalformedURLException {
+        if (url == null) {
+            return null;
         }
-        // The user info ends at the last index of '@' from the previously
-        // computed subsequence.
-        endIndex = url.substring(startIndex, nextSlashIndex).lastIndexOf('@');
-        if (endIndex != -1) {
-          userInfo = url.substring(startIndex, startIndex + endIndex);
+        if ((url.getAuthority() == null || "".equals(url.getAuthority())) && !"jar".equals(url.getProtocol())) {
+            return url;
         }
-      }
-    } catch (StringIndexOutOfBoundsException ex) {
-      System.err.println("String index out of bounds for:|" + url + "|");
-      System.err.println("Start index: " + startIndex);
-      System.err.println("Next slash index " + nextSlashIndex);
-      System.err.println("End index :" + endIndex);
-      System.err.println("User info :|" + userInfo + "|");
-      ex.printStackTrace();
-    }
-    return userInfo;
-  }
 
-  /**
-   * Gets the user from an userInfo string obtained from the starting URL. Used
-   * only by the constructor.
-   * 
-   * @param userInfo
-   *          userInfo, taken from the URL.
-   * @return The user.
-   */
-  private static String extractUser(String userInfo) {
-    if (userInfo == null) {
-      return null;
-    }
+        StringBuilder buf = new StringBuilder();
+        String protocol = url.getProtocol();
 
-    int index = userInfo.lastIndexOf(':');
-    if (index == -1) {
-      return userInfo;
-    } else {
-      return userInfo.substring(0, index);
-    }
-  }
-
-  /**
-   * Gets the password from an user info string obtained from the starting URL.
-   * 
-   * @param userInfo
-   *          userInfo, taken from the URL. If no user info specified returning
-   *          null. If user info not null but no password after ":" then
-   *          returning empty, (we have a user so the default pass for him is
-   *          empty string). See bug 6086.
-   * 
-   * @return The password.
-   */
-  private static String extractPassword(String userInfo) {
-    if (userInfo == null) {
-      return null;
-    }
-    String password = "";
-    int index = userInfo.lastIndexOf(':');
-    if (index != -1 && index < userInfo.length() - 1) {
-      // Extract password from the URL.
-      password = userInfo.substring(index + 1);
-    }
-    return password;
-  }
-
-  /**
-   * Clears the user info from an url.
-   * 
-   * @param systemID
-   *          the url to be cleaned.
-   * @return the cleaned url, or null if the argument is not an URL.
-   */
-  private static URL clearUserInfo(String systemID) {
-    try {
-      URL url = new URL(systemID);
-      // Do not clear user info on "file" urls 'cause on Windows the drive will
-      // have no ":"...
-      if (!"file".equals(url.getProtocol())) {
-        return attachUserInfo(url, null, null);
-      }
-      return url;
-    } catch (MalformedURLException e) {
-      return null;
-    }
-  }
-
-  /**
-   * Build the URL from the data obtained from the user.
-   * 
-   * @param url
-   *          The URL to be transformed.
-   * @param user
-   *          The user name.
-   * @param password
-   *          The password.
-   * @return The URL with userInfo.
-   * @exception MalformedURLException
-   *              Exception thrown if the URL is malformed.
-   */
-  private static URL attachUserInfo(URL url, String user, char[] password)
-      throws MalformedURLException {
-    if (url == null) {
-      return null;
-    }
-    if ((url.getAuthority() == null || "".equals(url.getAuthority()))
-        && !"jar".equals(url.getProtocol())) {
-      return url;
-    }
-
-    StringBuilder buf = new StringBuilder();
-    String protocol = url.getProtocol();
-
-    if (protocol.equals("jar")) {
-      URL newURL = new URL(url.getPath());
-      newURL = attachUserInfo(newURL, user, password);
-      buf.append("jar:");
-      buf.append(newURL.toString());
-    } else {
-
-      password = correctPassword(password);
-
-      user = correctUser(user);
-
-      buf.append(protocol);
-      buf.append("://");
-      if (!"file".equals(protocol) && user != null && user.trim().length() > 0) {
-        buf.append(user);
-        if (password != null && password.length > 0) {
-          buf.append(":");
-          buf.append(password);
-        }
-        buf.append("@");
-      }
-      buf.append(url.getHost());
-      if (url.getPort() > 0) {
-        buf.append(":");
-        buf.append(url.getPort());
-      }
-      buf.append(url.getPath());
-      String query = url.getQuery();
-      if (query != null && query.trim().length() > 0) {
-        buf.append("?").append(query);
-      }
-      String ref = url.getRef();
-      if (ref != null && ref.trim().length() > 0) {
-        buf.append("#").append(ref);
-      }
-    }
-    return new URL(buf.toString());
-  }
-
-  /**
-   * Escape the specified user.
-   * 
-   * @param user
-   *          The user name to correct.
-   * @return The escaped user.
-   */
-  private static String correctUser(String user) {
-    if (user != null && user.trim().length() > 0
-        && (false || user.indexOf('%') == -1)) {
-      String escaped = escapeSpecialAsciiAndNonAscii(user);
-      StringBuilder totalEscaped = new StringBuilder();
-      for (int i = 0; i < escaped.length(); i++) {
-        char ch = escaped.charAt(i);
-        if (ch == '@' || ch == '/' || ch == ':') {
-          totalEscaped.append('%')
-              .append(Integer.toHexString(ch).toUpperCase());
+        if (protocol.equals("jar")) {
+            URL newURL = new URL(url.getPath());
+            newURL = attachUserInfo(newURL, user, password);
+            buf.append("jar:");
+            buf.append(newURL.toString());
         } else {
-          totalEscaped.append(ch);
-        }
-      }
-      user = totalEscaped.toString();
-    }
-    return user;
-  }
 
-  /**
-   * Escape the specified password.
-   * 
-   * @param password
-   *          The password to be corrected.
-   * 
-   * @return The escaped password.
-   */
-  private static char[] correctPassword(char[] password) {
-    if (password != null && new String(password).indexOf('%') == -1) {
-      String escaped = escapeSpecialAsciiAndNonAscii(new String(password));
-      StringBuilder totalEscaped = new StringBuilder();
-      for (int i = 0; i < escaped.length(); i++) {
-        char ch = escaped.charAt(i);
-        if (ch == '@' || ch == '/' || ch == ':') {
-          totalEscaped.append('%')
-              .append(Integer.toHexString(ch).toUpperCase());
-        } else {
-          totalEscaped.append(ch);
+            password = correctPassword(password);
+
+            user = correctUser(user);
+
+            buf.append(protocol);
+            buf.append("://");
+            if (!"file".equals(protocol) && user != null && user.trim().length() > 0) {
+                buf.append(user);
+                if (password != null && password.length > 0) {
+                    buf.append(":");
+                    buf.append(password);
+                }
+                buf.append("@");
+            }
+            buf.append(url.getHost());
+            if (url.getPort() > 0) {
+                buf.append(":");
+                buf.append(url.getPort());
+            }
+            buf.append(url.getPath());
+            String query = url.getQuery();
+            if (query != null && query.trim().length() > 0) {
+                buf.append("?").append(query);
+            }
+            String ref = url.getRef();
+            if (ref != null && ref.trim().length() > 0) {
+                buf.append("#").append(ref);
+            }
         }
-      }
-      password = totalEscaped.toString().toCharArray();
+        return new URL(buf.toString());
     }
-    return password;
-  }
+
+    /**
+     * Escape the specified user.
+     *
+     * @param user
+     *          The user name to correct.
+     * @return The escaped user.
+     */
+    private static String correctUser(String user) {
+        if (user != null && user.trim().length() > 0 && (false || user.indexOf('%') == -1)) {
+            String escaped = escapeSpecialAsciiAndNonAscii(user);
+            StringBuilder totalEscaped = new StringBuilder();
+            for (int i = 0; i < escaped.length(); i++) {
+                char ch = escaped.charAt(i);
+                if (ch == '@' || ch == '/' || ch == ':') {
+                    totalEscaped.append('%').append(Integer.toHexString(ch).toUpperCase());
+                } else {
+                    totalEscaped.append(ch);
+                }
+            }
+            user = totalEscaped.toString();
+        }
+        return user;
+    }
+
+    /**
+     * Escape the specified password.
+     *
+     * @param password
+     *          The password to be corrected.
+     *
+     * @return The escaped password.
+     */
+    private static char[] correctPassword(char[] password) {
+        if (password != null && new String(password).indexOf('%') == -1) {
+            String escaped = escapeSpecialAsciiAndNonAscii(new String(password));
+            StringBuilder totalEscaped = new StringBuilder();
+            for (int i = 0; i < escaped.length(); i++) {
+                char ch = escaped.charAt(i);
+                if (ch == '@' || ch == '/' || ch == ':') {
+                    totalEscaped.append('%').append(Integer.toHexString(ch).toUpperCase());
+                } else {
+                    totalEscaped.append(ch);
+                }
+            }
+            password = totalEscaped.toString().toCharArray();
+        }
+        return password;
+    }
 }

--- a/src/main/java/org/ditang/relaxng/defaults/pool/RNGDefaultsEnabledGrammarPool.java
+++ b/src/main/java/org/ditang/relaxng/defaults/pool/RNGDefaultsEnabledGrammarPool.java
@@ -11,13 +11,13 @@ import org.ditang.relaxng.defaults.RelaxNGDefaultValues;
 
 /**
  * Caches RNG default values
- * 
+ *
  * @author radu_coravu
  */
 public interface RNGDefaultsEnabledGrammarPool {
     /**
      * Get RNG default values for a certain system ID
-     * 
+     *
      * @param systemID The main schema system ID
      * @return Returns the rng Default Values mapped to the main schema system ID.
      */

--- a/src/main/java/org/ditang/relaxng/defaults/pool/RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl.java
+++ b/src/main/java/org/ditang/relaxng/defaults/pool/RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl.java
@@ -9,7 +9,6 @@ package org.ditang.relaxng.defaults.pool;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.ditang.relaxng.defaults.RelaxNGDefaultValues;
 
 /**
@@ -17,8 +16,8 @@ import org.ditang.relaxng.defaults.RelaxNGDefaultValues;
  *
  * @author radu_coravu
  */
-public class RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl
-extends org.dita.dost.util.XMLGrammarPoolImplUtils implements RNGDefaultsEnabledGrammarPool {
+public class RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl extends org.dita.dost.util.XMLGrammarPoolImplUtils
+        implements RNGDefaultsEnabledGrammarPool {
 
     /**
      * Caches Relax NG default values based on the URL pointing to the RNG schemas.

--- a/src/test/java/org/dita/dost/EndToEndTest.java
+++ b/src/test/java/org/dita/dost/EndToEndTest.java
@@ -1,12 +1,11 @@
 package org.dita.dost;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.dita.dost.AbstractIntegrationTest.Transtype.*;
 
 import java.io.File;
 import java.nio.file.Paths;
-
-import static org.dita.dost.AbstractIntegrationTest.Transtype.*;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class EndToEndTest extends AbstractIntegrationTest {
 
@@ -21,36 +20,33 @@ public class EndToEndTest extends AbstractIntegrationTest {
 
     @Test
     public void xhtml() throws Throwable {
-        builder().name("e2e")
-                .transtype(XHTML)
-                .input(Paths.get("root.ditamap"))
-                .run();
+        builder().name("e2e").transtype(XHTML).input(Paths.get("root.ditamap")).run();
     }
 
     @Test
     public void html5() throws Throwable {
-        builder().name("e2e")
-                .transtype(HTML5)
-                .input(Paths.get("root.ditamap"))
-                .run();
+        builder().name("e2e").transtype(HTML5).input(Paths.get("root.ditamap")).run();
     }
 
     @Test
     public void pdf() throws Throwable {
-        builder().name("e2e")
+        builder()
+                .name("e2e")
                 .transtype(PDF)
                 .input(Paths.get("root.ditamap"))
-                .put("args.fo.userconfig", new File(resourceDir, "e2e" + File.separator + "fop.xconf").getAbsolutePath())
+                .put(
+                        "args.fo.userconfig",
+                        new File(resourceDir, "e2e" + File.separator + "fop.xconf").getAbsolutePath())
                 .run();
     }
 
     @Ignore
     @Test
     public void htmlhelp() throws Throwable {
-        builder().name("e2e")
+        builder()
+                .name("e2e")
                 .transtype(HTMLHELP)
                 .input(Paths.get("root.ditamap"))
                 .run();
     }
-
 }

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -8,47 +8,50 @@
 
 package org.dita.dost;
 
+import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Paths;
 import org.dita.dost.reader.GrammarPoolManager;
 import org.ditang.relaxng.defaults.pool.RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl;
 import org.junit.Test;
 
-import java.nio.file.Paths;
-
-import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS;
-import static org.junit.Assert.assertEquals;
-
 public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     public abstract AbstractIntegrationTest builder();
-    
+
     @Test
     public void testreltableHeaders() throws Throwable {
-        builder().name("reltableHeaders")
+        builder()
+                .name("reltableHeaders")
                 .transtype(PREPROCESS)
                 .input(Paths.get("reltableheader.ditamap"))
                 .test();
-    }    
-    
+    }
+
     @Test
     public void testreltableTextlink() throws Throwable {
-        builder().name("reltableTextlink")
+        builder()
+                .name("reltableTextlink")
                 .transtype(PREPROCESS)
                 .input(Paths.get("1132.ditamap"))
                 .errorCount(1)
                 .test();
     }
-    
+
     @Test
     public void testlocktitle() throws Throwable {
-        builder().name("locktitle")
+        builder()
+                .name("locktitle")
                 .transtype(PREPROCESS)
                 .input(Paths.get("TestingLocktitle.ditamap"))
                 .test();
     }
-    
+
     @Test
     public void testchunk_uplevel() throws Throwable {
-        builder().name("chunk_uplevel")
+        builder()
+                .name("chunk_uplevel")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/chunkup.ditamap"))
                 .put("outer.control", "quiet")
@@ -57,7 +60,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcopyto_extensions_metadata() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_extensions_metadata"))
+        builder()
+                .name(Paths.get("copyto", "copyto_extensions_metadata"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC1.ditamap"))
                 .warnCount(3)
@@ -66,7 +70,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcopyto() throws Throwable {
-        builder().name(Paths.get("copyto", "basic"))
+        builder()
+                .name(Paths.get("copyto", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC2.ditamap"))
                 .warnCount(2)
@@ -75,7 +80,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcopyto_sametarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_sametarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_sametarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC3.ditamap"))
                 .warnCount(3)
@@ -84,15 +90,17 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcopyto_circulartarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_circulartarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_circulartarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC4.ditamap"))
                 .test();
     }
-    
+
     @Test
     public void testcopyto_linktarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_linktarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_linktarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("linktarget.ditamap"))
                 .errorCount(2)
@@ -102,7 +110,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcopyto_sametarget2() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_sametarget2"))
+        builder()
+                .name(Paths.get("copyto", "copyto_sametarget2"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC6.ditamap"))
                 .warnCount(4)
@@ -111,7 +120,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testconkeyref_push() throws Throwable {
-        builder().name(Paths.get("conref", "conkeyref_push"))
+        builder()
+                .name(Paths.get("conref", "conkeyref_push"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("conref-push-test.ditamap"))
                 .put("dita.ext", ".dita")
@@ -120,17 +130,19 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testlink_foreignshortdesc() throws Throwable {
-        builder().name("link_foreignshortdesc")
+        builder()
+                .name("link_foreignshortdesc")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .put("validate", "false")
                 .warnCount(1)
                 .test();
     }
-    
+
     @Test
     public void testconrefend() throws Throwable {
-        builder().name(Paths.get("conref", "conrefend"))
+        builder()
+                .name(Paths.get("conref", "conrefend"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("range.ditamap"))
                 .test();
@@ -138,15 +150,17 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testmapref_topicrefID() throws Throwable {
-        builder().name(Paths.get("mapref", "mapref_topicrefID"))
+        builder()
+                .name(Paths.get("mapref", "mapref_topicrefID"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("bookmap.ditamap"))
                 .test();
     }
-    
+
     @Test
     public void testmapref_to_conref() throws Throwable {
-        builder().name(Paths.get("mapref", "mapref_to_conref"))
+        builder()
+                .name(Paths.get("mapref", "mapref_to_conref"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("root.ditamap"))
                 .test();
@@ -154,7 +168,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testmapref_reltables() throws Throwable {
-        builder().name(Paths.get("mapref", "mapref_reltables"))
+        builder()
+                .name(Paths.get("mapref", "mapref_reltables"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .test();
@@ -162,7 +177,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcoderef_source() throws Throwable {
-        builder().name("coderef_source")
+        builder()
+                .name("coderef_source")
                 .transtype(PREPROCESS)
                 .input(Paths.get("mp.ditamap"))
                 .put("transtype", "preprocess")
@@ -174,7 +190,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testconref() throws Throwable {
-        builder().name(Paths.get("conref", "basic"))
+        builder()
+                .name(Paths.get("conref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("lang-common1.dita"))
                 .put("validate", "false")
@@ -184,7 +201,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testconref_to_specialization() throws Throwable {
-        builder().name(Paths.get("conref", "conref_to_specialization"))
+        builder()
+                .name(Paths.get("conref", "conref_to_specialization"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("conref_to_specialization.dita"))
                 .put("validate", "false")
@@ -194,23 +212,26 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testconrefbreaksxref() throws Throwable {
-        builder().name(Paths.get("conref", "conrefbreaksxref"))
+        builder()
+                .name(Paths.get("conref", "conrefbreaksxref"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("conrefbreaksxref.dita"))
                 .test();
     }
-    
+
     @Test
     public void testconrefinsubmap() throws Throwable {
-        builder().name(Paths.get("conref", "conrefinsubmap"))
+        builder()
+                .name(Paths.get("conref", "conrefinsubmap"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("rootmap.ditamap"))
                 .test();
     }
-    
+
     @Test
     public void testconrefmissingfile() throws Throwable {
-        builder().name(Paths.get("conref", "conrefmissingfile"))
+        builder()
+                .name(Paths.get("conref", "conrefmissingfile"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("badconref.dita"))
                 .put("validate", "false")
@@ -221,7 +242,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile1() throws Throwable {
-        builder().name(Paths.get("filter", "map13_filter1"))
+        builder()
+                .name(Paths.get("filter", "map13_filter1"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map13.ditamap"))
                 .put("args.filter", Paths.get("filter1.ditaval"))
@@ -230,7 +252,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile2() throws Throwable {
-        builder().name(Paths.get("filter", "map13_filter2"))
+        builder()
+                .name(Paths.get("filter", "map13_filter2"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map13.ditamap"))
                 .put("args.filter", Paths.get("filter2.ditaval"))
@@ -239,7 +262,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile3() throws Throwable {
-        builder().name(Paths.get("filter", "map13_filter3"))
+        builder()
+                .name(Paths.get("filter", "map13_filter3"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map13.ditamap"))
                 .put("args.filter", Paths.get("filter3.ditaval"))
@@ -248,7 +272,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile4() throws Throwable {
-        builder().name(Paths.get("filter", "map31_filter_multi"))
+        builder()
+                .name(Paths.get("filter", "map31_filter_multi"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map31.ditamap"))
                 .put("args.filter", Paths.get("filter_multi.ditaval"))
@@ -258,7 +283,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile5() throws Throwable {
-        builder().name(Paths.get("filter", "map32_filter_multi"))
+        builder()
+                .name(Paths.get("filter", "map32_filter_multi"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map32.ditamap"))
                 .put("args.filter", Paths.get("filter_multi.ditaval"))
@@ -268,7 +294,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile6() throws Throwable {
-        builder().name(Paths.get("filter", "map33_filter2"))
+        builder()
+                .name(Paths.get("filter", "map33_filter2"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map33.ditamap"))
                 .put("args.filter", Paths.get("filter2.ditaval"))
@@ -277,7 +304,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile7() throws Throwable {
-        builder().name(Paths.get("filter", "map33_filter3"))
+        builder()
+                .name(Paths.get("filter", "map33_filter3"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map33.ditamap"))
                 .put("args.filter", Paths.get("filter3.ditaval"))
@@ -286,7 +314,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref() throws Throwable {
-        builder().name(Paths.get("keyref", "basic"))
+        builder()
+                .name(Paths.get("keyref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -294,7 +323,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testmapref() throws Throwable {
-        builder().name(Paths.get("mapref", "basic"))
+        builder()
+                .name(Paths.get("mapref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
@@ -304,26 +334,29 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testuplevelslink() throws Throwable {
-        builder().name("uplevelslink")
+        builder()
+                .name("uplevelslink")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/uplevel-in-topic.ditamap"))
                 .put("outer.control", "quiet")
                 .test();
     }
-    
+
     @Test
     public void testuplevelslinkOnlytopic() throws Throwable {
-        builder().name("uplevelslink")
+        builder()
+                .name("uplevelslink")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/uplevel-in-topic.ditamap"))
                 .put("outer.control", "quiet")
                 .put("onlytopic.in.map", "true")
                 .test();
     }
-    
+
     @Test
     public void testmappull_topicid() throws Throwable {
-        builder().name("mappull-topicid")
+        builder()
+                .name("mappull-topicid")
                 .transtype(PREPROCESS)
                 .input(Paths.get("reftopicid.ditamap"))
                 .put("validate", "false")
@@ -333,7 +366,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testCrawlTopicPreprocess() throws Throwable {
-        builder().name("crawl_topic")
+        builder()
+                .name("crawl_topic")
                 .transtype(PREPROCESS)
                 .input(Paths.get("input.ditamap"))
                 .put("link-crawl", "topic")
@@ -342,7 +376,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testCrawlMapPreprocess() throws Throwable {
-        builder().name("crawl_map")
+        builder()
+                .name("crawl_map")
                 .transtype(PREPROCESS)
                 .input(Paths.get("input.ditamap"))
                 .put("link-crawl", "map")
@@ -353,7 +388,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void testRng() throws Throwable {
-        builder().name("rng")
+        builder()
+                .name("rng")
                 .transtype(PREPROCESS)
                 .input(Paths.get("root.ditamap"))
                 .test();
@@ -361,7 +397,8 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void resource_map() throws Throwable {
-        builder().name("resource_map")
+        builder()
+                .name("resource_map")
                 .transtype(PREPROCESS)
                 .input(Paths.get("map.ditamap"))
                 .put("args.resources", Paths.get("keys.ditamap"))
@@ -370,28 +407,34 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void resource_topic() throws Throwable {
-        builder().name("resource_topic")
+        builder()
+                .name("resource_topic")
                 .transtype(PREPROCESS)
                 .input(Paths.get("topic.dita"))
                 .put("args.resources", Paths.get("keys.ditamap"))
                 .test();
     }
+
     @Test
     public void testRngGrammarPool() throws Throwable {
-        RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl grammarPool = (RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl) GrammarPoolManager.getGrammarPool();
+        RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl grammarPool =
+                (RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl) GrammarPoolManager.getGrammarPool();
         grammarPool.clear();
-        builder().name("bookmap-rng-based")
+        builder()
+                .name("bookmap-rng-based")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .test();
         assertEquals("One bookmap, one topic and one concept", 3, grammarPool.getCacheSize());
     }
-    
+
     @Test
     public void testRngNoGrammarPool() throws Throwable {
-        RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl grammarPool = (RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl) GrammarPoolManager.getGrammarPool();
+        RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl grammarPool =
+                (RNGDefaultsEnabledSynchronizedXMLGrammarPoolImpl) GrammarPoolManager.getGrammarPool();
         grammarPool.clear();
-        builder().name("bookmap-rng-based")
+        builder()
+                .name("bookmap-rng-based")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .put("args.grammar.cache", "no")

--- a/src/test/java/org/dita/dost/IntegrationTestHtml5.java
+++ b/src/test/java/org/dita/dost/IntegrationTestHtml5.java
@@ -8,14 +8,13 @@
 
 package org.dita.dost;
 
-import org.junit.Test;
-
-import java.io.File;
-import java.nio.file.Paths;
-
 import static org.dita.dost.AbstractIntegrationTest.Transtype.HTML5;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Paths;
+import org.junit.Test;
 
 public class IntegrationTestHtml5 extends AbstractIntegrationTest {
 
@@ -31,7 +30,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
     @Test
     public void html5_cssNoCopy() throws Throwable {
         final File srcDir = new File(resourceDir, "html5_css" + File.separator + "src");
-        final File actDir = builder().name("html5_css")
+        final File actDir = builder()
+                .name("html5_css")
                 .transtype(HTML5)
                 .input(Paths.get("topic.dita"))
                 .put("args.css", "custom.css")
@@ -45,7 +45,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
     @Test
     public void html5_css() throws Throwable {
         final File srcDir = new File(resourceDir, "html5_css" + File.separator + "src");
-        final File actDir = builder().name("html5_css")
+        final File actDir = builder()
+                .name("html5_css")
                 .transtype(HTML5)
                 .input(Paths.get("topic.dita"))
                 .put("args.css", "custom.css")
@@ -59,7 +60,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
     @Test
     public void html5_csspath() throws Throwable {
         final File srcDir = new File(resourceDir, "html5_csspath" + File.separator + "src");
-        final File actDir = builder().name("html5_csspath")
+        final File actDir = builder()
+                .name("html5_csspath")
                 .transtype(HTML5)
                 .input(Paths.get("topic.dita"))
                 .put("args.css", "custom.css")
@@ -74,7 +76,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
     @Test
     public void html5_csspathAbsolute() throws Throwable {
         final File srcDir = new File(resourceDir, "html5_csspath" + File.separator + "src");
-        final File actDir = builder().name("html5_csspath")
+        final File actDir = builder()
+                .name("html5_csspath")
                 .transtype(HTML5)
                 .input(Paths.get("topic.dita"))
                 .put("args.css", new File(srcDir, "custom.css").getAbsolutePath())
@@ -87,7 +90,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
 
     @Test
     public void html5_cssExternal() throws Throwable {
-        builder().name("html5_cssExternal")
+        builder()
+                .name("html5_cssExternal")
                 .transtype(HTML5)
                 .input(Paths.get("topic.dita"))
                 .put("args.css", "custom.css")
@@ -98,7 +102,8 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
     @Test
     public void html5_ditaval_passthrough_all() throws Throwable {
         final File srcDir = new File(resourceDir, "html5_ditaval" + File.separator + "src");
-        builder().name("html5_ditaval")
+        builder()
+                .name("html5_ditaval")
                 .transtype(HTML5)
                 .input(Paths.get("all.ditamap"))
                 .put("validate", "no")
@@ -106,5 +111,4 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
                 .warnCount(1)
                 .test();
     }
-
 }

--- a/src/test/java/org/dita/dost/IntegrationTestPdf.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPdf.java
@@ -8,11 +8,10 @@
 
 package org.dita.dost;
 
-import org.junit.Test;
+import static org.dita.dost.AbstractIntegrationTest.Transtype.PDF;
 
 import java.nio.file.Paths;
-
-import static org.dita.dost.AbstractIntegrationTest.Transtype.PDF;
+import org.junit.Test;
 
 public class IntegrationTestPdf extends AbstractIntegrationTest {
 
@@ -27,7 +26,8 @@ public class IntegrationTestPdf extends AbstractIntegrationTest {
 
     @Test
     public void pdf() throws Throwable {
-        builder().name("pdf")
+        builder()
+                .name("pdf")
                 .transtype(PDF)
                 .input(Paths.get("bookmap.ditamap"))
                 .warnCount(1)

--- a/src/test/java/org/dita/dost/IntegrationTestPreprocess1.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPreprocess1.java
@@ -11,7 +11,6 @@ package org.dita.dost;
 import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS;
 
 import java.nio.file.Paths;
-
 import org.junit.Test;
 
 public class IntegrationTestPreprocess1 extends IntegrationTest {
@@ -24,9 +23,11 @@ public class IntegrationTestPreprocess1 extends IntegrationTest {
     Transtype getTranstype(Transtype transtype) {
         return transtype;
     }
+
     @Test
     public void testRngGrammarPoolValidate() throws Throwable {
-        builder().name("bookmap-rng-based-validate")
+        builder()
+                .name("bookmap-rng-based-validate")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .put("validate", "true")
@@ -34,10 +35,11 @@ public class IntegrationTestPreprocess1 extends IntegrationTest {
                 .errorCount(1)
                 .test();
     }
-    
+
     @Test
     public void testRngGrammarPoolNoValidate() throws Throwable {
-        builder().name("bookmap-rng-based-no-validate")
+        builder()
+                .name("bookmap-rng-based-no-validate")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main.ditamap"))
                 .put("validate", "false")

--- a/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
@@ -13,7 +13,6 @@ import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS2;
 import static org.dita.dost.AbstractIntegrationTest.Transtype.XHTML_WITH_PREPROCESS2;
 
 import java.nio.file.Paths;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -38,7 +37,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto() throws Throwable {
-        builder().name(Paths.get("copyto", "basic"))
+        builder()
+                .name(Paths.get("copyto", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC2.ditamap"))
                 .warnCount(0)
@@ -47,7 +47,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
 
     @Test
     public void testconrefmissingfile() throws Throwable {
-        builder().name(Paths.get("conref", "conrefmissingfile"))
+        builder()
+                .name(Paths.get("conref", "conrefmissingfile"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("badconref.dita"))
                 .put("validate", "false")
@@ -58,7 +59,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
 
     @Test
     public void testmapref() throws Throwable {
-        builder().name(Paths.get("mapref", "basic"))
+        builder()
+                .name(Paths.get("mapref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
@@ -70,7 +72,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto_linktarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_linktarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_linktarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("linktarget.ditamap"))
                 .errorCount(1)
@@ -78,10 +81,10 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
                 .test();
     }
 
-
     @Test
     public void testcontrolValueFile4() throws Throwable {
-        builder().name(Paths.get("filter", "map31_filter_multi"))
+        builder()
+                .name(Paths.get("filter", "map31_filter_multi"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map31.ditamap"))
                 .put("args.filter", Paths.get("filter_multi.ditaval"))
@@ -92,7 +95,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto_extensions_metadata() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_extensions_metadata"))
+        builder()
+                .name(Paths.get("copyto", "copyto_extensions_metadata"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC1.ditamap"))
                 .warnCount(0)
@@ -102,7 +106,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto_circulartarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_circulartarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_circulartarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC4.ditamap"))
                 .test();
@@ -111,7 +116,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto_sametarget2() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_sametarget2"))
+        builder()
+                .name(Paths.get("copyto", "copyto_sametarget2"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC6.ditamap"))
                 .warnCount(4)
@@ -121,7 +127,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testcopyto_sametarget() throws Throwable {
-        builder().name(Paths.get("copyto", "copyto_sametarget"))
+        builder()
+                .name(Paths.get("copyto", "copyto_sametarget"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("TC3.ditamap"))
                 .warnCount(2)
@@ -130,7 +137,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
 
     @Test
     public void testcontrolValueFile5() throws Throwable {
-        builder().name(Paths.get("filter", "map32_filter_multi"))
+        builder()
+                .name(Paths.get("filter", "map32_filter_multi"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("map32.ditamap"))
                 .put("args.filter", Paths.get("filter_multi.ditaval"))
@@ -141,7 +149,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testuplevelslinkOnlytopic() throws Throwable {
-        builder().name("uplevelslink")
+        builder()
+                .name("uplevelslink")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/uplevel-in-topic.ditamap"))
                 .put("outer.control", "quiet")
@@ -153,7 +162,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testCrawlMapPreprocess() throws Throwable {
-        builder().name("crawl_map")
+        builder()
+                .name("crawl_map")
                 .transtype(PREPROCESS)
                 .input(Paths.get("input.ditamap"))
                 .put("link-crawl", "map")
@@ -165,7 +175,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testuplevelslink() throws Throwable {
-        builder().name("uplevelslink")
+        builder()
+                .name("uplevelslink")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/uplevel-in-topic.ditamap"))
                 .put("outer.control", "quiet")
@@ -175,7 +186,8 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     @Ignore
     @Test
     public void testchunk_uplevel() throws Throwable {
-        builder().name("chunk_uplevel")
+        builder()
+                .name("chunk_uplevel")
                 .transtype(PREPROCESS)
                 .input(Paths.get("main/chunkup.ditamap"))
                 .put("outer.control", "quiet")

--- a/src/test/java/org/dita/dost/IntegrationTestXhtml.java
+++ b/src/test/java/org/dita/dost/IntegrationTestXhtml.java
@@ -8,16 +8,15 @@
 
 package org.dita.dost;
 
-import org.junit.Test;
+import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS;
+import static org.dita.dost.AbstractIntegrationTest.Transtype.XHTML;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.dita.dost.AbstractIntegrationTest.Transtype.PREPROCESS;
-import static org.dita.dost.AbstractIntegrationTest.Transtype.XHTML;
+import org.junit.Test;
 
 public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
@@ -32,7 +31,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testlink_parentchild() throws Throwable {
-        builder().name("link_parentchild")
+        builder()
+                .name("link_parentchild")
                 .transtype(XHTML)
                 .input(Paths.get("03.ditamap"))
                 .test();
@@ -40,7 +40,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_dupkey() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_dupkey"))
+        builder()
+                .name(Paths.get("keyref", "keyref_dupkey"))
                 .transtype(XHTML)
                 .input(Paths.get("keyref-test-01.ditamap"))
                 .test();
@@ -48,7 +49,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_to_keyref() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_to_keyref"))
+        builder()
+                .name(Paths.get("keyref", "keyref_to_keyref"))
                 .transtype(XHTML)
                 .input(Paths.get("keyref-test-01.ditamap"))
                 .test();
@@ -56,7 +58,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testconref_with_xref() throws Throwable {
-        builder().name(Paths.get("conref", "conref_with_xref"))
+        builder()
+                .name(Paths.get("conref", "conref_with_xref"))
                 .transtype(XHTML)
                 .input(Paths.get("test-conref-xref-keyref-bug.ditamap"))
                 .test();
@@ -64,7 +67,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testlink_xref_extensiontest() throws Throwable {
-        builder().name("link_xref_extensiontest")
+        builder()
+                .name("link_xref_extensiontest")
                 .transtype(XHTML)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -72,7 +76,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testtitle_includes_markup() throws Throwable {
-        builder().name("title_includes_markup")
+        builder()
+                .name("title_includes_markup")
                 .transtype(XHTML)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -80,7 +85,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testimage_extension_mixedcase() throws Throwable {
-        builder().name("image_extension_mixedcase")
+        builder()
+                .name("image_extension_mixedcase")
                 .transtype(XHTML)
                 .input(Paths.get("testpng.ditamap"))
                 .test();
@@ -88,7 +94,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testcascade_processingrole() throws Throwable {
-        builder().name("cascade_processingrole")
+        builder()
+                .name("cascade_processingrole")
                 .transtype(XHTML)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -96,7 +103,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testconref_pushreplace() throws Throwable {
-        builder().name(Paths.get("conref", "conref_pushreplace"))
+        builder()
+                .name(Paths.get("conref", "conref_pushreplace"))
                 .transtype(XHTML)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -104,7 +112,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap1() throws Throwable {
-        builder().name("bookmap1")
+        builder()
+                .name("bookmap1")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata1.ditamap"))
                 .test();
@@ -112,7 +121,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap2() throws Throwable {
-        builder().name("bookmap2")
+        builder()
+                .name("bookmap2")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata2.ditamap"))
                 .errorCount(1)
@@ -121,7 +131,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap3() throws Throwable {
-        builder().name("bookmap3")
+        builder()
+                .name("bookmap3")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata3.ditamap"))
                 .test();
@@ -129,7 +140,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap4() throws Throwable {
-        builder().name("bookmap4")
+        builder()
+                .name("bookmap4")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata4.ditamap"))
                 .errorCount(1)
@@ -138,7 +150,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap5() throws Throwable {
-        builder().name("bookmap5")
+        builder()
+                .name("bookmap5")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata5.ditamap"))
                 .test();
@@ -146,7 +159,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap6() throws Throwable {
-        builder().name("bookmap6")
+        builder()
+                .name("bookmap6")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata6.ditamap"))
                 .errorCount(1)
@@ -155,16 +169,17 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testBookmap7() throws Throwable {
-        builder().name("bookmap7")
+        builder()
+                .name("bookmap7")
                 .transtype(XHTML)
                 .input(Paths.get("bookmap(2)_testdata7.ditamap"))
                 .test();
     }
 
-    
     @Test
     public void testconref_topiconly() throws Throwable {
-        builder().name(Paths.get("conref", "conref_topiconly"))
+        builder()
+                .name(Paths.get("conref", "conref_topiconly"))
                 .transtype(XHTML)
                 .input(Paths.get("conref_to_self.dita"))
                 .put("validate", "false")
@@ -174,7 +189,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile8() throws Throwable {
-        builder().name(Paths.get("filter", "map13_flag"))
+        builder()
+                .name(Paths.get("filter", "map13_flag"))
                 .transtype(XHTML)
                 .input(Paths.get("map13.ditamap"))
                 .put("args.filter", Paths.get("flag.ditaval"))
@@ -183,7 +199,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile9() throws Throwable {
-        builder().name(Paths.get("filter", "map13_flag2"))
+        builder()
+                .name(Paths.get("filter", "map13_flag2"))
                 .transtype(XHTML)
                 .input(Paths.get("map13.ditamap"))
                 .put("args.filter", Paths.get("flag2.ditaval"))
@@ -192,7 +209,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile10() throws Throwable {
-        builder().name(Paths.get("filter", "map33_flag"))
+        builder()
+                .name(Paths.get("filter", "map33_flag"))
                 .transtype(XHTML)
                 .input(Paths.get("map33.ditamap"))
                 .put("args.filter", Paths.get("flag.ditaval"))
@@ -201,7 +219,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testcontrolValueFile11() throws Throwable {
-        builder().name(Paths.get("filter", "map33_flag2"))
+        builder()
+                .name(Paths.get("filter", "map33_flag2"))
                 .transtype(XHTML)
                 .input(Paths.get("map33.ditamap"))
                 .put("args.filter", Paths.get("flag2.ditaval"))
@@ -210,7 +229,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testimage_scale() throws Throwable {
-        builder().name("image-scale")
+        builder()
+                .name("image-scale")
                 .transtype(XHTML)
                 .input(Paths.get("test.dita"))
                 .test();
@@ -218,7 +238,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref() throws Throwable {
-        builder().name(Paths.get("keyref", "basic"))
+        builder()
+                .name(Paths.get("keyref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .test();
@@ -226,7 +247,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_All_tags() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_All_tags"))
+        builder()
+                .name(Paths.get("keyref", "keyref_All_tags"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .warnCount(1)
@@ -235,7 +257,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Keyword_links() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Keyword_links"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Keyword_links"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .test();
@@ -243,7 +266,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_conref_1() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_conref_1"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_conref_1"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .test();
@@ -251,7 +275,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_conref_2() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_conref_2"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_conref_2"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author2.ditamap"))
                 .test();
@@ -259,7 +284,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_1() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_1"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_1"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .test();
@@ -267,7 +293,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_2() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_2"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_2"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author2.ditamap"))
                 .test();
@@ -275,7 +302,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_3() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_3"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_3"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author3.ditamap"))
                 .test();
@@ -283,7 +311,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_4() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_4"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_4"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author4.ditamap"))
                 .test();
@@ -291,7 +320,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_5() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_5"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_5"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author5.ditamap"))
                 .test();
@@ -299,7 +329,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Redirect_link_or_xref_6() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Redirect_link_or_xref_6"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Redirect_link_or_xref_6"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author6.ditamap"))
                 .test();
@@ -307,7 +338,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Splitting_combining_targets1() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Splitting_combining_targets_1"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Splitting_combining_targets_1"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .test();
@@ -315,7 +347,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Splitting_combining_targets2() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Splitting_combining_targets_2"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Splitting_combining_targets_2"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author2.ditamap"))
                 .test();
@@ -323,7 +356,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Splitting_combining_targets3() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Splitting_combining_targets_3"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Splitting_combining_targets_3"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author3.ditamap"))
                 .test();
@@ -331,7 +365,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_Swap_out_variable_content() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_Swap_out_variable_content"))
+        builder()
+                .name(Paths.get("keyref", "keyref_Swap_out_variable_content"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .test();
@@ -339,7 +374,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testkeyref_modify() throws Throwable {
-        builder().name(Paths.get("keyref", "keyref_modify"))
+        builder()
+                .name(Paths.get("keyref", "keyref_modify"))
                 .transtype(XHTML)
                 .input(Paths.get("mp_author1.ditamap"))
                 .warnCount(1)
@@ -348,7 +384,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testlang() throws Throwable {
-        builder().name("lang")
+        builder()
+                .name("lang")
                 .transtype(XHTML)
                 .input(Paths.get("lang.ditamap"))
                 .put("validate", "false")
@@ -358,7 +395,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testmapref() throws Throwable {
-        builder().name(Paths.get("mapref", "basic"))
+        builder()
+                .name(Paths.get("mapref", "basic"))
                 .transtype(PREPROCESS)
                 .input(Paths.get("test.ditamap"))
                 .put("generate-debug-attributes", "false")
@@ -368,7 +406,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testsubjectschema_case() throws Throwable {
-        builder().name("subjectschema_case")
+        builder()
+                .name("subjectschema_case")
                 .transtype(XHTML)
                 .input(Paths.get("simplemap.ditamap"))
                 .put("args.filter", Paths.get("filter.ditaval"))
@@ -380,12 +419,13 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
     public void testfilterlist() throws Throwable {
         final Path testDir = Paths.get("src", "test", "resources", "filterlist", "src");
         final String filters = Stream.of(
-                Paths.get("filter1.ditaval"),
-                Paths.get("subdir", "filter2.ditaval"),
-                Paths.get("missing.ditaval"))
+                        Paths.get("filter1.ditaval"),
+                        Paths.get("subdir", "filter2.ditaval"),
+                        Paths.get("missing.ditaval"))
                 .map(path -> testDir.resolve(path).toAbsolutePath().toString())
                 .collect(Collectors.joining(File.pathSeparator));
-        builder().name("filterlist")
+        builder()
+                .name("filterlist")
                 .transtype(XHTML)
                 .input(Paths.get("simplemap.ditamap"))
                 .put("args.filter", filters)
@@ -396,7 +436,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testuplevels1() throws Throwable {
-        builder().name("uplevels1")
+        builder()
+                .name("uplevels1")
                 .transtype(XHTML)
                 .input(Paths.get("maps/above.ditamap"))
                 .put("generate.copy.outer", "1")
@@ -406,26 +447,29 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testuplevels3() throws Throwable {
-        builder().name("uplevels3")
+        builder()
+                .name("uplevels3")
                 .transtype(XHTML)
                 .input(Paths.get("maps/above.ditamap"))
                 .put("generate.copy.outer", "3")
                 .put("outer.control", "quiet")
                 .test();
     }
-    
+
     @Test
     public void testonlytopic_in_map() throws Throwable {
-        builder().name("onlytopic.in.map")
+        builder()
+                .name("onlytopic.in.map")
                 .transtype(XHTML)
                 .input(Paths.get("input.ditamap"))
                 .put("onlytopic.in.map", "true")
                 .test();
     }
-    
+
     @Test
     public void testonlytopic_in_map_false() throws Throwable {
-        builder().name("onlytopic.in.map.false")
+        builder()
+                .name("onlytopic.in.map.false")
                 .transtype(XHTML)
                 .input(Paths.get("input.ditamap"))
                 .put("onlytopic.in.map", "false")
@@ -434,7 +478,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testCrawlTopic() throws Throwable {
-        builder().name("crawl_topic")
+        builder()
+                .name("crawl_topic")
                 .transtype(XHTML)
                 .input(Paths.get("input.ditamap"))
                 .put("link-crawl", "topic")
@@ -443,7 +488,8 @@ public class IntegrationTestXhtml extends AbstractIntegrationTest {
 
     @Test
     public void testCrawlMap() throws Throwable {
-        builder().name("crawl_map")
+        builder()
+                .name("crawl_map")
                 .transtype(XHTML)
                 .input(Paths.get("input.ditamap"))
                 .put("link-crawl", "map")

--- a/src/test/java/org/dita/dost/ProcessorFactoryTest.java
+++ b/src/test/java/org/dita/dost/ProcessorFactoryTest.java
@@ -1,10 +1,9 @@
 package org.dita.dost;
 
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class ProcessorFactoryTest {
 
@@ -36,5 +35,4 @@ public class ProcessorFactoryTest {
         final ProcessorFactory pf = ProcessorFactory.newInstance(new File(ditaDir));
         pf.newProcessor("xxx");
     }
-
 }

--- a/src/test/java/org/dita/dost/ProcessorTest.java
+++ b/src/test/java/org/dita/dost/ProcessorTest.java
@@ -1,17 +1,16 @@
 package org.dita.dost;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import org.apache.tools.ant.BuildException;
 import org.dita.dost.exception.DITAOTException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
-import static org.junit.Assert.assertEquals;
 
 public class ProcessorTest {
 
@@ -41,25 +40,25 @@ public class ProcessorTest {
 
     @Test
     public void testRun() throws DITAOTException, IOException, URISyntaxException {
-        final File mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/test.ditamap").toURI());
+        final File mapFile = new File(getClass()
+                .getClassLoader()
+                .getResource("ProcessorTest/test.ditamap")
+                .toURI());
         final File out = tempDirGenerator.newFolder("out");
-        p.setInput(mapFile)
-                .setOutputDir(out)
-                .run();
+        p.setInput(mapFile).setOutputDir(out).run();
 
         assertEquals(1, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
     }
 
-
     @Test(expected = DITAOTException.class)
     public void testBroken() throws DITAOTException, IOException, URISyntaxException {
-        final File mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/broken.dita").toURI());
+        final File mapFile = new File(getClass()
+                .getClassLoader()
+                .getResource("ProcessorTest/broken.dita")
+                .toURI());
         final File out = tempDirGenerator.newFolder("out");
         try {
-            p.setInput(mapFile)
-                    .setOutputDir(out)
-                    .createDebugLog(false)
-                    .run();
+            p.setInput(mapFile).setOutputDir(out).createDebugLog(false).run();
         } catch (Exception e) {
             assertEquals(0, tempDir.listFiles(File::isDirectory).length);
             assertEquals(0, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
@@ -69,18 +68,17 @@ public class ProcessorTest {
 
     @Test(expected = DITAOTException.class)
     public void testCleanTempOnFailure() throws DITAOTException, IOException, URISyntaxException {
-        final File mapFile = new File(getClass().getClassLoader().getResource("ProcessorTest/broken.dita").toURI());
+        final File mapFile = new File(getClass()
+                .getClassLoader()
+                .getResource("ProcessorTest/broken.dita")
+                .toURI());
         final File out = tempDirGenerator.newFolder("out");
         try {
-            p.setInput(mapFile)
-                    .setOutputDir(out)
-                    .cleanOnFailure(false)
-                    .run();
+            p.setInput(mapFile).setOutputDir(out).cleanOnFailure(false).run();
         } catch (BuildException e) {
             assertEquals(1, tempDir.listFiles(File::isDirectory).length);
             assertEquals(1, tempDir.listFiles(f -> f.isFile() && f.getName().endsWith(".log")).length);
             throw e;
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/TestUtils.java
+++ b/src/test/java/org/dita/dost/TestUtils.java
@@ -7,6 +7,26 @@
  */
 package org.dita.dost;
 
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.xmlunit.util.IterableNodeList.asList;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamResult;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.s9api.SaxonApiException;
@@ -28,27 +48,6 @@ import org.xml.sax.helpers.XMLFilterImpl;
 import org.xml.sax.helpers.XMLReaderFactory;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamResult;
-import java.io.*;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
-import static org.apache.commons.io.FileUtils.copyFile;
-import static org.xmlunit.util.IterableNodeList.asList;
 
 /**
  * Test utilities.
@@ -85,7 +84,8 @@ public class TestUtils {
         try {
             return new File(dir.toURI());
         } catch (URISyntaxException e) {
-            throw new RuntimeException("Failed to find resource for " + testClass.getSimpleName() + ":" + e.getMessage(), e);
+            throw new RuntimeException(
+                    "Failed to find resource for " + testClass.getSimpleName() + ":" + e.getMessage(), e);
         }
     }
 
@@ -97,8 +97,7 @@ public class TestUtils {
      * @throws IOException if creating directory failed
      */
     public static File createTempDir(final Class<?> testClass) throws IOException {
-        final File tempDir = new File(System.getProperty("java.io.tmpdir"),
-                testClass.getName());
+        final File tempDir = new File(System.getProperty("java.io.tmpdir"), testClass.getName());
         if (!tempDir.exists() && !tempDir.mkdirs()) {
             throw new IOException("Unable to create temporary directory " + tempDir.getAbsolutePath());
         }
@@ -166,8 +165,7 @@ public class TestUtils {
             if (clean) {
                 p = new CleaningXMLFilterImpl(p);
             }
-            serializer.transform(new SAXSource(p, new InputSource(in)),
-                    new StreamResult(std));
+            serializer.transform(new SAXSource(p, new InputSource(in)), new StreamResult(std));
         }
         return std.toString();
     }
@@ -180,15 +178,15 @@ public class TestUtils {
 
         @Override
         public void characters(final char[] ch, final int start, final int length) throws SAXException {
-            final char[] res = new String(ch, start, length).replaceAll("\\s+", " ").trim().toCharArray();
+            final char[] res =
+                    new String(ch, start, length).replaceAll("\\s+", " ").trim().toCharArray();
             getContentHandler().characters(res, 0, res.length);
         }
 
         @Override
         public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
-            //NOOP
+            // NOOP
         }
-
     }
 
     private static class CleaningXMLFilterImpl extends XMLFilterImpl {
@@ -198,10 +196,10 @@ public class TestUtils {
         }
 
         @Override
-        public void startElement(final String uri, final String localName, final String qName,
-                                 final Attributes atts) throws SAXException {
+        public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+                throws SAXException {
             final AttributesImpl attsBuf = new AttributesImpl(atts);
-            for (final String a : new String[]{"class", "domains", "xtrf", "xtrc"}) {
+            for (final String a : new String[] {"class", "domains", "xtrf", "xtrc"}) {
                 final int i = attsBuf.getIndex(a);
                 if (i != -1) {
                     attsBuf.removeAttribute(i);
@@ -214,7 +212,6 @@ public class TestUtils {
         public void processingInstruction(final String target, final String data) throws SAXException {
             // Ignore
         }
-
     }
 
     /**
@@ -268,15 +265,14 @@ public class TestUtils {
         final Transformer serializer = TransformerFactory.newInstance().newTransformer();
         final XMLReader parser = XMLReaderFactory.createXMLReader();
         parser.setEntityResolver(CatalogUtils.getCatalogResolver());
-        try (InputStream in = new BufferedInputStream(new FileInputStream(src)); OutputStream out = new BufferedOutputStream(new FileOutputStream(dst))) {
-            serializer.transform(new SAXSource(parser, new InputSource(in)),
-                    new StreamResult(out));
+        try (InputStream in = new BufferedInputStream(new FileInputStream(src));
+                OutputStream out = new BufferedOutputStream(new FileOutputStream(dst))) {
+            serializer.transform(new SAXSource(parser, new InputSource(in)), new StreamResult(out));
         }
     }
 
     public static void assertXMLEqual(Document exp, Document act) {
-        final Diff d = DiffBuilder
-                .compare(ignoreComments(exp))
+        final Diff d = DiffBuilder.compare(ignoreComments(exp))
                 .withTest(ignoreComments(act))
                 .ignoreWhitespace()
                 .normalizeWhitespace()
@@ -319,8 +315,8 @@ public class TestUtils {
     public static void assertXMLEqual(InputSource exp, InputSource act) {
         try {
             final Diff d;
-            d = DiffBuilder
-                    .compare(ignoreComments(builderFactory.newDocumentBuilder().parse(exp)))
+            d = DiffBuilder.compare(
+                            ignoreComments(builderFactory.newDocumentBuilder().parse(exp)))
                     .withTest(ignoreComments(builderFactory.newDocumentBuilder().parse(act)))
                     .ignoreWhitespace()
                     .withNodeFilter(node -> node.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE)
@@ -336,8 +332,8 @@ public class TestUtils {
     public static void assertHtmlEqual(InputSource exp, InputSource act) {
         final DocumentBuilderFactory builderFactory = new HTMLDocumentBuilderFactory();
         try {
-            final Diff d = DiffBuilder
-                    .compare(ignoreComments(builderFactory.newDocumentBuilder().parse(exp)))
+            final Diff d = DiffBuilder.compare(
+                            ignoreComments(builderFactory.newDocumentBuilder().parse(exp)))
                     .withTest(ignoreComments(builderFactory.newDocumentBuilder().parse(act)))
                     .ignoreWhitespace()
                     .normalizeWhitespace()
@@ -380,7 +376,8 @@ public class TestUtils {
 
     public static Document buildControlDocument(String content) {
         try {
-            return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            return DocumentBuilderFactory.newInstance()
+                    .newDocumentBuilder()
                     .parse(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
         } catch (SAXException | IOException | ParserConfigurationException e) {
             throw new RuntimeException(e);
@@ -403,24 +400,20 @@ public class TestUtils {
         }
 
         public void info(final String msg) {
-            //System.out.println(msg);
+            // System.out.println(msg);
         }
 
         @Override
-        public void info(String format, Object arg) {
-        }
+        public void info(String format, Object arg) {}
 
         @Override
-        public void info(String format, Object arg1, Object arg2) {
-        }
+        public void info(String format, Object arg1, Object arg2) {}
 
         @Override
-        public void info(String format, Object... arguments) {
-        }
+        public void info(String format, Object... arguments) {}
 
         @Override
-        public void info(String msg, Throwable t) {
-        }
+        public void info(String msg, Throwable t) {}
 
         @Override
         public boolean isWarnEnabled() {
@@ -428,24 +421,20 @@ public class TestUtils {
         }
 
         public void warn(final String msg) {
-            //System.err.println(msg);
+            // System.err.println(msg);
         }
 
         @Override
-        public void warn(String format, Object arg) {
-        }
+        public void warn(String format, Object arg) {}
 
         @Override
-        public void warn(String format, Object... arguments) {
-        }
+        public void warn(String format, Object... arguments) {}
 
         @Override
-        public void warn(String format, Object arg1, Object arg2) {
-        }
+        public void warn(String format, Object arg1, Object arg2) {}
 
         @Override
-        public void warn(String msg, Throwable t) {
-        }
+        public void warn(String msg, Throwable t) {}
 
         @Override
         public boolean isErrorEnabled() {
@@ -492,24 +481,19 @@ public class TestUtils {
         }
 
         @Override
-        public void trace(String msg) {
-        }
+        public void trace(String msg) {}
 
         @Override
-        public void trace(String format, Object arg) {
-        }
+        public void trace(String format, Object arg) {}
 
         @Override
-        public void trace(String format, Object arg1, Object arg2) {
-        }
+        public void trace(String format, Object arg1, Object arg2) {}
 
         @Override
-        public void trace(String format, Object... arguments) {
-        }
+        public void trace(String format, Object... arguments) {}
 
         @Override
-        public void trace(String msg, Throwable t) {
-        }
+        public void trace(String msg, Throwable t) {}
 
         @Override
         public boolean isDebugEnabled() {
@@ -517,30 +501,25 @@ public class TestUtils {
         }
 
         public void debug(final String msg) {
-            //System.out.println(msg);
+            // System.out.println(msg);
         }
 
         @Override
-        public void debug(String format, Object arg) {
-        }
+        public void debug(String format, Object arg) {}
 
         @Override
-        public void debug(String format, Object arg1, Object arg2) {
-        }
+        public void debug(String format, Object arg1, Object arg2) {}
 
         @Override
-        public void debug(String format, Object... arguments) {
-        }
+        public void debug(String format, Object... arguments) {}
 
         @Override
-        public void debug(String msg, Throwable t) {
-        }
+        public void debug(String msg, Throwable t) {}
 
         @Override
         public boolean isInfoEnabled() {
             return true;
         }
-
     }
 
     /**
@@ -667,24 +646,19 @@ public class TestUtils {
         }
 
         @Override
-        public void trace(String msg) {
-        }
+        public void trace(String msg) {}
 
         @Override
-        public void trace(String format, Object arg) {
-        }
+        public void trace(String format, Object arg) {}
 
         @Override
-        public void trace(String format, Object arg1, Object arg2) {
-        }
+        public void trace(String format, Object arg1, Object arg2) {}
 
         @Override
-        public void trace(String format, Object... arguments) {
-        }
+        public void trace(String format, Object... arguments) {}
 
         @Override
-        public void trace(String msg, Throwable t) {
-        }
+        public void trace(String msg, Throwable t) {}
 
         @Override
         public boolean isDebugEnabled() {
@@ -721,7 +695,13 @@ public class TestUtils {
         }
 
         public static final class Message {
-            public enum Level {DEBUG, INFO, WARN, ERROR, FATAL}
+            public enum Level {
+                DEBUG,
+                INFO,
+                WARN,
+                ERROR,
+                FATAL
+            }
 
             public final Level level;
             public final String message;
@@ -738,9 +718,9 @@ public class TestUtils {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
                 Message message1 = (Message) o;
-                return level == message1.level &&
-                        Objects.equals(message, message1.message) &&
-                        Objects.equals(exception, message1.exception);
+                return level == message1.level
+                        && Objects.equals(message, message1.message)
+                        && Objects.equals(exception, message1.exception);
             }
 
             @Override
@@ -751,18 +731,16 @@ public class TestUtils {
 
             @Override
             public String toString() {
-                return "Message{" +
-                        "level=" + level +
-                        ", message='" + message + '\'' +
-                        ", exception=" + exception +
-                        '}';
+                return "Message{" + "level="
+                        + level + ", message='"
+                        + message + '\'' + ", exception="
+                        + exception + '}';
             }
         }
 
         public List<Message> getMessages() {
             return Collections.unmodifiableList(buf);
         }
-
     }
 
     public static XdmNode parse(File input) throws SaxonApiException {

--- a/src/test/java/org/dita/dost/ant/ExtensibleAntInvokerTest.java
+++ b/src/test/java/org/dita/dost/ant/ExtensibleAntInvokerTest.java
@@ -8,6 +8,11 @@
 
 package org.dita.dost.ant;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
 import org.apache.tools.ant.Project;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
@@ -17,15 +22,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class ExtensibleAntInvokerTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
+
     private Project project;
     private File tempDir;
 

--- a/src/test/java/org/dita/dost/ant/PluginInstallTaskTest.java
+++ b/src/test/java/org/dita/dost/ant/PluginInstallTaskTest.java
@@ -8,12 +8,12 @@
 
 package org.dita.dost.ant;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.dita.dost.platform.Registry;
 import org.dita.dost.platform.Registry.Dependency;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class PluginInstallTaskTest {
 
@@ -27,10 +27,6 @@ public class PluginInstallTaskTest {
     }
 
     private Registry createRegistry(String version) {
-        return new Registry(null, "1.0.0",
-                new Dependency[]{
-                        new Dependency("org.dita.base", version)
-                },
-                null, null);
+        return new Registry(null, "1.0.0", new Dependency[] {new Dependency("org.dita.base", version)}, null, null);
     }
 }

--- a/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
+++ b/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
@@ -8,7 +8,16 @@
 
 package org.dita.dost.ant.types;
 
+import static org.junit.Assert.*;
+
 import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.tools.ant.types.Resource;
 import org.dita.dost.TestUtils;
 import org.dita.dost.ant.types.JobSourceSet.SelectorElem;
@@ -19,16 +28,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
 
 public class JobSourceSetTest {
 
@@ -49,7 +48,6 @@ public class JobSourceSetTest {
                     .format(ext)
                     .build());
         }
-
     }
 
     @Before
@@ -87,9 +85,7 @@ public class JobSourceSetTest {
 
     @Test
     public void testFilterIncludesFormat() {
-        jobSourceSet.addConfiguredIncludes(
-                new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null)
-        );
+        jobSourceSet.addConfiguredIncludes(new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
@@ -97,12 +93,8 @@ public class JobSourceSetTest {
 
     @Test
     public void testFilterIncludesMultipleFormat() {
-        jobSourceSet.addConfiguredIncludes(
-                new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null)
-        );
-        jobSourceSet.addConfiguredIncludes(
-                new SelectorElem(new HashSet<>(List.of("ditamap")), null, null, null, null)
-        );
+        jobSourceSet.addConfiguredIncludes(new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null));
+        jobSourceSet.addConfiguredIncludes(new SelectorElem(new HashSet<>(List.of("ditamap")), null, null, null, null));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
@@ -110,9 +102,7 @@ public class JobSourceSetTest {
 
     @Test
     public void testFilterExcludesFormat() {
-        jobSourceSet.addConfiguredExcludes(
-                new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null)
-        );
+        jobSourceSet.addConfiguredExcludes(new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));
@@ -120,12 +110,8 @@ public class JobSourceSetTest {
 
     @Test
     public void testFilterExcludesMultipleFormat() {
-        jobSourceSet.addConfiguredExcludes(
-                new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null)
-        );
-        jobSourceSet.addConfiguredExcludes(
-                new SelectorElem(new HashSet<>(List.of("ditamap")), null, null, null, null)
-        );
+        jobSourceSet.addConfiguredExcludes(new SelectorElem(new HashSet<>(List.of("dita")), null, null, null, null));
+        jobSourceSet.addConfiguredExcludes(new SelectorElem(new HashSet<>(List.of("ditamap")), null, null, null, null));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.dita"))));
         assertFalse(jobSourceSet.filter(job.getFileInfo(URI.create("a.ditamap"))));
         assertTrue(jobSourceSet.filter(job.getFileInfo(URI.create("a.html"))));

--- a/src/test/java/org/dita/dost/chunk/ChunkModuleOldTest.java
+++ b/src/test/java/org/dita/dost/chunk/ChunkModuleOldTest.java
@@ -8,6 +8,12 @@
 
 package org.dita.dost.chunk;
 
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import org.dita.dost.module.AbstractModuleTest;
 import org.dita.dost.module.AbstractPipelineModule;
 import org.dita.dost.module.ChunkModule;
@@ -17,29 +23,21 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
-
 @RunWith(Parameterized.class)
 public class ChunkModuleOldTest extends AbstractModuleTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"combine"},
-                {"dita"},
-                {"link"},
-                {"uplevels"},
-                {"format"},
-                {"nested"},
-                {"scope"},
-                {"topicgroup"},
-                {"topichead"},
-                {"map"}
+        return Arrays.asList(new Object[][] {
+            {"combine"},
+            {"dita"},
+            {"link"},
+            {"uplevels"},
+            {"format"},
+            {"nested"},
+            {"scope"},
+            {"topicgroup"},
+            {"topichead"},
+            {"map"}
         });
     }
 

--- a/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
+++ b/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
@@ -8,7 +8,13 @@
 
 package org.dita.dost.chunk;
 
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.*;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.module.AbstractModuleTest;
 import org.dita.dost.module.AbstractPipelineModule;
@@ -18,46 +24,38 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.File;
-import java.util.*;
-
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
-import static org.junit.Assert.assertEquals;
-
 @RunWith(Parameterized.class)
 public class ChunkModuleTest extends AbstractModuleTest {
     private final int warningCount;
 
     @Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"combine", Collections.emptyMap(), 2},
-                {"duplicate", Collections.emptyMap(), 0},
-                {"override", ImmutableMap.of("root-chunk-override", "combine"), 0},
-                {"dita", Collections.emptyMap(), 0},
-                {"combine-empty-ditabase", Collections.emptyMap(), 0},
-                {"link", Collections.emptyMap(), 0},
-                {"uplevels", Collections.emptyMap(), 0},
-                {"uplevels-dir", Collections.emptyMap(), 0},
-                {"uplevels-root", Collections.emptyMap(), 0},
-                {"uplevels-parallel", Collections.emptyMap(), 0},
-                {"format", Collections.emptyMap(), 0},
-                {"nested", Collections.emptyMap(), 0},
-                {"scope", Collections.emptyMap(), 0},
-                {"topicgroup", Collections.emptyMap(), 1},
-                {"topichead", Collections.emptyMap(), 1},
-                {"multiple", Collections.emptyMap(), 0},
-                {"map", Collections.emptyMap(), 0},
-
-                {"split", Collections.emptyMap(), 0},
-                {"split-dita", Collections.emptyMap(), 0},
-                {"split-hierarchy", Collections.emptyMap(), 0},
-                {"split-empty-ditabase", Collections.emptyMap(), 0},
-                {"split-map", Collections.emptyMap(), 0},
-                {"chunk-combine-within-split", Collections.emptyMap(), 0},
-                {"managing-links", Collections.emptyMap(), 0},
-                {"managing-links-duplicates", Collections.emptyMap(), 0}
+        return Arrays.asList(new Object[][] {
+            {"combine", Collections.emptyMap(), 2},
+            {"duplicate", Collections.emptyMap(), 0},
+            {"override", ImmutableMap.of("root-chunk-override", "combine"), 0},
+            {"dita", Collections.emptyMap(), 0},
+            {"combine-empty-ditabase", Collections.emptyMap(), 0},
+            {"link", Collections.emptyMap(), 0},
+            {"uplevels", Collections.emptyMap(), 0},
+            {"uplevels-dir", Collections.emptyMap(), 0},
+            {"uplevels-root", Collections.emptyMap(), 0},
+            {"uplevels-parallel", Collections.emptyMap(), 0},
+            {"format", Collections.emptyMap(), 0},
+            {"nested", Collections.emptyMap(), 0},
+            {"scope", Collections.emptyMap(), 0},
+            {"topicgroup", Collections.emptyMap(), 1},
+            {"topichead", Collections.emptyMap(), 1},
+            {"multiple", Collections.emptyMap(), 0},
+            {"map", Collections.emptyMap(), 0},
+            {"split", Collections.emptyMap(), 0},
+            {"split-dita", Collections.emptyMap(), 0},
+            {"split-hierarchy", Collections.emptyMap(), 0},
+            {"split-empty-ditabase", Collections.emptyMap(), 0},
+            {"split-map", Collections.emptyMap(), 0},
+            {"chunk-combine-within-split", Collections.emptyMap(), 0},
+            {"managing-links", Collections.emptyMap(), 0},
+            {"managing-links-duplicates", Collections.emptyMap(), 0}
         });
     }
 
@@ -77,9 +75,8 @@ public class ChunkModuleTest extends AbstractModuleTest {
     public void test() {
         initStore(job.getStore());
         super.test();
-        final List<Message> warnings = logger.getMessages().stream()
-                .filter(m -> m.level == WARN)
-                .toList();
+        final List<Message> warnings =
+                logger.getMessages().stream().filter(m -> m.level == WARN).toList();
         warnings.forEach(m -> System.err.println(m.level + ": " + m.message));
         assertEquals(warningCount, warnings.size());
     }

--- a/src/test/java/org/dita/dost/exception/DITAOTExceptionTest.java
+++ b/src/test/java/org/dita/dost/exception/DITAOTExceptionTest.java
@@ -40,5 +40,4 @@ public class DITAOTExceptionTest {
         new DITAOTException(null, null, null);
         new DITAOTException(new MessageBean(null, (MessageBean.Type) null, null, null), new RuntimeException(), "test");
     }
-
 }

--- a/src/test/java/org/dita/dost/exception/DITAOTXMLErrorHandlerTest.java
+++ b/src/test/java/org/dita/dost/exception/DITAOTXMLErrorHandlerTest.java
@@ -7,18 +7,18 @@
  */
 package org.dita.dost.exception;
 
+import org.dita.dost.TestUtils.TestLogger;
+import org.dita.dost.log.DITAOTLogger;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-import org.dita.dost.TestUtils.TestLogger;
-import org.dita.dost.log.DITAOTLogger;
 
 public class DITAOTXMLErrorHandlerTest {
 
     private final DITAOTLogger logger = new TestLogger();
     private final DITAOTXMLErrorHandler e = new DITAOTXMLErrorHandler("path", logger);
-    private final SAXParseException se = new SAXParseException("message", "publicId", "systemId", 3, 1,
-            new RuntimeException("msg"));
+    private final SAXParseException se =
+            new SAXParseException("message", "publicId", "systemId", 3, 1, new RuntimeException("msg"));
 
     @Test
     public void testDITAOTXMLErrorHandler() {
@@ -40,5 +40,4 @@ public class DITAOTXMLErrorHandlerTest {
     public void testWarning() throws SAXException {
         e.warning(se);
     }
-
 }

--- a/src/test/java/org/dita/dost/exception/SAXExceptionWrapperTest.java
+++ b/src/test/java/org/dita/dost/exception/SAXExceptionWrapperTest.java
@@ -8,6 +8,7 @@
 package org.dita.dost.exception;
 
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXParseException;
@@ -18,12 +19,15 @@ public class SAXExceptionWrapperTest {
         public int getColumnNumber() {
             return 1;
         }
+
         public int getLineNumber() {
             return 3;
         }
+
         public String getPublicId() {
             return "publicId";
         }
+
         public String getSystemId() {
             return "systemId";
         }
@@ -58,13 +62,8 @@ public class SAXExceptionWrapperTest {
     public void testGetMessage() {
         final SAXExceptionWrapper e = new SAXExceptionWrapper("message", new SAXParseException("msg", l));
         final String act = e.getMessage();
-        final String exp = "message" +
-                " Line " +
-                l.getLineNumber() +
-                ":" +
-                "msg" +
-                System.getProperty("line.separator");
+        final String exp =
+                "message" + " Line " + l.getLineNumber() + ":" + "msg" + System.getProperty("line.separator");
         assertEquals(exp, act);
     }
-
 }

--- a/src/test/java/org/dita/dost/index/IndexTermCollectionTest.java
+++ b/src/test/java/org/dita/dost/index/IndexTermCollectionTest.java
@@ -10,16 +10,14 @@ package org.dita.dost.index;
 import static org.dita.dost.TestUtils.assertHtmlEqual;
 import static org.junit.Assert.*;
 
-import org.dita.dost.TestUtils;
-import org.dita.dost.exception.DITAOTException;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-
+import org.dita.dost.TestUtils;
+import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.writer.HTMLIndexWriter;
 import org.junit.After;
 import org.junit.Before;
@@ -99,8 +97,7 @@ public class IndexTermCollectionTest {
         second.setTermName("second");
         second.setTermKey("second");
         i.addTerm(second);
-        assertEquals(new HashSet<>(new ArrayList<>(Arrays.asList(first, second))),
-                new HashSet<>(i.getTermList()));
+        assertEquals(new HashSet<>(new ArrayList<>(Arrays.asList(first, second))), new HashSet<>(i.getTermList()));
     }
 
     @Test
@@ -115,8 +112,7 @@ public class IndexTermCollectionTest {
         i.addTerm(second);
         i.addTerm(first);
         i.sort();
-        assertEquals(new ArrayList<>(Arrays.asList(first, second)),
-                i.getTermList());
+        assertEquals(new ArrayList<>(Arrays.asList(first, second)), i.getTermList());
     }
 
     @Test
@@ -134,21 +130,25 @@ public class IndexTermCollectionTest {
         i.addTerm(first);
         i.outputTerms();
 
-        assertHtmlEqual(new InputSource(new File(expDir, "foo.hhk").toURI().toString()),
+        assertHtmlEqual(
+                new InputSource(new File(expDir, "foo.hhk").toURI().toString()),
                 new InputSource(new File(tempDir, "foo.hhk").toURI().toString()));
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     public void testSetOutputFileRoot() {
         fail("Not yet implemented");
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     public void testGetPipelineHashIO() {
         fail("Not yet implemented");
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     public void testSetPipelineHashIO() {
         fail("Not yet implemented");
     }
@@ -157,5 +157,4 @@ public class IndexTermCollectionTest {
     public void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/index/IndexTermTargetTest.java
+++ b/src/test/java/org/dita/dost/index/IndexTermTargetTest.java
@@ -75,9 +75,9 @@ public class IndexTermTargetTest {
         assertFalse(simple.equals(""));
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     public void testToString() {
         fail("Not yet implemented");
     }
-
 }

--- a/src/test/java/org/dita/dost/index/IndexTermTest.java
+++ b/src/test/java/org/dita/dost/index/IndexTermTest.java
@@ -10,13 +10,11 @@ package org.dita.dost.index;
 import static org.dita.dost.index.IndexTerm.IndexTermPrefix.*;
 import static org.junit.Assert.*;
 
-import org.dita.dost.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-
+import org.dita.dost.util.StringUtils;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -79,7 +77,6 @@ public class IndexTermTest {
         assertNull(IndexTerm.getTermLocale());
         IndexTerm.setTermLocale(Locale.JAPAN);
         assertEquals(Locale.JAPAN, IndexTerm.getTermLocale());
-
     }
 
     @Test
@@ -196,8 +193,8 @@ public class IndexTermTest {
     public void testSortSubTerms() {
         IndexTerm.setTermLocale(DEFAULT_LOCALE);
         final IndexTerm root = new IndexTerm();
-        final String[] src = { "B", "b", "a", "A" };
-        for (final String key: src) {
+        final String[] src = {"B", "b", "a", "A"};
+        for (final String key : src) {
             final IndexTerm i = new IndexTerm();
             i.setTermName(key);
             i.setTermKey(key);
@@ -206,11 +203,11 @@ public class IndexTermTest {
         root.sortSubTerms();
 
         final List<String> act = new ArrayList<>();
-        for (final IndexTerm i: root.getSubTerms()) {
+        for (final IndexTerm i : root.getSubTerms()) {
             act.add(i.getTermKey());
         }
 
-        final String[] exp = { "a", "A", "b", "B" };
+        final String[] exp = {"a", "A", "b", "B"};
         assertArrayEquals(exp, act.toArray(new String[0]));
     }
 
@@ -224,7 +221,8 @@ public class IndexTermTest {
             IndexTerm.setTermLocale(null);
             new IndexTerm().compareTo(new IndexTerm());
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -249,7 +247,8 @@ public class IndexTermTest {
         assertFalse(simple.hasSubTerms());
     }
 
-    @Test @Ignore
+    @Test
+    @Ignore
     public void testToString() {
         fail("Not yet implemented");
     }
@@ -293,7 +292,7 @@ public class IndexTermTest {
         singleSub.setTermPrefix(SEE);
         single.addSubTerm(singleSub);
         single.updateSubTerm();
-        for (final IndexTerm s: single.getSubTerms()) {
+        for (final IndexTerm s : single.getSubTerms()) {
             assertEquals(SEE_ALSO, s.getTermPrefix());
         }
 
@@ -303,7 +302,7 @@ public class IndexTermTest {
         more.addSubTerm(moreSub);
         more.addSubTerm(new IndexTerm());
         more.updateSubTerm();
-        for (final IndexTerm m: more.getSubTerms()) {
+        for (final IndexTerm m : more.getSubTerms()) {
             assertFalse(SEE_ALSO.equals(m));
         }
     }
@@ -334,5 +333,4 @@ public class IndexTermTest {
         }
         return res;
     }
-
 }

--- a/src/test/java/org/dita/dost/invoker/ArgumentParserTest.java
+++ b/src/test/java/org/dita/dost/invoker/ArgumentParserTest.java
@@ -8,13 +8,12 @@
 
 package org.dita.dost.invoker;
 
-import org.apache.tools.ant.Project;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
+import org.apache.tools.ant.Project;
+import org.junit.Test;
 
 public class ArgumentParserTest {
 
@@ -27,12 +26,12 @@ public class ArgumentParserTest {
 
     @Test
     public void shortArguments() {
-        final ConversionArguments act = (ConversionArguments) parser.processArgs(new String[]{
-                "-i", "src",
-                "-f", "html5",
-                "-t", "tmp",
-                "-o", "out",
-                "-v"
+        final ConversionArguments act = (ConversionArguments) parser.processArgs(new String[] {
+            "-i", "src",
+            "-f", "html5",
+            "-t", "tmp",
+            "-o", "out",
+            "-v"
         });
         assertEquals(Collections.singletonList(new File("src").getAbsolutePath()), act.inputs);
         assertEquals(new File("src").getAbsolutePath(), act.definedProps.get("args.input"));
@@ -44,13 +43,8 @@ public class ArgumentParserTest {
 
     @Test
     public void longArguments() {
-        final ConversionArguments act = (ConversionArguments) parser.processArgs(new String[]{
-                "--input=src",
-                "--format=html5",
-                "--temp=tmp",
-                "--output=out",
-                "--verbose"
-        });
+        final ConversionArguments act = (ConversionArguments) parser.processArgs(
+                new String[] {"--input=src", "--format=html5", "--temp=tmp", "--output=out", "--verbose"});
         assertEquals(Collections.singletonList(new File("src").getAbsolutePath()), act.inputs);
         assertEquals(new File("src").getAbsolutePath(), act.definedProps.get("args.input"));
         assertEquals("html5", act.definedProps.get("transtype"));
@@ -61,108 +55,82 @@ public class ArgumentParserTest {
 
     @Test
     public void reinstallSubcommand() {
-        final InstallArguments act = (InstallArguments) parser.processArgs(new String[]{
-                "install"
-        });
+        final InstallArguments act = (InstallArguments) parser.processArgs(new String[] {"install"});
     }
 
     @Test
     public void installSubcommand() {
-        final InstallArguments act = (InstallArguments) parser.processArgs(new String[]{
-                "install",
-                "org.dita.eclipsehelp"
-        });
+        final InstallArguments act =
+                (InstallArguments) parser.processArgs(new String[] {"install", "org.dita.eclipsehelp"});
         assertEquals("org.dita.eclipsehelp", act.installFile);
     }
 
     @Test
     public void installSubcommand_optionForm() {
-        final InstallArguments act = (InstallArguments) parser.processArgs(new String[]{
-                "--install=org.dita.eclipsehelp"
-        });
+        final InstallArguments act =
+                (InstallArguments) parser.processArgs(new String[] {"--install=org.dita.eclipsehelp"});
         assertEquals("org.dita.eclipsehelp", act.installFile);
     }
 
     @Test
     public void installSubcommand_optionForm_globalArgument() {
-        final InstallArguments act = (InstallArguments) parser.processArgs(new String[]{
-                "-v",
-                "--install=org.dita.eclipsehelp"
-        });
+        final InstallArguments act =
+                (InstallArguments) parser.processArgs(new String[] {"-v", "--install=org.dita.eclipsehelp"});
         assertEquals("org.dita.eclipsehelp", act.installFile);
     }
 
     @Test
     public void uninstallSubcommand() {
-        final UninstallArguments act = (UninstallArguments) parser.processArgs(new String[]{
-                "uninstall",
-                "org.dita.eclipsehelp"
-        });
+        final UninstallArguments act =
+                (UninstallArguments) parser.processArgs(new String[] {"uninstall", "org.dita.eclipsehelp"});
         assertEquals("org.dita.eclipsehelp", act.uninstallId);
     }
 
     @Test
     public void uninstallSubcommand_optionForm() {
-        final UninstallArguments act = (UninstallArguments) parser.processArgs(new String[]{
-                "--uninstall=org.dita.eclipsehelp"
-        });
+        final UninstallArguments act =
+                (UninstallArguments) parser.processArgs(new String[] {"--uninstall=org.dita.eclipsehelp"});
         assertEquals("org.dita.eclipsehelp", act.uninstallId);
     }
 
     @Test
     public void pluginsSubcommand() {
-        final PluginsArguments act = (PluginsArguments) parser.processArgs(new String[]{
-                "plugins"
-        });
+        final PluginsArguments act = (PluginsArguments) parser.processArgs(new String[] {"plugins"});
     }
 
     @Test
     public void pluginsSubcommand_optionForm() {
-        final PluginsArguments act = (PluginsArguments) parser.processArgs(new String[]{
-                "--plugins"
-        });
+        final PluginsArguments act = (PluginsArguments) parser.processArgs(new String[] {"--plugins"});
     }
 
     @Test
     public void transtypesSubcommand() {
-        final TranstypesArguments act = (TranstypesArguments) parser.processArgs(new String[]{
-                "transtypes"
-        });
+        final TranstypesArguments act = (TranstypesArguments) parser.processArgs(new String[] {"transtypes"});
     }
 
     @Test
     public void transtypesSubcommand__optionForm() {
-        final TranstypesArguments act = (TranstypesArguments) parser.processArgs(new String[]{
-                "--transtypes"
-        });
+        final TranstypesArguments act = (TranstypesArguments) parser.processArgs(new String[] {"--transtypes"});
     }
 
     @Test
     public void deliverablesSubcommand() {
-        final DeliverablesArguments act = (DeliverablesArguments) parser.processArgs(new String[]{
-                "deliverables",
-                "project.json"
-        });
+        final DeliverablesArguments act =
+                (DeliverablesArguments) parser.processArgs(new String[] {"deliverables", "project.json"});
         assertEquals(new File("project.json").getAbsoluteFile(), act.projectFile);
     }
 
     @Test
     public void deliverablesSubcommand__withOption() {
-        final DeliverablesArguments act = (DeliverablesArguments) parser.processArgs(new String[]{
-                "deliverables",
-                "-p", "project.json"
-        });
+        final DeliverablesArguments act =
+                (DeliverablesArguments) parser.processArgs(new String[] {"deliverables", "-p", "project.json"});
         assertEquals(new File("project.json").getAbsoluteFile(), act.projectFile);
     }
 
     @Test
     public void deliverablesSubcommand__optionForm() {
-        final DeliverablesArguments act = (DeliverablesArguments) parser.processArgs(new String[]{
-                "--deliverables",
-                "-p", "project.json"
-        });
+        final DeliverablesArguments act =
+                (DeliverablesArguments) parser.processArgs(new String[] {"--deliverables", "-p", "project.json"});
         assertEquals(new File("project.json").getAbsoluteFile(), act.projectFile);
     }
-
-
 }

--- a/src/test/java/org/dita/dost/invoker/ConversionArgumentsTest.java
+++ b/src/test/java/org/dita/dost/invoker/ConversionArgumentsTest.java
@@ -8,13 +8,12 @@
 
 package org.dita.dost.invoker;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.File;
-
 import static java.io.File.pathSeparator;
 import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ConversionArgumentsTest {
 
@@ -27,63 +26,61 @@ public class ConversionArgumentsTest {
 
     @Test
     public void input_short() {
-        arguments.parse(new String[]{"-i", "foo.dita"});
+        arguments.parse(new String[] {"-i", "foo.dita"});
 
         assertEquals("foo.dita", arguments.definedProps.get("args.input"));
     }
 
     @Test
     public void input_long() {
-        arguments.parse(new String[]{"--input=foo.dita"});
+        arguments.parse(new String[] {"--input=foo.dita"});
 
         assertEquals("foo.dita", arguments.definedProps.get("args.input"));
     }
 
     @Test
     public void format_short() {
-        arguments.parse(new String[]{"-f", "html5"});
+        arguments.parse(new String[] {"-f", "html5"});
 
         assertEquals("html5", arguments.definedProps.get("transtype"));
     }
 
     @Test
     public void format_long() {
-        arguments.parse(new String[]{"--format=html5"});
+        arguments.parse(new String[] {"--format=html5"});
 
         assertEquals("html5", arguments.definedProps.get("transtype"));
     }
 
     @Test
     public void resource_short_multipleOptions() {
-        arguments.parse(new String[]{"-r", "foo.dita", "-r", "bar.dita"});
+        arguments.parse(new String[] {"-r", "foo.dita", "-r", "bar.dita"});
 
         assertEquals("foo.dita" + pathSeparator + "bar.dita", arguments.definedProps.get("args.resources"));
     }
 
     @Test
     public void resource_long_multipleOptions() {
-        arguments.parse(new String[]{"--resource=foo.dita", "--resource=bar.dita"});
+        arguments.parse(new String[] {"--resource=foo.dita", "--resource=bar.dita"});
 
         assertEquals("foo.dita" + pathSeparator + "bar.dita", arguments.definedProps.get("args.resources"));
     }
 
     @Test
     public void filter_multipleOptions() {
-        arguments.parse(new String[]{"--filter=foo.ditaval", "--filter=bar.ditaval"});
+        arguments.parse(new String[] {"--filter=foo.ditaval", "--filter=bar.ditaval"});
 
-        assertEquals(new File("foo.ditaval").getAbsolutePath()
-                        + pathSeparator
-                        + new File("bar.ditaval").getAbsolutePath(),
+        assertEquals(
+                new File("foo.ditaval").getAbsolutePath() + pathSeparator + new File("bar.ditaval").getAbsolutePath(),
                 arguments.definedProps.get("args.filter"));
     }
 
     @Test
     public void filter_listValue() {
-        arguments.parse(new String[]{"--filter=foo.ditaval" + pathSeparator + "bar.ditaval"});
+        arguments.parse(new String[] {"--filter=foo.ditaval" + pathSeparator + "bar.ditaval"});
 
-        assertEquals(new File("foo.ditaval").getAbsolutePath()
-                        + pathSeparator
-                        + new File("bar.ditaval").getAbsolutePath(),
+        assertEquals(
+                new File("foo.ditaval").getAbsolutePath() + pathSeparator + new File("bar.ditaval").getAbsolutePath(),
                 arguments.definedProps.get("args.filter"));
     }
 }

--- a/src/test/java/org/dita/dost/invoker/MainProjectTest.java
+++ b/src/test/java/org/dita/dost/invoker/MainProjectTest.java
@@ -8,12 +8,11 @@
 
 package org.dita.dost.invoker;
 
-import com.google.common.collect.ImmutableMap;
-import org.dita.dost.project.Project;
-import org.dita.dost.project.ProjectFactory;
-import org.junit.Before;
-import org.junit.Test;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -23,10 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import org.dita.dost.project.Project;
+import org.dita.dost.project.ProjectFactory;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MainProjectTest {
 
@@ -44,7 +43,10 @@ public class MainProjectTest {
 
     @Test
     public void collectProperties_simple() throws IOException, URISyntaxException {
-        projectFile = getClass().getClassLoader().getResource("org/dita/dost/project/simple.xml").toURI();
+        projectFile = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/simple.xml")
+                .toURI();
         project = factory.load(projectFile);
         final URI baseDir = projectFile.resolve("");
 
@@ -57,8 +59,15 @@ public class MainProjectTest {
                 .put("transtype", "html5")
                 .put("args.empty", "")
                 .put("args.rellinks", "noparent")
-                .put("args.path", Paths.get(baseDir).resolve("baz qux").toAbsolutePath().toString())
-                .put("args.filter", Paths.get(baseDir).resolve("site.ditaval").toAbsolutePath().toString())
+                .put(
+                        "args.path",
+                        Paths.get(baseDir).resolve("baz qux").toAbsolutePath().toString())
+                .put(
+                        "args.filter",
+                        Paths.get(baseDir)
+                                .resolve("site.ditaval")
+                                .toAbsolutePath()
+                                .toString())
                 .put("args.gen.task.lbl", "YES")
                 .put("args.uri", baseDir.resolve("foo%20bar").toString())
                 .build();
@@ -67,7 +76,10 @@ public class MainProjectTest {
 
     @Test
     public void collectProperties_profiles() throws IOException, URISyntaxException {
-        projectFile = getClass().getClassLoader().getResource("org/dita/dost/project/profiles.xml").toURI();
+        projectFile = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/profiles.xml")
+                .toURI();
         project = factory.load(projectFile);
         final URI baseDir = projectFile.resolve("");
 
@@ -78,9 +90,14 @@ public class MainProjectTest {
                 .put("output.dir", Paths.get("out", "site").toAbsolutePath().toString())
                 .put("args.input", baseDir.resolve("site.ditamap").toString())
                 .put("transtype", "html5")
-                .put("args.filter", Stream.of("site-html5.ditaval", "site.ditaval")
-                        .map(ditaval -> Paths.get(baseDir).resolve(ditaval).toAbsolutePath().toString())
-                        .collect(Collectors.joining(File.pathSeparator)))
+                .put(
+                        "args.filter",
+                        Stream.of("site-html5.ditaval", "site.ditaval")
+                                .map(ditaval -> Paths.get(baseDir)
+                                        .resolve(ditaval)
+                                        .toAbsolutePath()
+                                        .toString())
+                                .collect(Collectors.joining(File.pathSeparator)))
                 .build();
         assertEquals(singletonList(exp), act);
     }

--- a/src/test/java/org/dita/dost/invoker/MainTest.java
+++ b/src/test/java/org/dita/dost/invoker/MainTest.java
@@ -8,12 +8,8 @@
 
 package org.dita.dost.invoker;
 
-import org.dita.dost.project.Project.Deliverable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.dita.dost.invoker.Main.ANT_OUTPUT_DIR;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URI;
@@ -23,18 +19,21 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.dita.dost.invoker.Main.ANT_OUTPUT_DIR;
-import static org.junit.Assert.assertEquals;
+import org.dita.dost.project.Project.Deliverable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class MainTest {
 
     @Parameters(name = "{1}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"", "Without trailing slash"},
-                {"/", "With trailing slash"},
+        return Arrays.asList(new Object[][] {
+            {"", "Without trailing slash"},
+            {"/", "With trailing slash"},
         });
     }
 
@@ -99,11 +98,8 @@ public class MainTest {
     }
 
     private Path getOutputDir(final String output, final String arg) {
-        final Deliverable deliverable = new Deliverable(
-                null, null, null,
-                output != null ? URI.create(output + suffix) : null,
-                null
-        );
+        final Deliverable deliverable =
+                new Deliverable(null, null, null, output != null ? URI.create(output + suffix) : null, null);
         final Map<String, Object> props = new HashMap<>();
         if (arg != null) {
             props.put(ANT_OUTPUT_DIR, arg + suffix);

--- a/src/test/java/org/dita/dost/log/MessageBeanTest.java
+++ b/src/test/java/org/dita/dost/log/MessageBeanTest.java
@@ -68,12 +68,10 @@ public class MessageBeanTest {
         assertNull(new MessageBean(null, (MessageBean.Type) null, null, null).getType());
     }
 
-
     @Test
     public void testToString() {
         assertEquals("[null][null] null", new MessageBean(null, (MessageBean.Type) null, null, null).toString());
         assertEquals("[foo][INFO] baz qux", new MessageBean("foo", INFO, "baz", "qux").toString());
         assertEquals("[foo][INFO] baz", new MessageBean("foo", INFO, "baz", null).toString());
     }
-
 }

--- a/src/test/java/org/dita/dost/log/MessageUtilsTest.java
+++ b/src/test/java/org/dita/dost/log/MessageUtilsTest.java
@@ -10,9 +10,7 @@ package org.dita.dost.log;
 import static org.junit.Assert.*;
 
 import java.io.File;
-
 import org.dita.dost.TestUtils;
-
 import org.junit.Test;
 
 public class MessageUtilsTest {
@@ -21,14 +19,17 @@ public class MessageUtilsTest {
 
     @Test
     public void testGetMessageString() {
-        final MessageBean exp = new MessageBean("XXX123F", "FATAL", "Fatal reason.","Fatal response.");
+        final MessageBean exp = new MessageBean("XXX123F", "FATAL", "Fatal reason.", "Fatal response.");
         assertEquals(exp.toString(), MessageUtils.getMessage("XXX123F").toString());
     }
 
     @Test
     public void testGetMessageStringProperties() {
-        final MessageBean exp = new MessageBean("XXX234E", "ERROR", "Error foo reason bar baz.", "Error foo response bar baz.");
-        assertEquals(exp.toString(), MessageUtils.getMessage("XXX234E", "foo", "bar baz").toString());
+        final MessageBean exp =
+                new MessageBean("XXX234E", "ERROR", "Error foo reason bar baz.", "Error foo response bar baz.");
+        assertEquals(
+                exp.toString(),
+                MessageUtils.getMessage("XXX234E", "foo", "bar baz").toString());
     }
 
     @Test
@@ -39,8 +40,10 @@ public class MessageUtilsTest {
 
     @Test
     public void testGetMessageStringExtra() {
-        final MessageBean exp = new MessageBean("XXX234E", "ERROR", "Error foo reason bar baz.", "Error foo response bar baz.");
-        assertEquals(exp.toString(), MessageUtils.getMessage("XXX234E", "foo", "bar baz", "qux").toString());
+        final MessageBean exp =
+                new MessageBean("XXX234E", "ERROR", "Error foo reason bar baz.", "Error foo response bar baz.");
+        assertEquals(
+                exp.toString(),
+                MessageUtils.getMessage("XXX234E", "foo", "bar baz", "qux").toString());
     }
-    
 }

--- a/src/test/java/org/dita/dost/module/AbstractModuleTest.java
+++ b/src/test/java/org/dita/dost/module/AbstractModuleTest.java
@@ -7,7 +7,22 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
@@ -27,22 +42,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractModuleTest {
 
@@ -163,10 +162,10 @@ public abstract class AbstractModuleTest {
         if (cache instanceof CacheStore) {
             final File srcDir = new File(resourceDir, "src" + File.separator + testCase);
             try {
-                Files.walk(srcDir.toPath())
-                        .filter(Files::isRegularFile)
-                        .forEach(src -> {
-                    final URI dst = tempDir.toPath().resolve(srcDir.toPath().relativize(src)).toUri();
+                Files.walk(srcDir.toPath()).filter(Files::isRegularFile).forEach(src -> {
+                    final URI dst = tempDir.toPath()
+                            .resolve(srcDir.toPath().relativize(src))
+                            .toUri();
                     try (OutputStream out = cache.getOutputStream(dst)) {
                         Files.copy(src, out);
                     } catch (IOException e) {
@@ -206,9 +205,7 @@ public abstract class AbstractModuleTest {
         final Set<String> names = new HashSet<>();
         final String[] actList = actDir.list();
         if (actList != null) {
-            Stream.of(actList)
-                    .filter(f -> store.exists(new File(f).toURI()))
-                    .forEach(names::add);
+            Stream.of(actList).filter(f -> store.exists(new File(f).toURI())).forEach(names::add);
         }
         final String[] expList = expDir.list();
         if (expList != null) {
@@ -224,8 +221,8 @@ public abstract class AbstractModuleTest {
             } else {
                 final Document expDoc = getDocument(exp);
                 final Document actDoc = store.getDocument(act.toURI());
-//                assertXMLEqual("Comparing " + exp + " to " + act + ":",
-//                        expDoc, actDoc);
+                //                assertXMLEqual("Comparing " + exp + " to " + act + ":",
+                //                        expDoc, actDoc);
                 try {
                     assertXMLEqual(expDoc, actDoc);
                 } catch (AssertionError e) {
@@ -237,7 +234,7 @@ public abstract class AbstractModuleTest {
         }
         if (new File(expDir, ".job.xml").exists()) {
             final Job expJob = new Job(expDir, new StreamStore(expDir, xmlUtils));
-//            final Job actJob = new Job(actDir, new StreamStore(actDir, xmlUtils));
+            //            final Job actJob = new Job(actDir, new StreamStore(actDir, xmlUtils));
             final Collection<FileInfo> expFileInfo = new HashSet<>(expJob.getFileInfo());
             final Collection<FileInfo> actFileInfo = new HashSet<>(job.getFileInfo());
             try {
@@ -249,5 +246,4 @@ public abstract class AbstractModuleTest {
             }
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/BranchFilterModuleTest.java
@@ -7,6 +7,17 @@
  */
 package org.dita.dost.module;
 
+import static junit.framework.Assert.assertEquals;
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.store.StreamStore;
@@ -17,18 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static junit.framework.Assert.assertEquals;
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertNotNull;
 
 public class BranchFilterModuleTest extends BranchFilterModule {
 
@@ -51,7 +50,8 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 .uri(URI.create("input.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("linux.ditaval", "novice.ditaval", "advanced.ditaval", "mac.ditaval", "win.ditaval")) {
+        for (final String uri :
+                Arrays.asList("linux.ditaval", "novice.ditaval", "advanced.ditaval", "mac.ditaval", "win.ditaval")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -59,7 +59,8 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita", "exclude.dita")) {
+        for (final String uri :
+                Arrays.asList("install.dita", "perform-install.dita", "configure.dita", "exclude.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -67,7 +68,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITA)
                     .build());
         }
-        for (final String uri: Arrays.asList("installation-procedure.dita", "getting-started.dita")) {
+        for (final String uri : Arrays.asList("installation-procedure.dita", "getting-started.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .result(new File(tempDir, uri).toURI())
                     .uri(URI.create(uri))
@@ -75,7 +76,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         }
         return job;
     }
-    
+
     private Job getUplevelsJob(File uplevelsTempDir) throws IOException {
         final Job job = new Job(uplevelsTempDir, new StreamStore(uplevelsTempDir, new XMLUtils()));
         job.setInputDir(uplevelsTempDir.toURI());
@@ -85,7 +86,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 .uri(URI.create("main/testuplevels.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("main/advanced.ditaval", "main/novice.ditaval")) {
+        for (final String uri : Arrays.asList("main/advanced.ditaval", "main/novice.ditaval")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(uplevelsTempDir, uri).toURI())
                     .result(new File(uplevelsTempDir, uri).toURI())
@@ -93,8 +94,14 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("main/parent.dita", "main/kiddo.dita", "main/subdirkiddo.dita",
-                "peer/peerkiddo.dita","main/parentdefault.dita", "main/kiddodefault.dita", "main/subdirkiddodefault.dita",
+        for (final String uri : Arrays.asList(
+                "main/parent.dita",
+                "main/kiddo.dita",
+                "main/subdirkiddo.dita",
+                "peer/peerkiddo.dita",
+                "main/parentdefault.dita",
+                "main/kiddodefault.dita",
+                "main/subdirkiddodefault.dita",
                 "peer/peerkiddodefault.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .src(new File(uplevelsTempDir, uri).toURI())
@@ -103,8 +110,11 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITA)
                     .build());
         }
-        for (final String uri: Arrays.asList("main/weechild.dita", "main/subdir/weechild.dita",
-                "main/weechilddefault.dita", "main/subdir/weechilddefault.dita")) {
+        for (final String uri : Arrays.asList(
+                "main/weechild.dita",
+                "main/subdir/weechild.dita",
+                "main/weechilddefault.dita",
+                "main/subdir/weechilddefault.dita")) {
             job.add(new Job.FileInfo.Builder()
                     .result(new File(uplevelsTempDir, uri).toURI())
                     .uri(URI.create(uri))
@@ -118,18 +128,18 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         TestUtils.forceDelete(tempDir);
     }
 
-//    @Test
-//    public void testSplitBranches() throws ParserConfigurationException, IOException, SAXException {
-//        final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-//
-//        final Document act = builder.parse(new File(tempDir, "input.ditamap"));
-//        currentFile = new File(tempDir, "input.ditamap").toURI();
-//        setJob(job);
-//        splitBranches(act.getDocumentElement(), Branch.EMPTY);
-//
-//        final Document exp = builder.parse(new File(expDir, "input_splitBranches.ditamap"));
-//        assertXMLEqual(exp, act);
-//    }
+    //    @Test
+    //    public void testSplitBranches() throws ParserConfigurationException, IOException, SAXException {
+    //        final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    //
+    //        final Document act = builder.parse(new File(tempDir, "input.ditamap"));
+    //        currentFile = new File(tempDir, "input.ditamap").toURI();
+    //        setJob(job);
+    //        splitBranches(act.getDocumentElement(), Branch.EMPTY);
+    //
+    //        final Document exp = builder.parse(new File(expDir, "input_splitBranches.ditamap"));
+    //        assertXMLEqual(exp, act);
+    //    }
 
     @Test
     public void testProcessMap() throws IOException, SAXException {
@@ -139,131 +149,254 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
         m.setXmlUtils(new XMLUtils());
-        
+
         m.processMap(URI.create("input.ditamap"));
-        assertXMLEqual(new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
                 new InputSource(new File(tempDir, "input.ditamap").toURI().toString()));
 
         final List<String> exp = Arrays.asList(
-                "installation-procedure.dita", "getting-started.dita",
-                //"http://example.com/install.dita",
-                //"configure.dita",
-                "input.ditamap", "install.dita", "linux.ditaval", "perform-install.dita",
-                "configure-novice.dita", "novice.ditaval", "configure-admin.dita",
-                "advanced.ditaval", "install-mac.dita", "mac.ditaval",
-                "perform-install-mac.dita", "installation-procedure-mac.dita", "configure-novice-mac.dita",
-                "configure-admin-mac.dita", "install-win.dita", "win.ditaval", "perform-install-win.dita",
-                "installation-procedure-win.dita", "configure-novice-win.dita", "configure-admin-win.dita",
-                "install-linux.dita"
-        );
+                "installation-procedure.dita",
+                "getting-started.dita",
+                // "http://example.com/install.dita",
+                // "configure.dita",
+                "input.ditamap",
+                "install.dita",
+                "linux.ditaval",
+                "perform-install.dita",
+                "configure-novice.dita",
+                "novice.ditaval",
+                "configure-admin.dita",
+                "advanced.ditaval",
+                "install-mac.dita",
+                "mac.ditaval",
+                "perform-install-mac.dita",
+                "installation-procedure-mac.dita",
+                "configure-novice-mac.dita",
+                "configure-admin-mac.dita",
+                "install-win.dita",
+                "win.ditaval",
+                "perform-install-win.dita",
+                "installation-procedure-win.dita",
+                "configure-novice-win.dita",
+                "configure-admin-win.dita",
+                "install-linux.dita");
         assertEquals(exp.size(), job.getFileInfo().size());
         for (final String f : exp) {
             assertNotNull(job.getFileInfo(URI.create(f)));
         }
 
         final List<String> filesExp = Arrays.asList(
-                //"install.dita",
+                // "install.dita",
                 "configure.dita",
-                "perform-install.dita", "configure-novice.dita",
-                "configure-admin.dita", "install-mac.dita", "perform-install-mac.dita",
-                "installation-procedure-mac.dita", "configure-novice-mac.dita", "configure-admin-mac.dita",
-                "install-win.dita", "perform-install-win.dita", "installation-procedure-win.dita",
-                "configure-novice-win.dita", "configure-admin-win.dita", "install-linux.dita", "install.dita",
-                "exclude.dita"
-
-        );
+                "perform-install.dita",
+                "configure-novice.dita",
+                "configure-admin.dita",
+                "install-mac.dita",
+                "perform-install-mac.dita",
+                "installation-procedure-mac.dita",
+                "configure-novice-mac.dita",
+                "configure-admin-mac.dita",
+                "install-win.dita",
+                "perform-install-win.dita",
+                "installation-procedure-win.dita",
+                "configure-novice-win.dita",
+                "configure-admin-win.dita",
+                "install-linux.dita",
+                "install.dita",
+                "exclude.dita");
         Collections.sort(filesExp);
         final List<String> filesAct = Arrays.stream(tempDir.listFiles((dir, name) -> name.endsWith(".dita")))
-                .map(File::getName).sorted().collect(Collectors.toList());
+                .map(File::getName)
+                .sorted()
+                .collect(Collectors.toList());
         assertEquals(filesExp, filesAct);
-        assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+        assertEquals(
+                0,
+                logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
     }
-    
+
     @Test
     public void testUplevelsMap() throws IOException, SAXException {
-        final File uplevelsExpDir = new File (expDir, "uplevels");
-        final File uplevelsTempDir = new File (tempDir, "uplevels"); 
+        final File uplevelsExpDir = new File(expDir, "uplevels");
+        final File uplevelsTempDir = new File(tempDir, "uplevels");
         final BranchFilterModule m = new BranchFilterModule();
         final Job job = getUplevelsJob(uplevelsTempDir);
         m.setJob(job);
         final CachingLogger logger = new CachingLogger();
         m.setLogger(logger);
         m.setXmlUtils(new XMLUtils());
-        
+
         m.processMap(URI.create("main/testuplevels.ditamap"));
-        assertXMLEqual(new InputSource(new File(uplevelsExpDir, "main/testuplevels.ditamap").toURI().toString()),
-                new InputSource(new File(uplevelsTempDir, "main/testuplevels.ditamap").toURI().toString()));
+        assertXMLEqual(
+                new InputSource(new File(uplevelsExpDir, "main/testuplevels.ditamap")
+                        .toURI()
+                        .toString()),
+                new InputSource(new File(uplevelsTempDir, "main/testuplevels.ditamap")
+                        .toURI()
+                        .toString()));
 
         final List<String> exp = Arrays.asList(
-                "main/novice.ditaval", "main/advanced.ditaval",
-                "main/kiddodefault.dita", "main/parentdefault.dita", "main/parentdefault-1.dita", 
-                "main/parent-novice.dita",  "main/PREFIX-parent-advanced.dita", "main/PREFIX-weechild-advanced.dita", 
-                "main/subdirkiddodefault.dita", "main/testuplevels.ditamap", "main/weechilddefault-1.dita", 
-                "main/weechild-novice.dita", "main/subdir/PREFIX-weechild-advanced.dita", 
-                "main/subdir/weechilddefault-1.dita",  "main/subdir/weechild-novice.dita",
-                "peer/peerkiddodefault.dita",  "peer/peerkiddodefault-1.dita",
-                "peer/peerkiddo-novice.dita", "peer/PREFIX-peerkiddo-advanced.dita", "main/weechild.dita", 
-                "main/subdir/weechilddefault.dita", "main/subdir/weechild.dita", "main/weechilddefault.dita");
+                "main/novice.ditaval",
+                "main/advanced.ditaval",
+                "main/kiddodefault.dita",
+                "main/parentdefault.dita",
+                "main/parentdefault-1.dita",
+                "main/parent-novice.dita",
+                "main/PREFIX-parent-advanced.dita",
+                "main/PREFIX-weechild-advanced.dita",
+                "main/subdirkiddodefault.dita",
+                "main/testuplevels.ditamap",
+                "main/weechilddefault-1.dita",
+                "main/weechild-novice.dita",
+                "main/subdir/PREFIX-weechild-advanced.dita",
+                "main/subdir/weechilddefault-1.dita",
+                "main/subdir/weechild-novice.dita",
+                "peer/peerkiddodefault.dita",
+                "peer/peerkiddodefault-1.dita",
+                "peer/peerkiddo-novice.dita",
+                "peer/PREFIX-peerkiddo-advanced.dita",
+                "main/weechild.dita",
+                "main/subdir/weechilddefault.dita",
+                "main/subdir/weechild.dita",
+                "main/weechilddefault.dita");
         assertEquals(exp.size(), job.getFileInfo().size());
         for (final String f : exp) {
             assertNotNull(job.getFileInfo(URI.create(f)));
         }
 
         final List<String> filesExpMain = Arrays.asList(
-                "main/kiddo.dita", "main/kiddodefault.dita", "main/parent.dita", "main/parentdefault.dita",
-                "main/parentdefault-1.dita", "main/parent-novice.dita", "main/PREFIX-parent-advanced.dita",
-                "main/PREFIX-weechild-advanced.dita", "main/subdirkiddo.dita", "main/subdirkiddodefault.dita",
-                "main/weechilddefault-1.dita", "main/weechild-novice.dita"
-        );
+                "main/kiddo.dita",
+                "main/kiddodefault.dita",
+                "main/parent.dita",
+                "main/parentdefault.dita",
+                "main/parentdefault-1.dita",
+                "main/parent-novice.dita",
+                "main/PREFIX-parent-advanced.dita",
+                "main/PREFIX-weechild-advanced.dita",
+                "main/subdirkiddo.dita",
+                "main/subdirkiddodefault.dita",
+                "main/weechilddefault-1.dita",
+                "main/weechild-novice.dita");
         final List<String> filesExpMainSubdir = Arrays.asList(
-                "main/subdir/PREFIX-weechild-advanced.dita", "main/subdir/weechilddefault-1.dita", "main/subdir/weechild-novice.dita"
-        );
+                "main/subdir/PREFIX-weechild-advanced.dita",
+                "main/subdir/weechilddefault-1.dita",
+                "main/subdir/weechild-novice.dita");
         final List<String> filesExpPeer = Arrays.asList(
-                "peer/peerkiddo.dita", "peer/peerkiddodefault.dita", "peer/peerkiddodefault-1.dita",
-                "peer/peerkiddo-novice.dita", "peer/PREFIX-peerkiddo-advanced.dita"
-        );
+                "peer/peerkiddo.dita",
+                "peer/peerkiddodefault.dita",
+                "peer/peerkiddodefault-1.dita",
+                "peer/peerkiddo-novice.dita",
+                "peer/PREFIX-peerkiddo-advanced.dita");
         Collections.sort(filesExpMain);
         Collections.sort(filesExpMainSubdir);
         Collections.sort(filesExpPeer);
-        final List<String> filesActMain = Arrays.stream(new File (uplevelsTempDir + File.separator + "main").listFiles((dir, name) -> name.endsWith(".dita")))
+        final List<String> filesActMain = Arrays.stream(new File(uplevelsTempDir + File.separator + "main")
+                        .listFiles((dir, name) -> name.endsWith(".dita")))
                 .map(f -> "main/" + f.getName())
                 .collect(Collectors.toList());
-        final List<String> filesActMainSubdir = Arrays.stream(new File (uplevelsTempDir + File.separator + "main/subdir").listFiles((dir, name) -> name.endsWith(".dita")))
+        final List<String> filesActMainSubdir = Arrays.stream(new File(uplevelsTempDir + File.separator + "main/subdir")
+                        .listFiles((dir, name) -> name.endsWith(".dita")))
                 .map(f -> "main/subdir/" + f.getName())
                 .collect(Collectors.toList());
-        final List<String> filesActPeer = Arrays.stream(new File (uplevelsTempDir + File.separator + "peer").listFiles((dir, name) -> name.endsWith(".dita")))
+        final List<String> filesActPeer = Arrays.stream(new File(uplevelsTempDir + File.separator + "peer")
+                        .listFiles((dir, name) -> name.endsWith(".dita")))
                 .map(f -> "peer/" + f.getName())
                 .collect(Collectors.toList());
-        
+
         Collections.sort(filesActMain);
         Collections.sort(filesActMainSubdir);
         Collections.sort(filesActPeer);
         assertEquals(filesExpMain, filesActMain);
         assertEquals(filesExpMainSubdir, filesActMainSubdir);
         assertEquals(filesExpPeer, filesActPeer);
-        assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+        assertEquals(
+                0,
+                logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
     }
 
     private static final Optional<String> ABSENT_STRING = Optional.empty();
-    
+
     @Test
     public void testGenerateCopyTo() {
-        assertEquals(URI.create("foo.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("baz-foo.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo-baz.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("qux-foo-baz.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/baz-foo.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo-baz.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/qux-foo-baz.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo"), generateCopyTo(URI.create("foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("baz-foo"), generateCopyTo(URI.create("foo"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo-baz"), generateCopyTo(URI.create("foo"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("qux-foo-baz"), generateCopyTo(URI.create("foo"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/baz-foo"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo-baz"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/qux-foo-baz"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("baz-foo.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("qux-foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/baz-foo.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/qux-foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo"),
+                generateCopyTo(
+                        URI.create("foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("baz-foo"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo-baz"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("qux-foo-baz"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/baz-foo"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo-baz"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/qux-foo-baz"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
     }
 
     @Test
@@ -288,7 +421,9 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 .build());
 
         assertEquals(exp, new HashSet<>(job.getFileInfo()));
-        assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+        assertEquals(
+                0,
+                logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
     }
 
     private Set<Job.FileInfo> getDuplicateTopicFileInfos() {
@@ -299,7 +434,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                 .uri(URI.create("test.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("test.ditaval", "test2.ditaval")) {
+        for (final String uri : Arrays.asList("test.ditaval", "test2.ditaval")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -307,7 +442,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("t1.xml")) {
+        for (final String uri : Arrays.asList("t1.xml")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -318,19 +453,19 @@ public class BranchFilterModuleTest extends BranchFilterModule {
         return res;
     }
 
-	@Test
-	public void testRewriteReferencesContainingAnchors() throws IOException, SAXException {
-	    final BranchFilterModule m = new BranchFilterModule();
-	    final Job job = new Job(tempDir,  new StreamStore(tempDir, new XMLUtils()));
-	    job.setInputDir(tempDir.toURI());
-	    final Set<Job.FileInfo> res = new HashSet<>();
+    @Test
+    public void testRewriteReferencesContainingAnchors() throws IOException, SAXException {
+        final BranchFilterModule m = new BranchFilterModule();
+        final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+        job.setInputDir(tempDir.toURI());
+        final Set<Job.FileInfo> res = new HashSet<>();
         res.add(new Job.FileInfo.Builder()
                 .src(new File(tempDir, "topicAnchors.ditamap").toURI())
                 .result(new File(tempDir, "topicAnchors.ditamap").toURI())
                 .uri(URI.create("topicAnchors.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("filter_A.ditaval", "filter_B.ditaval")) {
+        for (final String uri : Arrays.asList("filter_A.ditaval", "filter_B.ditaval")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -338,7 +473,7 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("topic.dita")) {
+        for (final String uri : Arrays.asList("topic.dita")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -347,36 +482,43 @@ public class BranchFilterModuleTest extends BranchFilterModule {
                     .build());
         }
         job.addAll(res);
-	    m.setJob(job);
-	    final CachingLogger logger = new CachingLogger();
-	    m.setLogger(logger);
-	    m.setXmlUtils(new XMLUtils());
-	    
-	    m.processMap(URI.create("topicAnchors.ditamap")); 
-	    assertXMLEqual(new InputSource(new File(expDir, "topicAnchors.ditamap").toURI().toURL().toString()), 
-	    		new InputSource(new File(tempDir, "topicAnchors.ditamap").toURI().toURL().toString()));
-	}
+        m.setJob(job);
+        final CachingLogger logger = new CachingLogger();
+        m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
 
-        @Test
-        public void testNoRenameNonDITAResources() throws IOException, SAXException {
-            final BranchFilterModule m = new BranchFilterModule();
-            final Job job = getJob();
-            for (final String uri: Arrays.asList("test.pdf")) {
-                job.add(new Job.FileInfo.Builder()
-                        .src(new File(tempDir, uri).toURI())
-                        .result(new File(tempDir, uri).toURI())
-                        .uri(URI.create(uri))
-                        .format(ATTR_FORMAT_VALUE_NONDITA)
-                        .build());
-            }
-            m.setJob(job);
-            final CachingLogger logger = new CachingLogger();
-            m.setLogger(logger);
-            m.setXmlUtils(new XMLUtils());
-            
-            m.processMap(URI.create("inputNonDitaRes.ditamap"));
-            assertXMLEqual(new InputSource(new File(expDir, "inputNonDitaRes.ditamap").toURI().toString()),
-                    new InputSource(new File(tempDir, "inputNonDitaRes.ditamap").toURI().toString()));
+        m.processMap(URI.create("topicAnchors.ditamap"));
+        assertXMLEqual(
+                new InputSource(
+                        new File(expDir, "topicAnchors.ditamap").toURI().toURL().toString()),
+                new InputSource(new File(tempDir, "topicAnchors.ditamap")
+                        .toURI()
+                        .toURL()
+                        .toString()));
+    }
+
+    @Test
+    public void testNoRenameNonDITAResources() throws IOException, SAXException {
+        final BranchFilterModule m = new BranchFilterModule();
+        final Job job = getJob();
+        for (final String uri : Arrays.asList("test.pdf")) {
+            job.add(new Job.FileInfo.Builder()
+                    .src(new File(tempDir, uri).toURI())
+                    .result(new File(tempDir, uri).toURI())
+                    .uri(URI.create(uri))
+                    .format(ATTR_FORMAT_VALUE_NONDITA)
+                    .build());
         }
+        m.setJob(job);
+        final CachingLogger logger = new CachingLogger();
+        m.setLogger(logger);
+        m.setXmlUtils(new XMLUtils());
 
+        m.processMap(URI.create("inputNonDitaRes.ditamap"));
+        assertXMLEqual(
+                new InputSource(
+                        new File(expDir, "inputNonDitaRes.ditamap").toURI().toString()),
+                new InputSource(
+                        new File(tempDir, "inputNonDitaRes.ditamap").toURI().toString()));
+    }
 }

--- a/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
@@ -7,7 +7,13 @@
  */
 package org.dita.dost.module;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.ChunkMapReader;
@@ -17,13 +23,6 @@ import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 public class ChunkMapReaderTest {
 
@@ -43,54 +42,51 @@ public class ChunkMapReaderTest {
 
     @Test
     public void testunware_chunk_content() {
-        test("unware_chunk_content.ditamap",
+        test(
+                "unware_chunk_content.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("dita1.dita", "dita1.dita")
                         .put("one.dita#topicID", "two.dita#unique_2")
                         .put("one.dita", "two.dita#unique_2")
                         .put("two.dita", "two.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testunware_chunk_content2() {
-        test("unware_chunk_content2.ditamap",
+        test(
+                "unware_chunk_content2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("one.dita#topicID", "Chunk0.dita#unique_3")
                         .put("one.dita", "Chunk0.dita#unique_3")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "one.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testconflict_same_id() {
-        test("conflict_same_id.ditamap",
+        test(
+                "conflict_same_id.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("t1.dita", "Chunk0.dita#topic1")
                         .put("t1.dita#topic1", "Chunk0.dita#topic1")
                         .put("t2.dita#topic1", "Chunk0.dita#unique_1")
                         .put("t2.dita", "Chunk0.dita#unique_1")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "t1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testanchor1() {
-        test("anchor1.ditamap",
+        test(
+                "anchor1.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("reference1.dita#reference1", "Chunk0.dita#reference1")
                         .put("reference1.dita", "Chunk0.dita#reference1")
@@ -99,17 +95,16 @@ public class ChunkMapReaderTest {
                         .put("task1.dita", "Chunk0.dita#task1")
                         .put("concept1.dita#concept1r", "Chunk0.dita#concept1r")
                         .put("concept1.dita", "Chunk0.dita#concept1r")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "concept1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testanchor2() {
-        test("anchor2.ditamap",
+        test(
+                "anchor2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("reference1.dita#reference1", "Chunk1.dita#reference1")
                         .put("reference1.dita", "Chunk1.dita#reference1")
@@ -119,18 +114,17 @@ public class ChunkMapReaderTest {
                         .put("task1.dita", "Chunk1.dita#task1")
                         .put("concept1.dita#concept1r", "Chunk0.dita#concept1r")
                         .put("concept1.dita", "Chunk0.dita#concept1r")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "task1.dita")
                         .put("Chunk0.dita", "concept1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testcase1() {
-        test("case1.ditamap",
+        test(
+                "case1.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("three.dita", "three.dita")
                         .put("four.dita", "four.dita")
@@ -140,16 +134,14 @@ public class ChunkMapReaderTest {
                         .put("two.dita", "two.dita")
                         .put("ditabase.dita#one", "one.dita#one")
                         .put("ditabase.dita#three", "three.dita#three")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testcase2() {
-        test("case2.ditamap",
+        test(
+                "case2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("case2.dita", "case2.dita")
                         .put("ditabase.dita#two", "case2.dita#two")
@@ -159,48 +151,43 @@ public class ChunkMapReaderTest {
                         .put("nested.dita#nested", "case2.dita#nested")
                         .put("ditabase.dita#five", "case2.dita#five")
                         .put("ditabase.dita#three", "case2.dita#three")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testcase3() {
-        test("case3.ditamap",
+        test(
+                "case3.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("three.dita", "three.dita")
                         .put("child.dita", "child.dita")
                         .put("ditabase.dita#three", "three.dita#three")
                         .put("parent.dita", "parent.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testcase4() {
-        test("case4.ditamap",
+        test(
+                "case4.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child.dita", "Chunk0.dita#nested")
                         .put("case4.dita", "Chunk0.dita#parent")
                         .put("child.dita#nested", "Chunk0.dita#nested")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("case4.dita#parent", "Chunk0.dita#parent")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "case4.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testcase5() {
-        test("case5.ditamap",
+        test(
+                "case5.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("three.dita", "three.dita")
                         .put("four.dita", "four.dita")
@@ -210,16 +197,14 @@ public class ChunkMapReaderTest {
                         .put("two.dita", "two.dita")
                         .put("ditabase.dita#one", "one.dita#one")
                         .put("ditabase.dita#three", "three.dita#three")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testcase6() {
-        test("case6.ditamap",
+        test(
+                "case6.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("three.dita", "three.dita")
                         .put("four.dita", "four.dita")
@@ -229,16 +214,14 @@ public class ChunkMapReaderTest {
                         .put("two.dita", "two.dita")
                         .put("ditabase.dita#one", "one.dita#one")
                         .put("ditabase.dita#three", "three.dita#three")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testcase7() {
-        test("case7.ditamap",
+        test(
+                "case7.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child.dita#child", "Chunk0.dita#child")
                         .put("child.dita", "Chunk0.dita#child")
@@ -247,33 +230,30 @@ public class ChunkMapReaderTest {
                         .put("parent.dita#parent", "Chunk0.dita#parent")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("parent.dita", "Chunk0.dita#parent")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testlink1() {
-        test("link1.ditamap",
+        test(
+                "link1.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("ditabase.dita#topic", "topic.dita#topic")
                         .put("t1.dita", "topic.dita#topic1")
                         .put("t1.dita#topic1", "topic.dita#topic1")
                         .put("sub/t3.dita", "sub/t3.dita")
                         .put("topic.dita", "topic.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testlink2() {
-        test("link2.ditamap",
+        test(
+                "link2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("t3.dita", "Chunk0.dita#topic3")
                         .put("ditabase.dita#topic", "Chunk0.dita#topic")
@@ -283,33 +263,31 @@ public class ChunkMapReaderTest {
                         .put("t3.dita#topic3", "Chunk0.dita#topic3")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita", "Chunk0.dita#topic")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "t3.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testFixChunk_map1() {
-        test("FixChunk_map1.ditamap",
+        test(
+                "FixChunk_map1.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("parent1.dita", "Chunk0.dita#P1")
                         .put("parent1.dita#P1", "Chunk0.dita#P1")
                         .put("ditabase.dita#Y1", "Chunk0.dita#Y1")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testFixChunk_map2() {
-        test("FixChunk_map2.ditamap",
+        test(
+                "FixChunk_map2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("ditabase.dita#Y", "Chunk0.dita#Y")
                         .put("parent1.dita", "Chunk0.dita#P1")
@@ -318,17 +296,16 @@ public class ChunkMapReaderTest {
                         .put("ditabase.dita#Y2", "Chunk0.dita#Y2")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita#Y1a", "Chunk0.dita#Y1a")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testFixChunk_map3() {
-        test("FixChunk_map3.ditamap",
+        test(
+                "FixChunk_map3.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("ditabase.dita#Y", "Chunk0.dita#Y")
                         .put("ditabase.dita#X", "Chunk0.dita#X")
@@ -340,17 +317,16 @@ public class ChunkMapReaderTest {
                         .put("ditabase.dita#Z1", "Chunk0.dita#Z1")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita#Y1a", "Chunk0.dita#Y1a")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testFixChunk_map4() {
-        test("FixChunk_map4.ditamap",
+        test(
+                "FixChunk_map4.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1a", "parentchunk.dita#N1a")
                         .put("parent1.dita", "parentchunk.dita#P1")
@@ -358,16 +334,14 @@ public class ChunkMapReaderTest {
                         .put("parent1.dita#P1", "parentchunk.dita#P1")
                         .put("nested1.dita#N1", "parentchunk.dita#N1")
                         .put("nested1.dita", "parentchunk.dita#N1")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testFixChunk_map5() {
-        test("FixChunk_map5.ditamap",
+        test(
+                "FixChunk_map5.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child3.dita#C3", "parentchunk.dita#C3")
                         .put("child1.dita#C1", "parentchunk.dita#C1")
@@ -383,57 +357,49 @@ public class ChunkMapReaderTest {
                         .put("grandchild3.dita", "parentchunk.dita#GC3")
                         .put("child2.dita", "child2chunk.dita#C2")
                         .put("child2chunk.dita", "child2chunk.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testFixChunk_map6() {
-        test("FixChunk_map6.ditamap",
+        test(
+                "FixChunk_map6.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1", "nestedchunk.dita#N1")
                         .put("nestedchunk.dita", "nestedchunk.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testFixChunk_map7() {
-        test("FixChunk_map7.ditamap",
+        test(
+                "FixChunk_map7.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child1.dita", "child1.dita")
                         .put("parent1.dita", "parent1.dita")
                         .put("parent2.dita", "parent2.dita")
                         .put("child2.dita", "child2.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testFixChunk_map8() {
-        test("FixChunk_map8.ditamap",
+        test(
+                "FixChunk_map8.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested2.dita", "nested2.dita")
                         .put("nested1.dita", "nested1.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testByTopic_map2() {
-        test("ByTopic_map2.ditamap",
+        test(
+                "ByTopic_map2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1a", "N1a.dita#N1a")
                         .put("N1.dita", "N1.dita")
@@ -441,29 +407,25 @@ public class ChunkMapReaderTest {
                         .put("nested1.dita#N1", "N1.dita#N1")
                         .put("nested2.dita", "nested2.dita")
                         .put("nested1.dita", "N1.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testByTopic_map3() {
-        test("ByTopic_map3.ditamap",
+        test(
+                "ByTopic_map3.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("t1.dita", "t1.dita")
                         .put("nested1.dita", "nested1.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testByTopic_map4() {
-        test("ByTopic_map4.ditamap",
+        test(
+                "ByTopic_map4.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1a", "nest_split.dita#N1a")
                         .put("nested2.dita#N2a", "nest_split.dita#N2a")
@@ -472,16 +434,14 @@ public class ChunkMapReaderTest {
                         .put("nest_split.dita", "nest_split.dita")
                         .put("nested1.dita", "nest_split.dita#N1")
                         .put("nested2.dita#N2", "nest_split.dita#N2")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testByTopic_map5() {
-        test("ByTopic_map5.ditamap",
+        test(
+                "ByTopic_map5.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("map5.dita", "map5.dita")
                         .put("nested1.dita#N1a", "map5.dita#N1a")
@@ -492,17 +452,16 @@ public class ChunkMapReaderTest {
                         .put("t2.dita#topic2", "Chunk0.dita#topic2")
                         .put("t2.dita", "Chunk0.dita#topic2")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "map5.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testByTopic_map6() {
-        test("ByTopic_map6.ditamap",
+        test(
+                "ByTopic_map6.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1a", "Chunk1.dita#N1a")
                         .put("nested2.dita#N2a", "Chunk0.dita#N2a")
@@ -514,18 +473,17 @@ public class ChunkMapReaderTest {
                         .put("nested1.dita", "Chunk0.dita#N1")
                         .put("nested2.dita#N2", "Chunk0.dita#N2")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "t1.dita")
                         .put("Chunk0.dita", "nested1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testByTopic_map7() {
-        test("ByTopic_map7.ditamap",
+        test(
+                "ByTopic_map7.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested4.dita#N1a", "Chunk1.dita#N1a")
                         .put("nested1.dita#N1a", "N1a.dita#N1a")
@@ -537,18 +495,17 @@ public class ChunkMapReaderTest {
                         .put("nested4.dita", "Chunk0.dita")
                         .put("nested1.dita", "N1.dita")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "N1a.dita")
                         .put("Chunk0.dita", "N1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testtopicgroup_chunk() {
-        test("topicgroup_chunk.ditamap",
+        test(
+                "topicgroup_chunk.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Chunk19.dita", "Chunk23.dita#Chunk19")
                         .put("headkid.dita#topicID", "Chunk22.dita#topicID")
@@ -596,8 +553,7 @@ public class ChunkMapReaderTest {
                         .put("Chunk9.dita", "Chunk9.dita")
                         .put("groupkid.dita", "Chunk21.dita#topicID")
                         .put("dita6.dita", "Chunk11.dita#unique_12")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk20.dita", "container.dita")
                         .put("Chunk23.dita", "Chunk19.dita")
@@ -613,37 +569,40 @@ public class ChunkMapReaderTest {
                         .put("Chunk10.dita", "dita5.dita")
                         .put("Chunk9.dita", "dita4.dita")
                         .put("Chunk21.dita", "Chunk17.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testchunk_map_tocontent() {
-        test("chunk_map_tocontent.ditamap",
+        test(
+                "chunk_map_tocontent.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("chunk_map_tocontent/dita1.dita#topicID1", "chunk_map_tocontent/Chunk0.dita#topicID1")
                         .put("chunk_map_tocontent/Chunk0.dita", "chunk_map_tocontent/Chunk0.dita")
                         .put("chunk_map_tocontent/dita.xml", "chunk_map_tocontent/dita.xml")
                         .put("chunk_map_tocontent/sub_dita1.dita", "chunk_map_tocontent/Chunk0.dita#topicIDSUB")
-                        .put("chunk_map_tocontent/sub_dita2.dita#topicIDSUB", "chunk_map_tocontent/Chunk1.dita#topicIDSUB")
+                        .put(
+                                "chunk_map_tocontent/sub_dita2.dita#topicIDSUB",
+                                "chunk_map_tocontent/Chunk1.dita#topicIDSUB")
                         .put("chunk_map_tocontent/dita2.dita", "chunk_map_tocontent/Chunk1.dita#topicID1")
                         .put("chunk_map_tocontent/dita2.dita#topicID1", "chunk_map_tocontent/Chunk1.dita#topicID1")
-                        .put("chunk_map_tocontent/sub_dita1.dita#topicIDSUB", "chunk_map_tocontent/Chunk0.dita#topicIDSUB")
+                        .put(
+                                "chunk_map_tocontent/sub_dita1.dita#topicIDSUB",
+                                "chunk_map_tocontent/Chunk0.dita#topicIDSUB")
                         .put("chunk_map_tocontent/Chunk1.dita", "chunk_map_tocontent/Chunk1.dita")
                         .put("chunk_map_tocontent/sub_dita2.dita", "chunk_map_tocontent/Chunk1.dita#topicIDSUB")
                         .put("chunk_map_tocontent/dita1.dita", "chunk_map_tocontent/Chunk0.dita#topicID1")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("chunk_map_tocontent/Chunk0.dita", "chunk_map_tocontent/dita1.dita")
                         .put("chunk_map_tocontent/Chunk1.dita", "chunk_map_tocontent/dita2.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testconflict_by_topic() {
-        test("conflict_by_topic.ditamap",
+        test(
+                "conflict_by_topic.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested4.dita#N1a", "Chunk1.dita#N1a")
                         .put("nested1.dita#N1a", "N1a.dita#N1a")
@@ -655,18 +614,17 @@ public class ChunkMapReaderTest {
                         .put("nested4.dita", "Chunk0.dita")
                         .put("nested1.dita", "N1.dita")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "N1a.dita")
                         .put("Chunk0.dita", "N1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testchunk_hogs_memory() {
-        test("chunk_hogs_memory.ditamap",
+        test(
+                "chunk_hogs_memory.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("dita1.dita#C", "dita4.dita#C")
                         .put("dita1.dita#AAA", "dita2.dita#AAA")
@@ -680,33 +638,30 @@ public class ChunkMapReaderTest {
                         .put("sub_dita2.dita", "dita2.dita#unique_0")
                         .put("sub_dita1.dita#topicIDSUB", "dita2.dita#topicIDSUB")
                         .put("sub_dita1.dita", "dita2.dita#topicIDSUB")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testAttribute_map2() {
-        test("Attribute_map2.ditamap",
+        test(
+                "Attribute_map2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("parent1.dita", "Chunk0.dita#parent1")
                         .put("ditabase.dita#Y1", "Chunk0.dita#Y1")
                         .put("parent1.dita#parent1", "Chunk0.dita#parent1")
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita#Y1a", "Chunk0.dita#Y1a")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testAttribute_map3() {
-        test("Attribute_map3.ditamap",
+        test(
+                "Attribute_map3.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("ditabase.dita#Y", "Chunk0.dita#Y")
                         .put("ditabase.dita#X", "Chunk0.dita#X")
@@ -719,30 +674,27 @@ public class ChunkMapReaderTest {
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita#Y1a", "Chunk0.dita#Y1a")
                         .put("ditabase.dita", "Chunk0.dita#X")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testAttribute_map4() {
-        test("Attribute_map4.ditamap",
+        test(
+                "Attribute_map4.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("parentchunk.dita", "parentchunk.dita")
                         .put("nested1.dita", "nested1.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testAttribute_map5() {
-        test("Attribute_map5.ditamap",
+        test(
+                "Attribute_map5.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child2.dita#topicmerge", "child2chunk.dita#topicmerge")
                         .put("grandchild2.dita#grandchild2", "child2chunk.dita#grandchild2")
@@ -758,44 +710,38 @@ public class ChunkMapReaderTest {
                         .put("child2.dita", "child2chunk.dita#topicmerge")
                         .put("child2chunk.dita", "child2chunk.dita")
                         .put("child1.dita#child1", "parentchunk.dita#child1")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testAttribute_map6() {
-        test("Attribute_map6.ditamap",
+        test(
+                "Attribute_map6.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("nested1.dita#N1", "nestedchunk.dita#N1")
                         .put("nestedchunk.dita", "nestedchunk.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testAttribute_map7() {
-        test("Attribute_map7.ditamap",
+        test(
+                "Attribute_map7.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("child1.dita", "child1.dita")
                         .put("parent1.dita", "parent1.dita")
                         .put("parent2.dita", "parent2.dita")
                         .put("child2.dita", "child2.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testAttribute_map8() {
-        test("Attribute_map8.ditamap",
+        test(
+                "Attribute_map8.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("ditabase.dita#Y", "Chunk0.dita#Y")
                         .put("ditabase.dita#X", "Chunk0.dita#X")
@@ -808,17 +754,16 @@ public class ChunkMapReaderTest {
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("ditabase.dita#Y1a", "Chunk0.dita#Y1a")
                         .put("ditabase.dita", "Chunk0.dita#X")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "parent1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testAttribute_map9() {
-        test("Attribute_map9.ditamap",
+        test(
+                "Attribute_map9.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Y.dita", "Chunk0.dita#Y")
                         .put("Z.dita#Z1", "Chunk0.dita#Z1")
@@ -829,17 +774,16 @@ public class ChunkMapReaderTest {
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("Y.dita#Y1a", "Chunk0.dita#Y1a")
                         .put("Y.dita#Y1", "Chunk0.dita#Y1")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "Y.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testcopy_to1() {
-        test("copy_to1.ditamap",
+        test(
+                "copy_to1.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Y1a.dita", "Y1a.dita")
                         .put("Chunk16.dita", "Chunk16.dita")
@@ -899,8 +843,7 @@ public class ChunkMapReaderTest {
                         .put("documentX.dita#Y2", "Chunk14.dita#Y2")
                         .put("ditabase.dita#Y1a", "Chunk23.dita#Y1a")
                         .put("topicY.dita#Y", "Chunk1.dita#Y")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk23.dita", "Z.dita")
                         .put("Chunk20.dita", "Y2.dita")
@@ -926,13 +869,13 @@ public class ChunkMapReaderTest {
                         .put("Chunk21.dita", "Z.dita")
                         .put("Chunk13.dita", "Y1a.dita")
                         .put("Chunk4.dita", "documentY.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testcopy_to2() {
-        test("copy_to2.ditamap",
+        test(
+                "copy_to2.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Y1a.dita", "Y1a.dita")
                         .put("ditabase.dita#Y", "Chunk2.dita#Y")
@@ -958,8 +901,7 @@ public class ChunkMapReaderTest {
                         .put("Chunk4.dita", "Chunk4.dita")
                         .put("ditabase.dita#Y1a", "Chunk4.dita#Y1a")
                         .put("topicY.dita#Y", "Chunk1.dita#Y")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk5.dita", "Y2.dita")
                         .put("Chunk7.dita", "Z1.dita")
@@ -969,13 +911,13 @@ public class ChunkMapReaderTest {
                         .put("Chunk3.dita", "Y1.dita")
                         .put("Chunk0.dita", "topicX.dita")
                         .put("Chunk4.dita", "Y1a.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testByTopic_batseparate0() {
-        test("ByTopic_batseparate0.ditamap",
+        test(
+                "ByTopic_batseparate0.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("batfeeding.dita", "batfeeding.dita")
                         .put("batcaring.dita", "batcaring.dita")
@@ -985,17 +927,16 @@ public class ChunkMapReaderTest {
                         .put("battytasks.dita#battytasks", "Chunk0.dita#battytasks")
                         .put("battytasks.dita#batcaring", "batcaring.dita#batcaring")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk0.dita", "battytasks.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testchunk_duplicate_tocontent() {
-        test("chunk_duplicate_tocontent.ditamap",
+        test(
+                "chunk_duplicate_tocontent.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("dita2.dita", "Chunk1.dita#topicID1")
                         .put("Chunk1.dita", "Chunk1.dita")
@@ -1007,18 +948,17 @@ public class ChunkMapReaderTest {
                         .put("sub_dita1.dita", "Chunk0.dita#topicIDSUB")
                         .put("dita1.dita#topicID1", "Chunk0.dita#topicID1")
                         .put("Chunk0.dita", "Chunk0.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "dita2.dita")
                         .put("Chunk0.dita", "dita1.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testAttribute_map10() {
-        test("Attribute_map10.ditamap",
+        test(
+                "Attribute_map10.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Y1a.dita", "Y1a.dita")
                         .put("Z.dita#Z1", "Z1.dita#Z1")
@@ -1035,19 +975,18 @@ public class ChunkMapReaderTest {
                         .put("Y1.dita", "Y1.dita")
                         .put("Y.dita#Y1a", "Y1a.dita#Y1a")
                         .put("Y.dita#Y1", "Y1.dita#Y1")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "Y.dita")
                         .put("Chunk2.dita", "Z.dita")
                         .put("Chunk0.dita", "X.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testAttribute_map11() {
-        test("Attribute_map11.ditamap",
+        test(
+                "Attribute_map11.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("Y.dita", "Chunk1.dita#Y")
                         .put("Z.dita#Z1", "Chunk1.dita#Z1")
@@ -1060,18 +999,17 @@ public class ChunkMapReaderTest {
                         .put("Chunk0.dita", "Chunk0.dita")
                         .put("Y.dita#Y1a", "Chunk1.dita#Y1a")
                         .put("Y.dita#Y1", "Chunk1.dita#Y1")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk1.dita", "Y.dita")
                         .put("Chunk0.dita", "X.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testchunk_rewrite_tocontent() {
-        test("chunk_rewrite_tocontent.ditamap",
+        test(
+                "chunk_rewrite_tocontent.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("dita4.dita#topicID", "Chunk3.dita#topicID")
                         .put("dita3.dita#topicID", "Chunk0.dita#unique_2")
@@ -1088,19 +1026,18 @@ public class ChunkMapReaderTest {
                         .put("dita3.dita", "Chunk0.dita#unique_2")
                         .put("dita6.dita", "Chunk4.dita#unique_5")
                         .put("Chunk4.dita", "Chunk4.dita")
-                        .build()
-                ,
+                        .build(),
                 ImmutableMap.<String, String>builder()
                         .put("Chunk3.dita", "dita4.dita")
                         .put("Chunk0.dita", "dita1.dita")
                         .put("Chunk4.dita", "dita5.dita")
-                        .build()
-        );
+                        .build());
     }
 
     @Test
     public void testconflict_to_content() {
-        test("conflict_to_content.ditamap",
+        test(
+                "conflict_to_content.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("map5.dita", "map5.dita")
                         .put("nested1.dita#N1a", "map1.dita#N1a")
@@ -1111,24 +1048,19 @@ public class ChunkMapReaderTest {
                         .put("nested1.dita", "map1.dita#N1")
                         .put("t2.dita#topic2", "map5.dita#topic2")
                         .put("t2.dita", "map5.dita#topic2")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     @Test
     public void testexternal_chunk() {
-        test("external_chunk.ditamap",
+        test(
+                "external_chunk.ditamap",
                 ImmutableMap.<String, String>builder()
                         .put("dita1.dita#ditatask111", "ditatask111.dita#ditatask111")
                         .put("ditatask111.dita", "ditatask111.dita")
-                        .build()
-                ,
-                ImmutableMap.<String, String>builder()
-                        .build()
-        );
+                        .build(),
+                ImmutableMap.<String, String>builder().build());
     }
 
     private void test(final String testCase, final Map<String, String> change, final Map<String, String> conflict) {
@@ -1156,9 +1088,7 @@ public class ChunkMapReaderTest {
     private Map<String, String> relativize(Map<URI, URI> changeTable, File tempDir) {
         final URI t = tempDir.toURI();
         return changeTable.entrySet().stream()
-                .collect(Collectors.toMap(
-                        e -> t.relativize(e.getKey()).toString(),
-                        e -> t.relativize(e.getValue()).toString()));
+                .collect(Collectors.toMap(e -> t.relativize(e.getKey()).toString(), e -> t.relativize(e.getValue())
+                        .toString()));
     }
-
 }

--- a/src/test/java/org/dita/dost/module/ChunkModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ChunkModuleTest.java
@@ -7,77 +7,76 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
-
 @RunWith(Parameterized.class)
 public class ChunkModuleTest extends AbstractModuleTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"case1"},
-                {"case2"},
-                {"case3"},
-                {"case4"},
-                {"case5"},
-                {"case6"},
-                {"case7"},
-                {"conflict_by_topic"},
-                {"copy_to1"},
-                {"copy_to2"},
-                {"conflict_same_id"},
-                {"conflict_to_content"},
-                {"external_chunk"},
-                {"link1"},
-                {"link2"},
-                {"anchor1"},
-                {"anchor2"},
-//                {"Attribute_map1"},
-                {"Attribute_map2"},
-                {"Attribute_map3"},
-                {"Attribute_map4"},
-                {"Attribute_map5"},
-                {"Attribute_map6"},
-                {"Attribute_map7"},
-                {"Attribute_map8"},
-                {"Attribute_map9"},
-                {"Attribute_map10"},
-                {"Attribute_map11"},
-                {"ByTopic_map2"},
-                {"ByTopic_map3"},
-                {"ByTopic_map4"},
-                {"ByTopic_map5"},
-                {"ByTopic_map6"},
-                {"ByTopic_map7"},
-                {"ByTopic_batseparate0"},
-                {"FixChunk_map1"},
-                {"FixChunk_map2"},
-                {"FixChunk_map3"},
-                {"FixChunk_map4"},
-                {"FixChunk_map5"},
-                {"FixChunk_map6"},
-                {"FixChunk_map7"},
-                {"FixChunk_map8"},
-                {"chunk_duplicate_tocontent"},
-                {"chunk_hogs_memory"},
-                {"chunk_map_tocontent"},
-                {"chunk_rewrite_tocontent"},
-                {"topicgroup_chunk"},
-                {"unware_chunk_content"},
-                {"unware_chunk_content2"},
-                {"with_non_dita"},
-                {"to_content_with_namespace_mathml"},
-                {"to_content_with_namespace_xsi"}
+        return Arrays.asList(new Object[][] {
+            {"case1"},
+            {"case2"},
+            {"case3"},
+            {"case4"},
+            {"case5"},
+            {"case6"},
+            {"case7"},
+            {"conflict_by_topic"},
+            {"copy_to1"},
+            {"copy_to2"},
+            {"conflict_same_id"},
+            {"conflict_to_content"},
+            {"external_chunk"},
+            {"link1"},
+            {"link2"},
+            {"anchor1"},
+            {"anchor2"},
+            //                {"Attribute_map1"},
+            {"Attribute_map2"},
+            {"Attribute_map3"},
+            {"Attribute_map4"},
+            {"Attribute_map5"},
+            {"Attribute_map6"},
+            {"Attribute_map7"},
+            {"Attribute_map8"},
+            {"Attribute_map9"},
+            {"Attribute_map10"},
+            {"Attribute_map11"},
+            {"ByTopic_map2"},
+            {"ByTopic_map3"},
+            {"ByTopic_map4"},
+            {"ByTopic_map5"},
+            {"ByTopic_map6"},
+            {"ByTopic_map7"},
+            {"ByTopic_batseparate0"},
+            {"FixChunk_map1"},
+            {"FixChunk_map2"},
+            {"FixChunk_map3"},
+            {"FixChunk_map4"},
+            {"FixChunk_map5"},
+            {"FixChunk_map6"},
+            {"FixChunk_map7"},
+            {"FixChunk_map8"},
+            {"chunk_duplicate_tocontent"},
+            {"chunk_hogs_memory"},
+            {"chunk_map_tocontent"},
+            {"chunk_rewrite_tocontent"},
+            {"topicgroup_chunk"},
+            {"unware_chunk_content"},
+            {"unware_chunk_content2"},
+            {"with_non_dita"},
+            {"to_content_with_namespace_mathml"},
+            {"to_content_with_namespace_xsi"}
         });
     }
 

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -8,6 +8,16 @@
 
 package org.dita.dost.module;
 
+import static java.net.URI.create;
+import static org.dita.dost.util.Constants.OS_NAME;
+import static org.dita.dost.util.Constants.OS_NAME_WINDOWS;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.TestLogger;
 import org.dita.dost.store.StreamStore;
@@ -18,17 +28,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.net.URI.create;
-import static org.dita.dost.util.Constants.OS_NAME;
-import static org.dita.dost.util.Constants.OS_NAME_WINDOWS;
-import static org.junit.Assert.assertEquals;
 
 public class CleanPreprocessModuleTest {
 
@@ -51,10 +50,13 @@ public class CleanPreprocessModuleTest {
     @Test
     public void getCommonBase_unix() {
         if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-            assertEquals(create("file:/foo/bar/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/bar/b")));
+            assertEquals(
+                    create("file:/foo/bar/"),
+                    module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/bar/b")));
             assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/a"), create("file:/foo/bar/b")));
             assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/b")));
-            assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/baz/b")));
+            assertEquals(
+                    create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/baz/b")));
             assertEquals(create("file:/"), module.getCommonBase(create("file:/foo/a/b/c"), create("file:/bar/b/c/d")));
             assertEquals(null, module.getCommonBase(create("file:/foo/bar/a"), create("https://example.com/baz/b")));
         }
@@ -63,7 +65,8 @@ public class CleanPreprocessModuleTest {
     @Test
     public void getCommonBase_windows() {
         if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-            assertEquals(create("file:/F:/bar/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/bar/b")));
+            assertEquals(
+                    create("file:/F:/bar/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/bar/b")));
             assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/a"), create("file:/F:/bar/b")));
             assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/b")));
             assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/baz/b")));
@@ -84,9 +87,7 @@ public class CleanPreprocessModuleTest {
                 .uri(create("topics/topic.dita"))
                 .result(create("file:/foo/bar/topics/topic.dita"))
                 .build());
-        job.add(new Builder()
-                .uri(create("topics/null.dita"))
-                .build());
+        job.add(new Builder().uri(create("topics/null.dita")).build());
         job.add(new Builder()
                 .uri(create("topics/task.dita"))
                 .result(create("file:/foo/bar/topics/task.dita"))

--- a/src/test/java/org/dita/dost/module/ConrefPushModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ConrefPushModuleTest.java
@@ -8,41 +8,40 @@
 
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITAMAP;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.Configuration.Mode;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITAMAP;
-
 @RunWith(Parameterized.class)
 public class ConrefPushModuleTest extends AbstractModuleTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"conref_push", Mode.STRICT},
-                {"pushAfter_between_Specialization", Mode.STRICT},
-                {"pushAfter_with_crossRef", Mode.STRICT},
-                {"pushAfter_with_InvalidTarget", Mode.STRICT},
-                {"pushAfter_without_conref", Mode.STRICT},
-                {"pushBefore_between_Specialization", Mode.STRICT},
-                {"pushBefore_with_crossRef", Mode.STRICT},
-                {"pushBefore_with_InvalidTarget", Mode.LAX},
-                {"pushBefore_without_conref", Mode.STRICT},
-                {"pushReplace_between_Specialization", Mode.STRICT},
-                {"pushReplace_with_crossRef", Mode.STRICT},
-                {"pushReplace_with_InvalidTarget", Mode.LAX},
-                {"pushReplace_without_conref", Mode.STRICT},
-                {"simple_pushAfter", Mode.STRICT},
-                {"simple_pushBefore", Mode.STRICT},
-                {"simple_pushReplace", Mode.STRICT}
+        return Arrays.asList(new Object[][] {
+            {"conref_push", Mode.STRICT},
+            {"pushAfter_between_Specialization", Mode.STRICT},
+            {"pushAfter_with_crossRef", Mode.STRICT},
+            {"pushAfter_with_InvalidTarget", Mode.STRICT},
+            {"pushAfter_without_conref", Mode.STRICT},
+            {"pushBefore_between_Specialization", Mode.STRICT},
+            {"pushBefore_with_crossRef", Mode.STRICT},
+            {"pushBefore_with_InvalidTarget", Mode.LAX},
+            {"pushBefore_without_conref", Mode.STRICT},
+            {"pushReplace_between_Specialization", Mode.STRICT},
+            {"pushReplace_with_crossRef", Mode.STRICT},
+            {"pushReplace_with_InvalidTarget", Mode.LAX},
+            {"pushReplace_without_conref", Mode.STRICT},
+            {"simple_pushAfter", Mode.STRICT},
+            {"simple_pushBefore", Mode.STRICT},
+            {"simple_pushReplace", Mode.STRICT}
         });
     }
 
@@ -59,10 +58,8 @@ public class ConrefPushModuleTest extends AbstractModuleTest {
     @Override
     protected AbstractPipelineModule getModule(final File tempDir) {
         final ConrefPushModule conrefPushModule = new ConrefPushModule();
-        conrefPushModule.setFileInfoFilter(fileInfo ->
-                fileInfo.format.equals(ATTR_FORMAT_VALUE_DITA) ||
-                        fileInfo.format.equals(ATTR_FORMAT_VALUE_DITAMAP) && fileInfo.isInput
-        );
+        conrefPushModule.setFileInfoFilter(fileInfo -> fileInfo.format.equals(ATTR_FORMAT_VALUE_DITA)
+                || fileInfo.format.equals(ATTR_FORMAT_VALUE_DITAMAP) && fileInfo.isInput);
         return conrefPushModule;
     }
 }

--- a/src/test/java/org/dita/dost/module/DelegatingCollationUriResolverTest.java
+++ b/src/test/java/org/dita/dost/module/DelegatingCollationUriResolverTest.java
@@ -11,15 +11,12 @@ package org.dita.dost.module;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.CollationURIResolver;
 import net.sf.saxon.lib.StringCollator;
-import net.sf.saxon.trans.XPathException;
 import org.dita.dost.module.saxon.DelegatingCollationUriResolver;
 
 public class DelegatingCollationUriResolverTest implements DelegatingCollationUriResolver {
 
     @Override
-    public void setBaseResolver(CollationURIResolver baseResolver) {
-
-    }
+    public void setBaseResolver(CollationURIResolver baseResolver) {}
 
     @Override
     public StringCollator resolve(String collationURI, Configuration config) {

--- a/src/test/java/org/dita/dost/module/DummyPipelineModule.java
+++ b/src/test/java/org/dita/dost/module/DummyPipelineModule.java
@@ -7,21 +7,18 @@
  */
 package org.dita.dost.module;
 
-import org.dita.dost.exception.DITAOTException;
+import java.util.List;
+import java.util.function.Predicate;
 import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.module.AbstractPipelineModule;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
 
-import java.util.List;
-import java.util.function.Predicate;
-
 /**
  * Dummy pipeline module for testing.
- * 
+ *
  * @author Jarno Elovirta
  */
 public class DummyPipelineModule implements AbstractPipelineModule {

--- a/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
@@ -7,6 +7,16 @@
  */
 package org.dita.dost.module;
 
+import static java.net.URI.create;
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_OUTPUTDIR;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
@@ -21,17 +31,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.net.URI.create;
-import static org.apache.commons.io.FileUtils.copyFile;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_OUTPUTDIR;
-import static org.junit.Assert.assertEquals;
 
 public class ImageMetadataModuleTest {
 
@@ -55,12 +54,12 @@ public class ImageMetadataModuleTest {
         job.setInputDir(srcDir.toURI());
         job.addAll(Stream.of("img.xxx", "img.png", "img.gif", "img.jpg")
                 .map(p -> new Builder()
-                        .uri(create(p)).src(new File(srcDir, p).toURI()).format("html")
+                        .uri(create(p))
+                        .src(new File(srcDir, p).toURI())
+                        .format("html")
                         .build())
                 .collect(Collectors.toList()));
-        job.add(new Builder()
-                .uri(create("test.dita")).format("dita")
-                .build());
+        job.add(new Builder().uri(create("test.dita")).format("dita").build());
 
         final ImageMetadataModule filter = new ImageMetadataModule();
         filter.setLogger(new TestUtils.TestLogger());
@@ -70,7 +69,8 @@ public class ImageMetadataModuleTest {
         input.setAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR, new File(tempDir, "out").getAbsolutePath());
         filter.execute(input);
 
-        assertXMLEqual(new InputSource(new File(expDir, "test.dita").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "test.dita").toURI().toString()),
                 new InputSource(f.toURI().toString()));
         assertEquals("image", job.getFileInfo(create("img.png")).format);
         assertEquals("image", job.getFileInfo(create("img.gif")).format);
@@ -82,5 +82,4 @@ public class ImageMetadataModuleTest {
     public static void teardown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -8,7 +8,26 @@
 
 package org.dita.dost.module;
 
+import static java.net.URI.create;
+import static java.util.Collections.*;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.TestUtils.createTempDir;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
+import static org.dita.dost.util.Constants.MAP_TOPICREF;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.stream.StreamSource;
 import net.sf.saxon.event.Receiver;
 import net.sf.saxon.s9api.DOMDestination;
 import net.sf.saxon.s9api.SaxonApiException;
@@ -33,26 +52,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.*;
-
-import static java.net.URI.create;
-import static java.util.Collections.*;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.TestUtils.createTempDir;
-import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
-import static org.dita.dost.util.Constants.MAP_TOPICREF;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class KeyrefModuleTest {
 
@@ -114,24 +113,27 @@ public class KeyrefModuleTest {
 
     @After
     public void tearDown() throws IOException {
-       TestUtils.forceDelete(tempDir);
+        TestUtils.forceDelete(tempDir);
     }
 
     @Test
     public void testAdjustResourceRenames() {
-        final KeyScope scope = new KeyScope("scope", "scope",
+        final KeyScope scope = new KeyScope(
+                "scope",
+                "scope",
                 ImmutableMap.<String, KeyDef>builder()
                         .put("key", new KeyDef("key", create("target.dita"), null, null, null, null))
                         .build(),
                 emptyList());
-        final List<ResolveTask> src = singletonList(
-                new ResolveTask(
-                        scope,
-                        new Builder().uri(create("target.dita")).build(),
-                        new Builder().uri(create("target-1.dita")).build()));
+        final List<ResolveTask> src = singletonList(new ResolveTask(
+                scope,
+                new Builder().uri(create("target.dita")).build(),
+                new Builder().uri(create("target-1.dita")).build()));
         final List<ResolveTask> act = module.adjustResourceRenames(src);
 
-        final KeyScope exp = new KeyScope("scope", "scope",
+        final KeyScope exp = new KeyScope(
+                "scope",
+                "scope",
                 ImmutableMap.<String, KeyDef>builder()
                         .put("key", new KeyDef("key", create("target-1.dita"), null, null, null, null))
                         .build(),
@@ -142,10 +144,14 @@ public class KeyrefModuleTest {
 
     @Test
     public void testRewriteScopeTargets() {
-        final KeyScope src = new KeyScope("scope", "scope",
+        final KeyScope src = new KeyScope(
+                "scope",
+                "scope",
                 ImmutableMap.<String, KeyDef>builder()
                         .put("key", new KeyDef("key", create("target.dita"), null, null, null, null))
-                        .put("element", new KeyDef("element", create("target.dita#target/element"), null, null, null, null))
+                        .put(
+                                "element",
+                                new KeyDef("element", create("target.dita#target/element"), null, null, null, null))
                         .build(),
                 emptyList());
         final Map<URI, URI> rewrites = ImmutableMap.<URI, URI>builder()
@@ -153,10 +159,14 @@ public class KeyrefModuleTest {
                 .build();
         final KeyScope act = module.rewriteScopeTargets(src, rewrites);
 
-        final KeyScope exp = new KeyScope("scope", "scope",
+        final KeyScope exp = new KeyScope(
+                "scope",
+                "scope",
                 ImmutableMap.<String, KeyDef>builder()
                         .put("key", new KeyDef("key", create("target-1.dita"), null, null, null, null))
-                        .put("element", new KeyDef("element", create("target-1.dita#target/element"), null, null, null, null))
+                        .put(
+                                "element",
+                                new KeyDef("element", create("target-1.dita#target/element"), null, null, null, null))
                         .build(),
                 emptyList());
 
@@ -175,21 +185,20 @@ public class KeyrefModuleTest {
         job.add(inputMapFileInfo);
 
         final XdmNode src = parse(inputMapFileInfo.src);
-        final KeyScope childScope = new KeyScope("A", "A",
-                            ImmutableMap.of(
-                                    "VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null),
-                                    "A.VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null)
-                            ),
-                            EMPTY_LIST
-        );
-        final KeyScope keyScope =
-                new KeyScope("#root", null,
-                            ImmutableMap.of(
-                                    "VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null),
-                                    "A.VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null)
-                            ),
-                            singletonList(childScope)
-        );
+        final KeyScope childScope = new KeyScope(
+                "A",
+                "A",
+                ImmutableMap.of(
+                        "VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null)),
+                EMPTY_LIST);
+        final KeyScope keyScope = new KeyScope(
+                "#root",
+                null,
+                ImmutableMap.of(
+                        "VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR", new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null)),
+                singletonList(childScope));
         final List<ResolveTask> res = new ArrayList<>();
         final XdmDestination destination = new XdmDestination();
         final Receiver receiver = destination.getReceiver(
@@ -201,15 +210,17 @@ public class KeyrefModuleTest {
 
         final Document exp = b.parse(new File(baseDir, "exp" + File.separator + "test.ditamap"));
 
-        final ResolveTask subMapTask = res.stream().filter(r -> r.in().src.equals(subMap)).findFirst().get();
+        final ResolveTask subMapTask =
+                res.stream().filter(r -> r.in().src.equals(subMap)).findFirst().get();
         assertEquals(subMapTask.scope(), childScope);
 
         final Document act = toDocument(destination.getXdmNode());
         assertXMLEqual(exp, act);
     }
 
-	@Test
-	public void testWalkMapAndRewriteKeydefHref() throws ParserConfigurationException, IOException, SAXException, URISyntaxException, XPathException {
+    @Test
+    public void testWalkMapAndRewriteKeydefHref()
+            throws ParserConfigurationException, IOException, SAXException, URISyntaxException, XPathException {
         inputMapFileInfo = new Builder()
                 .uri(create("test2.ditamap"))
                 .src(new File(baseDir, "src" + File.separator + "test2.ditamap").toURI())
@@ -218,30 +229,31 @@ public class KeyrefModuleTest {
                 .isInput(true)
                 .build();
         job.add(inputMapFileInfo);
-	    final XdmNode act = parse(inputMapFileInfo.src);
-	    final KeyScope childScope1 = new KeyScope("A", "A",
-	    		ImmutableMap.of(
-	    				"VAR", new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"A.VAR", new KeyDef("A.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"A.VAR2", new KeyDef("A.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"A.VAR3", new KeyDef("A.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null)
-	    				),
-	    		EMPTY_LIST
-	    		);
-	    final KeyScope childScope2 = new KeyScope("B", "B",
-	    		ImmutableMap.of(
-	    				"VAR", new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"B.VAR", new KeyDef("B.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"B.VAR2", new KeyDef("B.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null),
-	    				"B.VAR3", new KeyDef("B.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null)
-	    				),
-	    		EMPTY_LIST
-	    		);
-	    final KeyScope keyScope =
-	            new KeyScope("#root", null, new HashMap<>(),
-	                        Arrays.asList(childScope1, childScope2)
-	    );
-	    final List<ResolveTask> res = new ArrayList<>();
+        final XdmNode act = parse(inputMapFileInfo.src);
+        final KeyScope childScope1 = new KeyScope(
+                "A",
+                "A",
+                ImmutableMap.of(
+                        "VAR", new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR",
+                                new KeyDef("A.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR2",
+                                new KeyDef("A.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR3", new KeyDef("A.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null)),
+                EMPTY_LIST);
+        final KeyScope childScope2 = new KeyScope(
+                "B",
+                "B",
+                ImmutableMap.of(
+                        "VAR", new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "B.VAR",
+                                new KeyDef("B.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "B.VAR2",
+                                new KeyDef("B.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null),
+                        "B.VAR3", new KeyDef("B.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null)),
+                EMPTY_LIST);
+        final KeyScope keyScope = new KeyScope("#root", null, new HashMap<>(), Arrays.asList(childScope1, childScope2));
+        final List<ResolveTask> res = new ArrayList<>();
         final XdmDestination destination = new XdmDestination();
         final Receiver receiver = destination.getReceiver(
                 xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
@@ -249,45 +261,45 @@ public class KeyrefModuleTest {
         receiver.open();
         module.walkMap(inputMapFileInfo, act, singletonList(keyScope), res, receiver);
         receiver.close();
-        
-	    ResolveTask task = res.get(0);
-	    assertEquals("topic.dita", task.in().file.toString());
-	    assertEquals(null, task.scope().name());
-	    
-	    task = res.get(1);
-	    assertEquals("topic.dita", task.in().file.toString());
-	    assertEquals("A", task.scope().name());
-	    KeyDef keyDef = task.scope().keyDefinition().get("VAR");
-	    assertEquals(new URI("topic.dita"), keyDef.href);
-	    keyDef = task.scope().keyDefinition().get("A.VAR");
-	    assertEquals(new URI("topic-1.dita"), keyDef.href);
-	    
-	    task = res.get(3);
-	    assertEquals("res.png", task.in().file.toString());
-	    assertEquals("A", task.scope().name());
-	    keyDef = task.scope().keyDefinition().get("A.VAR3");
-	    assertEquals(new URI("res.png"), keyDef.href);
-	    
-	    task = res.get(4);
-	    assertEquals("topic.dita", task.in().file.toString());
-	    assertEquals("B", task.scope().name());
-	    keyDef = task.scope().keyDefinition().get("VAR");
-	    assertEquals(new URI("topic.dita"), keyDef.href);
-	    keyDef = task.scope().keyDefinition().get("B.VAR");
-	    assertEquals(new URI("topic-2.dita"), keyDef.href);
-	    
-	    task = res.get(5);
-	    assertEquals("res.dita", task.in().file.toString());
-	    assertEquals("B", task.scope().name());
-	    keyDef = task.scope().keyDefinition().get("B.VAR2");
-	    assertEquals(new URI("res-1.dita"), keyDef.href);
-	    
-	    task = res.get(6);
-	    assertEquals("res.png", task.in().file.toString());
-	    assertEquals("B", task.scope().name());
-	    keyDef = task.scope().keyDefinition().get("B.VAR3");
-	    assertEquals(new URI("res.png"), keyDef.href);
-	}
+
+        ResolveTask task = res.get(0);
+        assertEquals("topic.dita", task.in().file.toString());
+        assertEquals(null, task.scope().name());
+
+        task = res.get(1);
+        assertEquals("topic.dita", task.in().file.toString());
+        assertEquals("A", task.scope().name());
+        KeyDef keyDef = task.scope().keyDefinition().get("VAR");
+        assertEquals(new URI("topic.dita"), keyDef.href);
+        keyDef = task.scope().keyDefinition().get("A.VAR");
+        assertEquals(new URI("topic-1.dita"), keyDef.href);
+
+        task = res.get(3);
+        assertEquals("res.png", task.in().file.toString());
+        assertEquals("A", task.scope().name());
+        keyDef = task.scope().keyDefinition().get("A.VAR3");
+        assertEquals(new URI("res.png"), keyDef.href);
+
+        task = res.get(4);
+        assertEquals("topic.dita", task.in().file.toString());
+        assertEquals("B", task.scope().name());
+        keyDef = task.scope().keyDefinition().get("VAR");
+        assertEquals(new URI("topic.dita"), keyDef.href);
+        keyDef = task.scope().keyDefinition().get("B.VAR");
+        assertEquals(new URI("topic-2.dita"), keyDef.href);
+
+        task = res.get(5);
+        assertEquals("res.dita", task.in().file.toString());
+        assertEquals("B", task.scope().name());
+        keyDef = task.scope().keyDefinition().get("B.VAR2");
+        assertEquals(new URI("res-1.dita"), keyDef.href);
+
+        task = res.get(6);
+        assertEquals("res.png", task.in().file.toString());
+        assertEquals("B", task.scope().name());
+        keyDef = task.scope().keyDefinition().get("B.VAR3");
+        assertEquals(new URI("res.png"), keyDef.href);
+    }
 
     private XdmNode parse(final URI in) {
         try {
@@ -303,9 +315,12 @@ public class KeyrefModuleTest {
         try {
             final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
-            final Document document = documentBuilderFactory.newDocumentBuilder().newDocument();
+            final Document document =
+                    documentBuilderFactory.newDocumentBuilder().newDocument();
             final DOMDestination destination = new DOMDestination(document);
-            final Receiver receiver = destination.getReceiver(xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(), new SerializationProperties());
+            final Receiver receiver = destination.getReceiver(
+                    xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
+                    new SerializationProperties());
             receiver.open();
             receiver.append(node.getUnderlyingNode());
             receiver.close();
@@ -315,55 +330,68 @@ public class KeyrefModuleTest {
         }
     }
 
-	@Test
-	public void testWalkMapAndRewriteKeydefHrefKeepAnchor() throws URISyntaxException, XPathException {
-	    inputMapFileInfo = new Builder()
-	            .uri(create("test3.ditamap"))
-	            .src(new File(baseDir, "src" + File.separator + "test3.ditamap").toURI())
-	            .result(new File(baseDir, "src" + File.separator + "test3.ditamap").toURI())
-	            .format("ditamap")
-	            .isInput(true)
-	            .build();
-	    job.add(inputMapFileInfo);
-	    final XdmNode act = parse(inputMapFileInfo.src);
-	    final KeyScope childScope1 = new KeyScope("A", "A",
-	    		ImmutableMap.of(
-	    				"VAR", new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null),
-	    				"A.VAR", new KeyDef("A.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null)
-	    				),
-	    		EMPTY_LIST
-	    		);
-	    final KeyScope childScope2 = new KeyScope("B", "B",
-	    		ImmutableMap.of(
-	    				"VAR", new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null),
-	    				"B.VAR", new KeyDef("B.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null)
-	    				),
-	    		EMPTY_LIST
-	    		);
-	    final KeyScope keyScope =
-	            new KeyScope("#root", null, new HashMap<>(),
-	                        Arrays.asList(childScope1, childScope2)
-	    );
-	    final List<ResolveTask> res = new ArrayList<>();
-	    final XdmDestination destination = new XdmDestination();
-	    final Receiver receiver = destination.getReceiver(
-	            xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
-	            new SerializationProperties());
-	    receiver.open();
-	    module.walkMap(inputMapFileInfo, act, singletonList(keyScope), res, receiver);
-	    receiver.close();
-	    
-	    XdmNode node = destination.getXdmNode();
+    @Test
+    public void testWalkMapAndRewriteKeydefHrefKeepAnchor() throws URISyntaxException, XPathException {
+        inputMapFileInfo = new Builder()
+                .uri(create("test3.ditamap"))
+                .src(new File(baseDir, "src" + File.separator + "test3.ditamap").toURI())
+                .result(new File(baseDir, "src" + File.separator + "test3.ditamap").toURI())
+                .format("ditamap")
+                .isInput(true)
+                .build();
+        job.add(inputMapFileInfo);
+        final XdmNode act = parse(inputMapFileInfo.src);
+        final KeyScope childScope1 = new KeyScope(
+                "A",
+                "A",
+                ImmutableMap.of(
+                        "VAR",
+                                new KeyDef(
+                                        "VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null),
+                        "A.VAR",
+                                new KeyDef(
+                                        "A.VAR",
+                                        new URI("topic.dita#abc"),
+                                        "local",
+                                        "dita",
+                                        inputMapFileInfo.src,
+                                        null)),
+                EMPTY_LIST);
+        final KeyScope childScope2 = new KeyScope(
+                "B",
+                "B",
+                ImmutableMap.of(
+                        "VAR",
+                                new KeyDef(
+                                        "VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null),
+                        "B.VAR",
+                                new KeyDef(
+                                        "B.VAR",
+                                        new URI("topic.dita#abc"),
+                                        "local",
+                                        "dita",
+                                        inputMapFileInfo.src,
+                                        null)),
+                EMPTY_LIST);
+        final KeyScope keyScope = new KeyScope("#root", null, new HashMap<>(), Arrays.asList(childScope1, childScope2));
+        final List<ResolveTask> res = new ArrayList<>();
+        final XdmDestination destination = new XdmDestination();
+        final Receiver receiver = destination.getReceiver(
+                xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
+                new SerializationProperties());
+        receiver.open();
+        module.walkMap(inputMapFileInfo, act, singletonList(keyScope), res, receiver);
+        receiver.close();
 
-		assertTrue(node
-				.select(Steps.descendant(MAP_TOPICREF.matcher())
-						.where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-1.dita#abc")))
-				.exists());
-		assertTrue(node
-				.select(Steps.descendant(MAP_TOPICREF.matcher())
-						.where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-2.dita#abc")))
-				.exists());
-	}
+        XdmNode node = destination.getXdmNode();
+
+        assertTrue(node.select(Steps.descendant(MAP_TOPICREF.matcher())
+                        .where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-1.dita#abc")))
+                .exists());
+        assertTrue(node.select(Steps.descendant(MAP_TOPICREF.matcher())
+                        .where(Predicates.attributeEq(ATTRIBUTE_NAME_HREF, "topic-2.dita#abc")))
+                .exists());
+    }
 
     @Test
     public void testNoNPEPeerMap() throws URISyntaxException, XPathException {
@@ -378,14 +406,11 @@ public class KeyrefModuleTest {
         final XdmNode act = parse(inputMapFileInfo.src);
         Map<String, KeyDef> defsMap = new HashMap<>();
         defsMap.put("Tool", new KeyDef("Tool", null, "local", "dita", inputMapFileInfo.src, null));
-        
+
         KeyScope submap1 = new KeyScope("submap", "mapref[6]map[6].submap", defsMap, List.of());
         KeyScope submap2 = new KeyScope("submap", "submap[8]map[6].submap", defsMap, List.of());
-        
-        final KeyScope keyScope =
-                new KeyScope("#root", null, defsMap, 
-                            Arrays.asList(submap1, submap2)
-        );
+
+        final KeyScope keyScope = new KeyScope("#root", null, defsMap, Arrays.asList(submap1, submap2));
         final List<ResolveTask> res = new ArrayList<>();
         final XdmDestination destination = new XdmDestination();
         final Receiver receiver = destination.getReceiver(
@@ -394,7 +419,7 @@ public class KeyrefModuleTest {
         receiver.open();
         module.walkMap(inputMapFileInfo, act, singletonList(keyScope), res, receiver);
         receiver.close();
-        
+
         XdmNode node = destination.getXdmNode();
         assertNotNull(node);
     }

--- a/src/test/java/org/dita/dost/module/MoveMetaModuleTest.java
+++ b/src/test/java/org/dita/dost/module/MoveMetaModuleTest.java
@@ -8,6 +8,16 @@
 
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_STYLE;
+import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.util.XMLUtils;
@@ -18,44 +28,33 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.w3c.dom.Document;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.File;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_STYLE;
-import static org.dita.dost.util.Constants.ANT_INVOKER_EXT_PARAM_TRANSTYPE;
-
 @RunWith(Parameterized.class)
 public class MoveMetaModuleTest extends AbstractModuleTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"MatadataInheritance_foreign"},
-                {"MatadataInheritance_keywords"},
-                {"MatadataInheritance_linktext"},
-                {"MatadataInheritance_othermeta"},
-                {"MatadataInheritance_pemissions"},
-                {"MatadataInheritance_pemissions_replace"},
-                {"MatadataInheritance_prodinfo"},
-                {"MatadataInheritance_publisher"},
-                {"MatadataInheritance_resourceid"},
-                {"MatadataInheritance_searchtitle"},
-                {"MatadataInheritance_shortdesc"},
-                {"MatadataInheritance_source"},
-                {"MatadataInheritance_source_replace"},
-                {"MatadataInheritance_unknown"},
-                {"MetadataInheritance_audience"},
-                {"MetadataInheritance_author"},
-                {"MetadataInheritance_category"},
-                {"MetadataInheritance_copyright"},
-                {"MetadataInheritance_critdates"},
-                {"MetadataInheritance_critdates_replace"},
-                {"MetadataInheritance_data"},
-                {"MetadataInheritance_dataabout"}
+        return Arrays.asList(new Object[][] {
+            {"MatadataInheritance_foreign"},
+            {"MatadataInheritance_keywords"},
+            {"MatadataInheritance_linktext"},
+            {"MatadataInheritance_othermeta"},
+            {"MatadataInheritance_pemissions"},
+            {"MatadataInheritance_pemissions_replace"},
+            {"MatadataInheritance_prodinfo"},
+            {"MatadataInheritance_publisher"},
+            {"MatadataInheritance_resourceid"},
+            {"MatadataInheritance_searchtitle"},
+            {"MatadataInheritance_shortdesc"},
+            {"MatadataInheritance_source"},
+            {"MatadataInheritance_source_replace"},
+            {"MatadataInheritance_unknown"},
+            {"MetadataInheritance_audience"},
+            {"MetadataInheritance_author"},
+            {"MetadataInheritance_category"},
+            {"MetadataInheritance_copyright"},
+            {"MetadataInheritance_critdates"},
+            {"MetadataInheritance_critdates_replace"},
+            {"MetadataInheritance_data"},
+            {"MetadataInheritance_dataabout"}
         });
     }
 
@@ -67,8 +66,10 @@ public class MoveMetaModuleTest extends AbstractModuleTest {
     protected AbstractPipelineInput getAbstractPipelineInput() {
         final AbstractPipelineInput input = new PipelineHashIO();
         input.setAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE, "html5");
-        input.setAttribute(ANT_INVOKER_EXT_PARAM_STYLE,
-                Paths.get("src", "main", "plugins", "org.dita.base", "xsl", "preprocess", "mappull.xsl").toString());
+        input.setAttribute(
+                ANT_INVOKER_EXT_PARAM_STYLE,
+                Paths.get("src", "main", "plugins", "org.dita.base", "xsl", "preprocess", "mappull.xsl")
+                        .toString());
         return input;
     }
 
@@ -86,7 +87,8 @@ public class MoveMetaModuleTest extends AbstractModuleTest {
         final DocumentBuilder b = f.newDocumentBuilder();
         for (File file : tempDir.listFiles((dir, name) -> name.endsWith("dita") || name.endsWith("ditamap"))) {
             final Document d = b.parse(file);
-            d.appendChild(d.createProcessingInstruction("workdir-uri", tempDir.toURI().toString()));
+            d.appendChild(
+                    d.createProcessingInstruction("workdir-uri", tempDir.toURI().toString()));
             xmlUtils.writeDocument(d, file);
         }
     }

--- a/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
+++ b/src/test/java/org/dita/dost/module/TestGenMapAndTopicListModule.java
@@ -7,6 +7,16 @@
  */
 package org.dita.dost.module;
 
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Job.FileInfo;
+import static org.dita.dost.util.Job.Generate.NOT_GENERATEOUTTER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.*;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.PipelineHashIO;
@@ -17,23 +27,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.*;
-import java.net.URI;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.Job.FileInfo;
-import static org.dita.dost.util.Job.Generate.NOT_GENERATEOUTTER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class TestGenMapAndTopicListModule {
 
     private static final File resourceDir = TestUtils.getResourceDir(TestGenMapAndTopicListModule.class);
     private static final File srcDir = new File(resourceDir, "src");
     private static final File expDir = new File(resourceDir, "exp");
-    
+
     private File tempDir;
 
     @Before
@@ -41,14 +40,16 @@ public class TestGenMapAndTopicListModule {
         tempDir = TestUtils.createTempDir(TestGenMapAndTopicListModule.class);
     }
 
-    private static Job generate(final File inputDir, final File inputMap, final File outDir, final File tempDir) throws DITAOTException, IOException {
+    private static Job generate(final File inputDir, final File inputMap, final File outDir, final File tempDir)
+            throws DITAOTException, IOException {
         final PipelineHashIO pipelineInput = new PipelineHashIO();
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_INPUTMAP, inputMap.getPath());
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_BASEDIR, srcDir.getAbsolutePath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, inputDir.getPath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR, outDir.getPath());
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_TEMPDIR, tempDir.getPath());
-        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, new File("src" + File.separator + "main").getAbsolutePath());
+        pipelineInput.setAttribute(
+                ANT_INVOKER_EXT_PARAM_DITADIR, new File("src" + File.separator + "main").getAbsolutePath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_INDEXTYPE, "xhtml");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_ENCODING, "en-US");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_TARGETEXT, ".html");
@@ -57,7 +58,7 @@ public class TestGenMapAndTopicListModule {
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL, "warn");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_CRAWL, "topic");
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_ONLYTOPICINMAP, Boolean.FALSE.toString());
-        //pipelineInput.setAttribute("ditalist", new File(tempDir, FILE_NAME_DITA_LIST).getPath());
+        // pipelineInput.setAttribute("ditalist", new File(tempDir, FILE_NAME_DITA_LIST).getPath());
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_MAPLINKS, new File(tempDir, "maplinks.unordered").getPath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAN_SETSYSTEMID, "no");
 
@@ -70,104 +71,85 @@ public class TestGenMapAndTopicListModule {
 
         return job;
     }
-        
+
     @Test
-    public void testFileContentParallel() throws Exception{
+    public void testFileContentParallel() throws Exception {
         final File inputDirParallel = new File("maps");
         final File inputMapParallel = new File(inputDirParallel, "root-map-01.ditamap");
         final File outDirParallel = new File(tempDir, "out");
         generate(inputDirParallel, inputMapParallel, outDirParallel, tempDir);
 
         final File e = new File(expDir, "parallel");
-        
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml",
-                        "topics/xreffin-topic-1.xml")),
+
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/target-topic-c.xml", "topics/target-topic a.xml", "topics/xreffin-topic-1.xml")),
                 readLines(new File(e, "canditopics.list")));
-        assertEquals(Collections.emptySet(), 
-                readLines(new File(e, "coderef.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conref.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conrefpush.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conreftargets.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "copytosource.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "copytotarget2sourcemap.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "flagimage.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "maps/root-map-01.ditamap")),
-                readLines(new File(e, "fullditamap.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
+        assertEquals(Collections.emptySet(), readLines(new File(e, "coderef.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conref.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conrefpush.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conreftargets.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "copytosource.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "copytotarget2sourcemap.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "flagimage.list")));
+        assertEquals(new HashSet<>(List.of("maps/root-map-01.ditamap")), readLines(new File(e, "fullditamap.list")));
+        assertEquals(
+                new HashSet<>(Arrays.asList(
                         "topics/target-topic-c.xml",
                         "topics/target-topic a.xml",
                         "maps/root-map-01.ditamap",
                         "topics/xreffin-topic-1.xml")),
                 readLines(new File(e, "fullditamapandtopic.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml",
-                        "topics/xreffin-topic-1.xml")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/target-topic-c.xml", "topics/target-topic a.xml", "topics/xreffin-topic-1.xml")),
                 readLines(new File(e, "fullditatopic.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "topics/xreffin-topic-1.xml")),
-                readLines(new File(e, "hrefditatopic.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml",
-                        "topics/xreffin-topic-1.xml")),
+        assertEquals(
+                new HashSet<>(List.of("topics/xreffin-topic-1.xml")), readLines(new File(e, "hrefditatopic.list")));
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/target-topic-c.xml", "topics/target-topic a.xml", "topics/xreffin-topic-1.xml")),
                 readLines(new File(e, "hreftargets.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "html.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "image.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "topics/xreffin-topic-1.xml")),
-                readLines(new File(e, "keyref.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml",
-                        "topics/xreffin-topic-1.xml")),
+        assertEquals(Collections.emptySet(), readLines(new File(e, "html.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "image.list")));
+        assertEquals(new HashSet<>(List.of("topics/xreffin-topic-1.xml")), readLines(new File(e, "keyref.list")));
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/target-topic-c.xml", "topics/target-topic a.xml", "topics/xreffin-topic-1.xml")),
                 readLines(new File(e, "outditafiles.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "relflagimage.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "resourceonly.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "skipchunk.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "subjectscheme.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "subtargets.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "maps/root-map-01.ditamap")),
-                readLines(new File(e, "usr.input.file.list")));
-        
+        assertEquals(Collections.emptySet(), readLines(new File(e, "relflagimage.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "resourceonly.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "skipchunk.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "subjectscheme.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "subtargets.list")));
+        assertEquals(new HashSet<>(List.of("maps/root-map-01.ditamap")), readLines(new File(e, "usr.input.file.list")));
+
         final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         assertEquals(".." + File.separator, job.getProperty("uplevels"));
 
         assertEquals(5, job.getFileInfo().size());
-        assertPaths(job.getFileInfo(new URI("topics/xreffin-topic-1.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/xreffin-topic-1.xml")),
                 srcDir.toURI().resolve("topics/xreffin-topic-1.xml"),
                 new URI("topics/xreffin-topic-1.xml"));
-        assertPaths(job.getFileInfo(new URI("topics/target-topic%20a.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/target-topic%20a.xml")),
                 srcDir.toURI().resolve("topics/target-topic%20a.xml"),
                 new URI("topics/target-topic%20a.xml"));
-        assertPaths(job.getFileInfo(new URI("topics/target-topic-c.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/target-topic-c.xml")),
                 srcDir.toURI().resolve("topics/target-topic-c.xml"),
                 new URI("topics/target-topic-c.xml"));
-        assertPaths(job.getFileInfo(new URI("maps/root-map-01.ditamap")),
+        assertPaths(
+                job.getFileInfo(new URI("maps/root-map-01.ditamap")),
                 srcDir.toURI().resolve("maps/root-map-01.ditamap"),
                 new URI("maps/root-map-01.ditamap"));
-        assertPaths(job.getFileInfo(new URI("topics/xreffin-topic-1-copy.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/xreffin-topic-1-copy.xml")),
                 null,
                 new URI("topics/xreffin-topic-1-copy.xml"));
     }
-    
+
     private void assertPaths(final FileInfo fi, final URI src, final URI path) {
         if (src != null) {
             assertEquals(fi.src, src);
@@ -176,123 +158,103 @@ public class TestGenMapAndTopicListModule {
     }
 
     @Test
-    public void testFileContentAbove() throws Exception{
+    public void testFileContentAbove() throws Exception {
         final File inputDirAbove = new File(".");
         final File inputMapAbove = new File(inputDirAbove, "root-map-02.ditamap");
         final File outDirAbove = new File(tempDir, "out");
         generate(inputDirAbove, inputMapAbove, outDirAbove, tempDir);
 
         final File e = new File(expDir, "above");
-                
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/xreffin-topic-1.xml",
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml")),
+
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/xreffin-topic-1.xml", "topics/target-topic-c.xml", "topics/target-topic a.xml")),
                 readLines(new File(e, "canditopics.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "coderef.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conref.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conrefpush.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "conreftargets.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "copytosource.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "copytotarget2sourcemap.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "flagimage.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "root-map-02.ditamap")),
-                readLines(new File(e, "fullditamap.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
+        assertEquals(Collections.emptySet(), readLines(new File(e, "coderef.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conref.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conrefpush.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "conreftargets.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "copytosource.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "copytotarget2sourcemap.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "flagimage.list")));
+        assertEquals(new HashSet<>(List.of("root-map-02.ditamap")), readLines(new File(e, "fullditamap.list")));
+        assertEquals(
+                new HashSet<>(Arrays.asList(
                         "topics/xreffin-topic-1.xml",
                         "topics/target-topic-c.xml",
                         "topics/target-topic a.xml",
                         "root-map-02.ditamap")),
                 readLines(new File(e, "fullditamapandtopic.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/xreffin-topic-1.xml",
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/xreffin-topic-1.xml", "topics/target-topic-c.xml", "topics/target-topic a.xml")),
                 readLines(new File(e, "fullditatopic.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "topics/xreffin-topic-1.xml")),
-                readLines(new File(e, "hrefditatopic.list")));
-        assertEquals(new HashSet<>(Arrays.asList(
-                        "topics/xreffin-topic-1.xml",
-                        "topics/target-topic-c.xml",
-                        "topics/target-topic a.xml")),
+        assertEquals(
+                new HashSet<>(List.of("topics/xreffin-topic-1.xml")), readLines(new File(e, "hrefditatopic.list")));
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "topics/xreffin-topic-1.xml", "topics/target-topic-c.xml", "topics/target-topic a.xml")),
                 readLines(new File(e, "hreftargets.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "html.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "image.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "topics/xreffin-topic-1.xml")),
-                readLines(new File(e, "keyref.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "outditafiles.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "relflagimage.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "resourceonly.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "skipchunk.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "subjectscheme.list")));
-        assertEquals(Collections.emptySet(),
-                readLines(new File(e, "subtargets.list")));
-        assertEquals(new HashSet<>(List.of(
-                        "root-map-02.ditamap")),
-                readLines(new File(e, "usr.input.file.list")));
-                
+        assertEquals(Collections.emptySet(), readLines(new File(e, "html.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "image.list")));
+        assertEquals(new HashSet<>(List.of("topics/xreffin-topic-1.xml")), readLines(new File(e, "keyref.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "outditafiles.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "relflagimage.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "resourceonly.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "skipchunk.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "subjectscheme.list")));
+        assertEquals(Collections.emptySet(), readLines(new File(e, "subtargets.list")));
+        assertEquals(new HashSet<>(List.of("root-map-02.ditamap")), readLines(new File(e, "usr.input.file.list")));
+
         final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
         assertEquals("", job.getProperty("uplevels"));
 
         assertEquals(5, job.getFileInfo().size());
-        assertPaths(job.getFileInfo(new URI("topics/xreffin-topic-1.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/xreffin-topic-1.xml")),
                 srcDir.toURI().resolve("topics/xreffin-topic-1.xml"),
                 new URI("topics/xreffin-topic-1.xml"));
-        assertPaths(job.getFileInfo(new URI("topics/target-topic%20a.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/target-topic%20a.xml")),
                 srcDir.toURI().resolve("topics/target-topic%20a.xml"),
                 new URI("topics/target-topic%20a.xml"));
-        assertPaths(job.getFileInfo(new URI("topics/target-topic-c.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/target-topic-c.xml")),
                 srcDir.toURI().resolve("topics/target-topic-c.xml"),
                 new URI("topics/target-topic-c.xml"));
-        assertPaths(job.getFileInfo(new URI("root-map-02.ditamap")),
+        assertPaths(
+                job.getFileInfo(new URI("root-map-02.ditamap")),
                 srcDir.toURI().resolve("root-map-02.ditamap"),
                 new URI("root-map-02.ditamap"));
-        assertPaths(job.getFileInfo(new URI("topics/xreffin-topic-1-copy.xml")),
+        assertPaths(
+                job.getFileInfo(new URI("topics/xreffin-topic-1-copy.xml")),
                 null,
                 new URI("topics/xreffin-topic-1-copy.xml"));
     }
 
     @Test
-    public void testConref() throws Exception{
+    public void testConref() throws Exception {
         final File inputDirParallel = new File("conref");
         final File inputMapParallel = new File(inputDirParallel, "main.ditamap");
         final File outDirParallel = new File(tempDir, "out");
         final Job job = generate(inputDirParallel, inputMapParallel, outDirParallel, tempDir);
 
-        assertEquals(new HashSet<>(Arrays.asList(
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-resource-only-ALSORESOURCEONLY.dita",
-                "resourceonly.dita",
-                "conref-from-normal.dita",
-                "conref-from-resource-only.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "link-from-normal-ALSORESOURCEONLY.dita",
+                        "conref-from-resource-only-ALSORESOURCEONLY.dita",
+                        "resourceonly.dita",
+                        "conref-from-normal.dita",
+                        "conref-from-resource-only.dita",
+                        "link-from-resource-only-ALSORESOURCEONLY.dita",
+                        "conref-from-normal-ALSORESOURCEONLY.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> f.isResourceOnly)
                         .map(fi -> fi.uri.toString())
                         .collect(Collectors.toSet()));
-        assertEquals(new HashSet<>(Arrays.asList(
-                "main.ditamap",
-                "link-from-normal.dita",
-                "link-from-resource-only.dita",
-                "normal.dita")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "main.ditamap", "link-from-normal.dita", "link-from-resource-only.dita", "normal.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> !f.isResourceOnly)
                         .map(fi -> fi.uri.toString())
@@ -300,29 +262,31 @@ public class TestGenMapAndTopicListModule {
     }
 
     @Test
-    public void testConrefLink() throws Exception{
+    public void testConrefLink() throws Exception {
         final File inputDirParallel = new File("conref");
         final File inputMapParallel = new File(inputDirParallel, "link.ditamap");
         final File outDirParallel = new File(tempDir, "out");
         final Job job = generate(inputDirParallel, inputMapParallel, outDirParallel, tempDir);
 
-        assertEquals(new HashSet<>(Arrays.asList(
-                "conref-from-resource-only-ALSORESOURCEONLY.dita",
-                "resourceonly.dita",
-                "conref-from-normal.dita",
-                "conref-from-resource-only.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "conref-from-resource-only-ALSORESOURCEONLY.dita",
+                        "resourceonly.dita",
+                        "conref-from-normal.dita",
+                        "conref-from-resource-only.dita",
+                        "conref-from-normal-ALSORESOURCEONLY.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> f.isResourceOnly)
                         .map(fi -> fi.uri.toString())
                         .collect(Collectors.toSet()));
-        assertEquals(new HashSet<>(Arrays.asList(
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "link.ditamap",
-                "link-from-normal.dita",
-                "link-from-resource-only.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "normal.dita")),
+        assertEquals(
+                new HashSet<>(Arrays.asList(
+                        "link-from-normal-ALSORESOURCEONLY.dita",
+                        "link.ditamap",
+                        "link-from-normal.dita",
+                        "link-from-resource-only.dita",
+                        "link-from-resource-only-ALSORESOURCEONLY.dita",
+                        "normal.dita")),
                 job.getFileInfo().stream()
                         .filter(f -> !f.isResourceOnly)
                         .map(fi -> fi.uri.toString())
@@ -330,7 +294,7 @@ public class TestGenMapAndTopicListModule {
     }
 
     @Test
-    public void testImage() throws Exception{
+    public void testImage() throws Exception {
         final File inputDir = new File("image");
         final File inputMap = new File(inputDir, "image.dita");
         final File outDir = new File(tempDir, "out");
@@ -340,9 +304,9 @@ public class TestGenMapAndTopicListModule {
         assertNotNull(job.getFileInfo(URI.create("image.svg")));
         assertNotNull(job.getFileInfo(URI.create("image.svg?media=print")));
     }
-    
+
     @Test
-    public void testImageKeydef() throws Exception{
+    public void testImageKeydef() throws Exception {
         final File inputDir = new File("image-keydef");
         final File inputMap = new File(inputDir, "svg.ditamap");
         final File outDir = new File(tempDir, "out");
@@ -362,14 +326,14 @@ public class TestGenMapAndTopicListModule {
         }
         return lines;
     }
-    
+
     @After
     public void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
 
     @Test
-    public void testResourcesUplevels() throws Exception{
+    public void testResourcesUplevels() throws Exception {
         final File inputDir = new File(".");
         final File inputMap = new File(inputDir, "image-keydef/svg.ditamap");
         final File outerMap = new File(srcDir, "root-map.ditamap");
@@ -380,7 +344,8 @@ public class TestGenMapAndTopicListModule {
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, inputDir.getPath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR, outDirAbove.getPath());
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_TEMPDIR, tempDir.getPath());
-        pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, new File("src" + File.separator + "main").getAbsolutePath());
+        pipelineInput.setAttribute(
+                ANT_INVOKER_EXT_PARAM_DITADIR, new File("src" + File.separator + "main").getAbsolutePath());
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER, Integer.toString(NOT_GENERATEOUTTER.type));
         pipelineInput.setAttribute(ANT_INVOKER_EXT_PARAM_OUTTERCONTROL, "warn");
         pipelineInput.setAttribute(ANT_INVOKER_PARAM_RESOURCES, outerMap.getCanonicalPath());
@@ -393,5 +358,4 @@ public class TestGenMapAndTopicListModule {
         module.execute(pipelineInput);
         assertEquals(srcDir.toURI().toString(), job.getInputDir().toString());
     }
-
 }

--- a/src/test/java/org/dita/dost/module/TestTopicMergeModule.java
+++ b/src/test/java/org/dita/dost/module/TestTopicMergeModule.java
@@ -10,17 +10,12 @@ package org.dita.dost.module;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITAMAP;
 import static org.dita.dost.util.Constants.INPUT_DIR_URI;
-import static org.dita.dost.util.Constants.INPUT_DITAMAP_URI;
-import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 import java.net.URI;
-
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.module.TopicMergeModule;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
@@ -30,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
 
 public class TestTopicMergeModule {
 
@@ -42,7 +36,7 @@ public class TestTopicMergeModule {
     //    private AbstractFacade facade;
 
     private PipelineHashIO pipelineInput;
-    private final File ditalistfile = new File (resourceDir, "compare.xml");
+    private final File ditalistfile = new File(resourceDir, "compare.xml");
     private File tobecomparefile;
     private File temporaryDir;
     private Job job;
@@ -53,7 +47,7 @@ public class TestTopicMergeModule {
 
         //        facade = new PipelineFacade();
         pipelineInput = new PipelineHashIO();
-        
+
         temporaryDir = new File(tempDir, "temp");
         final File srcDir = new File(tempDir, "src");
         srcDir.mkdirs();
@@ -70,7 +64,7 @@ public class TestTopicMergeModule {
         job.setProperty(INPUT_DIR_URI, srcDir.toURI().toString());
 
         final File inputMap = new File(temporaryDir, "test.ditamap");
-        
+
         final File outDir = new File(tempDir, "out");
         tobecomparefile = new File(outDir, "tobecompared.xml");
 
@@ -90,24 +84,22 @@ public class TestTopicMergeModule {
         pipelineInput.setAttribute("onlytopicinmap", "false");
         pipelineInput.setAttribute("ditalist", new File(temporaryDir, "dita.list").getPath());
         pipelineInput.setAttribute("maplinks", new File(temporaryDir, "maplinks.unordered").getPath());
-
     }
 
     @Test
-    public void testtopicmergemodule() throws DITAOTException, IOException, SAXException
-    {
+    public void testtopicmergemodule() throws DITAOTException, IOException, SAXException {
         final TopicMergeModule topicmergemodule = new TopicMergeModule();
         topicmergemodule.setLogger(new TestUtils.TestLogger());
         topicmergemodule.setJob(job);
         topicmergemodule.execute(pipelineInput);
-        
-        assertXMLEqual(new InputSource(ditalistfile.toURI().toString()),
-                       new InputSource(tobecomparefile.toURI().toString()));
+
+        assertXMLEqual(
+                new InputSource(ditalistfile.toURI().toString()),
+                new InputSource(tobecomparefile.toURI().toString()));
     }
 
     @After
     public void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/module/XsltModuleTest.java
+++ b/src/test/java/org/dita/dost/module/XsltModuleTest.java
@@ -8,7 +8,4 @@
 
 package org.dita.dost.module;
 
-public class XsltModuleTest {
-
-
-}
+public class XsltModuleTest {}

--- a/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
@@ -7,6 +7,20 @@
  */
 package org.dita.dost.module.filter;
 
+import static junit.framework.Assert.assertEquals;
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.module.BranchFilterModule.Branch;
@@ -20,21 +34,6 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static junit.framework.Assert.assertEquals;
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertNotNull;
 
 public class MapBranchFilterModuleTest extends MapBranchFilterModule {
 
@@ -56,14 +55,15 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
                 .uri(URI.create("input.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("linux.ditaval", "novice.ditaval", "advanced.ditaval", "mac.ditaval", "win.ditaval")) {
+        for (final String uri :
+                Arrays.asList("linux.ditaval", "novice.ditaval", "advanced.ditaval", "mac.ditaval", "win.ditaval")) {
             job.add(new FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .uri(URI.create(uri))
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: Arrays.asList("install.dita", "perform-install.dita", "configure.dita")) {
+        for (final String uri : Arrays.asList("install.dita", "perform-install.dita", "configure.dita")) {
             job.add(new FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .uri(URI.create(uri))
@@ -101,17 +101,17 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
         m.setLogger(logger);
         m.setXmlUtils(new XMLUtils());
 
-        final FileInfo fi = new FileInfo.Builder()
-                .uri(URI.create("input.ditamap"))
-                .build();
+        final FileInfo fi =
+                new FileInfo.Builder().uri(URI.create("input.ditamap")).build();
         m.processMap(fi);
-        assertXMLEqual(new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "input.ditamap").toURI().toString()),
                 new InputSource(new File(tempDir, "input.ditamap").toURI().toString()));
 
         final List<String> exp = Arrays.asList(
-//                "installation-procedure.dita",
-//                "getting-started.dita",
-//                "http://example.com/install.dita",
+                //                "installation-procedure.dita",
+                //                "getting-started.dita",
+                //                "http://example.com/install.dita",
                 "configure.dita",
                 "input.ditamap",
                 "install.dita",
@@ -124,68 +124,132 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
                 "install-mac.dita",
                 "mac.ditaval",
                 "perform-install-mac.dita",
-//                "installation-procedure-mac.dita",
+                //                "installation-procedure-mac.dita",
                 "configure-novice-mac.dita",
                 "configure-admin-mac.dita",
                 "install-win.dita",
                 "win.ditaval",
                 "perform-install-win.dita",
-//                "installation-procedure-win.dita",
+                //                "installation-procedure-win.dita",
                 "configure-novice-win.dita",
                 "configure-admin-win.dita",
-                "install-linux.dita"
-        );
+                "install-linux.dita");
         assertEquals(exp.size(), job.getFileInfo().size());
         for (final String f : exp) {
             assertNotNull(job.getFileInfo(URI.create(f)));
         }
 
         final List<String> filesExp = Arrays.asList(
-//                "install.dita",
+                //                "install.dita",
                 "configure.dita",
                 "perform-install.dita",
-//                "configure-novice.dita",
-//                "configure-admin.dita",
-//                "install-mac.dita",
-//                "perform-install-mac.dita",
-//                "installation-procedure-mac.dita",
-//                "configure-novice-mac.dita",
-//                "configure-admin-mac.dita",
-//                "install-win.dita",
-//                "perform-install-win.dita",
-//                "installation-procedure-win.dita",
-//                "configure-novice-win.dita",
-//                "configure-admin-win.dita",
-//                "install-linux.dita",
-                "install.dita"
-        );
+                //                "configure-novice.dita",
+                //                "configure-admin.dita",
+                //                "install-mac.dita",
+                //                "perform-install-mac.dita",
+                //                "installation-procedure-mac.dita",
+                //                "configure-novice-mac.dita",
+                //                "configure-admin-mac.dita",
+                //                "install-win.dita",
+                //                "perform-install-win.dita",
+                //                "installation-procedure-win.dita",
+                //                "configure-novice-win.dita",
+                //                "configure-admin-win.dita",
+                //                "install-linux.dita",
+                "install.dita");
         Collections.sort(filesExp);
         final List<String> filesAct = Arrays.stream(tempDir.listFiles((dir, name) -> name.endsWith(".dita")))
-                .map(File::getName).sorted().collect(Collectors.toList());
+                .map(File::getName)
+                .sorted()
+                .collect(Collectors.toList());
         assertEquals(filesExp, filesAct);
-        assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+        assertEquals(
+                0,
+                logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
     }
 
     private static final Optional<String> ABSENT_STRING = Optional.empty();
-    
+
     @Test
     public void testGenerateCopyTo() {
-        assertEquals(URI.create("foo.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("baz-foo.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo-baz.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("qux-foo-baz.bar"), generateCopyTo(URI.create("foo.bar"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/baz-foo.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo-baz.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/qux-foo-baz.bar"), generateCopyTo(URI.create("sub.dir/foo.bar"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo"), generateCopyTo(URI.create("foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("baz-foo"), generateCopyTo(URI.create("foo"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("foo-baz"), generateCopyTo(URI.create("foo"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("qux-foo-baz"), generateCopyTo(URI.create("foo"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/baz-foo"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/foo-baz"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
-        assertEquals(URI.create("sub.dir/qux-foo-baz"), generateCopyTo(URI.create("sub.dir/foo"), new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("baz-foo.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("qux-foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("foo.bar"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/baz-foo.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/qux-foo-baz.bar"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo.bar"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo"),
+                generateCopyTo(
+                        URI.create("foo"), new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("baz-foo"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("foo-baz"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("qux-foo-baz"),
+                generateCopyTo(
+                        URI.create("foo"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(ABSENT_STRING, ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/baz-foo"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(Optional.of("baz-"), ABSENT_STRING, ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/foo-baz"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(ABSENT_STRING, Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
+        assertEquals(
+                URI.create("sub.dir/qux-foo-baz"),
+                generateCopyTo(
+                        URI.create("sub.dir/foo"),
+                        new Branch(Optional.of("qux-"), Optional.of("-baz"), ABSENT_STRING, ABSENT_STRING)));
     }
 
     @Test
@@ -210,7 +274,9 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
                 .build());
 
         assertEquals(exp, new HashSet<>(job.getFileInfo()));
-        assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+        assertEquals(
+                0,
+                logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
     }
 
     private Set<Job.FileInfo> getDuplicateTopicFileInfos() {
@@ -221,7 +287,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
                 .uri(URI.create("test.ditamap"))
                 .format(ATTR_FORMAT_VALUE_DITAMAP)
                 .build());
-        for (final String uri: Arrays.asList("test.ditaval", "test2.ditaval")) {
+        for (final String uri : Arrays.asList("test.ditaval", "test2.ditaval")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -229,7 +295,7 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
                     .format(ATTR_FORMAT_VALUE_DITAVAL)
                     .build());
         }
-        for (final String uri: List.of("t1.xml")) {
+        for (final String uri : List.of("t1.xml")) {
             res.add(new Job.FileInfo.Builder()
                     .src(new File(tempDir, uri).toURI())
                     .result(new File(tempDir, uri).toURI())
@@ -239,5 +305,4 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
         }
         return res;
     }
-
 }

--- a/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
@@ -8,16 +8,14 @@
 
 package org.dita.dost.module.reader;
 
-import org.dita.dost.TestUtils;
-import org.dita.dost.reader.GenListModuleReader;
 import static org.dita.dost.util.Constants.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.net.URI;
-
-import static org.junit.Assert.*;
+import org.dita.dost.TestUtils;
+import org.dita.dost.reader.GenListModuleReader;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MapReaderModuleTest {
 
@@ -37,20 +35,22 @@ public class MapReaderModuleTest {
 
     @Test
     public void categorizeReferenceFileDitamap() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.ditamap"), ATTR_FORMAT_VALUE_DITAMAP));
+        reader.categorizeReferenceFile(new GenListModuleReader.Reference(
+                URI.create("file:///foo/bar/baz.ditamap"), ATTR_FORMAT_VALUE_DITAMAP));
         assertEquals(1, reader.waitList.size());
     }
 
     @Test
     public void categorizeReferenceFileDitaval() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.ditaval"), ATTR_FORMAT_VALUE_DITAVAL));
+        reader.categorizeReferenceFile(new GenListModuleReader.Reference(
+                URI.create("file:///foo/bar/baz.ditaval"), ATTR_FORMAT_VALUE_DITAVAL));
         assertEquals(1, reader.formatSet.size());
     }
 
     @Test
     public void categorizeReferenceFileImage() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.jpg"), ATTR_FORMAT_VALUE_IMAGE));
+        reader.categorizeReferenceFile(
+                new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.jpg"), ATTR_FORMAT_VALUE_IMAGE));
         assertEquals(1, reader.formatSet.size());
     }
-
 }

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -8,6 +8,11 @@
 
 package org.dita.dost.module.reader;
 
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
 import org.dita.dost.TestUtils;
 import org.dita.dost.pipeline.PipelineHashIO;
 import org.dita.dost.reader.GenListModuleReader;
@@ -19,12 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertEquals;
 
 public class TopicReaderModuleTest {
 
@@ -68,30 +67,33 @@ public class TopicReaderModuleTest {
 
     @Test
     public void categorizeReferenceFileDitamap() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.ditamap"), ATTR_FORMAT_VALUE_DITAMAP));
+        reader.categorizeReferenceFile(new GenListModuleReader.Reference(
+                URI.create("file:///foo/bar/baz.ditamap"), ATTR_FORMAT_VALUE_DITAMAP));
         assertEquals(0, reader.htmlSet.size());
         assertEquals(0, reader.waitList.size());
     }
 
     @Test
     public void categorizeReferenceFileDitaval() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.ditaval"), ATTR_FORMAT_VALUE_DITAVAL));
+        reader.categorizeReferenceFile(new GenListModuleReader.Reference(
+                URI.create("file:///foo/bar/baz.ditaval"), ATTR_FORMAT_VALUE_DITAVAL));
         assertEquals(0, reader.htmlSet.size());
         assertEquals(0, reader.formatSet.size());
     }
 
     @Test
     public void categorizeReferenceFileHtml() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.html"), ATTR_FORMAT_VALUE_HTML));
+        reader.categorizeReferenceFile(
+                new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.html"), ATTR_FORMAT_VALUE_HTML));
         assertEquals(1, reader.htmlSet.size());
         assertEquals(0, reader.formatSet.size());
     }
 
     @Test
     public void categorizeReferenceFileImage() throws Exception {
-        reader.categorizeReferenceFile(new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.jpg"), ATTR_FORMAT_VALUE_IMAGE));
+        reader.categorizeReferenceFile(
+                new GenListModuleReader.Reference(URI.create("file:///foo/bar/baz.jpg"), ATTR_FORMAT_VALUE_IMAGE));
         assertEquals(0, reader.htmlSet.size());
         assertEquals(1, reader.formatSet.size());
     }
-
 }

--- a/src/test/java/org/dita/dost/pipeline/PipelineHashIOTest.java
+++ b/src/test/java/org/dita/dost/pipeline/PipelineHashIOTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * Unit test for {@link PipelineHashIO}
- * 
+ *
  * @author Jarno Elovirta
  */
 public class PipelineHashIOTest {
@@ -36,5 +36,4 @@ public class PipelineHashIOTest {
         p.setAttribute("foo", "bar");
         assertEquals("bar", p.getAttribute("foo"));
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/FeaturesTest.java
+++ b/src/test/java/org/dita/dost/platform/FeaturesTest.java
@@ -7,18 +7,17 @@
  */
 package org.dita.dost.platform;
 
+import static java.util.Arrays.asList;
+import static org.dita.dost.platform.PluginParser.FEATURE_ELEM;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.*;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.File;
-import java.util.*;
-
-import static java.util.Arrays.asList;
-import static org.dita.dost.platform.PluginParser.FEATURE_ELEM;
-import static org.junit.Assert.*;
 
 public class FeaturesTest {
 
@@ -26,7 +25,7 @@ public class FeaturesTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-       doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
     }
 
     @Test
@@ -36,7 +35,9 @@ public class FeaturesTest {
 
     @Test
     public void testGetLocation() {
-        assertEquals(new File("base", "plugins"), new Features(new File("base", "plugins"), new File("base")).getPluginDir());
+        assertEquals(
+                new File("base", "plugins"),
+                new Features(new File("base", "plugins"), new File("base")).getPluginDir());
     }
 
     @Test
@@ -47,7 +48,8 @@ public class FeaturesTest {
         try {
             f.addExtensionPoint(null);
             fail();
-        } catch (final NullPointerException ex) {}
+        } catch (final NullPointerException ex) {
+        }
     }
 
     @Test
@@ -92,9 +94,12 @@ public class FeaturesTest {
         f.addFeature("foo", getElement(" bar, baz ", null));
         assertEquals(asList("bar", "baz"), f.getFeature("foo"));
         f.addFeature("foo", getElement("bar, baz", "file"));
-        assertEquals(asList("bar","baz",
-                "base" + File.separator + "plugins" + File.separator + "bar",
-                "base" + File.separator + "plugins" + File.separator + "baz"),
+        assertEquals(
+                asList(
+                        "bar",
+                        "baz",
+                        "base" + File.separator + "plugins" + File.separator + "bar",
+                        "base" + File.separator + "plugins" + File.separator + "baz"),
                 f.getFeature("foo"));
     }
 
@@ -105,7 +110,8 @@ public class FeaturesTest {
         try {
             f.addRequire(null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -116,7 +122,8 @@ public class FeaturesTest {
         try {
             f.addRequire(null, null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -131,7 +138,7 @@ public class FeaturesTest {
         while (requirements.hasNext()) {
             final PluginRequirement requirement = requirements.next();
             final List<String> plugins = new ArrayList<>();
-            for (final Iterator<String> ps = requirement.getPlugins(); ps.hasNext();) {
+            for (final Iterator<String> ps = requirement.getPlugins(); ps.hasNext(); ) {
                 plugins.add(ps.next());
             }
             Collections.sort(plugins);
@@ -155,7 +162,8 @@ public class FeaturesTest {
         try {
             f.addMeta("bar", null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -194,12 +202,8 @@ public class FeaturesTest {
             }
             return Objects.compare(a0.value(), a1.value(), String::compareTo);
         });
-        assertEquals(Arrays.asList(
-                null,
-                new Value("base", "bar"),
-                new Value("base", "foo"),
-                new Value("base", "foo")),
-                act);
+        assertEquals(
+                Arrays.asList(null, new Value("base", "bar"), new Value("base", "foo"), new Value("base", "foo")), act);
     }
 
     private static Element getElement(final String value, final String type) {
@@ -212,5 +216,4 @@ public class FeaturesTest {
         }
         return feature;
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
+++ b/src/test/java/org/dita/dost/platform/FileGeneratorTest.java
@@ -7,16 +7,13 @@
  */
 package org.dita.dost.platform;
 
+import static java.util.Arrays.*;
+import static javax.xml.XMLConstants.NULL_NS_URI;
 import static org.apache.commons.io.FileUtils.*;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.platform.PluginParser.FEATURE_ELEM;
-import static org.junit.Assert.assertEquals;
-import static java.util.Arrays.*;
 import static org.dita.dost.util.XMLUtils.*;
-import static javax.xml.XMLConstants.NULL_NS_URI;
-
-import org.dita.dost.TestUtils;
-import org.dita.dost.log.DITAOTLogger;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +23,10 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.dita.dost.TestUtils;
+import org.dita.dost.log.DITAOTLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,29 +36,21 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 public class FileGeneratorTest {
 
     final File resourceDir = TestUtils.getResourceDir(FileGeneratorTest.class);
     private File tempDir;
 
     private static File tempFile;
-    private final static Hashtable<String, List<Value>> features = new Hashtable<>();
+    private static final Hashtable<String, List<Value>> features = new Hashtable<>();
+
     static {
-        features.put("element", asList(
-                new Value(null, "foo"),
-                new Value(null, "bar"),
-                new Value(null, "baz")
-        ));
-        features.put("attribute", asList(
-                new Value(null, "foo"),
-                new Value(null, "bar"),
-                new Value(null, "baz")
-        ));
+        features.put("element", asList(new Value(null, "foo"), new Value(null, "bar"), new Value(null, "baz")));
+        features.put("attribute", asList(new Value(null, "foo"), new Value(null, "bar"), new Value(null, "baz")));
     }
-    private final static Map<String, Features> plugins = new HashMap<>();
+
+    private static final Map<String, Features> plugins = new HashMap<>();
+
     static {
         Document doc;
         try {
@@ -92,7 +84,10 @@ public class FileGeneratorTest {
         final FileGenerator f = new FileGenerator(features, plugins);
         f.generate(tempFile);
 
-        assertXMLEqual(new InputSource(new File(resourceDir, "exp" + File.separator + "dummy.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(resourceDir, "exp" + File.separator + "dummy.xml")
+                        .toURI()
+                        .toString()),
                 new InputSource(new File(tempDir, "dummy.xml").toURI().toString()));
     }
 
@@ -101,24 +96,29 @@ public class FileGeneratorTest {
         TestUtils.forceDelete(tempDir);
     }
 
-    private static abstract class AbstractAction implements IAction {
+    private abstract static class AbstractAction implements IAction {
         protected List<Value> inputs = new ArrayList<>();
         protected Map<String, String> params = new HashMap<>();
         protected Map<String, Features> features;
+
         @Override
         public void setInput(final List<Value> input) {
             inputs.addAll(input);
         }
+
         @Override
         public void addParam(final String name, final String value) {
             params.put(name, value);
         }
+
         @Override
         public void setFeatures(final Map<String, Features> features) {
             this.features = features;
         }
+
         @Override
         public abstract String getResult();
+
         @Override
         public void setLogger(final DITAOTLogger logger) {
             // NOOP
@@ -133,16 +133,19 @@ public class FileGeneratorTest {
             paramsExp.put("id", "element");
             paramsExp.put("behavior", this.getClass().getName());
             assertEquals(paramsExp, params);
-            final List<Value> inputExp = Arrays.asList(
-                    new Value(null, "foo"),
-                    new Value(null, "bar"),
-                    new Value(null, "baz"));
+            final List<Value> inputExp =
+                    Arrays.asList(new Value(null, "foo"), new Value(null, "bar"), new Value(null, "baz"));
             assertEquals(inputExp, inputs);
             assertEquals(FileGeneratorTest.plugins, features);
-            output.startElement(NULL_NS_URI, "foo", "foo", new AttributesBuilder().add("bar", "baz").build());
+            output.startElement(
+                    NULL_NS_URI,
+                    "foo",
+                    "foo",
+                    new AttributesBuilder().add("bar", "baz").build());
             output.characters(new char[] {'q', 'u', 'z'}, 0, 3);
             output.endElement(NULL_NS_URI, "foo", "foo");
         }
+
         @Override
         public String getResult() {
             throw new UnsupportedOperationException();
@@ -166,5 +169,4 @@ public class FileGeneratorTest {
             throw new UnsupportedOperationException();
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/IntegratorTest.java
+++ b/src/test/java/org/dita/dost/platform/IntegratorTest.java
@@ -17,15 +17,12 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
-
-import org.xml.sax.InputSource;
-
 import org.dita.dost.TestUtils;
-import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.util.Constants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.xml.sax.InputSource;
 
 public class IntegratorTest {
 
@@ -41,14 +38,13 @@ public class IntegratorTest {
 
     @Test
     public void testConvertMessage() {
-        assertEquals("The index term ''{1}'' uses both an index-see element and {0} element. Convert the index-see element to ''index-see-also''.",
-                Integrator.convertMessage("The index term '%2' uses both an index-see element and %1 element. Convert the index-see element to 'index-see-also'."));
-        assertEquals("{0} foo {1} bar {2}",
-                Integrator.convertMessage("%1 foo %2 bar %3"));
-        assertEquals("'{0}",
-                Integrator.convertMessage("{0}"));
-        assertEquals("foo bar baz",
-                Integrator.convertMessage("  foo  bar\nbaz  "));
+        assertEquals(
+                "The index term ''{1}'' uses both an index-see element and {0} element. Convert the index-see element to ''index-see-also''.",
+                Integrator.convertMessage(
+                        "The index term '%2' uses both an index-see element and %1 element. Convert the index-see element to 'index-see-also'."));
+        assertEquals("{0} foo {1} bar {2}", Integrator.convertMessage("%1 foo %2 bar %3"));
+        assertEquals("'{0}", Integrator.convertMessage("{0}"));
+        assertEquals("foo bar baz", Integrator.convertMessage("  foo  bar\nbaz  "));
     }
 
     @Test
@@ -89,26 +85,55 @@ public class IntegratorTest {
         i.setLogger(new TestUtils.TestLogger());
         i.execute();
 
-        final Properties expProperties = getProperties(new File(expDir, "lib" + File.separator + Integrator.class.getPackage().getName() + File.separator + Constants.GEN_CONF_PROPERTIES));
+        final Properties expProperties = getProperties(new File(
+                expDir,
+                "lib" + File.separator + Integrator.class.getPackage().getName() + File.separator
+                        + Constants.GEN_CONF_PROPERTIES));
         expProperties.setProperty("plugin.org.dita.base.dir", new File("plugins/org.dita.base").getPath());
         expProperties.setProperty("plugin.base.dir", "plugins/base");
         expProperties.setProperty("plugin.dummy.dir", "plugins/dummy");
-        final Properties actProperties = getProperties(new File(tempDir, "config" + File.separator + Integrator.class.getPackage().getName() + File.separator + Constants.GEN_CONF_PROPERTIES));
+        final Properties actProperties = getProperties(new File(
+                tempDir,
+                "config" + File.separator + Integrator.class.getPackage().getName() + File.separator
+                        + Constants.GEN_CONF_PROPERTIES));
         // supported_image_extensions needs to be tested separately
-        assertEquals(new HashSet<>(Arrays.asList(expProperties.getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS).split(";"))),
-                     new HashSet<>(Arrays.asList(expProperties.getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS).split(";"))));
+        assertEquals(
+                new HashSet<>(Arrays.asList(expProperties
+                        .getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS)
+                        .split(";"))),
+                new HashSet<>(Arrays.asList(expProperties
+                        .getProperty(CONF_SUPPORTED_IMAGE_EXTENSIONS)
+                        .split(";"))));
         expProperties.remove(CONF_SUPPORTED_IMAGE_EXTENSIONS);
         actProperties.remove(CONF_SUPPORTED_IMAGE_EXTENSIONS);
         assertEquals(expProperties, actProperties);
 
-        assertXMLEqual(new InputSource(new File(expDir, "build.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "build.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "build.xml").toURI().toString()));
-        assertXMLEqual(new InputSource(new File(expDir, "catalog.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "catalog.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "catalog.xml").toURI().toString()));
-        assertXMLEqual(new InputSource(new File(expDir, "xsl" + File.separator + "shell.xsl").toURI().toString()),
-                new InputSource(new File(tempDir, "xsl" + File.separator + "shell.xsl").toURI().toString()));
-        assertXMLEqual(new InputSource(new File(expDir, "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator + "shell.xsl").toURI().toString()),
-                new InputSource(new File(tempDir, "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator + "shell.xsl").toURI().toString()));
+        assertXMLEqual(
+                new InputSource(new File(expDir, "xsl" + File.separator + "shell.xsl")
+                        .toURI()
+                        .toString()),
+                new InputSource(new File(tempDir, "xsl" + File.separator + "shell.xsl")
+                        .toURI()
+                        .toString()));
+        assertXMLEqual(
+                new InputSource(new File(
+                                expDir,
+                                "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator
+                                        + "shell.xsl")
+                        .toURI()
+                        .toString()),
+                new InputSource(new File(
+                                tempDir,
+                                "plugins" + File.separator + "dummy" + File.separator + "xsl" + File.separator
+                                        + "shell.xsl")
+                        .toURI()
+                        .toString()));
     }
 
     @Test(expected = UncheckedIOException.class)
@@ -142,5 +167,4 @@ public class IntegratorTest {
     public void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/PluginParserTest.java
+++ b/src/test/java/org/dita/dost/platform/PluginParserTest.java
@@ -7,17 +7,15 @@
  */
 package org.dita.dost.platform;
 
-import static org.junit.Assert.*;
 import static java.util.Arrays.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-
 import org.dita.dost.TestUtils;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,8 +35,7 @@ public class PluginParserTest {
         final Features f = p.getFeatures();
         assertEquals(
                 Arrays.asList(
-                        new Value("dummy", "xsl/shell_template.xsl"),
-                        new Value("dummy", "xsl/shell2_template.xsl")),
+                        new Value("dummy", "xsl/shell_template.xsl"), new Value("dummy", "xsl/shell2_template.xsl")),
                 f.getAllTemplates());
     }
 
@@ -49,9 +46,9 @@ public class PluginParserTest {
         exp.put("foo", true);
         exp.put("bar", true);
         exp.put("baz", false);
-        for (final Iterator<PluginRequirement> i = f.getRequireListIter(); i.hasNext();) {
+        for (final Iterator<PluginRequirement> i = f.getRequireListIter(); i.hasNext(); ) {
             final PluginRequirement r = i.next();
-            for (final Iterator<String> ps = r.getPlugins(); ps.hasNext();) {
+            for (final Iterator<String> ps = r.getPlugins(); ps.hasNext(); ) {
                 final String p = ps.next();
                 assertTrue(exp.containsKey(p));
                 assertEquals(exp.get(p), r.getRequired());
@@ -78,19 +75,22 @@ public class PluginParserTest {
     @Test
     public void testFileValueFeature() {
         final Features f = p.getFeatures();
-        assertEquals(asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
+        assertEquals(
+                asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
                 f.getFeature("type_file"));
-        assertEquals(asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
+        assertEquals(
+                asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
                 f.getFeature("multiple_type_file"));
     }
 
     @Test
     public void testFileFeature() {
         final Features f = p.getFeatures();
-        assertEquals(asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
+        assertEquals(
+                asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
                 f.getFeature("file"));
-        assertEquals(asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
+        assertEquals(
+                asList(new File(resourceDir, "foo").toString(), new File(resourceDir, "bar").toString()),
                 f.getFeature("multiple_file"));
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/PluginRequirementTest.java
+++ b/src/test/java/org/dita/dost/platform/PluginRequirementTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import org.junit.Test;
 
 public class PluginRequirementTest {
@@ -29,7 +28,8 @@ public class PluginRequirementTest {
         try {
             pr.addPlugins(null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -45,12 +45,11 @@ public class PluginRequirementTest {
         pr.addPlugins("foo | bar | baz");
 
         final List<String> act = new ArrayList<>();
-        for (final Iterator<String> i = pr.getPlugins(); i.hasNext();) {
+        for (final Iterator<String> i = pr.getPlugins(); i.hasNext(); ) {
             act.add(i.next());
         }
 
-        assertArrayEquals(new String[] {"foo ", " bar ", " baz"},
-                act.toArray(new String[0]));
+        assertArrayEquals(new String[] {"foo ", " bar ", " baz"}, act.toArray(new String[0]));
     }
 
     @Test
@@ -69,5 +68,4 @@ public class PluginRequirementTest {
         pr.addPlugins("foo | bar | baz");
         assertEquals("[foo ,  bar ,  baz]", pr.toString());
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/SemVerMatchTest.java
+++ b/src/test/java/org/dita/dost/platform/SemVerMatchTest.java
@@ -8,11 +8,11 @@
 
 package org.dita.dost.platform;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 public class SemVerMatchTest {
 
@@ -31,54 +31,39 @@ public class SemVerMatchTest {
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 2, 4)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 2, 4)),
                 new SemVerMatch("1.2.3"));
     }
 
     @Test
     public void testXRangeConstructor() {
         //    * := >=0.0.0 (Any version satisfies)
-        assertEquals(
-                new SemVerMatch(
-                        new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        null
-                ),
-                new SemVerMatch("*"));
+        assertEquals(new SemVerMatch(new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0), null), new SemVerMatch("*"));
         //        1.x := >=1.0.0 <2.0.0 (Matching major version)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 new SemVerMatch("1.x"));
         //        1.2.x := >=1.2.0 <1.3.0 (Matching major and minor versions)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)),
                 new SemVerMatch("1.2.x"));
         //        "" (empty string) := * := >=0.0.0
-        assertEquals(
-                new SemVerMatch(
-                        new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        null
-                ),
-                new SemVerMatch("*"));
+        assertEquals(new SemVerMatch(new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0), null), new SemVerMatch("*"));
         //        1 := 1.x.x := >=1.0.0 <2.0.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 new SemVerMatch("1"));
         //        1.2 := 1.2.x := >=1.2.0 <1.3.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)),
                 new SemVerMatch("1.2"));
     }
 
@@ -88,51 +73,45 @@ public class SemVerMatchTest {
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)),
                 new SemVerMatch("~1.2.3"));
         //        ~1.2 := >=1.2.0 <1.(2+1).0 := >=1.2.0 <1.3.0 (Same as 1.2.x)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)),
                 new SemVerMatch("~1.2"));
         //        ~1 := >=1.0.0 <(1+1).0.0 := >=1.0.0 <2.0.0 (Same as 1.x)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 new SemVerMatch("~1"));
         //        ~0.2.3 := >=0.2.3 <0.(2+1).0 := >=0.2.3 <0.3.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 2, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)),
                 new SemVerMatch("~0.2.3"));
         //        ~0.2 := >=0.2.0 <0.(2+1).0 := >=0.2.0 <0.3.0 (Same as 0.2.x)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 2, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)),
                 new SemVerMatch("~0.2"));
         //        ~0 := >=0.0.0 <(0+1).0.0 := >=0.0.0 <1.0.0 (Same as 0.x)
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)),
                 new SemVerMatch("~0"));
         //        ~1.2.3-beta.2 := >=1.2.3-beta.2 <1.3.0
-//        assertEquals(
-//                new SemVerMatch(
-//                        new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
-//                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
-//                ),
-//                new SemVerMatch("~1.2.3-beta.2"));
+        //        assertEquals(
+        //                new SemVerMatch(
+        //                        new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
+        //                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 3, 0)
+        //                ),
+        //                new SemVerMatch("~1.2.3-beta.2"));
     }
 
     @Test
@@ -142,72 +121,64 @@ public class SemVerMatchTest {
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 actual1);
         //        ^0.2.3 := >=0.2.3 <0.3.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 2, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 3, 0)),
                 new SemVerMatch("^0.2.3"));
         //        ^0.0.3 := >=0.0.3 <0.0.4
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 3),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 0, 4)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 0, 4)),
                 new SemVerMatch("^0.0.3"));
         //        ^1.2.3-beta.2 := >=1.2.3-beta.2 <2.0.0
-//        assertEquals(
-//                new SemVerMatch(
-//                        new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
-//                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-//                ),
-//                new SemVerMatch("1.2.3-beta.2"));
+        //        assertEquals(
+        //                new SemVerMatch(
+        //                        new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 3),
+        //                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
+        //                ),
+        //                new SemVerMatch("1.2.3-beta.2"));
         //        ^0.0.3-beta := >=0.0.3-beta <0.0.4
-//        assertEquals(
-//                new SemVerMatch(
-//                        new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 3),
-//                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 0, 4)
-//                ),
-//                new SemVerMatch("^0.0.3-beta"));
+        //        assertEquals(
+        //                new SemVerMatch(
+        //                        new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 3),
+        //                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 0, 4)
+        //                ),
+        //                new SemVerMatch("^0.0.3-beta"));
         //        ^1.2.x := >=1.2.0 <2.0.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 2, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 new SemVerMatch("^1.2.x"));
         //        ^0.0.x := >=0.0.0 <0.1.0
         final SemVerMatch actual = new SemVerMatch("^0.0.x");
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 1, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 1, 0)),
                 actual);
         //        ^0.0 := >=0.0.0 <0.1.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 1, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 0, 1, 0)),
                 new SemVerMatch("^0.0"));
         //        ^1.x := >=1.0.0 <2.0.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 1, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 2, 0, 0)),
                 new SemVerMatch("^1.x"));
         //        ^0.x := >=0.0.0 <1.0.0
         assertEquals(
                 new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)
-                ),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)),
                 new SemVerMatch("^0.x"));
     }
 
@@ -221,18 +192,13 @@ public class SemVerMatchTest {
 
     @Test
     public void testContains() {
-        assertTrue(
-                new SemVerMatch(
-                    new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                    new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)
-                )
-                .contains(new SemVer(0, 1, 0)));
-        assertFalse(
-                new SemVerMatch(
+        assertTrue(new SemVerMatch(
                         new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
-                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0)
-                )
-                        .contains(new SemVer(2, 0, 0)));
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0))
+                .contains(new SemVer(0, 1, 0)));
+        assertFalse(new SemVerMatch(
+                        new SemVerMatch.Range(SemVerMatch.Match.GE, 0, 0, 0),
+                        new SemVerMatch.Range(SemVerMatch.Match.LT, 1, 0, 0))
+                .contains(new SemVer(2, 0, 0)));
     }
-
 }

--- a/src/test/java/org/dita/dost/platform/SemVerTest.java
+++ b/src/test/java/org/dita/dost/platform/SemVerTest.java
@@ -8,12 +8,11 @@
 
 package org.dita.dost.platform;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class SemVerTest {
 
@@ -61,5 +60,4 @@ public class SemVerTest {
         assertEquals(1, new SemVer("1.3.0").compareTo(new SemVer("1.2.3")));
         assertEquals(1, new SemVer("2.0.0").compareTo(new SemVer("1.2.3")));
     }
-
 }

--- a/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectBuilderTest.java
@@ -12,33 +12,29 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class ProjectBuilderTest {
 
     @Parameters(name = "{0}")
     public static Collection<String[]> data() {
-        return Arrays.asList(new String[][]{
-                {"simple"}, {"common"}, {"product"}, {"root"}, {"minimal"}, {"multiple"}
-        });
+        return Arrays.asList(new String[][] {{"simple"}, {"common"}, {"product"}, {"root"}, {"minimal"}, {"multiple"}});
     }
 
     private final String name;
     private final ObjectReader jsonReader = new ObjectMapper()
             .readerFor(ProjectBuilder.class)
             .with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
-    private final ObjectReader yamlReader = new YAMLMapper()
-            .readerFor(ProjectBuilder.class)
-            .with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+    private final ObjectReader yamlReader =
+            new YAMLMapper().readerFor(ProjectBuilder.class).with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
     public ProjectBuilderTest(final String name) {
         this.name = name;
@@ -46,14 +42,16 @@ public class ProjectBuilderTest {
 
     @Test()
     public void deserializeJson() throws IOException {
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/" + name + ".json")) {
+        try (InputStream in =
+                getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/" + name + ".json")) {
             jsonReader.readValue(in);
         }
     }
 
     @Test
     public void deserializeYaml() throws IOException {
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/" + name + ".yaml")) {
+        try (InputStream in =
+                getClass().getClassLoader().getResourceAsStream("org/dita/dost/project/" + name + ".yaml")) {
             yamlReader.readValue(in);
         }
     }

--- a/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectFactoryTest.java
@@ -8,12 +8,9 @@
 
 package org.dita.dost.project;
 
-import org.dita.dost.project.Project.Context;
-import org.dita.dost.project.Project.Deliverable;
-import org.dita.dost.project.Project.Publication;
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URI;
@@ -21,10 +18,12 @@ import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import org.dita.dost.project.Project.Context;
+import org.dita.dost.project.Project.Deliverable;
+import org.dita.dost.project.Project.Publication;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.SAXException;
 
 public class ProjectFactoryTest {
 
@@ -39,71 +38,43 @@ public class ProjectFactoryTest {
     public void resolveReferences_deliverable() {
         final Project src = new Project(
                 singletonList(
-                        new Deliverable(
-                                null,
-                                null,
-                                null,
-                                null,
-                                new Publication(
-                                        null,
-                                        null,
-                                        "id",
-                                        null,
-                                        null,
-                                        null)
-                        )
-                ),
+                        new Deliverable(null, null, null, null, new Publication(null, null, "id", null, null, null))),
                 null,
-                singletonList(
-                        new Publication(
-                                null,
-                                "id",
-                                null,
-                                null,
-                                null,
-                                null)
-                ),
-                null
-        );
+                singletonList(new Publication(null, "id", null, null, null, null)),
+                null);
         ProjectFactory.resolveReferences(src);
     }
 
     @Test
     public void resolveReferences_publicationRefWithParam() {
         final Project src = new Project(
-                singletonList(
-                        new Deliverable(
-                                null,
-                                null,
-                                null,
-                                null,
-                                new Publication(
-                                        null,
-                                        null,
-                                        "id",
-                                        null,
-                                        List.of(new Publication.Param("different", "override", null, null)),
-                                        null)
-                        )
-                ),
-                null,
-                singletonList(
+                singletonList(new Deliverable(
+                        null,
+                        null,
+                        null,
+                        null,
                         new Publication(
+                                null,
                                 null,
                                 "id",
                                 null,
-                                null,
-                                Arrays.asList(
-                                        new Publication.Param("different", "base", null, null),
-                                        new Publication.Param("same", "base", null, null)
-                                ),
-                                null)
-                ),
-                null
-        );
+                                List.of(new Publication.Param("different", "override", null, null)),
+                                null))),
+                null,
+                singletonList(new Publication(
+                        null,
+                        "id",
+                        null,
+                        null,
+                        Arrays.asList(
+                                new Publication.Param("different", "base", null, null),
+                                new Publication.Param("same", "base", null, null)),
+                        null)),
+                null);
         final Project act = ProjectFactory.resolveReferences(src);
 
-        final List<Publication.Param> params = new ArrayList<>(act.deliverables().get(0).publication().params());
+        final List<Publication.Param> params =
+                new ArrayList<>(act.deliverables().get(0).publication().params());
         params.sort(Comparator.comparing(Publication.Param::name));
         assertEquals(2, params.size());
         assertEquals("different", params.get(0).name());
@@ -115,96 +86,92 @@ public class ProjectFactoryTest {
     @Test
     public void resolveReferences_context() {
         final Project src = new Project(
-                singletonList(
-                        new Deliverable(
-                                null,
-                                null,
-                                new Context(
-                                        null,
-                                        null,
-                                        "id",
-                                        null,
-                                        null),
-                                null,
-                                null
-                        )
-                ),
+                singletonList(new Deliverable(null, null, new Context(null, null, "id", null, null), null, null)),
                 null,
                 null,
-                singletonList(
-                        new Context(
-                                null,
-                                "id",
-                                null,
-                                null,
-                                null)
-                )
-        );
+                singletonList(new Context(null, "id", null, null, null)));
         ProjectFactory.resolveReferences(src);
     }
 
     @Test(expected = RuntimeException.class)
     public void resolveReferences_notFound() {
         final Project src = new Project(
-                singletonList(
-                        new Deliverable(
-                                null,
-                                null,
-                                null,
-                                null,
-                                new Publication(
-                                        null,
-                                        null,
-                                        "missing",
-                                        null,
-                                        null,
-                                        null)
-                        )
-                ),
+                singletonList(new Deliverable(
+                        null, null, null, null, new Publication(null, null, "missing", null, null, null))),
                 null,
                 Collections.emptyList(),
-                null
-        );
+                null);
         final Project act = ProjectFactory.resolveReferences(src);
         assertEquals("id", act.deliverables().get(0).publication().id());
     }
 
     @Test
     public void read() throws IOException, URISyntaxException, SAXException {
-        final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/simple.json").toURI();
+        final URI file = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/simple.json")
+                .toURI();
         final Project project = factory.load(file);
         assertEquals(1, project.deliverables().size());
-        assertTrue(project.deliverables().get(0).context().inputs().inputs().get(0).href().isAbsolute());
+        assertTrue(project.deliverables()
+                .get(0)
+                .context()
+                .inputs()
+                .inputs()
+                .get(0)
+                .href()
+                .isAbsolute());
         assertTrue(project.includes().isEmpty());
     }
 
     @Test
     public void read_product() throws IOException, URISyntaxException {
-        for (String extension : new String[]{"xml", "yaml", "json"}) {
+        for (String extension : new String[] {"xml", "yaml", "json"}) {
             final String path = String.format("org/dita/dost/project/product.%s", extension);
             final URI file = getClass().getClassLoader().getResource(path).toURI();
             final Project project = factory.load(file);
             assertEquals(1, project.deliverables().size());
-            assertTrue(project.deliverables().get(0).context().inputs().inputs().get(0).href().isAbsolute());
+            assertTrue(project.deliverables()
+                    .get(0)
+                    .context()
+                    .inputs()
+                    .inputs()
+                    .get(0)
+                    .href()
+                    .isAbsolute());
             assertEquals(3, project.deliverables().get(0).publication().params().size());
-            final Map<String, Project.Publication.Param> params = project.deliverables().get(0).publication().params().stream()
-                    .collect(Collectors.toMap(Publication.Param::name, Function.identity()));
+            final Map<String, Project.Publication.Param> params =
+                    project.deliverables().get(0).publication().params().stream()
+                            .collect(Collectors.toMap(Publication.Param::name, Function.identity()));
             assertEquals("NO", params.get("args.gen.task.lbl").value());
         }
     }
 
     @Test
     public void readMultiple() throws IOException, URISyntaxException, SAXException {
-        final URI file = getClass().getClassLoader().getResource("org/dita/dost/project/multiple.json").toURI();
+        final URI file = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/multiple.json")
+                .toURI();
         final Project project = factory.load(file);
         assertEquals(1, project.deliverables().size());
-        assertTrue(project.deliverables().get(0).context().inputs().inputs().get(0).href().isAbsolute());
+        assertTrue(project.deliverables()
+                .get(0)
+                .context()
+                .inputs()
+                .inputs()
+                .get(0)
+                .href()
+                .isAbsolute());
         assertTrue(project.includes().isEmpty());
     }
 
     @Test
     public void deserializeJsonRoot() throws IOException, URISyntaxException, SAXException {
-        final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/root.json").toURI();
+        final URI input = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/root.json")
+                .toURI();
         final Project project = factory.load(input);
         assertEquals(1, project.deliverables().size());
         assertEquals(2, project.includes().size());
@@ -212,17 +179,23 @@ public class ProjectFactoryTest {
 
     @Test
     public void deserializeJsonProduct() throws IOException, URISyntaxException, SAXException {
-        final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/product.json").toURI();
+        final URI input = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/product.json")
+                .toURI();
         final Project project = factory.load(input);
         assertEquals(1, project.deliverables().size());
         assertEquals(1, project.publications().size());
-        assertEquals("common-sitePub2", project.deliverables().get(0).publication().id());
+        assertEquals(
+                "common-sitePub2", project.deliverables().get(0).publication().id());
     }
 
     @Test(expected = RuntimeException.class)
     public void deserializeJsonRecursive() throws IOException, URISyntaxException, SAXException {
-        final URI input = getClass().getClassLoader().getResource("org/dita/dost/project/recursive.json").toURI();
+        final URI input = getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/recursive.json")
+                .toURI();
         factory.load(input);
     }
-
 }

--- a/src/test/java/org/dita/dost/project/ProjectTest.java
+++ b/src/test/java/org/dita/dost/project/ProjectTest.java
@@ -11,6 +11,9 @@ package org.dita.dost.project;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
 import org.dita.dost.project.Project.Context;
 import org.dita.dost.project.Project.Deliverable.Inputs;
 import org.dita.dost.project.Project.Deliverable.Inputs.Input;
@@ -19,15 +22,10 @@ import org.dita.dost.project.Project.Deliverable.Profile.DitaVal;
 import org.dita.dost.project.Project.Publication;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-
 public class ProjectTest {
 
-    private final ObjectWriter jsonWriter = new ObjectMapper()
-            .writerFor(Project.class)
-            .with(SerializationFeature.INDENT_OUTPUT);
+    private final ObjectWriter jsonWriter =
+            new ObjectMapper().writerFor(Project.class).with(SerializationFeature.INDENT_OUTPUT);
 
     @Test
     public void serializeJsonSimple() throws IOException {
@@ -37,41 +35,38 @@ public class ProjectTest {
 
     @Test
     public void serializeJsonRoot() throws IOException {
-        final Project project = new Project(
-                null,
-                Arrays.asList(
-                        new Project.ProjectRef(URI.create("simple.json"))
-                ),
-                null,
-                null
-        );
+        final Project project =
+                new Project(null, Arrays.asList(new Project.ProjectRef(URI.create("simple.json"))), null, null);
         jsonWriter.writeValueAsString(project);
     }
 
     private Project getProject() {
         return new Project(
-                Arrays.asList(
-                        new Project.Deliverable(
-                                "name",
-                                "id",
-                                new Context("Site", "site", null,
-                                        new Inputs(//"inputs-name",
-//                        "inputs-ref",
-                                                Arrays.asList(new Input(URI.create("site.ditamap")))),
-                                        new Profile(//"profile-name",
-//                        "profile-ref",
-                                                Arrays.asList(new DitaVal(URI.create("site.ditaval"))))
-                                ),
-                                URI.create("./site"),
-                                new Publication("Site", "site", null, "html5", Arrays.asList(
+                Arrays.asList(new Project.Deliverable(
+                        "name",
+                        "id",
+                        new Context(
+                                "Site",
+                                "site",
+                                null,
+                                new Inputs( // "inputs-name",
+                                        //                        "inputs-ref",
+                                        Arrays.asList(new Input(URI.create("site.ditamap")))),
+                                new Profile( // "profile-name",
+                                        //                        "profile-ref",
+                                        Arrays.asList(new DitaVal(URI.create("site.ditaval"))))),
+                        URI.create("./site"),
+                        new Publication(
+                                "Site",
+                                "site",
+                                null,
+                                "html5",
+                                Arrays.asList(
                                         new Publication.Param("args.gen.task.lbl", "YES", null, null),
-                                        new Publication.Param("args.rellinks", "noparent", null, null)
-                                ), null)
-                        )
-                ),
+                                        new Publication.Param("args.rellinks", "noparent", null, null)),
+                                null))),
                 null,
                 null,
-                null
-        );
+                null);
     }
 }

--- a/src/test/java/org/dita/dost/project/XmlReaderTest.java
+++ b/src/test/java/org/dita/dost/project/XmlReaderTest.java
@@ -8,16 +8,15 @@
 
 package org.dita.dost.project;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.SAXException;
 
 public class XmlReaderTest {
 
@@ -61,7 +60,10 @@ public class XmlReaderTest {
 
     @Test
     public void deserializeXmlCommon() throws IOException, URISyntaxException, SAXException {
-        final ProjectBuilder project = xmlReader.read(getClass().getClassLoader().getResource("org/dita/dost/project/common.xml").toURI());
+        final ProjectBuilder project = xmlReader.read(getClass()
+                .getClassLoader()
+                .getResource("org/dita/dost/project/common.xml")
+                .toURI());
         assertTrue(project.deliverables.isEmpty());
         assertTrue(project.includes.isEmpty());
         assertEquals(1, project.contexts.size());

--- a/src/test/java/org/dita/dost/reader/CopyToReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/CopyToReaderTest.java
@@ -7,7 +7,16 @@
  */
 package org.dita.dost.reader;
 
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.net.URI;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
@@ -19,17 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
-
-import java.io.File;
-import java.net.URI;
-import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
-
-import static org.junit.Assert.assertEquals;
 
 public class CopyToReaderTest {
 
@@ -62,8 +60,7 @@ public class CopyToReaderTest {
                 inputFile.resolve("direct.dita"), inputFile.resolve("topic.dita"),
                 inputFile.resolve("keyref.dita"), inputFile.resolve("topic.dita"),
                 inputFile.resolve("b.dita"), inputFile.resolve("a.dita"),
-                inputFile.resolve("skip-b.dita"), inputFile.resolve("skip-a.dita")
-        );
+                inputFile.resolve("skip-b.dita"), inputFile.resolve("skip-a.dita"));
 
         assertEquals(exp, reader.getCopyToMap());
         assertEquals(0, logger.getMessages().size());
@@ -75,9 +72,8 @@ public class CopyToReaderTest {
         reader.setCurrentFile(inputFile);
         parser.parse(inputFile.toString());
 
-        final Map<URI, URI> exp = ImmutableMap.of(
-                inputFile.resolve("keyref-target.dita"), inputFile.resolve("keyref-source-a.dita")
-        );
+        final Map<URI, URI> exp =
+                ImmutableMap.of(inputFile.resolve("keyref-target.dita"), inputFile.resolve("keyref-source-a.dita"));
 
         assertEquals(exp, reader.getCopyToMap());
         assertEquals(0, logger.getMessages().size());
@@ -89,13 +85,16 @@ public class CopyToReaderTest {
         reader.setCurrentFile(inputFile);
         parser.parse(inputFile.toString());
 
-        final Map<URI, URI> exp = ImmutableMap.of(
-                inputFile.resolve("target.dita"), inputFile.resolve("source-a.dita")
-        );
+        final Map<URI, URI> exp = ImmutableMap.of(inputFile.resolve("target.dita"), inputFile.resolve("source-a.dita"));
 
         assertEquals(exp, reader.getCopyToMap());
-        final List<Message> expLog = Arrays.asList(
-                new Message(WARN, MessageFormat.format(MessageUtils.getMessage("DOTX065W").toString(), "source-b.dita", new File(srcDir, "target.dita").toURI()), null));
+        final List<Message> expLog = Arrays.asList(new Message(
+                WARN,
+                MessageFormat.format(
+                        MessageUtils.getMessage("DOTX065W").toString(),
+                        "source-b.dita",
+                        new File(srcDir, "target.dita").toURI()),
+                null));
         assertEquals(expLog, logger.getMessages());
     }
 }

--- a/src/test/java/org/dita/dost/reader/IndexTermReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/IndexTermReaderTest.java
@@ -17,7 +17,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-
+import org.dita.dost.TestUtils;
+import org.dita.dost.index.IndexTerm;
+import org.dita.dost.index.IndexTermCollection;
+import org.dita.dost.index.IndexTermTarget;
 import org.dita.dost.util.XMLUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -25,14 +28,10 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-import org.dita.dost.TestUtils;
-import org.dita.dost.index.IndexTerm;
-import org.dita.dost.index.IndexTermCollection;
-import org.dita.dost.index.IndexTermTarget;
 
 /**
  * IndexTermReader unit test.
- * 
+ *
  * @author Jarno Elovirta
  */
 public class IndexTermReaderTest {
@@ -74,11 +73,11 @@ public class IndexTermReaderTest {
         final List<IndexTerm> exp = new ArrayList<>();
         exp.add(generateIndexTerms(target, "Primary", "Secondary", "Tertiary"));
         exp.add(generateIndexTerms(target, "Primary normalized", "Secondary normalized", "Tertiary normalized"));
-        exp.add(generateIndexTerms(target, " Primary unnormalized ", " Secondary unnormalized ", " Tertiary unnormalized "));
+        exp.add(generateIndexTerms(
+                target, " Primary unnormalized ", " Secondary unnormalized ", " Tertiary unnormalized "));
         exp.add(generateIndexTermErrorCondition(target, "Test empty title"));
 
-        assertEquals(new HashSet<>(exp),
-                new HashSet<>(act));
+        assertEquals(new HashSet<>(exp), new HashSet<>(act));
     }
 
     @After
@@ -88,7 +87,7 @@ public class IndexTermReaderTest {
 
     private IndexTerm generateIndexTerms(final File target, final String... texts) {
         final LinkedList<IndexTerm> stack = new LinkedList<>();
-        for (final String text: texts) {
+        for (final String text : texts) {
             final IndexTerm primary = generateIndexTerm(target, text);
             if (!stack.isEmpty()) {
                 stack.getLast().addSubTerm(primary);
@@ -110,7 +109,7 @@ public class IndexTermReaderTest {
         }
         return primary;
     }
-    
+
     private IndexTerm generateIndexTermErrorCondition(final File target, final String text) {
         final IndexTerm primary = new IndexTerm();
         primary.setTermName(text);
@@ -123,5 +122,4 @@ public class IndexTermReaderTest {
         }
         return primary;
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
+++ b/src/test/java/org/dita/dost/reader/KeydefFilterTest.java
@@ -7,27 +7,26 @@
  */
 package org.dita.dost.reader;
 
-import static org.junit.Assert.assertEquals;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-
+import org.dita.dost.TestUtils;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
-import org.dita.dost.TestUtils;
 
 public class KeydefFilterTest {
 
     public static KeydefFilter reader;
     private static XMLReader parser;
-    
+
     private static final File baseDir = TestUtils.getResourceDir(KeydefFilterTest.class);
     private static final File srcDir = new File(baseDir, "src");
     private static final File inputDir = new File(srcDir, "maps");
@@ -35,7 +34,7 @@ public class KeydefFilterTest {
     private static File tempDir;
 
     @Before
-    public void setUp() throws Exception{
+    public void setUp() throws Exception {
         tempDir = TestUtils.createTempDir(KeydefFilterTest.class);
         File ditaDir = new File("src" + File.separator + "main").getAbsoluteFile();
 
@@ -44,9 +43,9 @@ public class KeydefFilterTest {
         reader.setCurrentFile(rootFile.toURI());
         reader.setCurrentDir(inputDir.toURI());
         reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
-        
+
         reader.setContentHandler(new DefaultHandler());
-        
+
         parser = XMLUtils.getXMLReader();
         CatalogUtils.setDitaDir(ditaDir);
         parser.setEntityResolver(CatalogUtils.getCatalogResolver());
@@ -54,18 +53,58 @@ public class KeydefFilterTest {
     }
 
     @Test
-    public void testParse() throws Exception{
+    public void testParse() throws Exception {
         parser.parse(new File(rootFile.getPath()).toURI().toString());
-        
+
         final Map<String, KeyDef> expKeyDefMap = new HashMap<>();
-        expKeyDefMap.put("target_topic_1", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null,null));
-        expKeyDefMap.put("target_topic_2", new KeyDef("target_topic_2", new File(srcDir, "topics" + File.separator + "target-topic-c.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null,null));
-        expKeyDefMap.put("target_topic_3", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null,null));
-        expKeyDefMap.put("target_topic_4", new KeyDef("target_topic_1", new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(), ATTR_SCOPE_VALUE_LOCAL, null, null,null));
-        expKeyDefMap.put("peer", new KeyDef("peer", toURI("../topics/peer.xml"), ATTR_SCOPE_VALUE_PEER, null,null, null));
-        expKeyDefMap.put("external", new KeyDef("external", toURI("http://www.example.com/external.xml"), ATTR_SCOPE_VALUE_EXTERNAL, null, null,null));
-        
-        assertEquals(expKeyDefMap, reader.getKeysDMap());                
+        expKeyDefMap.put(
+                "target_topic_1",
+                new KeyDef(
+                        "target_topic_1",
+                        new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(),
+                        ATTR_SCOPE_VALUE_LOCAL,
+                        null,
+                        null,
+                        null));
+        expKeyDefMap.put(
+                "target_topic_2",
+                new KeyDef(
+                        "target_topic_2",
+                        new File(srcDir, "topics" + File.separator + "target-topic-c.xml").toURI(),
+                        ATTR_SCOPE_VALUE_LOCAL,
+                        null,
+                        null,
+                        null));
+        expKeyDefMap.put(
+                "target_topic_3",
+                new KeyDef(
+                        "target_topic_1",
+                        new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(),
+                        ATTR_SCOPE_VALUE_LOCAL,
+                        null,
+                        null,
+                        null));
+        expKeyDefMap.put(
+                "target_topic_4",
+                new KeyDef(
+                        "target_topic_1",
+                        new File(srcDir, "topics" + File.separator + "target-topic-a.xml").toURI(),
+                        ATTR_SCOPE_VALUE_LOCAL,
+                        null,
+                        null,
+                        null));
+        expKeyDefMap.put(
+                "peer", new KeyDef("peer", toURI("../topics/peer.xml"), ATTR_SCOPE_VALUE_PEER, null, null, null));
+        expKeyDefMap.put(
+                "external",
+                new KeyDef(
+                        "external",
+                        toURI("http://www.example.com/external.xml"),
+                        ATTR_SCOPE_VALUE_EXTERNAL,
+                        null,
+                        null,
+                        null));
+
+        assertEquals(expKeyDefMap, reader.getKeysDMap());
     }
-    
 }

--- a/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
@@ -7,8 +7,13 @@
  */
 package org.dita.dost.reader;
 
+import static org.dita.dost.TestUtils.assertXMLEqual;
+
+import java.io.File;
+import java.io.IOException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
-import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
@@ -17,13 +22,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
 
 public class MapMetaReaderTest {
 
@@ -34,10 +32,10 @@ public class MapMetaReaderTest {
     private static MapMetaReader reader;
 
     @BeforeClass
-    public static void setUp() throws Exception{
+    public static void setUp() throws Exception {
         CatalogUtils.setDitaDir(new File("src" + File.separator + "main").getAbsoluteFile());
         tempDir = TestUtils.createTempDir(MapMetaReaderTest.class);
-        for (final File f: srcDir.listFiles()) {
+        for (final File f : srcDir.listFiles()) {
             TestUtils.normalize(f, new File(tempDir, f.getName()));
         }
 
@@ -50,17 +48,15 @@ public class MapMetaReaderTest {
     }
 
     @Test
-    public void testRead() throws SAXException, IOException, ParserConfigurationException{
+    public void testRead() throws SAXException, IOException, ParserConfigurationException {
         final DocumentBuilder db = XMLUtils.getDocumentBuilder();
         db.setEntityResolver(CatalogUtils.getCatalogResolver());
 
-        assertXMLEqual(db.parse(new File(expDir, "test.ditamap")),
-                db.parse(new File(tempDir, "test.ditamap")));
+        assertXMLEqual(db.parse(new File(expDir, "test.ditamap")), db.parse(new File(tempDir, "test.ditamap")));
     }
 
     @AfterClass
     public static void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeMapParserTest.java
@@ -7,6 +7,16 @@
  */
 package org.dita.dost.reader;
 
+import static org.dita.dost.TestUtils.assertXMLEqual;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.store.CacheStore;
 import org.dita.dost.store.StreamStore;
@@ -18,17 +28,6 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
-
 public class MergeMapParserTest {
 
     final File resourceDir = TestUtils.getResourceDir(MergeMapParserTest.class);
@@ -36,8 +35,7 @@ public class MergeMapParserTest {
     private final File expDir = new File(resourceDir, "exp");
 
     @Before
-    public void setUp() {
-    }
+    public void setUp() {}
 
     @Test
     public void testReadStringString() throws SAXException, IOException {
@@ -49,7 +47,8 @@ public class MergeMapParserTest {
         parser.setOutputStream(output);
         parser.read(new File(srcDir, "test.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(StandardCharsets.UTF_8));
-        assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
 
@@ -63,7 +62,8 @@ public class MergeMapParserTest {
         parser.setOutputStream(output);
         parser.read(new File(srcDir, "space in map name.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(StandardCharsets.UTF_8));
-        assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
 
@@ -78,7 +78,9 @@ public class MergeMapParserTest {
         parser.read(new File(srcDir, "testcomposite.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(StandardCharsets.UTF_8));
 
-        assertXMLEqual(new InputSource(new File(expDir, "mergedwithditasub.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(
+                        new File(expDir, "mergedwithditasub.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
 
@@ -93,7 +95,8 @@ public class MergeMapParserTest {
         parser.read(new File(srcDir, "testsubtopic.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(StandardCharsets.UTF_8));
 
-        assertXMLEqual(new InputSource(new File(expDir, "mergedsub.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "mergedsub.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
 
@@ -105,7 +108,7 @@ public class MergeMapParserTest {
         final CacheStore store = new CacheStore(tmpDir, new XMLUtils());
         final Job job = new Job(tmpDir, store);
         final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        for (String child : new String[]{"test.ditamap", "test.xml", "test2.xml"}) {
+        for (String child : new String[] {"test.ditamap", "test.xml", "test2.xml"}) {
             final Document doc = builder.parse(new File(srcDir, child));
             store.writeDocument(doc, new File(tmpDir, child).toURI());
         }
@@ -115,8 +118,8 @@ public class MergeMapParserTest {
         parser.setOutputStream(output);
         parser.read(new File(tmpDir, "test.ditamap").getAbsoluteFile(), srcDir.getAbsoluteFile());
         output.write("</wrapper>".getBytes(StandardCharsets.UTF_8));
-        assertXMLEqual(new InputSource(new File(expDir, "merged.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "merged.xml").toURI().toString()),
                 new InputSource(new ByteArrayInputStream(output.toByteArray())));
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
@@ -7,6 +7,20 @@
  */
 package org.dita.dost.reader;
 
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
 import org.dita.dost.TestUtils;
 import org.dita.dost.store.CacheStore;
 import org.dita.dost.store.StreamStore;
@@ -19,21 +33,6 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.DefaultHandler;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.URI;
-
-import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
 
 public class MergeTopicParserTest {
 
@@ -139,7 +138,8 @@ public class MergeTopicParserTest {
         store.writeDocument(doc, uri);
 
         parser.setOutput(new File(tmpDir, "test.xml"));
-        final Method method = MergeTopicParser.class.getDeclaredMethod("handleLocalDita", URI.class, AttributesImpl.class);
+        final Method method =
+                MergeTopicParser.class.getDeclaredMethod("handleLocalDita", URI.class, AttributesImpl.class);
         method.setAccessible(true);
 
         parser.parse("test.xml", tmpDir.getAbsoluteFile());
@@ -150,5 +150,4 @@ public class MergeTopicParserTest {
         assertEquals("#unique_7", val.toString());
         assertEquals("unique_7", util.getIdValue(new File(tmpDir, "test.jpg").toURI()));
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/SvgMetadataReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/SvgMetadataReaderTest.java
@@ -7,6 +7,11 @@
  */
 package org.dita.dost.reader;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.io.InputStream;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.ImageMetadataFilter;
 import org.junit.Before;
@@ -14,12 +19,6 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-
-import java.io.IOException;
-import java.io.InputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class SvgMetadataReaderTest {
 
@@ -40,7 +39,8 @@ public class SvgMetadataReaderTest {
 
     @Test
     public void testImageWithDoctype() throws IOException, SAXException {
-        try (final InputStream in = this.getClass().getResourceAsStream("/SvgMetadataReaderTest/SVG_example_markup_grid.svg")) {
+        try (final InputStream in =
+                this.getClass().getResourceAsStream("/SvgMetadataReaderTest/SVG_example_markup_grid.svg")) {
             reader.parse(new InputSource(in));
             final ImageMetadataFilter.Dimensions dimensions = svgMetadataReader.getDimensions();
             assertEquals("391", dimensions.width);
@@ -61,5 +61,4 @@ public class SvgMetadataReaderTest {
             assertNull(dimensions.horizontalDpi);
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
+++ b/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
@@ -7,6 +7,18 @@
  */
 package org.dita.dost.reader;
 
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.TestUtils.buildControlDocument;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
 import org.dita.dost.store.StreamStore;
@@ -17,19 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.util.Hashtable;
-import java.util.Map;
-
-import static junit.framework.TestCase.assertEquals;
-import static org.apache.commons.io.FileUtils.copyFile;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.TestUtils.buildControlDocument;
 
 public class TestConrefPushReader {
 
@@ -57,16 +56,20 @@ public class TestConrefPushReader {
 
         final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = pushReader.getPushMap();
         assertEquals(1, pushSet.entrySet().size());
-        final Hashtable<MoveKey, DocumentFragment> act = pushSet.values().iterator().next();
+        final Hashtable<MoveKey, DocumentFragment> act =
+                pushSet.values().iterator().next();
         assertXMLEqual(
                 toDocument(act.get(new MoveKey("#X/A", "pushbefore"))),
-                buildControlDocument("<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>before</cmd></step>"));
+                buildControlDocument(
+                        "<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>before</cmd></step>"));
         assertXMLEqual(
                 toDocument(act.get(new MoveKey("#X/B", "pushafter"))),
-                buildControlDocument("<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>after</cmd></step>"));
+                buildControlDocument(
+                        "<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>after</cmd></step>"));
         assertXMLEqual(
                 toDocument(act.get(new MoveKey("#X/C", "pushreplace"))),
-                buildControlDocument("<step class='- topic/li task/step ' id='C'><cmd class='- topic/ph task/cmd '>replace</cmd></step>"));
+                buildControlDocument(
+                        "<step class='- topic/li task/step ' id='C'><cmd class='- topic/ph task/cmd '>replace</cmd></step>"));
     }
 
     private Document toDocument(final DocumentFragment fragment) {
@@ -79,5 +82,4 @@ public class TestConrefPushReader {
     public void teardown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/TestDitaValReader.java
+++ b/src/test/java/org/dita/dost/reader/TestDitaValReader.java
@@ -7,8 +7,20 @@
  */
 package org.dita.dost.reader;
 
+import static java.util.Collections.emptySet;
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.xml.namespace.QName;
 import org.dita.dost.TestUtils;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.store.StreamStore;
@@ -20,20 +32,6 @@ import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.xml.namespace.QName;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptySet;
-import static javax.xml.XMLConstants.XML_NS_URI;
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.WARN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class TestDitaValReader {
 
     private static final QName PLATFORM = QName.valueOf("platform");
@@ -44,7 +42,6 @@ public class TestDitaValReader {
     private static final QName REV = QName.valueOf("rev");
     private static final QName LANG = new QName(XML_NS_URI, "lang", "xml");
     private static final QName CONFIDENTIALITY = new QName("http://www.cms.com/", "confidentiality");
-
 
     private final File resourceDir = TestUtils.getResourceDir(TestDitaValReader.class);
 
@@ -94,10 +91,11 @@ public class TestDitaValReader {
                 new FilterKey(PLATFORM, "windows"), Action.EXCLUDE,
                 new FilterKey(LANG, "fr"), Action.EXCLUDE,
                 new FilterKey(CONFIDENTIALITY, "confidential"), Action.EXCLUDE,
-                new FilterKey(QName.valueOf("default"), null), Action.INCLUDE
-        );
+                new FilterKey(QName.valueOf("default"), null), Action.INCLUDE);
         assertEquals(exp, act);
-        assertEquals(List.of(WARN), logger.getMessages().stream().map(msg -> msg.level).collect(Collectors.toList()));
+        assertEquals(
+                List.of(WARN),
+                logger.getMessages().stream().map(msg -> msg.level).collect(Collectors.toList()));
     }
 
     @Test
@@ -114,9 +112,7 @@ public class TestDitaValReader {
                 new FilterKey(LANG, "fr"), Action.EXCLUDE,
                 new FilterKey(CONFIDENTIALITY, "confidential"), Action.EXCLUDE,
                 new FilterKey(REV, "10"), Action.EXCLUDE,
-                new FilterKey(QName.valueOf("default"), null), Action.INCLUDE
-        );
+                new FilterKey(QName.valueOf("default"), null), Action.INCLUDE);
         assertEquals(exp, act);
     }
-
 }

--- a/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
+++ b/src/test/java/org/dita/dost/reader/TestGenListModuleReader.java
@@ -7,6 +7,21 @@
  */
 package org.dita.dost.reader;
 
+import static java.util.Collections.emptySet;
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.stripFragment;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.dita.dost.TestUtils;
 import org.dita.dost.log.MessageUtils;
@@ -24,22 +39,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.emptySet;
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.stripFragment;
-import static org.junit.Assert.*;
 
 public class TestGenListModuleReader {
 
@@ -80,21 +79,31 @@ public class TestGenListModuleReader {
     @Test
     public void startElement() throws SAXException {
         reader.startDocument();
-        reader.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
-                .add(ATTRIBUTE_NAME_ID, "abc")
-                .build());
+        reader.startElement(
+                NULL_NS_URI,
+                TOPIC_TOPIC.localName,
+                TOPIC_TOPIC.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                        .add(ATTRIBUTE_NAME_ID, "abc")
+                        .build());
     }
 
     @Test
     public void startElement_localImage() throws SAXException {
         reader.startDocument();
-        reader.startElement(NULL_NS_URI, TOPIC_IMAGE.localName, TOPIC_IMAGE.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
-                .add(ATTRIBUTE_NAME_HREF, "image.png")
-                .build());
+        reader.startElement(
+                NULL_NS_URI,
+                TOPIC_IMAGE.localName,
+                TOPIC_IMAGE.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
+                        .add(ATTRIBUTE_NAME_HREF, "image.png")
+                        .build());
         assertEquals(1, reader.getNonConrefCopytoTargets().size());
-        assertEquals(ATTR_FORMAT_VALUE_IMAGE, reader.getNonConrefCopytoTargets().iterator().next().format);
+        assertEquals(
+                ATTR_FORMAT_VALUE_IMAGE,
+                reader.getNonConrefCopytoTargets().iterator().next().format);
         assertEquals(
                 inputDir.toURI().resolve("image.png"),
                 reader.getNonConrefCopytoTargets().iterator().next().filename);
@@ -107,11 +116,15 @@ public class TestGenListModuleReader {
     @Test
     public void startElement_externalImage_withScope() throws SAXException {
         reader.startDocument();
-        reader.startElement(NULL_NS_URI, TOPIC_IMAGE.localName, TOPIC_IMAGE.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
-                .add(ATTRIBUTE_NAME_HREF, "file://example.com/image.png")
-                .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
-                .build());
+        reader.startElement(
+                NULL_NS_URI,
+                TOPIC_IMAGE.localName,
+                TOPIC_IMAGE.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
+                        .add(ATTRIBUTE_NAME_HREF, "file://example.com/image.png")
+                        .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
+                        .build());
         reader.endElement(NULL_NS_URI, TOPIC_IMAGE.localName, TOPIC_IMAGE.localName);
         assertTrue(reader.getNonConrefCopytoTargets().isEmpty());
         assertTrue(reader.getNonTopicrefReferenceSet().isEmpty());
@@ -120,11 +133,15 @@ public class TestGenListModuleReader {
     @Test
     public void startElement_externalImage_withoutScope() throws SAXException {
         reader.startDocument();
-        for (String scheme : new String[]{ "http", "https", "ftp", "ftps", "sftp", "mailto" }) {
-            reader.startElement(NULL_NS_URI, TOPIC_IMAGE.localName, TOPIC_IMAGE.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
-                    .add(ATTRIBUTE_NAME_HREF, scheme + "://example.com/image.png")
-                    .build());
+        for (String scheme : new String[] {"http", "https", "ftp", "ftps", "sftp", "mailto"}) {
+            reader.startElement(
+                    NULL_NS_URI,
+                    TOPIC_IMAGE.localName,
+                    TOPIC_IMAGE.localName,
+                    new AttributesBuilder()
+                            .add(ATTRIBUTE_NAME_CLASS, TOPIC_IMAGE.toString())
+                            .add(ATTRIBUTE_NAME_HREF, scheme + "://example.com/image.png")
+                            .build());
             reader.endElement(NULL_NS_URI, TOPIC_IMAGE.localName, TOPIC_IMAGE.localName);
         }
         assertTrue(reader.getNonConrefCopytoTargets().isEmpty());
@@ -138,19 +155,20 @@ public class TestGenListModuleReader {
 
         assertTrue(reader.getConrefTargets().isEmpty());
 
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("topics/xreffin-topic-1.xml"),
-                srcDirUri.resolve("topics/target-topic-c.xml"),
-                srcDirUri.resolve("topics/target-topic-a.xml"))),
+        assertEquals(
+                new HashSet(Arrays.asList(
+                        srcDirUri.resolve("topics/xreffin-topic-1.xml"),
+                        srcDirUri.resolve("topics/target-topic-c.xml"),
+                        srcDirUri.resolve("topics/target-topic-a.xml"))),
                 reader.getHrefTargets());
 
-        final Set<URI> nonConrefCopytoTargets = reader.getNonConrefCopytoTargets().stream()
-                .map(r -> r.filename)
-                .collect(Collectors.toSet());
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("topics/xreffin-topic-1.xml"),
-                srcDirUri.resolve("topics/target-topic-c.xml"),
-                srcDirUri.resolve("topics/target-topic-a.xml"))),
+        final Set<URI> nonConrefCopytoTargets =
+                reader.getNonConrefCopytoTargets().stream().map(r -> r.filename).collect(Collectors.toSet());
+        assertEquals(
+                new HashSet(Arrays.asList(
+                        srcDirUri.resolve("topics/xreffin-topic-1.xml"),
+                        srcDirUri.resolve("topics/target-topic-c.xml"),
+                        srcDirUri.resolve("topics/target-topic-a.xml"))),
                 nonConrefCopytoTargets);
 
         final Set<Reference> nonCopytoResult = new LinkedHashSet<>(128);
@@ -167,29 +185,31 @@ public class TestGenListModuleReader {
         for (final URI filename : reader.getCoderefTargetSet()) {
             nonCopytoResult.add(new Reference(stripFragment(filename)));
         }
-        assertEquals(new HashSet(Arrays.asList(
-                new Reference(srcDirUri.resolve("topics/xreffin-topic-1.xml")),
-                new Reference(srcDirUri.resolve("topics/target-topic-c.xml")),
-                new Reference(srcDirUri.resolve("topics/target-topic-a.xml")))),
+        assertEquals(
+                new HashSet(Arrays.asList(
+                        new Reference(srcDirUri.resolve("topics/xreffin-topic-1.xml")),
+                        new Reference(srcDirUri.resolve("topics/target-topic-c.xml")),
+                        new Reference(srcDirUri.resolve("topics/target-topic-a.xml")))),
                 nonCopytoResult);
 
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("topics/xreffin-topic-1.xml"),
-                srcDirUri.resolve("topics/target-topic-c.xml"),
-                srcDirUri.resolve("topics/target-topic-a.xml"))),
+        assertEquals(
+                new HashSet(Arrays.asList(
+                        srcDirUri.resolve("topics/xreffin-topic-1.xml"),
+                        srcDirUri.resolve("topics/target-topic-c.xml"),
+                        srcDirUri.resolve("topics/target-topic-a.xml"))),
                 reader.getOutDitaFilesSet());
 
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("topics/xreffin-topic-1.xml"),
-                srcDirUri.resolve("topics/target-topic-c.xml"),
-                srcDirUri.resolve("topics/target-topic-a.xml"))),
+        assertEquals(
+                new HashSet(Arrays.asList(
+                        srcDirUri.resolve("topics/xreffin-topic-1.xml"),
+                        srcDirUri.resolve("topics/target-topic-c.xml"),
+                        srcDirUri.resolve("topics/target-topic-a.xml"))),
                 reader.getOutDitaFilesSet());
 
         final Set<URI> nonTopicrefReferenceSet = new HashSet<>(reader.getNonTopicrefReferenceSet());
         nonTopicrefReferenceSet.removeAll(reader.getNormalProcessingRoleSet());
         nonTopicrefReferenceSet.removeAll(reader.getResourceOnlySet());
-        assertEquals(emptySet(),
-                nonTopicrefReferenceSet);
+        assertEquals(emptySet(), nonTopicrefReferenceSet);
 
         final Set<URI> resourceOnlySet = new HashSet<>(reader.getResourceOnlySet());
         resourceOnlySet.removeAll(reader.getNormalProcessingRoleSet());
@@ -213,16 +233,11 @@ public class TestGenListModuleReader {
 
         assertTrue(reader.getConrefTargets().isEmpty());
 
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("maps/toolbars.dita"))),
-                reader.getHrefTargets());
+        assertEquals(new HashSet(Arrays.asList(srcDirUri.resolve("maps/toolbars.dita"))), reader.getHrefTargets());
 
-        final Set<URI> nonConrefCopytoTargets = reader.getNonConrefCopytoTargets().stream()
-                .map(r -> r.filename)
-                .collect(Collectors.toSet());
-        assertEquals(new HashSet(Arrays.asList(
-                srcDirUri.resolve("maps/toolbars.dita"))),
-                nonConrefCopytoTargets);
+        final Set<URI> nonConrefCopytoTargets =
+                reader.getNonConrefCopytoTargets().stream().map(r -> r.filename).collect(Collectors.toSet());
+        assertEquals(new HashSet(Arrays.asList(srcDirUri.resolve("maps/toolbars.dita"))), nonConrefCopytoTargets);
 
         final Set<Reference> nonCopytoResult_computed = new LinkedHashSet<>(128);
         nonCopytoResult_computed.addAll(reader.getNonConrefCopytoTargets());
@@ -238,8 +253,8 @@ public class TestGenListModuleReader {
         for (final URI filename : reader.getCoderefTargetSet()) {
             nonCopytoResult_computed.add(new Reference(stripFragment(filename)));
         }
-        assertEquals(new HashSet(Arrays.asList(
-                new Reference(srcDirUri.resolve("maps/toolbars.dita")))),
+        assertEquals(
+                new HashSet(Arrays.asList(new Reference(srcDirUri.resolve("maps/toolbars.dita")))),
                 nonCopytoResult_computed);
 
         assertTrue(reader.getOutDitaFilesSet().isEmpty());
@@ -255,8 +270,7 @@ public class TestGenListModuleReader {
         final Set<URI> nonTopicrefReferenceSet = new HashSet<>(reader.getNonTopicrefReferenceSet());
         nonTopicrefReferenceSet.removeAll(reader.getNormalProcessingRoleSet());
         nonTopicrefReferenceSet.removeAll(reader.getResourceOnlySet());
-        assertEquals(emptySet(),
-                nonTopicrefReferenceSet);
+        assertEquals(emptySet(), nonTopicrefReferenceSet);
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());
@@ -276,27 +290,28 @@ public class TestGenListModuleReader {
 
         assertTrue(reader.getConrefTargets().isEmpty());
 
-        assertEquals(Stream.of(
-                "resourceonly.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "normal.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-resource-only-ALSORESOURCEONLY.dita")
+        assertEquals(
+                Stream.of(
+                                "resourceonly.dita",
+                                "link-from-resource-only-ALSORESOURCEONLY.dita",
+                                "link-from-normal-ALSORESOURCEONLY.dita",
+                                "normal.dita",
+                                "conref-from-normal-ALSORESOURCEONLY.dita",
+                                "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(conrefDirUri::resolve)
                         .collect(Collectors.toSet()),
                 reader.getHrefTargets());
 
-        final Set<URI> nonConrefCopytoTargets = reader.getNonConrefCopytoTargets().stream()
-                .map(r -> r.filename)
-                .collect(Collectors.toSet());
-        assertEquals(Stream.of(
-                "resourceonly.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "normal.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-resource-only-ALSORESOURCEONLY.dita")
+        final Set<URI> nonConrefCopytoTargets =
+                reader.getNonConrefCopytoTargets().stream().map(r -> r.filename).collect(Collectors.toSet());
+        assertEquals(
+                Stream.of(
+                                "resourceonly.dita",
+                                "link-from-resource-only-ALSORESOURCEONLY.dita",
+                                "link-from-normal-ALSORESOURCEONLY.dita",
+                                "normal.dita",
+                                "conref-from-normal-ALSORESOURCEONLY.dita",
+                                "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(conrefDirUri::resolve)
                         .collect(Collectors.toSet()),
                 nonConrefCopytoTargets);
@@ -315,13 +330,14 @@ public class TestGenListModuleReader {
         for (final URI filename : reader.getCoderefTargetSet()) {
             nonCopytoResult.add(new Reference(stripFragment(filename)));
         }
-        assertEquals(Stream.of(
-                "resourceonly.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "normal.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-resource-only-ALSORESOURCEONLY.dita")
+        assertEquals(
+                Stream.of(
+                                "resourceonly.dita",
+                                "link-from-resource-only-ALSORESOURCEONLY.dita",
+                                "link-from-normal-ALSORESOURCEONLY.dita",
+                                "normal.dita",
+                                "conref-from-normal-ALSORESOURCEONLY.dita",
+                                "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(f -> new Reference(conrefDirUri.resolve(f)))
                         .collect(Collectors.toSet()),
                 nonCopytoResult);
@@ -330,12 +346,13 @@ public class TestGenListModuleReader {
 
         final Set<URI> resourceOnlySet = new HashSet<>(reader.getResourceOnlySet());
         resourceOnlySet.removeAll(reader.getNormalProcessingRoleSet());
-        assertEquals(Stream.of(
-                "resourceonly.dita",
-                "link-from-resource-only-ALSORESOURCEONLY.dita",
-                "link-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-normal-ALSORESOURCEONLY.dita",
-                "conref-from-resource-only-ALSORESOURCEONLY.dita")
+        assertEquals(
+                Stream.of(
+                                "resourceonly.dita",
+                                "link-from-resource-only-ALSORESOURCEONLY.dita",
+                                "link-from-normal-ALSORESOURCEONLY.dita",
+                                "conref-from-normal-ALSORESOURCEONLY.dita",
+                                "conref-from-resource-only-ALSORESOURCEONLY.dita")
                         .map(conrefDirUri::resolve)
                         .collect(Collectors.toSet()),
                 resourceOnlySet);
@@ -345,8 +362,7 @@ public class TestGenListModuleReader {
         final Set<URI> nonTopicrefReferenceSet = new HashSet<>(reader.getNonTopicrefReferenceSet());
         nonTopicrefReferenceSet.removeAll(reader.getNormalProcessingRoleSet());
         nonTopicrefReferenceSet.removeAll(reader.getResourceOnlySet());
-        assertEquals(emptySet(),
-                nonTopicrefReferenceSet);
+        assertEquals(emptySet(), nonTopicrefReferenceSet);
 
         assertFalse(reader.isDitaTopic());
         assertTrue(reader.isDitaMap());
@@ -370,7 +386,8 @@ public class TestGenListModuleReader {
         parser.parse(rootFile.toURI().toString());
     }
 
-    private XMLReader initXMLReader(final File ditaDir, final boolean validate, final File rootFile) throws SAXException, IOException {
+    private XMLReader initXMLReader(final File ditaDir, final boolean validate, final File rootFile)
+            throws SAXException, IOException {
         final XMLReader parser = XMLUtils.getXMLReader();
         if (validate == true) {
             parser.setFeature(FEATURE_VALIDATION, true);
@@ -387,5 +404,4 @@ public class TestGenListModuleReader {
 
         return parser;
     }
-
 }

--- a/src/test/java/org/dita/dost/store/StoreTest.java
+++ b/src/test/java/org/dita/dost/store/StoreTest.java
@@ -8,15 +8,13 @@
 
 package org.dita.dost.store;
 
-import static org.junit.Assert.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.net.URI;
-
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
-
 import org.dita.dost.TestUtils;
 import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
@@ -27,40 +25,40 @@ public class StoreTest {
     private final File resourceDir = TestUtils.getResourceDir(StoreTest.class);
     private final File srcDir = new File(resourceDir, "src").getAbsoluteFile();
     private final URI srcDirUri = srcDir.toURI();
-    
+
     private Store store;
-    
+
     @Before
     public void setup() {
         store = new StreamStore(srcDir, new XMLUtils());
     }
-    
+
     @Test
     public void testGetPath() {
         // fail("Not yet implemented");
     }
 
-//    @Test
-//    public void testGetFile() {
-//        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File("root.xml")));
-//        assertEquals(new File(srcDir, "folder" + File.separator + "leaf.xml"), store.getFile(new File("folder" + File.separator + "leaf.xml")));
-//        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File(srcDir, "root.xml")));
-//    }
+    //    @Test
+    //    public void testGetFile() {
+    //        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File("root.xml")));
+    //        assertEquals(new File(srcDir, "folder" + File.separator + "leaf.xml"), store.getFile(new File("folder" +
+    // File.separator + "leaf.xml")));
+    //        assertEquals(new File(srcDir, "root.xml"), store.getFile(new File(srcDir, "root.xml")));
+    //    }
 
     @Test
     public void testGetUri() {
         assertEquals(srcDirUri.resolve("root.xml"), store.getUri(toURI("root.xml")));
         assertEquals(srcDirUri.resolve("folder/leaf.xml"), store.getUri(toURI("folder/leaf.xml")));
         assertEquals(srcDirUri.resolve("root.xml"), store.getUri(srcDirUri.resolve("root.xml")));
-
     }
 
     @Test
     public void testResolve() throws TransformerException {
         final Source s = store.resolve("root.xml", srcDirUri.toString());
         assertEquals(srcDirUri.resolve("root.xml"), toURI(s.getSystemId()));
-        
-//        assertNull(store.resolve("root.xml", "file:/dummy/"));
+
+        //        assertNull(store.resolve("root.xml", "file:/dummy/"));
     }
 
     @Test
@@ -82,5 +80,4 @@ public class StoreTest {
     public void testGetResultURI() {
         // fail("Not yet implemented");
     }
-
 }

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -8,6 +8,17 @@
 
 package org.dita.dost.store;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.Serializer;
 import net.sf.saxon.s9api.XdmNode;
@@ -18,18 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class StreamStoreTest {
 
@@ -56,7 +55,7 @@ public class StreamStoreTest {
         final Serializer serializer = store.getSerializer(tmpDir.toURI().resolve("foo/bar"));
         serializer.serializeNode(source);
     }
-    
+
     @Test
     public void exists_WhenFileExists_ShouldReturnTrue() throws IOException {
         Files.writeString(tmpDir.toPath().resolve("dummy.xml"), "<dummy/>");
@@ -77,7 +76,9 @@ public class StreamStoreTest {
     public void copy_WhenFileExists_ShouldCreateCopy() throws IOException {
         Files.writeString(tmpDir.toPath().resolve("src.xml"), "<dummy/>");
 
-        store.copy(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.copy(
+                tmpDir.toPath().resolve("src.xml").toUri(),
+                tmpDir.toPath().resolve("dst.xml").toUri());
 
         assertTrue(Files.exists(tmpDir.toPath().resolve("src.xml")));
         assertTrue(Files.exists(tmpDir.toPath().resolve("dst.xml")));
@@ -85,12 +86,15 @@ public class StreamStoreTest {
 
     @Test(expected = IOException.class)
     public void copy_WhenFileIsMissing_ShouldThrowException() throws IOException {
-        store.copy(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.copy(
+                tmpDir.toPath().resolve("src.xml").toUri(),
+                tmpDir.toPath().resolve("dst.xml").toUri());
     }
 
     @Test(expected = IOException.class)
     public void copy_WhenSrcIsHttp_ShouldThrowException() throws IOException {
-        store.copy(URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.copy(
+                URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
     }
 
     @Test(expected = IOException.class)
@@ -102,7 +106,9 @@ public class StreamStoreTest {
     public void move_WhenFileExists_ShouldCreateCopy() throws IOException {
         Files.writeString(tmpDir.toPath().resolve("src.xml"), "<dummy/>");
 
-        store.move(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.move(
+                tmpDir.toPath().resolve("src.xml").toUri(),
+                tmpDir.toPath().resolve("dst.xml").toUri());
 
         assertFalse(Files.exists(tmpDir.toPath().resolve("src.xml")));
         assertTrue(Files.exists(tmpDir.toPath().resolve("dst.xml")));
@@ -110,12 +116,15 @@ public class StreamStoreTest {
 
     @Test(expected = IOException.class)
     public void move_WhenFileIsMissing_ShouldThrowException() throws IOException {
-        store.move(tmpDir.toPath().resolve("src.xml").toUri(), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.move(
+                tmpDir.toPath().resolve("src.xml").toUri(),
+                tmpDir.toPath().resolve("dst.xml").toUri());
     }
 
     @Test(expected = IOException.class)
     public void move_WhenSrcIsHttp_ShouldThrowException() throws IOException {
-        store.move(URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
+        store.move(
+                URI.create("http://src.xml"), tmpDir.toPath().resolve("dst.xml").toUri());
     }
 
     @Test(expected = IOException.class)
@@ -125,9 +134,9 @@ public class StreamStoreTest {
 
     @Test
     public void transformWithAnchorInURIPath() throws IOException, DITAOTException, URISyntaxException {
-    	final Path target = Paths.get(tmpDir.getAbsolutePath(), "source.xml");
+        final Path target = Paths.get(tmpDir.getAbsolutePath(), "source.xml");
         Files.writeString(target, "<root/>");
         final URI uri = new URI(target.toUri() + "#abc");
-    	store.transform(uri, Collections.emptyList());
+        store.transform(uri, Collections.emptyList());
     }
 }

--- a/src/test/java/org/dita/dost/util/ClassPathResolver.java
+++ b/src/test/java/org/dita/dost/util/ClassPathResolver.java
@@ -7,13 +7,13 @@
  */
 package org.dita.dost.util;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * URI resolver that support accessing classpath resources.

--- a/src/test/java/org/dita/dost/util/DitaClassTest.java
+++ b/src/test/java/org/dita/dost/util/DitaClassTest.java
@@ -15,12 +15,10 @@ import static org.junit.Assert.fail;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.helpers.AttributesImpl;
-
 
 public class DitaClassTest {
 
@@ -36,7 +34,8 @@ public class DitaClassTest {
         try {
             new DitaClass(null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -84,14 +83,15 @@ public class DitaClassTest {
 
     @Test
     public void testMatchesNode() throws ParserConfigurationException {
-        final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final Document doc =
+                DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         final Element elem = doc.createElement("qux");
         elem.setAttribute(ATTRIBUTE_NAME_CLASS, "- foo/bar baz/qux ");
         assertTrue(new DitaClass("- foo/bar ").matches(elem));
         assertTrue(new DitaClass("- foo/bar baz/qux ").matches(elem));
         assertFalse(new DitaClass("- bar/baz ").matches(elem));
     }
-    
+
     @Test
     public void testValidDitaClass() {
         assertTrue(new DitaClass("- topic/p ").isValid());
@@ -118,5 +118,4 @@ public class DitaClassTest {
         final DitaClass second = DitaClass.getInstance("-  foo/bar  ");
         assertTrue(first == second);
     }
-
 }

--- a/src/test/java/org/dita/dost/util/FileInfoTest.java
+++ b/src/test/java/org/dita/dost/util/FileInfoTest.java
@@ -8,14 +8,13 @@
 package org.dita.dost.util;
 
 import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertEquals;
 import static org.dita.dost.util.Job.FileInfo;
 import static org.dita.dost.util.Job.FileInfo.Builder;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 public final class FileInfoTest {
@@ -26,19 +25,20 @@ public final class FileInfoTest {
         assertEquals(new File("foo" + File.separator + "bar"), f.file);
         assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
     }
-    
+
     @Test
     public void testFileBuilder() throws URISyntaxException {
-        final FileInfo f = new Builder().file(new File("foo" + File.separator + "bar")).build();
+        final FileInfo f =
+                new Builder().file(new File("foo" + File.separator + "bar")).build();
         assertEquals(new File("foo" + File.separator + "bar"), f.file);
         assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
     }
 
     @Test
     public void testURIBuilder() throws URISyntaxException {
-        final FileInfo f = new Builder().uri(new URI("foo" + URI_SEPARATOR + "bar")).build();
+        final FileInfo f =
+                new Builder().uri(new URI("foo" + URI_SEPARATOR + "bar")).build();
         assertEquals(new File("foo" + File.separator + "bar"), f.file);
         assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
     }
-    
 }

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -7,20 +7,6 @@
  */
 package org.dita.dost.util;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.dita.dost.TestUtils;
-import org.dita.dost.util.FilterUtils.Action;
-import org.dita.dost.util.FilterUtils.FilterKey;
-import org.dita.dost.util.FilterUtils.Flag;
-import org.dita.dost.util.XMLUtils.AttributesBuilder;
-import org.junit.Test;
-import org.xml.sax.Attributes;
-import org.xml.sax.helpers.AttributesImpl;
-
-import javax.xml.namespace.QName;
-import java.util.*;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -29,6 +15,19 @@ import static javax.xml.XMLConstants.XML_NS_URI;
 import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_PLATFORM;
 import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_REV;
 import static org.junit.Assert.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.*;
+import javax.xml.namespace.QName;
+import org.dita.dost.TestUtils;
+import org.dita.dost.util.FilterUtils.Action;
+import org.dita.dost.util.FilterUtils.FilterKey;
+import org.dita.dost.util.FilterUtils.Flag;
+import org.dita.dost.util.XMLUtils.AttributesBuilder;
+import org.junit.Test;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.AttributesImpl;
 
 public class FilterUtilsTest {
 
@@ -79,17 +78,25 @@ public class FilterUtilsTest {
         fm.put(new FilterKey(QName.valueOf(ATTRIBUTE_NAME_REV), null), Action.EXCLUDE);
         fm.put(new FilterKey(lang, "fr"), Action.EXCLUDE);
         fm.put(new FilterKey(confidentiality, "confidential"), Action.EXCLUDE);
-        final FilterUtils f = new FilterUtils(false, fm, null, null,
-            ImmutableSet.of(QName.valueOf(ATTRIBUTE_NAME_REV), lang, confidentiality), emptySet()
-        );
+        final FilterUtils f = new FilterUtils(
+                false,
+                fm,
+                null,
+                null,
+                ImmutableSet.of(QName.valueOf(ATTRIBUTE_NAME_REV), lang, confidentiality),
+                emptySet());
         f.setLogger(new TestUtils.TestLogger());
 
-        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
-        assertTrue(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
+        assertTrue(f.needExclude(
+                new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(lang, "en").build(), new QName[0][0]));
         assertTrue(f.needExclude(new AttributesBuilder().add(lang, "fr").build(), new QName[0][0]));
-        assertTrue(f.needExclude(new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
+        assertTrue(f.needExclude(
+                new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
     }
 
     @Test
@@ -101,12 +108,16 @@ public class FilterUtilsTest {
         final FilterUtils f = new FilterUtils(false, fm, null, null);
         f.setLogger(new TestUtils.TestLogger());
 
-        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(ATTRIBUTE_NAME_PLATFORM, "unix").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(ATTRIBUTE_NAME_REV, "1").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(lang, "en").build(), new QName[0][0]));
         assertFalse(f.needExclude(new AttributesBuilder().add(lang, "fr").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
-        assertFalse(f.needExclude(new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(confidentiality, "confidential").build(), new QName[0][0]));
+        assertFalse(f.needExclude(
+                new AttributesBuilder().add(confidentiality, "public").build(), new QName[0][0]));
     }
 
     @Test
@@ -163,10 +174,10 @@ public class FilterUtilsTest {
         assertFalse(f.needExclude(attr(OS, "amiga unix windows"), new QName[][] {{PROPS, OS}}));
         assertFalse(f.needExclude(attr(OS, "amiga windows"), new QName[][] {{PROPS, OS}}));
         assertFalse(f.needExclude(attr(OS, "amiga windows"), new QName[][] {{PROPS, OS, GUI}}));
-        assertFalse(f.needExclude(attr(GUI, "amiga windows"),new QName[][] {{PROPS, OS, GUI}}));
+        assertFalse(f.needExclude(attr(GUI, "amiga windows"), new QName[][] {{PROPS, OS, GUI}}));
         assertTrue(f.needExclude(attr(OS, "windows"), new QName[][] {{PROPS, OS}}));
     }
-    
+
     @Test
     public void testNeedExcludeLabel() {
         final Map<FilterKey, Action> fm = new HashMap<>();
@@ -181,7 +192,7 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(attr(PROPS, "os(windows)"), new QName[][] {{PROPS, OS}}));
         assertTrue(f.needExclude(attr(PROPS, "   os(   windows   )   "), new QName[][] {{PROPS, OS}}));
     }
-    
+
     @Test
     public void testNeedExcludeOtherpropsLabel() {
         final Map<FilterKey, Action> fm = new HashMap<>();
@@ -198,66 +209,65 @@ public class FilterUtilsTest {
     @Test
     public void testgetFlagsDefaultFlag() {
         final Flag flag = new Flag("prop", "red", null, null, null, null, null, null);
-        final FilterUtils f = new FilterUtils(false,
+        final FilterUtils f = new FilterUtils(
+                false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, null), flag)
-                        .build(), null, null);
+                        .build(),
+                null,
+                null);
         f.setLogger(new TestUtils.TestLogger());
 
-        assertEquals(
-                emptySet(),
-                f.getFlags(new AttributesImpl(), new QName[0][0]));
-        assertEquals(
-                singleton(flag),
-                f.getFlags(attr(PLATFORM, "amiga unix windows"), new QName[0][0]));
+        assertEquals(emptySet(), f.getFlags(new AttributesImpl(), new QName[0][0]));
+        assertEquals(singleton(flag), f.getFlags(attr(PLATFORM, "amiga unix windows"), new QName[0][0]));
     }
 
     @Test
     public void testGetFlags() {
         final Flag flag = new Flag("prop", "red", null, null, null, null, null, null);
         final Flag revflag = new Flag("revprop", null, null, null, "solid", null, null, null);
-        final FilterUtils f = new FilterUtils(false,
+        final FilterUtils f = new FilterUtils(
+                false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, "unix"), flag)
                         .put(new FilterKey(PLATFORM, "osx"), flag)
                         .put(new FilterKey(PLATFORM, "linux"), flag)
                         .put(new FilterKey(AUDIENCE, "expert"), flag)
                         .put(new FilterKey(REV, "r1"), revflag)
-                        .build(), null, null);
+                        .build(),
+                null,
+                null);
         f.setLogger(new TestUtils.TestLogger());
 
-        assertEquals(
-                singleton(flag),
-                f.getFlags(attr(PLATFORM, "amiga unix windows"), new QName[0][0]));
-        assertEquals(
-                singleton(flag),
-                f.getFlags(attr(PLATFORM, "amiga unix"), new QName[0][0]));
-        assertEquals(
-                singleton(revflag),
-                f.getFlags(attr(REV, "r1 r2"), new QName[0][0]));
-        assertEquals(
-                emptySet(),
-                f.getFlags(attr(PLATFORM, "amiga"), new QName[0][0]));
-        assertEquals(
-                emptySet(),
-                f.getFlags(attr(PLATFORM, "windows"), new QName[0][0]));
+        assertEquals(singleton(flag), f.getFlags(attr(PLATFORM, "amiga unix windows"), new QName[0][0]));
+        assertEquals(singleton(flag), f.getFlags(attr(PLATFORM, "amiga unix"), new QName[0][0]));
+        assertEquals(singleton(revflag), f.getFlags(attr(REV, "r1 r2"), new QName[0][0]));
+        assertEquals(emptySet(), f.getFlags(attr(PLATFORM, "amiga"), new QName[0][0]));
+        assertEquals(emptySet(), f.getFlags(attr(PLATFORM, "windows"), new QName[0][0]));
     }
 
     @Test
     public void testGetFlagsForSpecialization() {
         final Flag flagBase = new Flag("prop", "red", null, null, null, null, null, null);
         final Flag flagSpecialization = new Flag("prop", "blue", null, null, null, null, null, null);
-        final FilterUtils f = new FilterUtils(false,
+        final FilterUtils f = new FilterUtils(
+                false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(PLATFORM, "unix"), flagBase)
                         .put(new FilterKey(OS, "amiga"), flagSpecialization)
-                        .build(), null, null);
+                        .build(),
+                null,
+                null);
         f.setLogger(new TestUtils.TestLogger());
 
         assertEquals(
                 Set.of(flagBase, flagSpecialization),
-                f.getFlags(new AttributesBuilder().add(OS, "amiga").add(PLATFORM, "unix").build(),
-                           new QName[][] {{PROPS, OS}}));
+                f.getFlags(
+                        new AttributesBuilder()
+                                .add(OS, "amiga")
+                                .add(PLATFORM, "unix")
+                                .build(),
+                        new QName[][] {{PROPS, OS}}));
     }
 
     // DITA 1.3
@@ -273,14 +283,14 @@ public class FilterUtilsTest {
 
         assertFalse(f.extCheckExclude(new QName[] {PLATFORM, OS}, Arrays.asList("amiga", "unix", "windows")));
         assertTrue(f.extCheckExclude(new QName[] {PLATFORM, OS}, Arrays.asList("osx")));
-        assertFalse(f.extCheckExclude(new QName[] {PLATFORM, OS}, Arrays.asList( "unix", "amiga", "windows")));
+        assertFalse(f.extCheckExclude(new QName[] {PLATFORM, OS}, Arrays.asList("unix", "amiga", "windows")));
     }
-    
+
     @Test
     public void testNoInfoMessageFilter() {
-        //Do not issue information messages that certain values
-        //were not specified in the ditaval filter if the filter has default exclude rules.
-        for (FilterKey filterKey: new FilterKey[]{ new FilterKey(OS, null), FilterUtils.DEFAULT }) {
+        // Do not issue information messages that certain values
+        // were not specified in the ditaval filter if the filter has default exclude rules.
+        for (FilterKey filterKey : new FilterKey[] {new FilterKey(OS, null), FilterUtils.DEFAULT}) {
             final Map<FilterKey, Action> fm = new HashMap<>();
             fm.put(filterKey, Action.EXCLUDE);
             fm.put(new FilterKey(OS, "amiga"), Action.INCLUDE);
@@ -289,15 +299,15 @@ public class FilterUtilsTest {
             f.setLogger(new TestUtils.TestLogger() {
                 @Override
                 public void info(String msg) {
-                   infoMsg.append(msg);
-               }
+                    infoMsg.append(msg);
+                }
             });
 
             assertTrue(f.extCheckExclude(new QName[] {OS}, Arrays.asList("osx")));
             assertEquals("Should not output info message " + infoMsg, "", infoMsg.toString());
         }
     }
-    
+
     @Test
     public void testNeedExcludeGroup() {
         final Map<FilterKey, Action> fm = new HashMap<>();
@@ -313,7 +323,6 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(attr(PLATFORM, "os(windows)"), new QName[0][0]));
         assertTrue(f.needExclude(attr(PLATFORM, "   os(   windows   )   "), new QName[0][0]));
     }
-    
 
     @Test
     public void testNeedExcludeGroupMultiple() {
@@ -331,7 +340,7 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(attr(PLATFORM, "os(windows) database(mongo)"), new QName[0][0]));
         assertTrue(f.needExclude(attr(PLATFORM, "   os(   windows   )   database(  mongo  )   "), new QName[0][0]));
     }
-    
+
     @Test
     public void testNeedExcludeMixedGroups() {
         final Map<FilterKey, Action> fm = new HashMap<>();
@@ -345,11 +354,11 @@ public class FilterUtilsTest {
         assertTrue(f.needExclude(attr(PLATFORM, "windows database(mongodb couchbase) unix"), new QName[0][0]));
         assertTrue(f.needExclude(attr(PLATFORM, "database(mongodb couchbase) unix"), new QName[0][0]));
     }
-    
+
     @Test
     public void testGetUngroupedValue() {
         final FilterUtils f = new FilterUtils(false);
-        
+
         {
             final Map<QName, List<String>> exp = new HashMap<>();
             exp.put(null, Arrays.asList("foo", "bar", "bax"));
@@ -391,7 +400,7 @@ public class FilterUtilsTest {
             assertEquals(exp, f.getGroups("group1() group2(a)"));
         }
     }
-    
+
     private Attributes attr(final QName name, final String value) {
         final AttributesImpl res = new AttributesImpl();
         XMLUtils.addOrSetAttribute(res, name, value);
@@ -402,12 +411,15 @@ public class FilterUtilsTest {
     public void testGetFlagLabel() {
         final Flag flagRed = new Flag("prop", "red", null, null, null, null, null, null);
         final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null, null);
-        
-        final FilterUtils f = new FilterUtils(false,
+
+        final FilterUtils f = new FilterUtils(
+                false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(OS, "amiga"), flagRed)
                         .put(new FilterKey(OS, null), flagBlue)
-                        .build(), null, null);
+                        .build(),
+                null,
+                null);
         f.setLogger(new TestUtils.TestLogger());
 
         assertEquals(
@@ -419,41 +431,35 @@ public class FilterUtilsTest {
         assertEquals(
                 new HashSet<>(asList(flagRed, flagBlue)),
                 f.getFlags(attr(PROPS, "gui(amiga windows)"), new QName[][] {{PROPS, OS, GUI}}));
+        assertEquals(singleton(flagBlue), f.getFlags(attr(PROPS, "os(windows)"), new QName[][] {{PROPS, OS}}));
         assertEquals(
-                singleton(flagBlue),
-                f.getFlags(attr(PROPS, "os(windows)"), new QName[][] {{PROPS, OS}}));
-        assertEquals(
-                singleton(flagBlue),
-                f.getFlags(attr(PROPS, "   os(   windows   )   "), new QName[][] {{PROPS, OS}}));
+                singleton(flagBlue), f.getFlags(attr(PROPS, "   os(   windows   )   "), new QName[][] {{PROPS, OS}}));
     }
 
     @Test
     public void testConflict() {
         final Flag flagRed = new Flag("prop", "red", null, null, null, null, null, null);
         final Flag flagBlue = new Flag("prop", "blue", null, null, null, null, null, null);
-        final FilterUtils f = new FilterUtils(false,
+        final FilterUtils f = new FilterUtils(
+                false,
                 ImmutableMap.<FilterKey, Action>builder()
                         .put(new FilterKey(OS, "amiga"), flagRed)
                         .put(new FilterKey(OS, null), flagBlue)
-                        .build(), "yellow", "green");
+                        .build(),
+                "yellow",
+                "green");
         f.setLogger(new TestUtils.TestLogger());
 
         final Flag flagYellow = new Flag("prop", "yellow", null, null, null, null, null, null);
         assertEquals(
-                singleton(flagYellow),
-                f.getFlags(attr(PROPS, "os(amiga unix windows)"), new QName[][] {{PROPS, OS}}));
+                singleton(flagYellow), f.getFlags(attr(PROPS, "os(amiga unix windows)"), new QName[][] {{PROPS, OS}}));
         assertEquals(
-                singleton(flagYellow),
-                f.getFlags(attr(PROPS, "os(amiga windows)"), new QName[][] {{PROPS, OS, GUI}}));
+                singleton(flagYellow), f.getFlags(attr(PROPS, "os(amiga windows)"), new QName[][] {{PROPS, OS, GUI}}));
         assertEquals(
-                singleton(flagYellow),
-                f.getFlags(attr(PROPS, "gui(amiga windows)"), new QName[][] {{PROPS, OS, GUI}}));
+                singleton(flagYellow), f.getFlags(attr(PROPS, "gui(amiga windows)"), new QName[][] {{PROPS, OS, GUI}}));
+        assertEquals(singleton(flagBlue), f.getFlags(attr(PROPS, "os(windows)"), new QName[][] {{PROPS, OS}}));
         assertEquals(
-                singleton(flagBlue),
-                f.getFlags(attr(PROPS, "os(windows)"), new QName[][] {{PROPS, OS}}));
-        assertEquals(
-                singleton(flagBlue),
-                f.getFlags(attr(PROPS, "   os(   windows   )   "), new QName[][] {{PROPS, OS}}));
+                singleton(flagBlue), f.getFlags(attr(PROPS, "   os(   windows   )   "), new QName[][] {{PROPS, OS}}));
     }
 
     @Test

--- a/src/test/java/org/dita/dost/util/JobTest.java
+++ b/src/test/java/org/dita/dost/util/JobTest.java
@@ -7,6 +7,16 @@
  */
 package org.dita.dost.util;
 
+import static org.dita.dost.util.Constants.INPUT_DIR;
+import static org.dita.dost.util.Constants.INPUT_DIR_URI;
+import static org.dita.dost.util.URLUtils.toURI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.store.StreamStore;
 import org.junit.AfterClass;
@@ -14,24 +24,13 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static org.dita.dost.util.Constants.INPUT_DIR;
-import static org.dita.dost.util.Constants.INPUT_DIR_URI;
-import static org.dita.dost.util.URLUtils.toURI;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 public final class JobTest {
 
     private static final File resourceDir = TestUtils.getResourceDir(JobTest.class);
     private static final File srcDir = new File(resourceDir, "src");
     private static File tempDir;
     private static Job job;
-    
+
     @BeforeClass
     public static void setUp() throws IOException {
         tempDir = TestUtils.createTempDir(JobTest.class);
@@ -95,5 +94,4 @@ public final class JobTest {
     public static void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-    
 }

--- a/src/test/java/org/dita/dost/util/KeyDefTest.java
+++ b/src/test/java/org/dita/dost/util/KeyDefTest.java
@@ -7,12 +7,11 @@
  */
 package org.dita.dost.util;
 
-import static org.junit.Assert.*;
 import static org.dita.dost.util.URLUtils.*;
+import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.junit.Test;
 
 public class KeyDefTest {
@@ -30,13 +29,12 @@ public class KeyDefTest {
         assertEquals("local", n.scope);
         assertNull(n.source);
     }
-    
+
     @Test
     public void testKeyDefToString() {
-        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope","dita", toURI("baz"), null);
+        final KeyDef k = new KeyDef("foo", toURI("bar"), "scope", "dita", toURI("baz"), null);
         assertEquals("foo=bar(scope)(baz)", k.toString());
         final KeyDef n = new KeyDef("foo", null, null, null, null, null);
         assertEquals("foo=(local)", n.toString());
     }
-
 }

--- a/src/test/java/org/dita/dost/util/LangUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/LangUtilsTest.java
@@ -8,12 +8,11 @@
 
 package org.dita.dost.util;
 
-import org.junit.Test;
-
-import java.util.*;
-
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
+
+import java.util.*;
+import org.junit.Test;
 
 public class LangUtilsTest {
 

--- a/src/test/java/org/dita/dost/util/TestDITAOTCollator.java
+++ b/src/test/java/org/dita/dost/util/TestDITAOTCollator.java
@@ -7,16 +7,15 @@
  */
 package org.dita.dost.util;
 
-import java.util.Locale;
-import org.dita.dost.util.DITAOTCollator;
-import org.junit.Test;
 import static org.junit.Assert.assertNotSame;
+
+import java.util.Locale;
+import org.junit.Test;
+
 public class TestDITAOTCollator {
     @Test
-    public void testgetinstance()
-    {
+    public void testgetinstance() {
 
-        assertNotSame(DITAOTCollator.getInstance(Locale.US),DITAOTCollator.getInstance(Locale.UK));
+        assertNotSame(DITAOTCollator.getInstance(Locale.US), DITAOTCollator.getInstance(Locale.UK));
     }
-
 }

--- a/src/test/java/org/dita/dost/util/TestDITAOTCopy.java
+++ b/src/test/java/org/dita/dost/util/TestDITAOTCopy.java
@@ -9,12 +9,11 @@ package org.dita.dost.util;
 
 import static org.apache.commons.io.FileUtils.*;
 import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
-
-import org.apache.tools.ant.Project;
-
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
 import org.dita.dost.TestUtils;
 import org.dita.dost.ant.DITAOTCopy;
 import org.junit.AfterClass;
@@ -33,26 +32,23 @@ public class TestDITAOTCopy {
     }
 
     @Test
-    public void testexecute() throws BuildException, IOException
-    {
+    public void testexecute() throws BuildException, IOException {
         final File myFile = new File(tempDir, "testbuild.xml");
         copyFile(new File(srcDir, "testbuild.xml"), myFile);
         final File mydestFile = new File(tempDir, "testbuild.xml");
 
-        final DITAOTCopy ditaotcopy= new DITAOTCopy();
+        final DITAOTCopy ditaotcopy = new DITAOTCopy();
         ditaotcopy.setProject(new Project());
         ditaotcopy.setIncludes(myFile.getPath());
         ditaotcopy.setTodir(tempDir);
         ditaotcopy.setRelativePaths(mydestFile.getName());
         ditaotcopy.execute();
 
-        assertEquals(TestUtils.readFileToString(myFile),
-                TestUtils.readFileToString(mydestFile));
+        assertEquals(TestUtils.readFileToString(myFile), TestUtils.readFileToString(mydestFile));
     }
 
     @AfterClass
     public static void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/util/TestFileUtils.java
+++ b/src/test/java/org/dita/dost/util/TestFileUtils.java
@@ -7,15 +7,14 @@
  */
 package org.dita.dost.util;
 
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
 import org.dita.dost.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-
-import static org.junit.Assert.*;
 
 public class TestFileUtils {
 
@@ -54,38 +53,60 @@ public class TestFileUtils {
         assertTrue(FileUtils.isSupportedImageFile("image.tif"));
         assertFalse(FileUtils.isSupportedImageFile("image.abc"));
         assertFalse(FileUtils.isSupportedImageFile("image"));
-
     }
 
     @Test
     public void testGetRelativePathFromMap() {
-        assertEquals("../a.dita",FileUtils.getRelativeUnixPath("c:/map/map.ditamap", "c:/a.dita"));
-        assertEquals("../a.dita",FileUtils.getRelativeUnixPath("c:\\map\\map.ditamap", "c:\\a.dita"));
-        assertEquals("d:/a.dita",FileUtils.getRelativeUnixPath("c:/map.ditamap", "d:/a.dita"));
-        assertEquals("d:\\a.dita",FileUtils.getRelativeUnixPath("c:\\map.ditamap", "d:\\a.dita"));
+        assertEquals("../a.dita", FileUtils.getRelativeUnixPath("c:/map/map.ditamap", "c:/a.dita"));
+        assertEquals("../a.dita", FileUtils.getRelativeUnixPath("c:\\map\\map.ditamap", "c:\\a.dita"));
+        assertEquals("d:/a.dita", FileUtils.getRelativeUnixPath("c:/map.ditamap", "d:/a.dita"));
+        assertEquals("d:\\a.dita", FileUtils.getRelativeUnixPath("c:\\map.ditamap", "d:\\a.dita"));
         assertEquals("a.dita", FileUtils.getRelativeUnixPath("c:/map1/map2/map.ditamap", "c:/map1/map2/a.dita"));
         assertEquals("a.dita", FileUtils.getRelativeUnixPath("c:\\map1\\map2\\map.ditamap", "c:\\map1\\map2\\a.dita"));
-        assertEquals("../topic/a.dita",FileUtils.getRelativeUnixPath("c:/map1/map.ditamap", "c:/topic/a.dita"));
-        assertEquals("../topic/a.dita",FileUtils.getRelativeUnixPath("c:\\map1\\map.ditamap", "c:\\topic\\a.dita"));
+        assertEquals("../topic/a.dita", FileUtils.getRelativeUnixPath("c:/map1/map.ditamap", "c:/topic/a.dita"));
+        assertEquals("../topic/a.dita", FileUtils.getRelativeUnixPath("c:\\map1\\map.ditamap", "c:\\topic\\a.dita"));
     }
-    
+
     @Test
     public void testGetRelativePathFromMapFileFile() {
         if (File.separator.equals(SEPARATOR_WINDOWS)) {
-            assertEquals(new File("../a.dita"), FileUtils.getRelativePath(new File("c:\\map\\map.ditamap"), new File("c:\\a.dita")));
-            assertEquals(new File("d:\\a.dita"), FileUtils.getRelativePath(new File("c:\\map.ditamap"), new File("d:\\a.dita")));
-            assertEquals(new File("a.dita"), FileUtils.getRelativePath(new File("c:\\map1\\map2\\map.ditamap"), new File("c:\\map1\\map2\\a.dita")));
-            assertEquals(new File("../topic/a.dita"), FileUtils.getRelativePath(new File("c:\\map1\\map.ditamap"), new File("c:\\topic\\a.dita")));
-            assertEquals(new File("D:\\top_level_error\\out\\pdf-OPENME2\\index.html"), FileUtils.getRelativePath(new File("B1\\B2\\B3\\B4\\topic.dita"), new File("D:\\top_level_error\\out\\pdf-OPENME2\\index.html")));
+            assertEquals(
+                    new File("../a.dita"),
+                    FileUtils.getRelativePath(new File("c:\\map\\map.ditamap"), new File("c:\\a.dita")));
+            assertEquals(
+                    new File("d:\\a.dita"),
+                    FileUtils.getRelativePath(new File("c:\\map.ditamap"), new File("d:\\a.dita")));
+            assertEquals(
+                    new File("a.dita"),
+                    FileUtils.getRelativePath(
+                            new File("c:\\map1\\map2\\map.ditamap"), new File("c:\\map1\\map2\\a.dita")));
+            assertEquals(
+                    new File("../topic/a.dita"),
+                    FileUtils.getRelativePath(new File("c:\\map1\\map.ditamap"), new File("c:\\topic\\a.dita")));
+            assertEquals(
+                    new File("D:\\top_level_error\\out\\pdf-OPENME2\\index.html"),
+                    FileUtils.getRelativePath(
+                            new File("B1\\B2\\B3\\B4\\topic.dita"),
+                            new File("D:\\top_level_error\\out\\pdf-OPENME2\\index.html")));
         } else {
-            assertEquals(new File("../a.dita"), FileUtils.getRelativePath(new File("/map/map.ditamap"), new File("/a.dita")));
+            assertEquals(
+                    new File("../a.dita"),
+                    FileUtils.getRelativePath(new File("/map/map.ditamap"), new File("/a.dita")));
             assertEquals(new File("a.dita"), FileUtils.getRelativePath(new File("/map.ditamap"), new File("/a.dita")));
-            assertEquals(new File("a.dita"), FileUtils.getRelativePath(new File("/map1/map2/map.ditamap"), new File("/map1/map2/a.dita")));
-            assertEquals(new File("../topic/a.dita"), FileUtils.getRelativePath(new File("/map1/map.ditamap"), new File("/topic/a.dita")));
-            assertEquals(new File("/top_level_error/out/pdf-OPENME2/index.html"), FileUtils.getRelativePath(new File("B1/B2/B3/B4/topic.dita"), new File("/top_level_error/out/pdf-OPENME2/index.html")));
+            assertEquals(
+                    new File("a.dita"),
+                    FileUtils.getRelativePath(new File("/map1/map2/map.ditamap"), new File("/map1/map2/a.dita")));
+            assertEquals(
+                    new File("../topic/a.dita"),
+                    FileUtils.getRelativePath(new File("/map1/map.ditamap"), new File("/topic/a.dita")));
+            assertEquals(
+                    new File("/top_level_error/out/pdf-OPENME2/index.html"),
+                    FileUtils.getRelativePath(
+                            new File("B1/B2/B3/B4/topic.dita"),
+                            new File("/top_level_error/out/pdf-OPENME2/index.html")));
         }
     }
-    
+
     @Test
     public void testGetRelativePathFile() {
         if (File.separator.equals(SEPARATOR_WINDOWS)) {
@@ -97,7 +118,7 @@ public class TestFileUtils {
             assertEquals(null, FileUtils.getRelativePath(new File("map.ditamap")));
             assertEquals(new File("../../"), FileUtils.getRelativePath(new File("map1/map2/map.ditamap")));
         }
-    }    
+    }
 
     @Test
     public void testGetPathtoProject() {
@@ -105,83 +126,89 @@ public class TestFileUtils {
         assertEquals("../../", FileUtils.getRelativeUnixPath("dir/dir/file.xml"));
         assertEquals("../", FileUtils.getRelativeUnixPath("dir/file.xml"));
         assertNull(FileUtils.getRelativeUnixPath("file.xml"));
-
     }
 
     @Test
     public void testGetPathtoProjectFile() {
-        assertEquals(new File(".." + File.separator + ".." + File.separator), FileUtils.getRelativePath(new File(File.separator + "dir" + File.separator + "dir" + File.separator + "file.xml")));
-        assertEquals(new File(".." + File.separator + ".." + File.separator), FileUtils.getRelativePath(new File("dir" + File.separator + "dir" + File.separator + "file.xml")));
-        assertEquals(new File(".." + File.separator), FileUtils.getRelativePath(new File("dir" + File.separator + "file.xml")));
+        assertEquals(
+                new File(".." + File.separator + ".." + File.separator),
+                FileUtils.getRelativePath(
+                        new File(File.separator + "dir" + File.separator + "dir" + File.separator + "file.xml")));
+        assertEquals(
+                new File(".." + File.separator + ".." + File.separator),
+                FileUtils.getRelativePath(new File("dir" + File.separator + "dir" + File.separator + "file.xml")));
+        assertEquals(
+                new File(".." + File.separator),
+                FileUtils.getRelativePath(new File("dir" + File.separator + "file.xml")));
         assertNull(FileUtils.getRelativePath(new File("file.xml")));
     }
-    
+
     @Test
     public void testResolveTopic() {
         if (File.separator.equals(SEPARATOR_WINDOWS)) {
-            assertEquals("c:\\dir\\file.xml", FileUtils.resolveTopic("c:\\dir","file.xml"));
-            assertEquals("c:\\dir\\file.xml#topicid", FileUtils.resolveTopic("c:\\dir","file.xml#topicid"));
-            assertEquals("c:\\file.xml", FileUtils.resolveTopic("c:\\dir","..\\file.xml"));
-            assertEquals("file.xml", FileUtils.resolveTopic("","file.xml"));
-            assertEquals("file.xml", FileUtils.resolveTopic((String) null,"file.xml"));
+            assertEquals("c:\\dir\\file.xml", FileUtils.resolveTopic("c:\\dir", "file.xml"));
+            assertEquals("c:\\dir\\file.xml#topicid", FileUtils.resolveTopic("c:\\dir", "file.xml#topicid"));
+            assertEquals("c:\\file.xml", FileUtils.resolveTopic("c:\\dir", "..\\file.xml"));
+            assertEquals("file.xml", FileUtils.resolveTopic("", "file.xml"));
+            assertEquals("file.xml", FileUtils.resolveTopic((String) null, "file.xml"));
         } else {
-            assertEquals("/dir/file.xml", FileUtils.resolveTopic("/dir","file.xml"));
-            assertEquals("/dir/file.xml#topicid", FileUtils.resolveTopic("/dir","file.xml#topicid"));
-            assertEquals("/file.xml", FileUtils.resolveTopic("/dir","../file.xml"));
-            assertEquals("file.xml", FileUtils.resolveTopic("","file.xml"));
-            assertEquals("file.xml", FileUtils.resolveTopic((String) null,"file.xml"));
+            assertEquals("/dir/file.xml", FileUtils.resolveTopic("/dir", "file.xml"));
+            assertEquals("/dir/file.xml#topicid", FileUtils.resolveTopic("/dir", "file.xml#topicid"));
+            assertEquals("/file.xml", FileUtils.resolveTopic("/dir", "../file.xml"));
+            assertEquals("file.xml", FileUtils.resolveTopic("", "file.xml"));
+            assertEquals("file.xml", FileUtils.resolveTopic((String) null, "file.xml"));
         }
     }
 
     @Test
     public void testResolveFile() {
         if (File.separator.equals(SEPARATOR_WINDOWS)) {
-            assertEquals(new File("c:\\dir\\file.xml"), FileUtils.resolve("c:\\dir","file.xml"));
-            assertEquals(new File("c:\\dir\\file.xml"), FileUtils.resolve("c:\\dir","file.xml#topicid"));
-            assertEquals(new File("c:\\file.xml"), FileUtils.resolve("c:\\dir","..\\file.xml"));
-            assertEquals(new File("file.xml"), FileUtils.resolve("","file.xml"));
-            assertEquals(new File("file.xml"), FileUtils.resolve((String) null,"file.xml"));
+            assertEquals(new File("c:\\dir\\file.xml"), FileUtils.resolve("c:\\dir", "file.xml"));
+            assertEquals(new File("c:\\dir\\file.xml"), FileUtils.resolve("c:\\dir", "file.xml#topicid"));
+            assertEquals(new File("c:\\file.xml"), FileUtils.resolve("c:\\dir", "..\\file.xml"));
+            assertEquals(new File("file.xml"), FileUtils.resolve("", "file.xml"));
+            assertEquals(new File("file.xml"), FileUtils.resolve((String) null, "file.xml"));
         } else {
-            assertEquals(new File("/dir/file.xml"), FileUtils.resolve("/dir","file.xml"));
-            assertEquals(new File("/dir/file.xml"), FileUtils.resolve("/dir","file.xml#topicid"));
-            assertEquals(new File("/file.xml"), FileUtils.resolve("/dir","../file.xml"));
-            assertEquals(new File("file.xml"), FileUtils.resolve("","file.xml"));
-            assertEquals(new File("file.xml"), FileUtils.resolve((String) null,"file.xml"));
+            assertEquals(new File("/dir/file.xml"), FileUtils.resolve("/dir", "file.xml"));
+            assertEquals(new File("/dir/file.xml"), FileUtils.resolve("/dir", "file.xml#topicid"));
+            assertEquals(new File("/file.xml"), FileUtils.resolve("/dir", "../file.xml"));
+            assertEquals(new File("file.xml"), FileUtils.resolve("", "file.xml"));
+            assertEquals(new File("file.xml"), FileUtils.resolve((String) null, "file.xml"));
         }
     }
 
     @Test
     public void testNormalizeDirectory() {
         if (File.separator.equals(SEPARATOR_WINDOWS)) {
-            assertEquals(new File("c:\\dir1\\dir2\\file.xml"),FileUtils.resolve("c:\\dir1", "dir2\\file.xml"));
-            assertEquals(new File("c:\\dir1\\file.xml"),FileUtils.resolve("c:\\dir1\\dir2", "..\\file.xml"));
-            assertEquals(new File("\\file.xml"),FileUtils.resolve("", "\\file.xml#topicid"));
-            assertEquals(new File("c:\\file.xml"),FileUtils.resolve("", "c:\\file.xml"));
-            assertEquals(new File("c:\\file.xml"),FileUtils.resolve((String) null, "c:\\file.xml#topicid"));
+            assertEquals(new File("c:\\dir1\\dir2\\file.xml"), FileUtils.resolve("c:\\dir1", "dir2\\file.xml"));
+            assertEquals(new File("c:\\dir1\\file.xml"), FileUtils.resolve("c:\\dir1\\dir2", "..\\file.xml"));
+            assertEquals(new File("\\file.xml"), FileUtils.resolve("", "\\file.xml#topicid"));
+            assertEquals(new File("c:\\file.xml"), FileUtils.resolve("", "c:\\file.xml"));
+            assertEquals(new File("c:\\file.xml"), FileUtils.resolve((String) null, "c:\\file.xml#topicid"));
         } else {
-            assertEquals(new File("/dir1/dir2/file.xml"),FileUtils.resolve("/dir1", "dir2/file.xml"));
-            assertEquals(new File("/dir1/file.xml"),FileUtils.resolve("/dir1/dir2", "../file.xml"));
-            assertEquals(new File("/file.xml"),FileUtils.resolve("", "/file.xml#topicid"));
-            assertEquals(new File("/file.xml"),FileUtils.resolve("", "/file.xml"));
-            assertEquals(new File("/file.xml"),FileUtils.resolve((String) null, "/file.xml#topicid"));
-            assertEquals(new File("file.xml"), FileUtils.resolve("","file.xml"));
-            assertEquals(new File("file.xml"), FileUtils.resolve((String) null,"file.xml"));
+            assertEquals(new File("/dir1/dir2/file.xml"), FileUtils.resolve("/dir1", "dir2/file.xml"));
+            assertEquals(new File("/dir1/file.xml"), FileUtils.resolve("/dir1/dir2", "../file.xml"));
+            assertEquals(new File("/file.xml"), FileUtils.resolve("", "/file.xml#topicid"));
+            assertEquals(new File("/file.xml"), FileUtils.resolve("", "/file.xml"));
+            assertEquals(new File("/file.xml"), FileUtils.resolve((String) null, "/file.xml#topicid"));
+            assertEquals(new File("file.xml"), FileUtils.resolve("", "file.xml"));
+            assertEquals(new File("file.xml"), FileUtils.resolve((String) null, "file.xml"));
         }
     }
-    
+
     @Test
     public void testIsAbsolutePath() {
         assertFalse(FileUtils.isAbsolutePath(null));
         assertFalse(FileUtils.isAbsolutePath(""));
         assertFalse(FileUtils.isAbsolutePath(" "));
-        if(File.separator.equals(SEPARATOR_WINDOWS)){
+        if (File.separator.equals(SEPARATOR_WINDOWS)) {
             assertTrue(FileUtils.isAbsolutePath("C:\\file.xml"));
             assertTrue(FileUtils.isAbsolutePath("c:\\file.xml"));
             assertFalse(FileUtils.isAbsolutePath("\\dic\\file.xml"));
             assertFalse(FileUtils.isAbsolutePath("file.xml"));
             // Microsoft Windows UNC
             assertTrue(FileUtils.isAbsolutePath("\\\\ComputerName\\SharedFolder\\Resource"));
-        }else if(File.separator.equals(SEPARATOR_UNIX)){
+        } else if (File.separator.equals(SEPARATOR_UNIX)) {
             assertTrue(FileUtils.isAbsolutePath("/file.xml"));
             assertFalse(FileUtils.isAbsolutePath("file.xml"));
         }
@@ -193,19 +220,16 @@ public class TestFileUtils {
         final String extName = ".dita";
         assertEquals("filename.dita", FileUtils.replaceExtension("filename.xml", extName));
         // if there is a topic marked with sharp
-        assertEquals("filename.dita#topicid", FileUtils
-                .replaceExtension("filename.xml#topicid", extName));
+        assertEquals("filename.dita#topicid", FileUtils.replaceExtension("filename.xml#topicid", extName));
         // if the input just is a topicid
         assertEquals("#topicid", FileUtils.replaceExtension("#topicid", extName));
         // if there is an extra dot.
-        assertEquals("file.name.dita", FileUtils
-                .replaceExtension("file.name.xml", extName));
-        assertEquals("file.name.dita#topicid", FileUtils
-                .replaceExtension("file.name.xml#topicid", extName));
+        assertEquals("file.name.dita", FileUtils.replaceExtension("file.name.xml", extName));
+        assertEquals("file.name.dita#topicid", FileUtils.replaceExtension("file.name.xml#topicid", extName));
         // if there is no extension.
         assertEquals("file", FileUtils.replaceExtension("file", extName));
     }
-    
+
     @Test
     public void testGetExtName() {
         assertEquals("xml", FileUtils.getExtension("filename.xml"));
@@ -215,7 +239,7 @@ public class TestFileUtils {
         assertEquals("xml", FileUtils.getExtension("file.name.xml#topicid"));
         assertNull(FileUtils.getExtension("file"));
     }
-    
+
     @Test
     public void testDeriveFilename() {
         assertEquals("baz.qux", FileUtils.getName("/foo/bar/baz.qux"));
@@ -227,7 +251,7 @@ public class TestFileUtils {
     public void testDerivePath() {
         assertEquals("/foo/bar", FileUtils.getFullPathNoEndSeparator("/foo/bar/baz.qux"));
         assertEquals("foo/bar", FileUtils.getFullPathNoEndSeparator("foo/bar/baz.qux"));
-        //assertEquals("", FileUtils.derivePath("baz.qux"));
+        // assertEquals("", FileUtils.derivePath("baz.qux"));
     }
 
     @Test
@@ -243,7 +267,7 @@ public class TestFileUtils {
         assertEquals("", FileUtils.getFragment("foo#"));
         assertNull(FileUtils.getFragment("foo"));
     }
-    
+
     @Test
     public void testGetFragmentStringString() {
         assertEquals("bar", FileUtils.getFragment("foo#bar", "baz"));
@@ -265,7 +289,7 @@ public class TestFileUtils {
         assertEquals("foo", FileUtils.setFragment("foo", null));
         assertEquals("", FileUtils.setFragment("#bar", null));
     }
-    
+
     @Test
     public void testDirectoryContains() {
         assertTrue(FileUtils.directoryContains(srcDir, new File(srcDir, "test.txt")));
@@ -273,10 +297,9 @@ public class TestFileUtils {
         assertFalse(FileUtils.directoryContains(new File(srcDir, "test"), srcDir));
         assertFalse(FileUtils.directoryContains(srcDir, new File(srcDir, ".." + File.separator + "test.txt")));
     }
-    
+
     @AfterClass
     public static void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/util/TestMergeUtils.java
+++ b/src/test/java/org/dita/dost/util/TestMergeUtils.java
@@ -7,22 +7,18 @@
  */
 package org.dita.dost.util;
 
+import static org.dita.dost.util.URLUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import static org.dita.dost.util.URLUtils.*;
-
 import java.io.File;
 import java.io.IOException;
-
+import org.dita.dost.TestUtils;
 import org.dita.dost.store.StreamStore;
 import org.junit.After;
-
-import org.dita.dost.TestUtils;
-import org.dita.dost.util.MergeUtils;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -55,7 +51,6 @@ public class TestMergeUtils {
         assertFalse(mergeUtils.findId(toURI("dir/a.xml#topicid")));
     }
 
-
     @Test
     public void testAddIdString() {
         assertEquals(null, mergeUtils.addId(null));
@@ -64,7 +59,8 @@ public class TestMergeUtils {
         assertNull(mergeUtils.addId(null));
     }
 
-    @Test@Ignore
+    @Test
+    @Ignore
     public void testAddIdStringString() {
         fail("Not yet implemented");
     }
@@ -81,7 +77,7 @@ public class TestMergeUtils {
 
     @Test
     public void testIsVisited() {
-        //set visitSet
+        // set visitSet
         mergeUtils.visit(toURI("dir/dir1/a.xml#topicid"));
         mergeUtils.visit(toURI("dir/a b.xml"));
         assertTrue(mergeUtils.isVisited(toURI("dir/a%20b.xml")));
@@ -89,11 +85,12 @@ public class TestMergeUtils {
         assertFalse(mergeUtils.isVisited(toURI("a%20b.xml")));
         assertTrue(mergeUtils.isVisited(toURI("dir/dir1/a.xml")));
         assertTrue(mergeUtils.isVisited(toURI("dir/dir1/a.xml#topicid")));
-        //if topic id in the path are not the same
+        // if topic id in the path are not the same
         assertTrue(mergeUtils.isVisited(toURI("dir/dir1/a.xml#another")));
     }
 
-    @Test@Ignore
+    @Test
+    @Ignore
     // This method has been tested in the previous method.
     public void testVisit() {
         fail("Not yet implemented");
@@ -101,10 +98,9 @@ public class TestMergeUtils {
 
     @Test
     public void testGetFirstTopicId() {
-        //assertEquals("task",mergeUtils.getFirstTopicId("stub.xml", "TEST_STUB"));
+        // assertEquals("task",mergeUtils.getFirstTopicId("stub.xml", "TEST_STUB"));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), false));
         assertEquals("task", mergeUtils.getFirstTopicId(srcDir.toURI().resolve("stub.xml"), true));
         assertNull(mergeUtils.getFirstTopicId(srcDir.toURI().resolve("filedoesnotexist.xml"), false));
     }
-
 }

--- a/src/test/java/org/dita/dost/util/TestStringUtils.java
+++ b/src/test/java/org/dita/dost/util/TestStringUtils.java
@@ -13,10 +13,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
-
-import org.junit.Test;
-
 import javax.xml.namespace.QName;
+import org.junit.Test;
 
 public class TestStringUtils {
 
@@ -45,23 +43,26 @@ public class TestStringUtils {
     @Test
     public void testGetExtProps() {
         final QName props = QName.valueOf("props");
-        assertArrayEquals(new QName[][] {{props, QName.valueOf("foo")}, {props, QName.valueOf("bar")}},
-                          StringUtils.getExtProps("a(props foo) a(props bar)"));
-        assertArrayEquals(new QName[][] {{props, QName.valueOf("bar")}, {props, QName.valueOf("qux")}},
-                          StringUtils.getExtProps("(topic foo) a(props bar) (topic baz) a(props qux)"));
-        assertArrayEquals(new QName[][] {{props, QName.valueOf("foo")}},
-                          StringUtils.getExtProps("  a(props   foo  )   "));
-        assertArrayEquals(new QName[0][0],
-                          StringUtils.getExtProps("(topic task)"));
+        assertArrayEquals(
+                new QName[][] {{props, QName.valueOf("foo")}, {props, QName.valueOf("bar")}},
+                StringUtils.getExtProps("a(props foo) a(props bar)"));
+        assertArrayEquals(
+                new QName[][] {{props, QName.valueOf("bar")}, {props, QName.valueOf("qux")}},
+                StringUtils.getExtProps("(topic foo) a(props bar) (topic baz) a(props qux)"));
+        assertArrayEquals(
+                new QName[][] {{props, QName.valueOf("foo")}}, StringUtils.getExtProps("  a(props   foo  )   "));
+        assertArrayEquals(new QName[0][0], StringUtils.getExtProps("(topic task)"));
     }
 
     @Test
     public void getExtPropsFromSpecializations() {
         final QName props = QName.valueOf("props");
-        assertArrayEquals(new QName[][] {{props, QName.valueOf("foo")}, {props, QName.valueOf("bar")}},
-                          StringUtils.getExtPropsFromSpecializations("@props/foo @props/bar"));
-        assertArrayEquals(new QName[][] {{props, QName.valueOf("foo")}},
-                          StringUtils.getExtPropsFromSpecializations("  @props/foo   "));
+        assertArrayEquals(
+                new QName[][] {{props, QName.valueOf("foo")}, {props, QName.valueOf("bar")}},
+                StringUtils.getExtPropsFromSpecializations("@props/foo @props/bar"));
+        assertArrayEquals(
+                new QName[][] {{props, QName.valueOf("foo")}},
+                StringUtils.getExtPropsFromSpecializations("  @props/foo   "));
     }
 
     @Test
@@ -85,29 +86,30 @@ public class TestStringUtils {
         assertEquals("input1input2", result);
         result = StringUtils.setOrAppend(input1, input2, true);
         assertEquals("input1 input2", result);
-
     }
 
     @Test
     public void testGetLocale() {
-        final Locale expected1 = new Locale("zh","cn");
+        final Locale expected1 = new Locale("zh", "cn");
         final Locale result1 = StringUtils.getLocale("zh-cn");
         assertEquals(expected1, result1);
         final Locale expected2 = new Locale("zh");
         final Locale result2 = StringUtils.getLocale("zh_cn");
         assertEquals(expected2, result2);
-        final Locale expected3 = new Locale("zh","cn","gb2312");
+        final Locale expected3 = new Locale("zh", "cn", "gb2312");
         final Locale result3 = StringUtils.getLocale("zh-cn-gb2312");
         assertEquals(expected3, result3);
         assertNull(StringUtils.getLocale("xx-1234567890"));
         try {
             assertNull(StringUtils.getLocale("xx-1234567890-xx"));
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
         try {
             StringUtils.getLocale(null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -117,11 +119,10 @@ public class TestStringUtils {
         assertEquals(" foo bar baz ", runNormalizeAndCollapseWhitespace("  foo  bar  baz  "));
         assertEquals(" foo bar baz ", runNormalizeAndCollapseWhitespace("\nfoo\nbar\nbaz\n"));
     }
-    
+
     private String runNormalizeAndCollapseWhitespace(final String text) {
         final StringBuilder sb = new StringBuilder(text);
         StringUtils.normalizeAndCollapseWhitespace(sb);
         return sb.toString();
     }
-    
 }

--- a/src/test/java/org/dita/dost/util/URLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/URLUtilsTest.java
@@ -7,62 +7,61 @@
  */
 package org.dita.dost.util;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.dita.dost.util.URLUtils.toDirURI;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import static org.dita.dost.util.URLUtils.toDirURI;
-import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class URLUtilsTest {
 
     @Test
     public void testCorrectFile() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
     public void testCorrectURL() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
     public void testDecode() {
         assertEquals("foo bar.dita", URLUtils.decode("foo%20bar.dita"));
         assertEquals("foo bar.dita", URLUtils.decode("foo+bar.dita"));
-        
+
         assertEquals("f\u00f6\u00e5.dita", URLUtils.decode("f%C3%B6%C3%A5.dita"));
-        
+
         assertEquals("foo/bar.dita", URLUtils.decode("foo/bar.dita"));
         assertEquals("foo\\bar.dita", URLUtils.decode("foo%5Cbar.dita"));
-        
+
         assertEquals("foo?bar=baz&qux=quxx", URLUtils.decode("foo?bar=baz&qux=quxx"));
     }
-    
+
     @Test
     public void testUncorrect() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
     public void testGetCanonicalFileFromFileUrl() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
     public void testCorrectStringBoolean() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
     public void testGetURL() {
-        //fail("Not yet implemented");
+        // fail("Not yet implemented");
     }
 
     @Test
@@ -74,15 +73,15 @@ public class URLUtilsTest {
         assertEquals("foobar.dita%25", URLUtils.clean("foobar.dita%"));
 
         assertEquals("f%C3%B6%C3%A5.dita", URLUtils.clean("f\u00f6\u00e5.dita"));
-        
+
         assertEquals("foo/bar.dita", URLUtils.clean("foo/bar.dita"));
         assertEquals("foo/bar.dita", URLUtils.clean("foo\\bar.dita"));
-        
+
         assertEquals("foo?bar=baz&qux=quxx", URLUtils.clean("foo?bar=baz&qux=quxx"));
 
         assertEquals("http://www.example.com/foo/bar", URLUtils.clean("http://www.example.com/foo/bar"));
     }
-    
+
     @Test
     public void testCleanASCII() {
         assertEquals("foo.dita", URLUtils.clean("foo.dita", true));
@@ -98,7 +97,7 @@ public class URLUtilsTest {
         assertFalse(URLUtils.directoryContains(new URI("file:/src/test/"), new URI("file:/src/")));
         assertFalse(URLUtils.directoryContains(new URI("file:/src/"), new URI("file:/src/../test.txt")));
     }
-    
+
     @Test
     public void testIsAbsolute() throws URISyntaxException {
         assertTrue(URLUtils.isAbsolute(new URI("file:/foo")));
@@ -106,16 +105,16 @@ public class URLUtilsTest {
         assertFalse(URLUtils.isAbsolute(new URI("file:foo")));
         assertFalse(URLUtils.isAbsolute(new URI("foo")));
     }
- 
+
     @Test
     public void testToFileString() throws Exception {
         final Method method = URLUtils.class.getDeclaredMethod("toFile", String.class);
-        method.setAccessible(true);        
+        method.setAccessible(true);
         assertEquals(new File("test.txt"), method.invoke(null, "test.txt"));
         assertEquals(new File("foo bar.txt"), method.invoke(null, "foo%20bar.txt"));
         assertEquals(new File("foo" + File.separator + "bar.txt"), method.invoke(null, "foo/bar.txt"));
     }
-    
+
     @Test
     public void testToFileUri() throws URISyntaxException {
         assertEquals(new File("test.txt"), URLUtils.toFile(new URI("test.txt")));
@@ -123,9 +122,11 @@ public class URLUtilsTest {
         assertEquals(new File("foo bar.txt"), URLUtils.toFile(new URI("foo%20bar.txt")));
         assertEquals(new File(File.separator + "foo bar.txt"), URLUtils.toFile(new URI("file:/foo%20bar.txt")));
         assertEquals(new File("foo" + File.separator + "bar.txt"), URLUtils.toFile(new URI("foo/bar.txt")));
-        assertEquals(new File(File.separator + "foo" + File.separator + "bar.txt"), URLUtils.toFile(new URI("file:/foo/bar.txt")));
+        assertEquals(
+                new File(File.separator + "foo" + File.separator + "bar.txt"),
+                URLUtils.toFile(new URI("file:/foo/bar.txt")));
     }
-    
+
     @Test
     public void testFileToUri() throws URISyntaxException {
         assertEquals(new URI("test.txt"), URLUtils.toURI(new File("test.txt")));
@@ -146,21 +147,43 @@ public class URLUtilsTest {
 
     @Test
     public void testGetRelativePathFromMap() throws URISyntaxException {
-        assertEquals(new URI("../a.dita"), URLUtils.getRelativePath(new URI("file:/map/map.ditamap"), new URI("file:/a.dita")));
+        assertEquals(
+                new URI("../a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map/map.ditamap"), new URI("file:/a.dita")));
         assertEquals(new URI("../a.dita"), URLUtils.getRelativePath(new URI("file:/map/"), new URI("file:/a.dita")));
-        assertEquals(new URI("a.dita"), URLUtils.getRelativePath(new URI("file:/map.ditamap"), new URI("file:/a.dita")));
-        assertEquals(new URI("a.dita"), URLUtils.getRelativePath(new URI("file:/map1/map2/map.ditamap"), new URI("file:/map1/map2/a.dita")));
-        assertEquals(new URI("a.dita"), URLUtils.getRelativePath(new URI("file:/map1/map2/"), new URI("file:/map1/map2/a.dita")));
-        assertEquals(new URI("map2/a.dita"), URLUtils.getRelativePath(new URI("file:/map1/map.ditamap"), new URI("file:/map1/map2/a.dita")));
-        assertEquals(new URI("map2/a.dita"), URLUtils.getRelativePath(new URI("file:/map1/"), new URI("file:/map1/map2/a.dita")));
-        assertEquals(new URI("../topic/a.dita"), URLUtils.getRelativePath(new URI("file:/map1/map.ditamap"), new URI("file:/topic/a.dita")));
-        assertEquals(new URI("a.dita#bar"), URLUtils.getRelativePath(new URI("file:/map.ditamap#foo"), new URI("file:/a.dita#bar")));
+        assertEquals(
+                new URI("a.dita"), URLUtils.getRelativePath(new URI("file:/map.ditamap"), new URI("file:/a.dita")));
+        assertEquals(
+                new URI("a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map1/map2/map.ditamap"), new URI("file:/map1/map2/a.dita")));
+        assertEquals(
+                new URI("a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map1/map2/"), new URI("file:/map1/map2/a.dita")));
+        assertEquals(
+                new URI("map2/a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map1/map.ditamap"), new URI("file:/map1/map2/a.dita")));
+        assertEquals(
+                new URI("map2/a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map1/"), new URI("file:/map1/map2/a.dita")));
+        assertEquals(
+                new URI("../topic/a.dita"),
+                URLUtils.getRelativePath(new URI("file:/map1/map.ditamap"), new URI("file:/topic/a.dita")));
+        assertEquals(
+                new URI("a.dita#bar"),
+                URLUtils.getRelativePath(new URI("file:/map.ditamap#foo"), new URI("file:/a.dita#bar")));
         assertEquals(new URI("a.dita"), URLUtils.getRelativePath(new URI("file:/a.dita"), new URI("file:/a.dita")));
-        assertEquals(new URI("#bar"), URLUtils.getRelativePath(new URI("file:/a.dita#foo"), new URI("file:/a.dita#bar")));
+        assertEquals(
+                new URI("#bar"), URLUtils.getRelativePath(new URI("file:/a.dita#foo"), new URI("file:/a.dita#bar")));
         assertEquals(new URI("#bar"), URLUtils.getRelativePath(new URI("file:/a.dita"), new URI("#bar")));
-        assertEquals(new URI("file://a.dita"), URLUtils.getRelativePath(new URI("/map.ditamap"), new URI("file://a.dita")));
-        assertEquals(new URI("https://localhost/map.ditamap") ,URLUtils.getRelativePath(new URI("http://localhost/map.ditamap"), new URI("https://localhost/map.ditamap")));
-        assertEquals(new URI("http:///map.ditamap"), URLUtils.getRelativePath(new URI("http://localhost/map.ditamap"), new URI("http:///map.ditamap")));
+        assertEquals(
+                new URI("file://a.dita"), URLUtils.getRelativePath(new URI("/map.ditamap"), new URI("file://a.dita")));
+        assertEquals(
+                new URI("https://localhost/map.ditamap"),
+                URLUtils.getRelativePath(
+                        new URI("http://localhost/map.ditamap"), new URI("https://localhost/map.ditamap")));
+        assertEquals(
+                new URI("http:///map.ditamap"),
+                URLUtils.getRelativePath(new URI("http://localhost/map.ditamap"), new URI("http:///map.ditamap")));
     }
 
     @Test
@@ -168,7 +191,7 @@ public class URLUtilsTest {
         assertEquals(new URI("../"), URLUtils.getRelativePath(new URI("map/map.ditamap")));
         assertEquals(null, URLUtils.getRelativePath(new URI("map.ditamap")));
         assertEquals(new URI("../../"), URLUtils.getRelativePath(new URI("map1/map2/map.ditamap")));
-    } 
+    }
 
     @Test
     public void testSetFragment() throws URISyntaxException {
@@ -182,15 +205,20 @@ public class URLUtilsTest {
         assertEquals(new URI(""), URLUtils.setFragment(new URI("#bar"), null));
         assertEquals(new URI("file:/foo/bar#baz"), URLUtils.setFragment(new URI("file:/foo/bar"), "baz"));
         assertEquals(new URI("file:/foo/bar"), URLUtils.setFragment(new URI("file:/foo/bar"), null));
-        assertEquals(new URI("file://localhost/foo/bar#baz"), URLUtils.setFragment(new URI("file://localhost/foo/bar"), "baz"));
-        assertEquals(new URI("file://localhost/foo/bar"), URLUtils.setFragment(new URI("file://localhost/foo/bar"), null));
+        assertEquals(
+                new URI("file://localhost/foo/bar#baz"),
+                URLUtils.setFragment(new URI("file://localhost/foo/bar"), "baz"));
+        assertEquals(
+                new URI("file://localhost/foo/bar"), URLUtils.setFragment(new URI("file://localhost/foo/bar"), null));
         assertEquals(new URI("urn:foo:bar#baz"), URLUtils.setFragment(new URI("urn:foo:bar"), "baz"));
         assertEquals(new URI("urn:foo:bar"), URLUtils.setFragment(new URI("urn:foo:bar"), null));
     }
 
     @Test
     public void setFragment_mailto() {
-        assertEquals(URI.create("mailto:email@example.com?subject=Email"), URLUtils.setFragment(URI.create("mailto:email@example.com?subject=Email"), null));
+        assertEquals(
+                URI.create("mailto:email@example.com?subject=Email"),
+                URLUtils.setFragment(URI.create("mailto:email@example.com?subject=Email"), null));
     }
 
     @Test
@@ -203,7 +231,7 @@ public class URLUtilsTest {
         assertEquals(new URI("file://localhost/foo/bar"), URLUtils.removeFragment(new URI("file://localhost/foo/bar")));
         assertEquals(new URI("urn:foo:bar"), URLUtils.removeFragment(new URI("urn:foo:bar")));
     }
-    
+
     @Test
     public void testStripFragment() throws URISyntaxException {
         assertEquals(new URI("foo"), URLUtils.stripFragment(new URI("foo#bar")));
@@ -230,7 +258,8 @@ public class URLUtilsTest {
         try {
             assertNull(URLUtils.getTopicID(null));
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -245,7 +274,8 @@ public class URLUtilsTest {
         try {
             assertNull(URLUtils.getElementID(null));
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -255,11 +285,13 @@ public class URLUtilsTest {
         try {
             URLUtils.setElementID(new URI("foo#"), "qux");
             fail();
-        } catch (final IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {
+        }
         try {
             URLUtils.setElementID(new URI("foo"), "qux");
             fail();
-        } catch (final IllegalArgumentException e) {}
+        } catch (final IllegalArgumentException e) {
+        }
 
         assertEquals(new URI("foo#bar"), URLUtils.setElementID(new URI("foo#bar/baz"), null));
         assertEquals(new URI("foo#bar"), URLUtils.setElementID(new URI("foo#bar"), null));
@@ -269,7 +301,8 @@ public class URLUtilsTest {
         try {
             URLUtils.setElementID(null, null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Rule
@@ -299,12 +332,15 @@ public class URLUtilsTest {
 
     @Test
     public void setQuery_mailto() {
-        assertEquals(URI.create("mailto:email@example.com?subject=Email"), URLUtils.setQuery(URI.create("mailto:email@example.com?subject=Email"), null));
+        assertEquals(
+                URI.create("mailto:email@example.com?subject=Email"),
+                URLUtils.setQuery(URI.create("mailto:email@example.com?subject=Email"), null));
     }
 
     @Test
     public void addSuffixToPath() {
-        assertEquals(URI.create("file:/foo/barquz.baz"), URLUtils.addSuffixToPath(URI.create("file:/foo/bar.baz"), "quz"));
+        assertEquals(
+                URI.create("file:/foo/barquz.baz"), URLUtils.addSuffixToPath(URI.create("file:/foo/bar.baz"), "quz"));
         assertEquals(URI.create("file:/foo/barquz"), URLUtils.addSuffixToPath(URI.create("file:/foo/bar"), "quz"));
     }
 }

--- a/src/test/java/org/dita/dost/util/UriBasenameTaskTest.java
+++ b/src/test/java/org/dita/dost/util/UriBasenameTaskTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.tools.ant.Project;
 import org.dita.dost.ant.UriBasenameTask;
 import org.junit.Before;
@@ -20,7 +19,7 @@ import org.junit.Test;
 public class UriBasenameTaskTest {
 
     private UriBasenameTask basename;
-    
+
     @Before
     public void setUp() throws URISyntaxException {
         final Project project = new Project();
@@ -28,7 +27,7 @@ public class UriBasenameTaskTest {
         basename.setProject(project);
         basename.setProperty("test");
     }
-    
+
     @Test
     public void testPlain() throws URISyntaxException {
         basename.setFile(new URI("foo/bar.baz"));
@@ -50,7 +49,7 @@ public class UriBasenameTaskTest {
         basename.execute();
         assertEquals("bar", basename.getProject().getProperty("test"));
     }
-    
+
     @Test
     public void testDotSuffix() throws URISyntaxException {
         basename.setFile(new URI("file:/foo/bar.baz"));
@@ -58,7 +57,7 @@ public class UriBasenameTaskTest {
         basename.execute();
         assertEquals("bar", basename.getProject().getProperty("test"));
     }
-    
+
     @Test
     public void testSuffixNoMatch() throws URISyntaxException {
         basename.setFile(new URI("file:/foo/bar.baz"));
@@ -66,7 +65,7 @@ public class UriBasenameTaskTest {
         basename.execute();
         assertEquals("bar.baz", basename.getProject().getProperty("test"));
     }
-    
+
     @Test
     public void testWildcardSuffix() throws URISyntaxException {
         basename.setFile(new URI("file:/foo/bar.baz"));
@@ -74,7 +73,7 @@ public class UriBasenameTaskTest {
         basename.execute();
         assertEquals("bar", basename.getProject().getProperty("test"));
     }
-    
+
     @Test
     public void testWildcardSuffixNoMatch() throws URISyntaxException {
         basename.setFile(new URI("file:/foo/bar"));
@@ -82,5 +81,4 @@ public class UriBasenameTaskTest {
         basename.execute();
         assertEquals("bar", basename.getProject().getProperty("test"));
     }
-    
 }

--- a/src/test/java/org/dita/dost/util/UriDirnameTaskTest.java
+++ b/src/test/java/org/dita/dost/util/UriDirnameTaskTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.tools.ant.Project;
 import org.dita.dost.ant.UriDirnameTask;
 import org.junit.Before;
@@ -20,7 +19,7 @@ import org.junit.Test;
 public class UriDirnameTaskTest {
 
     private UriDirnameTask dirname;
-    
+
     @Before
     public void setUp() throws URISyntaxException {
         final Project project = new Project();
@@ -28,19 +27,18 @@ public class UriDirnameTaskTest {
         dirname.setProject(project);
         dirname.setProperty("test");
     }
-    
+
     @Test
     public void testPlain() throws URISyntaxException {
         dirname.setFile(new URI("foo/"));
         dirname.execute();
         assertEquals("foo/", dirname.getProject().getProperty("test"));
     }
-    
+
     @Test
     public void testFile() throws URISyntaxException {
         dirname.setFile(new URI("foo/bar.baz"));
         dirname.execute();
         assertEquals("foo/", dirname.getProject().getProperty("test"));
     }
-
 }

--- a/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLGrammarPoolImplUtilsTest.java
@@ -7,15 +7,14 @@
  */
 package org.dita.dost.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.apache.xerces.impl.dtd.DTDGrammar;
 import org.apache.xerces.impl.dtd.XMLDTDDescription;
 import org.apache.xerces.xni.grammars.Grammar;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 
 public class XMLGrammarPoolImplUtilsTest {
 
@@ -77,5 +76,4 @@ public class XMLGrammarPoolImplUtilsTest {
     private XMLDTDDescription getXmldtdDescription(String base, String systemId, String publicId) {
         return new XMLDTDDescription(publicId, "topic.dtd", base, systemId, "topic");
     }
-
 }

--- a/src/test/java/org/dita/dost/util/XMLSerializerTest.java
+++ b/src/test/java/org/dita/dost/util/XMLSerializerTest.java
@@ -7,27 +7,24 @@
  */
 package org.dita.dost.util;
 
+import static org.dita.dost.TestUtils.assertXMLEqual;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.sax.TransformerHandler;
-
-
 import org.dita.dost.TestUtils;
+import org.junit.Test;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
-import org.xml.sax.SAXException;
-import org.junit.Test;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
 
 public class XMLSerializerTest {
 
@@ -43,11 +40,7 @@ public class XMLSerializerTest {
         serializer.writeStartDocument();
         serializer.writeStartElement("topic");
         serializer.writeAttribute("class", "- topic/topic ");
-        serializer.writeCharacters("\n" +
-                "foo" + "\n" +
-                "&<" + "\n" +
-                "bar" + "\n" +
-                "entity" + "\n");
+        serializer.writeCharacters("\n" + "foo" + "\n" + "&<" + "\n" + "bar" + "\n" + "entity" + "\n");
         serializer.writeComment("foo & <");
         serializer.writeCharacters("\n");
         serializer.writeProcessingInstruction("foo", "bar & <");
@@ -77,7 +70,8 @@ public class XMLSerializerTest {
         serializer.writeEndDocument();
         serializer.close();
 
-        assertXMLEqual(new InputSource(new File(expDir, "test.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "test.xml").toURI().toString()),
                 new InputSource(new StringReader(buf.toString())));
     }
 
@@ -93,7 +87,8 @@ public class XMLSerializerTest {
         serializer.writeEndDocument();
         serializer.close();
 
-        assertXMLEqual(new InputSource(new StringReader("<first><second><third/></second></first>")),
+        assertXMLEqual(
+                new InputSource(new StringReader("<first><second><third/></second></first>")),
                 new InputSource(new StringReader(buf.toString())));
     }
 
@@ -108,7 +103,8 @@ public class XMLSerializerTest {
         serializer.writeEndDocument();
         serializer.close();
 
-        assertXMLEqual(new InputSource(new StringReader("<data>first</data>")),
+        assertXMLEqual(
+                new InputSource(new StringReader("<data>first</data>")),
                 new InputSource(new StringReader(buf.toString())));
     }
 
@@ -124,7 +120,8 @@ public class XMLSerializerTest {
         serializer.writeEndDocument();
         serializer.close();
 
-        assertXMLEqual(new InputSource(new StringReader("<data>first</data>")),
+        assertXMLEqual(
+                new InputSource(new StringReader("<data>first</data>")),
                 new InputSource(new StringReader(buf.toString())));
     }
 
@@ -159,10 +156,10 @@ public class XMLSerializerTest {
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);
         }
-        assertXMLEqual(builder.parse(new InputSource(new StringReader("<root>" +
-                "<att att='value'/>" +
-                "<att xmlns:ns1='uri1' xmlns:ns2='uri2' xmlns:ns3='uri3' ns1:att='value' ns2:att='value' ns3:att='value'/>" +
-                "</root>"))),
+        assertXMLEqual(
+                builder.parse(new InputSource(new StringReader("<root>" + "<att att='value'/>"
+                        + "<att xmlns:ns1='uri1' xmlns:ns2='uri2' xmlns:ns3='uri3' ns1:att='value' ns2:att='value' ns3:att='value'/>"
+                        + "</root>"))),
                 builder.parse(new InputSource(new StringReader(buf.toString()))));
     }
 
@@ -206,28 +203,28 @@ public class XMLSerializerTest {
         serializer.writeEndDocument();
         serializer.close();
 
-        assertXMLEqual(new InputSource(new StringReader("<root>" +
-                "<ns1:same-uri xmlns:ns1='uri1'>" +
-                "<ns1:same-uri xmlns:ns1='uri1'>" +
-                "<ns1:same-uri/>" +
-                "</ns1:same-uri>" +
-                "</ns1:same-uri>" +
-                "<ns1:different-uri xmlns:ns1='uri1'>" +
-                "<ns1:different-uri xmlns:ns1='uri2'>" +
-                "<ns1:different-uri xmlns:ns1='uri1'/>" +
-                "</ns1:different-uri>" +
-                "</ns1:different-uri>" +
-                "<ns1:different-prefix xmlns:ns1='uri1'>" +
-                "<ns2:different-prefix xmlns:ns2='uri1'>" +
-                "<ns3:different-prefix xmlns:ns3='uri1'/>" +
-                "</ns2:different-prefix>" +
-                "</ns1:different-prefix>" +
-                "<ns1:different-prefix xmlns:ns1='uri1'>" +
-                "<ns2:different-prefix xmlns:ns2='uri1'>" +
-                "<ns1:different-prefix/>" +
-                "</ns2:different-prefix>" +
-                "</ns1:different-prefix>" +
-                "</root>")),
+        assertXMLEqual(
+                new InputSource(new StringReader("<root>" + "<ns1:same-uri xmlns:ns1='uri1'>"
+                        + "<ns1:same-uri xmlns:ns1='uri1'>"
+                        + "<ns1:same-uri/>"
+                        + "</ns1:same-uri>"
+                        + "</ns1:same-uri>"
+                        + "<ns1:different-uri xmlns:ns1='uri1'>"
+                        + "<ns1:different-uri xmlns:ns1='uri2'>"
+                        + "<ns1:different-uri xmlns:ns1='uri1'/>"
+                        + "</ns1:different-uri>"
+                        + "</ns1:different-uri>"
+                        + "<ns1:different-prefix xmlns:ns1='uri1'>"
+                        + "<ns2:different-prefix xmlns:ns2='uri1'>"
+                        + "<ns3:different-prefix xmlns:ns3='uri1'/>"
+                        + "</ns2:different-prefix>"
+                        + "</ns1:different-prefix>"
+                        + "<ns1:different-prefix xmlns:ns1='uri1'>"
+                        + "<ns2:different-prefix xmlns:ns2='uri1'>"
+                        + "<ns1:different-prefix/>"
+                        + "</ns2:different-prefix>"
+                        + "</ns1:different-prefix>"
+                        + "</root>")),
                 new InputSource(new StringReader(buf.toString())));
     }
 
@@ -248,9 +245,8 @@ public class XMLSerializerTest {
             in.close();
         }
 
-        assertXMLEqual(new InputSource(new File(expDir, "test.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "test.xml").toURI().toString()),
                 new InputSource(new StringReader(buf.toString())));
     }
-
-
 }

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -7,6 +7,19 @@
  */
 package org.dita.dost.util;
 
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.instruct.TerminationException;
 import net.sf.saxon.expr.parser.Loc;
@@ -36,27 +49,12 @@ import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.LocatorImpl;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static javax.xml.XMLConstants.XML_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.*;
-
 public class XMLUtilsTest {
 
     private static final File resourceDir = TestUtils.getResourceDir(XMLUtilsTest.class);
     private static final File srcDir = new File(resourceDir, "src");
     private static final File expDir = new File(resourceDir, "exp");
     private static File tempDir;
-
 
     @BeforeClass
     public static void setUp() throws IOException {
@@ -86,7 +84,8 @@ public class XMLUtilsTest {
         try {
             XMLUtils.getPrefix(null);
             fail();
-        } catch (final NullPointerException e) {}
+        } catch (final NullPointerException e) {
+        }
     }
 
     @Test
@@ -114,9 +113,10 @@ public class XMLUtilsTest {
     @Test
     public void testAddOrSetAttributeAttributesImplNode() throws ParserConfigurationException {
         final AttributesImpl atts = new AttributesImpl();
-        final DOMImplementation dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
+        final DOMImplementation dom =
+                DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
         final Document doc = dom.createDocument(null, "foo", null);
-        
+
         doc.getDocumentElement().setAttribute("foo", "foo");
         final Attr att = doc.getDocumentElement().getAttributeNode("foo");
         XMLUtils.addOrSetAttribute(atts, att);
@@ -126,11 +126,11 @@ public class XMLUtilsTest {
         assertEquals("foo", atts.getQName(i));
         assertEquals("foo", atts.getLocalName(i));
         assertEquals("foo", atts.getValue(i));
-        
+
         doc.getDocumentElement().setAttributeNS(XML_NS_URI, "xml:lang", "en");
         final Attr lang = doc.getDocumentElement().getAttributeNodeNS(XML_NS_URI, "lang");
         XMLUtils.addOrSetAttribute(atts, lang);
-        
+
         final int l = atts.getIndex(XML_NS_URI, "lang");
         assertEquals(XML_NS_URI, atts.getURI(l));
         assertEquals("xml:lang", atts.getQName(l));
@@ -149,9 +149,10 @@ public class XMLUtilsTest {
 
     @Test
     public void testGetStringValue() throws ParserConfigurationException {
-        final DOMImplementation dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
+        final DOMImplementation dom =
+                DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
         final Document doc = dom.createDocument(null, "foo", null);
-        
+
         final Element root = doc.getDocumentElement();
         root.appendChild(doc.createTextNode("foo"));
         assertEquals("foo", XMLUtils.getStringValue(root));
@@ -162,12 +163,12 @@ public class XMLUtilsTest {
         root.appendChild(doc.createTextNode(" bar"));
         assertEquals("foo nested bar", XMLUtils.getStringValue(root));
     }
-    
+
     @Test
     public void testAttributesBuilder() throws ParserConfigurationException {
-        final XMLUtils.AttributesBuilder b = new XMLUtils.AttributesBuilder(); 
+        final XMLUtils.AttributesBuilder b = new XMLUtils.AttributesBuilder();
         assertEquals(0, b.build().getLength());
-        
+
         b.add("foo", "bar");
         b.add("uri", "foo", "prefix:foo", "CDATA", "qux");
         final Attributes a = b.build();
@@ -183,12 +184,12 @@ public class XMLUtilsTest {
                 assertEquals("qux", a.getValue(i));
             }
         }
-        
+
         b.add("foo", "quxx");
         final Attributes aa = b.build();
         assertEquals("quxx", aa.getValue("foo"));
         assertEquals(2, aa.getLength());
-        
+
         final AttributesImpl ai = new AttributesImpl();
         ai.addAttribute(NULL_NS_URI, "baz", "baz", "CDATA", "all");
         b.addAll(ai);
@@ -196,7 +197,8 @@ public class XMLUtilsTest {
         assertEquals("all", aaa.getValue("baz"));
         assertEquals(3, aaa.getLength());
 
-        final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final Document doc =
+                DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         final Attr domAttr = doc.createAttributeNS(XML_NS_URI, "xml:space");
         domAttr.setValue("preserve");
         b.add(domAttr);
@@ -211,12 +213,13 @@ public class XMLUtilsTest {
         }
     }
 
-
     @Test
     public void testEscapeXMLString() {
         String result = null;
-        final String input = "<this is test of char update for xml href=\" see link: http://www.ibm.com/download.php?abc=123&def=456\">'test' </test>";
-        final String expected = "&lt;this is test of char update for xml href=&quot; see link: http://www.ibm.com/download.php?abc=123&amp;def=456&quot;&gt;&apos;test&apos; &lt;/test&gt;";
+        final String input =
+                "<this is test of char update for xml href=\" see link: http://www.ibm.com/download.php?abc=123&def=456\">'test' </test>";
+        final String expected =
+                "&lt;this is test of char update for xml href=&quot; see link: http://www.ibm.com/download.php?abc=123&amp;def=456&quot;&gt;&apos;test&apos; &lt;/test&gt;";
         result = XMLUtils.escapeXML(input);
         assertEquals(expected, result);
     }
@@ -224,12 +227,15 @@ public class XMLUtilsTest {
     @Test
     public void testEscapeXMLCharArrayIntInt() {
         String result = null;
-        final char[] input = "<this is test of char update for xml href=\" see link: http://www.ibm.com/download.php?abc=123&def=456\">'test' </test>".toCharArray();
-        final String expected = "&lt;this is test of char update for xml href=&quot; see link: http://www.ibm.com/download.php?abc=123&amp;def=456&quot;&gt;&apos;test&apos; &lt;/test&gt;";
+        final char[] input =
+                "<this is test of char update for xml href=\" see link: http://www.ibm.com/download.php?abc=123&def=456\">'test' </test>"
+                        .toCharArray();
+        final String expected =
+                "&lt;this is test of char update for xml href=&quot; see link: http://www.ibm.com/download.php?abc=123&amp;def=456&quot;&gt;&apos;test&apos; &lt;/test&gt;";
         result = XMLUtils.escapeXML(input, 0, input.length);
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void testNonDitaContext() {
         /* Queue assumes the following values:
@@ -277,10 +283,8 @@ public class XMLUtilsTest {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.text("message "),
-                    Saplings.elem("debug")
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(Saplings.text("message "), Saplings.elem("debug"))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         listener.message(msg, null, false, null);
@@ -295,12 +299,12 @@ public class XMLUtilsTest {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.pi("error-code", "DOTX037W"),
-                    Saplings.pi("level", "WARN"),
-                    Saplings.text("message "),
-                    Saplings.elem("debug")
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(
+                        Saplings.pi("error-code", "DOTX037W"),
+                        Saplings.pi("level", "WARN"),
+                        Saplings.text("message "),
+                        Saplings.elem("debug"))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         listener.message(msg, null, false, null);
@@ -315,11 +319,8 @@ public class XMLUtilsTest {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.pi("error-code", "DOTX037W"),
-                    Saplings.text("message "),
-                    Saplings.elem("debug")
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(Saplings.pi("error-code", "DOTX037W"), Saplings.text("message "), Saplings.elem("debug"))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         listener.message(msg, null, false, null);
@@ -334,12 +335,12 @@ public class XMLUtilsTest {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.pi("error-code", "DOTX037W"),
-                    Saplings.pi("level", "WARN"),
-                    Saplings.text("message "),
-                    Saplings.elem("debug")
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(
+                        Saplings.pi("error-code", "DOTX037W"),
+                        Saplings.pi("level", "WARN"),
+                        Saplings.text("message "),
+                        Saplings.elem("debug"))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         try {
@@ -357,11 +358,8 @@ public class XMLUtilsTest {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.pi("level", "ERROR"),
-                    Saplings.text("message "),
-                    Saplings.elem("debug")
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(Saplings.pi("level", "ERROR"), Saplings.text("message "), Saplings.elem("debug"))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         listener.message(msg, null, false, null);
@@ -370,23 +368,22 @@ public class XMLUtilsTest {
         assertEquals(1, act.size());
         assertEquals(new Message(Message.Level.ERROR, "message <debug/>", null), act.get(0));
     }
-    
+
     @Test
     public void toMessageListenerProperElemsSerialization() throws SaxonApiException {
         final CachingLogger logger = new CachingLogger();
         final MessageListener2 listener = XMLUtils.toMessageListener(logger);
 
-        final XdmNode msg = Saplings.doc().withChild(
-                    Saplings.text("abc "),
-                    Saplings.elem("def").withChild(Saplings.elem("hij"))
-                )
+        final XdmNode msg = Saplings.doc()
+                .withChild(Saplings.text("abc "), Saplings.elem("def").withChild(Saplings.elem("hij")))
                 .toXdmNode(new XMLUtils().getProcessor());
 
         listener.message(msg, null, false, null);
 
         final List<Message> act = logger.getMessages();
         assertEquals(1, act.size());
-        assertEquals("""
+        assertEquals(
+                """
                 abc <def>
                    <hij/>
                 </def>""", act.get(0).message);
@@ -413,8 +410,7 @@ public class XMLUtilsTest {
         loc.setLineNumber(1);
         loc.setColumnNumber(2);
         loc.setSystemId("foo:///bar");
-        errorReporter.report(new XmlProcessingException(
-                new XPathException("msg", null, Loc.makeFromSax(loc))));
+        errorReporter.report(new XmlProcessingException(new XPathException("msg", null, Loc.makeFromSax(loc))));
 
         assertEquals(1, logger.getMessages().size());
         final Message message = logger.getMessages().get(0);
@@ -441,77 +437,82 @@ public class XMLUtilsTest {
         assertEquals(Message.Level.WARN, message.level);
     }
 
-//    @Test
-//    public void transform() throws Exception {
-//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
-//        final Job job = new Job(tempDir);
-//        final URI src = new File(tempDir, "test.dita").toURI();
-//
-//        // two filters that assume processing order
-//        final URI act = new File(tempDir, "order.dita").toURI();
-//        job.transform(src, act, Arrays.asList(
-//            (XMLFilter) new XMLFilterImpl() {
-//                @Override
-//                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
-//                    getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
-//                }
-//                @Override
-//                public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-//                    getContentHandler().endElement(uri, localName + "_x", qName + "_x");
-//                }
-//            },
-//            (XMLFilter) new XMLFilterImpl() {
-//                @Override
-//                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
-//                    getContentHandler().startElement(uri, localName + "_y", qName + "_y", atts);
-//                }
-//                @Override
-//                public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-//                    getContentHandler().endElement(uri, localName + "_y", qName + "_y");
-//                }
-//            }));
-//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "order.dita").toURI().toString()),
-//                new InputSource(new File(tempDir, "order.dita").toURI().toString()));
-//    }
-//
-//    @Test
-//    public void transform_single() throws Exception {
-//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
-//        final Job job = new Job(tempDir);
-//        final URI src = new File(tempDir, "test.dita").toURI();
-//
-//        // single filter that prefixes each element name
-//        final URI act = new File(tempDir, "single.dita").toURI();
-//        job.transform(src, act, Arrays.asList((XMLFilter) new XMLFilterImpl() {
-//            @Override
-//            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
-//                getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
-//            }
-//            @Override
-//            public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-//                getContentHandler().endElement(uri, localName + "_x", qName + "_x");
-//            }
-//        }));
-//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "single.dita").toURI().toString()),
-//                       new InputSource(new File(tempDir, "single.dita").toURI().toString()));
-//    }
-//
-//    @Test
-//    public void transform_empty() throws Exception {
-//        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
-//        final Job job = new Job(tempDir);
-//        final URI src = new File(tempDir, "test.dita").toURI();
-//
-//        // identity without a filter
-//        final URI act = new File(tempDir, "identity.dita").toURI();
-//        job.transform(src, act, Collections.EMPTY_LIST);
-//        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "identity.dita").toURI().toString()),
-//                       new InputSource(new File(tempDir, "identity.dita").toURI().toString()));
-//    }
+    //    @Test
+    //    public void transform() throws Exception {
+    //        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+    //        final Job job = new Job(tempDir);
+    //        final URI src = new File(tempDir, "test.dita").toURI();
+    //
+    //        // two filters that assume processing order
+    //        final URI act = new File(tempDir, "order.dita").toURI();
+    //        job.transform(src, act, Arrays.asList(
+    //            (XMLFilter) new XMLFilterImpl() {
+    //                @Override
+    //                public void startElement(final String uri, final String localName, final String qName, final
+    // Attributes atts) throws SAXException {
+    //                    getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
+    //                }
+    //                @Override
+    //                public void endElement(final String uri, final String localName, final String qName) throws
+    // SAXException {
+    //                    getContentHandler().endElement(uri, localName + "_x", qName + "_x");
+    //                }
+    //            },
+    //            (XMLFilter) new XMLFilterImpl() {
+    //                @Override
+    //                public void startElement(final String uri, final String localName, final String qName, final
+    // Attributes atts) throws SAXException {
+    //                    getContentHandler().startElement(uri, localName + "_y", qName + "_y", atts);
+    //                }
+    //                @Override
+    //                public void endElement(final String uri, final String localName, final String qName) throws
+    // SAXException {
+    //                    getContentHandler().endElement(uri, localName + "_y", qName + "_y");
+    //                }
+    //            }));
+    //        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "order.dita").toURI().toString()),
+    //                new InputSource(new File(tempDir, "order.dita").toURI().toString()));
+    //    }
+    //
+    //    @Test
+    //    public void transform_single() throws Exception {
+    //        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+    //        final Job job = new Job(tempDir);
+    //        final URI src = new File(tempDir, "test.dita").toURI();
+    //
+    //        // single filter that prefixes each element name
+    //        final URI act = new File(tempDir, "single.dita").toURI();
+    //        job.transform(src, act, Arrays.asList((XMLFilter) new XMLFilterImpl() {
+    //            @Override
+    //            public void startElement(final String uri, final String localName, final String qName, final
+    // Attributes atts) throws SAXException {
+    //                getContentHandler().startElement(uri, localName + "_x", qName + "_x", atts);
+    //            }
+    //            @Override
+    //            public void endElement(final String uri, final String localName, final String qName) throws
+    // SAXException {
+    //                getContentHandler().endElement(uri, localName + "_x", qName + "_x");
+    //            }
+    //        }));
+    //        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "single.dita").toURI().toString()),
+    //                       new InputSource(new File(tempDir, "single.dita").toURI().toString()));
+    //    }
+    //
+    //    @Test
+    //    public void transform_empty() throws Exception {
+    //        copyFile(new File(srcDir, "test.dita"), new File(tempDir, "test.dita"));
+    //        final Job job = new Job(tempDir);
+    //        final URI src = new File(tempDir, "test.dita").toURI();
+    //
+    //        // identity without a filter
+    //        final URI act = new File(tempDir, "identity.dita").toURI();
+    //        job.transform(src, act, Collections.EMPTY_LIST);
+    //        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "identity.dita").toURI().toString()),
+    //                       new InputSource(new File(tempDir, "identity.dita").toURI().toString()));
+    //    }
 
     @AfterClass
     public static void tearDown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/util/XSpecTest.java
+++ b/src/test/java/org/dita/dost/util/XSpecTest.java
@@ -7,6 +7,19 @@
  */
 package org.dita.dost.util;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -16,20 +29,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class XSpecTest {
@@ -46,7 +45,7 @@ public class XSpecTest {
 
         final List<Object[]> params = new ArrayList<>(cases.size());
         for (final File f : cases) {
-            final Object[] arr = new Object[]{f};
+            final Object[] arr = new Object[] {f};
             params.add(arr);
         }
         return params;
@@ -73,8 +72,8 @@ public class XSpecTest {
     @BeforeClass
     public static void setUpClass() throws TransformerException {
         transformerFactory = TransformerFactory.newInstance();
-        final File ditaDir = new File(Optional.ofNullable(System.getProperty("dita.dir"))
-                .orElse("src" + File.separator + "main"))
+        final File ditaDir = new File(
+                        Optional.ofNullable(System.getProperty("dita.dir")).orElse("src" + File.separator + "main"))
                 .getAbsoluteFile();
         CatalogUtils.setDitaDir(ditaDir);
         final CatalogResolver catalogResolver = CatalogUtils.getCatalogResolver();
@@ -92,21 +91,30 @@ public class XSpecTest {
 
         final Transformer compiledXspec = transformerFactory.newTransformer(new DOMSource(stylesheet.getNode()));
         final DOMResult results = new DOMResult();
-        compiledXspec.transform(new DOMSource(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()), results);
+        compiledXspec.transform(
+                new DOMSource(DocumentBuilderFactory.newInstance()
+                        .newDocumentBuilder()
+                        .newDocument()),
+                results);
 
         final NodeList tests = ((Document) results.getNode()).getElementsByTagNameNS(XSPEC_NS, "test");
         for (int i = 0; i < tests.getLength(); i++) {
             final Element test = (Element) tests.item(i);
-            final boolean res = Boolean.parseBoolean(test.getAttribute("successful"))
-                    || test.getAttributeNode("pending") != null;
+            final boolean res =
+                    Boolean.parseBoolean(test.getAttribute("successful")) || test.getAttributeNode("pending") != null;
             if (!res) {
                 final Element scenario = (Element) test.getParentNode();
-                final Node label = scenario.getElementsByTagNameNS(XSPEC_NS, "label").item(0).getFirstChild();
-                final String act = ((Element) scenario.getElementsByTagNameNS(XSPEC_NS, "result").item(0)).getAttribute("select");
-                final String exp = ((Element) test.getElementsByTagNameNS(XSPEC_NS, "expect").item(0)).getAttribute("select");
+                final Node label = scenario.getElementsByTagNameNS(XSPEC_NS, "label")
+                        .item(0)
+                        .getFirstChild();
+                final String act = ((Element) scenario.getElementsByTagNameNS(XSPEC_NS, "result")
+                                .item(0))
+                        .getAttribute("select");
+                final String exp = ((Element)
+                                test.getElementsByTagNameNS(XSPEC_NS, "expect").item(0))
+                        .getAttribute("select");
                 assertEquals(label != null ? label.getTextContent() : null, exp, act);
             }
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ConkeyrefFilterTest.java
@@ -7,6 +7,18 @@
  */
 package org.dita.dost.writer;
 
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.toURI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.store.StreamStore;
@@ -20,19 +32,6 @@ import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.URLUtils.toURI;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class ConkeyrefFilterTest {
 
@@ -59,67 +58,107 @@ public class ConkeyrefFilterTest {
     @Test
     public void testKey() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, toURI("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                toURI("library.dita"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                toURI("main.ditamap"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertEquals("library.dita", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo").build());
     }
 
     @Test
     public void testKeyAndElement() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", toURI("library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, toURI("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                toURI("library.dita"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                toURI("main.ditamap"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 // FIXME: this would be right only for maps, for topics the root topic ID should be added
                 assertEquals("library.dita#bar", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar").build());
     }
 
     @Test
     public void testElementInTarget() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", toURI("library.dita#baz"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, toURI("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                toURI("library.dita#baz"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                toURI("main.ditamap"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertEquals("library.dita#baz/bar", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar").build());
     }
 
     @Test
     public void testRelativePaths() throws SAXException, IOException {
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setCurrentFile(job.tempDirURI.resolve("product/sub%20folder/this.dita"));
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", toURI("common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, toURI("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                toURI("common/library.dita"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                toURI("main.ditamap"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertEquals("../../common/library.dita", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo").build());
     }
 
     @Test
@@ -145,17 +184,27 @@ public class ConkeyrefFilterTest {
 
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setCurrentFile(job.tempDirURI.resolve("product/topic.dita"));
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", URI.create("../common/library.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, job.tempDirURI.resolve("maps/root.map"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                URI.create("../common/library.dita"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                job.tempDirURI.resolve("maps/root.map"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertEquals("../common/library.dita", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo").build());
     }
 
     @Test
@@ -181,17 +230,27 @@ public class ConkeyrefFilterTest {
 
         final ConkeyrefFilter f = getConkeyrefFilter();
         f.setCurrentFile(job.tempDirURI.resolve("topic.dita"));
-        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef("foo", URI.create("LIBRARY.dita"), ATTR_SCOPE_VALUE_LOCAL, ATTR_FORMAT_VALUE_DITA, URI.create("main.ditamap"), null))));
+        f.setKeyDefinitions(createKeyScope(toMap(new KeyDef(
+                "foo",
+                URI.create("LIBRARY.dita"),
+                ATTR_SCOPE_VALUE_LOCAL,
+                ATTR_FORMAT_VALUE_DITA,
+                URI.create("main.ditamap"),
+                null))));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertEquals("LIBRARY.dita", atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
 
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo").build());
     }
 
     @Test
@@ -200,16 +259,20 @@ public class ConkeyrefFilterTest {
         f.setKeyDefinitions(createKeyScope(Collections.emptyMap()));
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 assertNull(atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
 
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_CONKEYREF, "foo/bar").build());
 
         assertEquals(1, l.getMessages().size());
         assertEquals(CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
@@ -222,5 +285,4 @@ public class ConkeyrefFilterTest {
         f.setCurrentFile(job.tempDirURI.resolve("this.dita"));
         return f;
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ForceUniqueFilterTest.java
@@ -7,7 +7,21 @@
  */
 package org.dita.dost.writer;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXSource;
 import org.dita.dost.TestUtils;
 import org.dita.dost.module.reader.DefaultTempFileScheme;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -22,21 +36,6 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXSource;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-
-import static org.junit.Assert.assertEquals;
 
 public class ForceUniqueFilterTest {
 
@@ -57,7 +56,7 @@ public class ForceUniqueFilterTest {
                 .result(srcDir.toURI().resolve("test.ditamap"))
                 .format("ditamap")
                 .build());
-        for (String name : new String[]{"test.dita", "test3.dita", "test2.dita", "topic.dita"}) {
+        for (String name : new String[] {"test.dita", "test3.dita", "test2.dita", "topic.dita"}) {
             job.add(new Builder()
                     .src(srcDir.toURI().resolve(name))
                     .uri(URI.create(name))
@@ -85,16 +84,17 @@ public class ForceUniqueFilterTest {
 
         TestUtils.assertXMLEqual(exp, act);
 
-        assertEquals(new HashMap<>(ImmutableMap.of(
-                createFileInfo("test.dita", "test_3.dita"),
-                createFileInfo("test.dita", "test.dita"),
-                createFileInfo("test.dita", "test_2.dita"),
-                createFileInfo("test.dita", "test.dita"),
-                createFileInfo(null, "copy-to_2.dita"),
-                createFileInfo(null, "copy-to.dita"),
-                createFileInfo("topic.dita", "topic_2.dita"),
-                createFileInfo("topic.dita", "topic.dita")
-        )), f.copyToMap);
+        assertEquals(
+                new HashMap<>(ImmutableMap.of(
+                        createFileInfo("test.dita", "test_3.dita"),
+                        createFileInfo("test.dita", "test.dita"),
+                        createFileInfo("test.dita", "test_2.dita"),
+                        createFileInfo("test.dita", "test.dita"),
+                        createFileInfo(null, "copy-to_2.dita"),
+                        createFileInfo(null, "copy-to.dita"),
+                        createFileInfo("topic.dita", "topic_2.dita"),
+                        createFileInfo("topic.dita", "topic.dita"))),
+                f.copyToMap);
     }
 
     private FileInfo createFileInfo(final String src, final String tmp) {
@@ -102,16 +102,16 @@ public class ForceUniqueFilterTest {
         if (src != null) {
             builder.src(srcDir.toURI().resolve(src));
         }
-        return builder.uri(URI.create(tmp))
-                .result(srcDir.toURI().resolve(tmp))
-                .build();
+        return builder.uri(URI.create(tmp)).result(srcDir.toURI().resolve(tmp)).build();
     }
 
     private Document parse(File input) throws ParserConfigurationException, IOException, SAXException {
         final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
         builderFactory.setNamespaceAware(true);
         builderFactory.setIgnoringComments(true);
-        return builderFactory.newDocumentBuilder().parse(new InputSource(input.toURI().toString()));
+        return builderFactory
+                .newDocumentBuilder()
+                .parse(new InputSource(input.toURI().toString()));
     }
 
     private Document filter(File input, XMLReader f) throws TransformerException {

--- a/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
@@ -16,12 +16,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
+import org.dita.dost.TestUtils;
 import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,10 +28,6 @@ import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import org.dita.dost.TestUtils;
-import org.dita.dost.exception.DITAOTException;
-import org.dita.dost.util.Job;
 
 public class ImageMetadataFilterTest {
 
@@ -59,9 +54,11 @@ public class ImageMetadataFilterTest {
         filter.setJob(job);
         filter.write(f.getAbsoluteFile());
 
-        assertXMLEqual(new InputSource(new File(expDir, "test.dita").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "test.dita").toURI().toString()),
                 new InputSource(f.toURI().toString()));
-        assertEquals(Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
+        assertEquals(
+                Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
                         .map(img -> new File(srcDir, img).toURI())
                         .collect(Collectors.toSet()),
                 cache.keySet());
@@ -81,9 +78,11 @@ public class ImageMetadataFilterTest {
         filter.setJob(job);
         filter.write(f.getAbsoluteFile());
 
-        assertXMLEqual(new InputSource(new File(expDir, "test.dita").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "test.dita").toURI().toString()),
                 new InputSource(f.toURI().toString()));
-        assertEquals(Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
+        assertEquals(
+                Arrays.asList("img.png", "img.gif", "img.jpg", "img.xxx").stream()
                         .map(img -> new File(srcDir, img).toURI())
                         .collect(Collectors.toSet()),
                 cache.keySet());
@@ -93,5 +92,4 @@ public class ImageMetadataFilterTest {
     public static void teardown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -15,9 +15,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import javax.xml.transform.stream.StreamSource;
-
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.TestUtils;
 import org.dita.dost.reader.KeyrefReader;
 import org.dita.dost.store.StreamStore;
@@ -28,9 +28,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.InputSource;
-
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.XdmNode;
 
 public class KeyrefPaserTest {
 
@@ -64,10 +61,11 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "a.xml").toURI());
         parser.write(new File(tempDir, "a.xml"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "a.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "a.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "a.xml").toURI().toString()));
     }
-    
+
     @Test
     public void testTopicWriteSubdir() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
@@ -78,7 +76,10 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempSubDir, "subdirtopic.xml").toURI());
         parser.write(new File(tempSubDir, "subdirtopic.xml"));
 
-        assertXMLEqual(new InputSource(new File(expDir + File.separator + "subdir", "subdirtopic.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir + File.separator + "subdir", "subdirtopic.xml")
+                        .toURI()
+                        .toString()),
                 new InputSource(new File(tempSubDir, "subdirtopic.xml").toURI().toString()));
     }
 
@@ -91,10 +92,11 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "id.xml").toURI());
         parser.write(new File(tempDir, "id.xml"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "id.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "id.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "id.xml").toURI().toString()));
     }
-    
+
     @Test
     public void testFallback() throws Exception {
         final KeyrefPaser parser = new KeyrefPaser();
@@ -104,7 +106,8 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "fallback.xml").toURI());
         parser.write(new File(tempDir, "fallback.xml"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "fallback.xml").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "fallback.xml").toURI().toString()),
                 new InputSource(new File(tempDir, "fallback.xml").toURI().toString()));
     }
 
@@ -117,7 +120,8 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "b.ditamap").toURI());
         parser.write(new File(tempDir, "b.ditamap"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "b.ditamap").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "b.ditamap").toURI().toString()),
                 new InputSource(new File(tempDir, "b.ditamap").toURI().toString()));
     }
 
@@ -127,11 +131,16 @@ public class KeyrefPaserTest {
         parser.setLogger(new TestUtils.TestLogger());
         parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         parser.setKeyDefinition(readKeyMap(Paths.get("subdir", "c.ditamap")));
-        parser.setCurrentFile(new File(tempDir, "subdir"+ File.separator +"c.ditamap").toURI());
-        parser.write(new File(tempDir, "subdir"+ File.separator +"c.ditamap"));
+        parser.setCurrentFile(new File(tempDir, "subdir" + File.separator + "c.ditamap").toURI());
+        parser.write(new File(tempDir, "subdir" + File.separator + "c.ditamap"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "subdir"+ File.separator +"c.ditamap").toURI().toString()),
-                new InputSource(new File(tempDir, "subdir"+ File.separator +"c.ditamap").toURI().toString()));
+        assertXMLEqual(
+                new InputSource(new File(expDir, "subdir" + File.separator + "c.ditamap")
+                        .toURI()
+                        .toString()),
+                new InputSource(new File(tempDir, "subdir" + File.separator + "c.ditamap")
+                        .toURI()
+                        .toString()));
     }
 
     @Test
@@ -143,7 +152,8 @@ public class KeyrefPaserTest {
         parser.setCurrentFile(new File(tempDir, "d.ditamap").toURI());
         parser.write(new File(tempDir, "d.ditamap"));
 
-        assertXMLEqual(new InputSource(new File(expDir, "d.ditamap").toURI().toString()),
+        assertXMLEqual(
+                new InputSource(new File(expDir, "d.ditamap").toURI().toString()),
                 new InputSource(new File(tempDir, "d.ditamap").toURI().toString()));
     }
 
@@ -176,8 +186,9 @@ public class KeyrefPaserTest {
         parser.setKeyDefinition(kd);
         parser.setCurrentFile(new File(tempDir, "copy-to-keys.dita").toURI());
         parser.write(new File(tempDir, "copy-to-keys.dita"));
-        
-        assertXMLEqual(new InputSource(new File(expDir, "copy-to-keys.dita").toURI().toString()),
+
+        assertXMLEqual(
+                new InputSource(new File(expDir, "copy-to-keys.dita").toURI().toString()),
                 new InputSource(new File(tempDir, "copy-to-keys.dita").toURI().toString()));
     }
 }

--- a/src/test/java/org/dita/dost/writer/LinkFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/LinkFilterTest.java
@@ -8,17 +8,16 @@
 
 package org.dita.dost.writer;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-
-import static org.junit.Assert.assertEquals;
 
 public class LinkFilterTest {
 
@@ -66,5 +65,4 @@ public class LinkFilterTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeCodeblockTest.java
@@ -8,14 +8,9 @@
 
 package org.dita.dost.writer;
 
-import org.dita.dost.TestUtils;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
-import org.xmlunit.builder.DiffBuilder;
-import org.xmlunit.diff.Diff;
+import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -23,9 +18,13 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
-import java.io.File;
-
-import static org.junit.Assert.assertEquals;
+import org.dita.dost.TestUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 public class NormalizeCodeblockTest {
 
@@ -104,10 +103,7 @@ public class NormalizeCodeblockTest {
     }
 
     private void assertXMLEqual(Document exp, Document act) {
-        final Diff d = DiffBuilder
-                .compare(exp)
-                .withTest(act)
-                .build();
+        final Diff d = DiffBuilder.compare(exp).withTest(act).build();
         if (d.hasDifferences()) {
             throw new AssertionError(d.toString());
         }
@@ -128,5 +124,4 @@ public class NormalizeCodeblockTest {
 
         return (Document) result.getNode();
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/NormalizeFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeFilterTest.java
@@ -7,16 +7,16 @@
  */
 package org.dita.dost.writer;
 
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertEquals;
+
 import org.dita.dost.TestUtils;
 import org.dita.dost.util.XMLUtils;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertEquals;
 
 public class NormalizeFilterTest {
 
@@ -26,13 +26,18 @@ public class NormalizeFilterTest {
         f.setLogger(new TestUtils.TestLogger());
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(String uri, String localName,
-                                     String qName, Attributes attributes) throws SAXException {
+            public void startElement(String uri, String localName, String qName, Attributes attributes)
+                    throws SAXException {
                 assertEquals(ATTRIBUTE_CASCADE_VALUE_NOMERGE, attributes.getValue(ATTRIBUTE_NAME_CASCADE));
             }
         });
-        f.startElement(NULL_NS_URI, MAP_MAP.localName, MAP_MAP.localName, new XMLUtils.AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString()).build());
+        f.startElement(
+                NULL_NS_URI,
+                MAP_MAP.localName,
+                MAP_MAP.localName,
+                new XMLUtils.AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString())
+                        .build());
     }
 
     @Test
@@ -41,17 +46,25 @@ public class NormalizeFilterTest {
         f.setLogger(new TestUtils.TestLogger());
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(String uri, String localName,
-                                     String qName, Attributes attributes) throws SAXException {
-                assertEquals("(topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d) a(props audience) a(props deliveryTarget) a(props platform) a(props product) a(props otherprops)",
+            public void startElement(String uri, String localName, String qName, Attributes attributes)
+                    throws SAXException {
+                assertEquals(
+                        "(topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d) a(props audience) a(props deliveryTarget) a(props platform) a(props product) a(props otherprops)",
                         attributes.getValue(ATTRIBUTE_NAME_DOMAINS));
-                assertEquals("@props/audience @props/deliveryTarget @props/platform @props/product @props/otherprops",
+                assertEquals(
+                        "@props/audience @props/deliveryTarget @props/platform @props/product @props/otherprops",
                         attributes.getValue(ATTRIBUTE_NAME_SPECIALIZATIONS));
             }
         });
-        f.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new XMLUtils.AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
-                .add(ATTRIBUTE_NAME_DOMAINS, """
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_TOPIC.localName,
+                TOPIC_TOPIC.localName,
+                new XMLUtils.AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                        .add(
+                                ATTRIBUTE_NAME_DOMAINS,
+                                """
                         (topic hi-d)
                         (topic ut-d)
                         (topic indexing-d)
@@ -65,7 +78,7 @@ public class NormalizeFilterTest {
                         a(props platform)
                         a(props product)
                         a(props otherprops)   \s""")
-                .build());
+                        .build());
     }
 
     @Test
@@ -74,23 +87,31 @@ public class NormalizeFilterTest {
         f.setLogger(new TestUtils.TestLogger());
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(String uri, String localName,
-                                     String qName, Attributes attributes) throws SAXException {
-                assertEquals("a(props audience) a(props deliveryTarget) a(props platform) a(props product) a(props otherprops)",
+            public void startElement(String uri, String localName, String qName, Attributes attributes)
+                    throws SAXException {
+                assertEquals(
+                        "a(props audience) a(props deliveryTarget) a(props platform) a(props product) a(props otherprops)",
                         attributes.getValue(ATTRIBUTE_NAME_DOMAINS));
-                assertEquals("@props/audience @props/deliveryTarget @props/platform @props/product @props/otherprops",
+                assertEquals(
+                        "@props/audience @props/deliveryTarget @props/platform @props/product @props/otherprops",
                         attributes.getValue(ATTRIBUTE_NAME_SPECIALIZATIONS));
             }
         });
-        f.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new XMLUtils.AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
-                .add(ATTRIBUTE_NAME_SPECIALIZATIONS, """
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_TOPIC.localName,
+                TOPIC_TOPIC.localName,
+                new XMLUtils.AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                        .add(
+                                ATTRIBUTE_NAME_SPECIALIZATIONS,
+                                """
                           @props/audience
                         @props/deliveryTarget
                         @props/platform
                         @props/product
                         @props/otherprops \s""")
-                .build());
+                        .build());
     }
 
     @Test
@@ -99,14 +120,18 @@ public class NormalizeFilterTest {
         f.setLogger(new TestUtils.TestLogger());
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(String uri, String localName,
-                                     String qName, Attributes attributes) throws SAXException {
+            public void startElement(String uri, String localName, String qName, Attributes attributes)
+                    throws SAXException {
                 assertEquals(ATTRIBUTE_CASCADE_VALUE_MERGE, attributes.getValue(ATTRIBUTE_NAME_CASCADE));
             }
         });
-        f.startElement(NULL_NS_URI, MAP_MAP.localName, MAP_MAP.localName, new XMLUtils.AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString())
-                .add(ATTRIBUTE_NAME_CASCADE, ATTRIBUTE_CASCADE_VALUE_MERGE).build());
+        f.startElement(
+                NULL_NS_URI,
+                MAP_MAP.localName,
+                MAP_MAP.localName,
+                new XMLUtils.AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString())
+                        .add(ATTRIBUTE_NAME_CASCADE, ATTRIBUTE_CASCADE_VALUE_MERGE)
+                        .build());
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeSimpleTableFilterTest.java
@@ -7,21 +7,20 @@
  */
 package org.dita.dost.writer;
 
-import org.dita.dost.TestUtils;
-import org.dita.dost.util.XMLUtils;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
+import static org.dita.dost.TestUtils.assertXMLEqual;
 
+import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXSource;
-import java.io.InputStream;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
+import org.dita.dost.TestUtils;
+import org.dita.dost.util.XMLUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 public class NormalizeSimpleTableFilterTest {
 
@@ -61,10 +60,12 @@ public class NormalizeSimpleTableFilterTest {
 
     private void test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
-        final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
+        final InputStream expStream =
+                getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
 
         final Transformer t = tf.newTransformer();
-        final InputStream src = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
+        final InputStream src =
+                getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
         final NormalizeSimpleTableFilter f = new NormalizeSimpleTableFilter();
         f.setParent(XMLUtils.getXMLReader());
         f.setLogger(new TestUtils.TestLogger());
@@ -74,5 +75,4 @@ public class NormalizeSimpleTableFilterTest {
         t.transform(s, new DOMResult(act));
         assertXMLEqual(db.parse(expStream), act);
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/NormalizeTableFilterTest.java
@@ -7,26 +7,24 @@
  */
 package org.dita.dost.writer;
 
-import org.dita.dost.TestUtils.CachingLogger;
-import org.dita.dost.TestUtils.CachingLogger.Message;
-import org.dita.dost.util.XMLUtils;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.*;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.junit.Assert.assertEquals;
 
+import java.io.InputStream;
+import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXSource;
-import java.io.InputStream;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.dita.dost.TestUtils.CachingLogger.Message.Level.*;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.junit.Assert.assertEquals;
+import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.TestUtils.CachingLogger.Message;
+import org.dita.dost.util.XMLUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 public class NormalizeTableFilterTest {
 
@@ -63,7 +61,7 @@ public class NormalizeTableFilterTest {
     public void rowspan() throws Exception {
         test("rowspan.dita");
     }
-    
+
     @Test
     public void onlyrows() throws Exception {
         test("onlyRows.dita");
@@ -87,18 +85,19 @@ public class NormalizeTableFilterTest {
     @Test
     public void broken() throws Exception {
         final CachingLogger logger = test("broken.dita");
-        final List<Message> errors = logger.getMessages().stream()
-                .filter(m -> m.level == ERROR)
-                .toList();
+        final List<Message> errors =
+                logger.getMessages().stream().filter(m -> m.level == ERROR).toList();
         assertEquals(8, errors.size());
     }
 
     private CachingLogger test(final String file) throws Exception {
         final DocumentBuilder db = dbf.newDocumentBuilder();
-        final InputStream expStream = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
+        final InputStream expStream =
+                getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/exp/" + file);
 
         final Transformer t = tf.newTransformer();
-        final InputStream src = getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
+        final InputStream src =
+                getClass().getClassLoader().getResourceAsStream(this.getClass().getSimpleName() + "/src/" + file);
         final NormalizeTableFilter f = new NormalizeTableFilter();
         f.setParent(XMLUtils.getXMLReader());
         final CachingLogger logger = new CachingLogger();
@@ -110,5 +109,4 @@ public class NormalizeTableFilterTest {
         assertXMLEqual(db.parse(expStream), act);
         return logger;
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/ProfilingFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ProfilingFilterTest.java
@@ -7,7 +7,20 @@
  */
 package org.dita.dost.writer;
 
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.FilterUtils.Action.EXCLUDE;
+import static org.dita.dost.util.FilterUtils.Action.INCLUDE;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.InputStream;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXSource;
 import org.dita.dost.TestUtils;
 import org.dita.dost.util.FilterUtils;
 import org.dita.dost.util.FilterUtils.Action;
@@ -16,20 +29,6 @@ import org.dita.dost.util.XMLUtils;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
-
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXSource;
-import java.io.InputStream;
-import java.util.Map;
-
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.FilterUtils.Action.EXCLUDE;
-import static org.dita.dost.util.FilterUtils.Action.INCLUDE;
 
 public class ProfilingFilterTest {
 
@@ -56,8 +55,7 @@ public class ProfilingFilterTest {
                 new FilterKey(QName.valueOf("default"), null), EXCLUDE,
                 new FilterKey(QName.valueOf("audience"), null), EXCLUDE,
                 new FilterKey(QName.valueOf("audience"), "novice"), INCLUDE,
-                new FilterKey(QName.valueOf("platform"), "windows"), EXCLUDE
-        );
+                new FilterKey(QName.valueOf("platform"), "windows"), EXCLUDE);
         final FilterUtils filterUtils = new FilterUtils(false, filterMap, null, null);
 
         test(filterUtils, "topic.dita", "topic1.dita");
@@ -75,13 +73,11 @@ public class ProfilingFilterTest {
                 new FilterKey(QName.valueOf("default"), null), EXCLUDE,
                 new FilterKey(QName.valueOf("audience"), null), EXCLUDE,
                 new FilterKey(QName.valueOf("audience"), "novice"), INCLUDE,
-                new FilterKey(QName.valueOf("platform"), "windows"), EXCLUDE
-        );
+                new FilterKey(QName.valueOf("platform"), "windows"), EXCLUDE);
         final FilterUtils filterUtils = new FilterUtils(false, filterMap, null, null);
 
         test(filterUtils, "topic_2.dita", "topic1_2.dita");
     }
-
 
     @Test
     public void testFilter_xhtml() throws Exception {
@@ -108,7 +104,8 @@ public class ProfilingFilterTest {
             transformerFactory.newTransformer().transform(s, d);
         }
 
-        try (final InputStream exp = getClass().getClassLoader().getResourceAsStream("ProfilingFilterTest/exp/" + expFile)) {
+        try (final InputStream exp =
+                getClass().getClassLoader().getResourceAsStream("ProfilingFilterTest/exp/" + expFile)) {
             assertXMLEqual(documentBuilder.parse(exp), act);
         }
     }

--- a/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
+++ b/src/test/java/org/dita/dost/writer/TestConrefPushParser.java
@@ -7,6 +7,12 @@
  */
 package org.dita.dost.writer;
 
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.dita.dost.TestUtils.buildControlDocument;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Hashtable;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.reader.ConrefPushReader.MoveKey;
@@ -20,13 +26,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Hashtable;
-
-import static org.apache.commons.io.FileUtils.copyFile;
-import static org.dita.dost.TestUtils.buildControlDocument;
 
 public class TestConrefPushParser {
 
@@ -46,12 +45,18 @@ public class TestConrefPushParser {
     @Test
     public void testWrite() throws DITAOTException, SAXException, IOException {
         final Hashtable<MoveKey, DocumentFragment> pushActions = new Hashtable<>();
-        pushActions.put(new MoveKey("#X/A", "pushbefore"),
-                getFragment("<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>before</cmd></step>"));
-        pushActions.put(new MoveKey("#X/B", "pushafter"),
-                getFragment("<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>after</cmd></step>"));
-        pushActions.put(new MoveKey("#X/C", "pushreplace"),
-                getFragment("<step class='- topic/li task/step ' id='C'><cmd class='- topic/ph task/cmd '>replace</cmd></step>"));
+        pushActions.put(
+                new MoveKey("#X/A", "pushbefore"),
+                getFragment(
+                        "<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>before</cmd></step>"));
+        pushActions.put(
+                new MoveKey("#X/B", "pushafter"),
+                getFragment(
+                        "<step class='- topic/li task/step '><cmd class='- topic/ph task/cmd '>after</cmd></step>"));
+        pushActions.put(
+                new MoveKey("#X/C", "pushreplace"),
+                getFragment(
+                        "<step class='- topic/li task/step ' id='C'><cmd class='- topic/ph task/cmd '>replace</cmd></step>"));
 
         final ConrefPushParser parser = new ConrefPushParser();
         parser.setLogger(new TestUtils.TestLogger());
@@ -61,8 +66,7 @@ public class TestConrefPushParser {
 
         TestUtils.assertXMLEqual(
                 new InputSource(new File(expDir, "conrefpush_stub2.xml").toURI().toString()),
-                new InputSource(targetFile.toURI().toString())
-        );
+                new InputSource(targetFile.toURI().toString()));
     }
 
     private DocumentFragment getFragment(final String text) {

--- a/src/test/java/org/dita/dost/writer/TopicFragmentFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/TopicFragmentFilterTest.java
@@ -11,13 +11,11 @@ import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_HREF;
 
 import java.io.File;
-
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXSource;
-
 import org.dita.dost.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +30,6 @@ public class TopicFragmentFilterTest {
     private static final File srcDir = new File(resourceDir, "src");
     private static final File expDir = new File(resourceDir, "exp");
 
-    
     @Before
     public void setUp() throws Exception {
         tempDir = TestUtils.createTempDir(TopicFragmentFilterTest.class);
@@ -47,9 +44,16 @@ public class TopicFragmentFilterTest {
     public void test() throws Exception {
         final TopicFragmentFilter f = new TopicFragmentFilter(ATTRIBUTE_NAME_HREF);
         f.setParent(SAXParserFactory.newInstance().newSAXParser().getXMLReader());
-                
+
         final DOMResult dst = new DOMResult();
-        TransformerFactory.newInstance().newTransformer().transform(new SAXSource(f, new InputSource(new File(srcDir, "topic.dita").toURI().toString())), dst);
+        TransformerFactory.newInstance()
+                .newTransformer()
+                .transform(
+                        new SAXSource(
+                                f,
+                                new InputSource(
+                                        new File(srcDir, "topic.dita").toURI().toString())),
+                        dst);
 
         final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
         builderFactory.setNamespaceAware(true);
@@ -57,5 +61,4 @@ public class TopicFragmentFilterTest {
         final Document exp = builderFactory.newDocumentBuilder().parse(new File(expDir, "topic.dita"));
         assertXMLEqual(exp, (Document) dst.getNode());
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/TopicRefWriterTest.java
+++ b/src/test/java/org/dita/dost/writer/TopicRefWriterTest.java
@@ -7,6 +7,24 @@
  */
 package org.dita.dost.writer;
 
+import static java.net.URI.create;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXSource;
 import org.dita.dost.TestUtils;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
@@ -23,25 +41,6 @@ import org.xml.sax.XMLReader;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.sax.SAXSource;
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.net.URI.create;
-
 @RunWith(Parameterized.class)
 public class TopicRefWriterTest {
 
@@ -55,66 +54,67 @@ public class TopicRefWriterTest {
 
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {
-                        "image",
-                        "<image class='- topic/image ' href='same.png'/>",
-                        "<image class='- topic/image ' href='same.png'/>"
-                },
-                {
-                        "object",
-                        "<object class='- topic/object ' data='same.pdf'/>",
-                        "<object class='- topic/object ' data='same.pdf'/>"
-                },
-                {
-                        "xrefSame",
-                        "<xref class='- topic/xref ' href='same.dita'/>",
-                        "<xref class='- topic/xref ' href='same.dita'/>"
-                },
-                {
-                        "xrefWithoutId",
-                        "<xref class='- topic/xref ' href='source.dita'/>",
-                        "<xref class='- topic/xref ' href='change.dita'/>"
-                },
-                {
-                        "xrefWithId",
-                        "<xref class='- topic/xref ' href='source.dita#from'/>",
-                        "<xref class='- topic/xref ' href='change.dita#to'/>"
-                },
-                {
-                        "xrefWithElementId",
-                        "<xref class='- topic/xref ' href='source.dita#from/element'/>",
-                        "<xref class='- topic/xref ' href='change.dita#to/element'/>"
-                },
-                {
-                        "xrefWithFileChange",
-                        "<xref class='- topic/xref ' href='source.dita#other'/>",
-                        "<xref class='- topic/xref ' href='change.dita#other'/>"
-                },
-                {
-                        "xrefWithFileChangeElementId",
-                        "<xref class='- topic/xref ' href='source.dita#other/element'/>",
-                        "<xref class='- topic/xref ' href='change.dita#other/element'/>"
-                },
-                {
-                        "xrefUnmapped",
-                        "<xref class='- topic/xref ' href='unmapped.dita'/>",
-                        "<xref class='- topic/xref ' href='unmapped.dita'/>"
-                },
-                {
-                        "xrefUnmappedWithTopicId",
-                        "<xref class='- topic/xref ' href='unmapped.dita#topic'/>",
-                        "<xref class='- topic/xref ' href='unmapped.dita#topic'/>"
-                },
-                {
-                        "xrefUnmappedWithElementId",
-                        "<xref class='- topic/xref ' href='unmapped.dita#topic/element'/>",
-                        "<xref class='- topic/xref ' href='unmapped.dita#topic/element'/>"
-                }
+        return Arrays.asList(new Object[][] {
+            {
+                "image",
+                "<image class='- topic/image ' href='same.png'/>",
+                "<image class='- topic/image ' href='same.png'/>"
+            },
+            {
+                "object",
+                "<object class='- topic/object ' data='same.pdf'/>",
+                "<object class='- topic/object ' data='same.pdf'/>"
+            },
+            {
+                "xrefSame",
+                "<xref class='- topic/xref ' href='same.dita'/>",
+                "<xref class='- topic/xref ' href='same.dita'/>"
+            },
+            {
+                "xrefWithoutId",
+                "<xref class='- topic/xref ' href='source.dita'/>",
+                "<xref class='- topic/xref ' href='change.dita'/>"
+            },
+            {
+                "xrefWithId",
+                "<xref class='- topic/xref ' href='source.dita#from'/>",
+                "<xref class='- topic/xref ' href='change.dita#to'/>"
+            },
+            {
+                "xrefWithElementId",
+                "<xref class='- topic/xref ' href='source.dita#from/element'/>",
+                "<xref class='- topic/xref ' href='change.dita#to/element'/>"
+            },
+            {
+                "xrefWithFileChange",
+                "<xref class='- topic/xref ' href='source.dita#other'/>",
+                "<xref class='- topic/xref ' href='change.dita#other'/>"
+            },
+            {
+                "xrefWithFileChangeElementId",
+                "<xref class='- topic/xref ' href='source.dita#other/element'/>",
+                "<xref class='- topic/xref ' href='change.dita#other/element'/>"
+            },
+            {
+                "xrefUnmapped",
+                "<xref class='- topic/xref ' href='unmapped.dita'/>",
+                "<xref class='- topic/xref ' href='unmapped.dita'/>"
+            },
+            {
+                "xrefUnmappedWithTopicId",
+                "<xref class='- topic/xref ' href='unmapped.dita#topic'/>",
+                "<xref class='- topic/xref ' href='unmapped.dita#topic'/>"
+            },
+            {
+                "xrefUnmappedWithElementId",
+                "<xref class='- topic/xref ' href='unmapped.dita#topic/element'/>",
+                "<xref class='- topic/xref ' href='unmapped.dita#topic/element'/>"
+            }
         });
     }
 
-    public TopicRefWriterTest(final String name, final String src, final String exp) throws ParserConfigurationException {
+    public TopicRefWriterTest(final String name, final String src, final String exp)
+            throws ParserConfigurationException {
         this.src = src;
         this.exp = exp;
         final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -132,14 +132,11 @@ public class TopicRefWriterTest {
         reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
         reader.setCurrentFile(create("file:/tmp/dir/bar.dita"));
 
-        reader.setup(map(
-                "file:/tmp/dir/same.dita", "file:/tmp/dir/same.dita"
-        ));
+        reader.setup(map("file:/tmp/dir/same.dita", "file:/tmp/dir/same.dita"));
         reader.setChangeTable(map(
                 "file:/tmp/dir/same.dita", "file:/tmp/dir/same.dita",
                 "file:/tmp/dir/source.dita", "file:/tmp/dir/change.dita",
-                "file:/tmp/dir/source.dita#from", "file:/tmp/dir/change.dita#to"
-        ));
+                "file:/tmp/dir/source.dita#from", "file:/tmp/dir/change.dita#to"));
         reader.setFixpath(null);
 
         parser = XMLUtils.getXMLReader();
@@ -162,8 +159,7 @@ public class TopicRefWriterTest {
     private void assertEquals(final String exp, final Document act) {
         try {
             try (Reader in = new StringReader(exp)) {
-                final Diff d = DiffBuilder
-                        .compare(db.parse(new InputSource(in)))
+                final Diff d = DiffBuilder.compare(db.parse(new InputSource(in)))
                         .withTest(act)
                         .ignoreWhitespace()
                         .normalizeWhitespace()
@@ -181,10 +177,7 @@ public class TopicRefWriterTest {
         try {
             final Document doc = db.newDocument();
             final InputSource inputSource = new InputSource(new StringReader(content));
-            transformerFactory.newTransformer().transform(
-                    new SAXSource(reader, inputSource),
-                    new DOMResult(doc)
-            );
+            transformerFactory.newTransformer().transform(new SAXSource(reader, inputSource), new DOMResult(doc));
             return doc;
         } catch (TransformerException e) {
             throw new RuntimeException(e);

--- a/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
@@ -9,15 +9,14 @@ package org.dita.dost.writer;
 
 import static javax.xml.XMLConstants.*;
 import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.*;
 import static org.dita.dost.util.XMLUtils.AttributesBuilder;
+import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.util.Configuration;
@@ -44,22 +43,29 @@ public class ValidationFilterTest {
         final List<String> res = new ArrayList<>();
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 res.add(atts.getValue(XML_NS_URI, "lang"));
             }
         });
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
 
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add(XML_NS_URI, "lang", "en_us")
-            .build());
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add(XML_NS_URI, "lang", "en-GB")
-            .build());
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder().add(XML_NS_URI, "lang", "en_us").build());
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder().add(XML_NS_URI, "lang", "en-GB").build());
 
         assertEquals(1, l.getMessages().size());
-        assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
+        assertEquals(
+                TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
         assertEquals("en-us", res.get(0));
         assertEquals("en-GB", res.get(1));
     }
@@ -69,49 +75,71 @@ public class ValidationFilterTest {
         final List<String> res = new ArrayList<>();
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 res.add(atts.getValue(ATTRIBUTE_NAME_HREF));
             }
         });
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
 
-        f.startElement(NULL_NS_URI, TOPIC_XREF.localName, TOPIC_XREF.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_HREF, "http://example.com/foo\\bar baz:qux")
-                .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_XREF.localName, TOPIC_XREF.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_HREF, "http://example.com/valid/bar+baz:qux")
-                .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_XREF.localName,
+                TOPIC_XREF.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_HREF, "http://example.com/foo\\bar baz:qux")
+                        .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_XREF.localName,
+                TOPIC_XREF.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_HREF, "http://example.com/valid/bar+baz:qux")
+                        .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
+                        .build());
 
         assertEquals(1, l.getMessages().size());
-        assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
+        assertEquals(
+                TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
         assertEquals("http://example.com/foo/bar%20baz:qux", res.get(0));
         assertEquals("http://example.com/valid/bar+baz:qux", res.get(1));
     }
-    
+
     @Test
     public void testConref() throws SAXException, URISyntaxException {
         final List<String> res = new ArrayList<>();
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 res.add(atts.getValue(ATTRIBUTE_NAME_CONREF));
             }
         });
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
 
-        f.startElement(NULL_NS_URI, TOPIC_KEYWORD.localName, TOPIC_KEYWORD.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONREF, "sub\\backslash.dita#topic/back")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_KEYWORD.localName, TOPIC_KEYWORD.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CONREF, "sub/slash.dita#topic/valid")
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_KEYWORD.localName,
+                TOPIC_KEYWORD.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CONREF, "sub\\backslash.dita#topic/back")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_KEYWORD.localName,
+                TOPIC_KEYWORD.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CONREF, "sub/slash.dita#topic/valid")
+                        .build());
 
         assertEquals(1, l.getMessages().size());
-        assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
+        assertEquals(
+                TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
         assertEquals("sub/backslash.dita#topic/back", res.get(0));
         assertEquals("sub/slash.dita#topic/valid", res.get(1));
     }
@@ -121,20 +149,30 @@ public class ValidationFilterTest {
         final List<String> res = new ArrayList<>();
         f.setContentHandler(new DefaultHandler() {
             @Override
-            public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+            public void startElement(
+                    final String uri, final String localName, final String qName, final Attributes atts)
+                    throws SAXException {
                 res.add(atts.getValue(ATTRIBUTE_NAME_HREF));
             }
         });
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
 
-        f.startElement(NULL_NS_URI, TOPIC_XREF.localName, TOPIC_XREF.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_HREF, "http://example.com/broken")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_XREF.localName, TOPIC_XREF.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_HREF, "http://example.com/valid")
-                .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
-                .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_XREF.localName,
+                TOPIC_XREF.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_HREF, "http://example.com/broken")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_XREF.localName,
+                TOPIC_XREF.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_HREF, "http://example.com/valid")
+                        .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
+                        .build());
 
         assertEquals(1, l.getMessages().size());
         assertEquals(TestUtils.CachingLogger.Message.Level.WARN, l.getMessages().get(0).level);
@@ -146,33 +184,57 @@ public class ValidationFilterTest {
         f.setContentHandler(new DefaultHandler());
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
-        
-        f.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
-                .add(ATTRIBUTE_NAME_ID, "topic")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
-                .add(ATTRIBUTE_NAME_ID, "first")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
-                .add(ATTRIBUTE_NAME_ID, "second")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
-                .add(ATTRIBUTE_NAME_ID, "first")
-                .build());
+
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_TOPIC.localName,
+                TOPIC_TOPIC.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                        .add(ATTRIBUTE_NAME_ID, "topic")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
+                        .add(ATTRIBUTE_NAME_ID, "first")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
+                        .add(ATTRIBUTE_NAME_ID, "second")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
+                        .add(ATTRIBUTE_NAME_ID, "first")
+                        .build());
         assertEquals(1, l.getMessages().size());
-        f.startElement(NULL_NS_URI, TOPIC_TOPIC.localName, TOPIC_TOPIC.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
-                .add(ATTRIBUTE_NAME_ID, "topic")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
-                .add(ATTRIBUTE_NAME_ID, "second")
-                .build());
-        
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_TOPIC.localName,
+                TOPIC_TOPIC.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_TOPIC.toString())
+                        .add(ATTRIBUTE_NAME_ID, "topic")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_CLASS, TOPIC_P.toString())
+                        .add(ATTRIBUTE_NAME_ID, "second")
+                        .build());
+
         assertEquals(1, l.getMessages().size());
         assertEquals(TestUtils.CachingLogger.Message.Level.WARN, l.getMessages().get(0).level);
     }
@@ -182,85 +244,129 @@ public class ValidationFilterTest {
         f.setContentHandler(new DefaultHandler());
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
-        
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_KEYS, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:@!$&'()*+,;=")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_KEYS, "foo bar baz")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_KEYS, " foo ")
-                .build());
+
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(
+                                ATTRIBUTE_NAME_KEYS,
+                                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:@!$&'()*+,;=")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYS, "foo bar baz").build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYS, " foo ").build());
         assertEquals(0, l.getMessages().size());
-        
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_KEYS, "foo/bar")
-                .build());
-        f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                .add(ATTRIBUTE_NAME_KEYS, "foo\u00E4bar")
-                .build());
-        
+
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYS, "foo/bar").build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYS, "foo\u00E4bar").build());
+
         assertEquals(2, l.getMessages().size());
-        for (final Message m: l.getMessages()) {
-            assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, m.level);            
+        for (final Message m : l.getMessages()) {
+            assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, m.level);
         }
     }
 
-       @Test
-        public void testKeyscope() throws SAXException, URISyntaxException {
-            f.setContentHandler(new DefaultHandler());
-            final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
-            f.setLogger(l);
+    @Test
+    public void testKeyscope() throws SAXException, URISyntaxException {
+        f.setContentHandler(new DefaultHandler());
+        final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
+        f.setLogger(l);
 
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_KEYSCOPE, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:@!$&'()*+,;=")
-                    .build());
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_KEYSCOPE, "foo bar baz")
-                    .build());
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_KEYSCOPE, " foo ")
-                    .build());
-            assertEquals(0, l.getMessages().size());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(
+                                ATTRIBUTE_NAME_KEYSCOPE,
+                                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:@!$&'()*+,;=")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_KEYSCOPE, "foo bar baz")
+                        .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYSCOPE, " foo ").build());
+        assertEquals(0, l.getMessages().size());
 
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_KEYSCOPE, "foo/bar")
-                    .build());
-            f.startElement(NULL_NS_URI, TOPIC_P.localName, TOPIC_P.localName, new AttributesBuilder()
-                    .add(ATTRIBUTE_NAME_KEYSCOPE, "foo\u00E4bar")
-                    .build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder().add(ATTRIBUTE_NAME_KEYSCOPE, "foo/bar").build());
+        f.startElement(
+                NULL_NS_URI,
+                TOPIC_P.localName,
+                TOPIC_P.localName,
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_KEYSCOPE, "foo\u00E4bar")
+                        .build());
 
-            assertEquals(2, l.getMessages().size());
-            for (final Message m: l.getMessages()) {
-                assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, m.level);
-            }
+        assertEquals(2, l.getMessages().size());
+        for (final Message m : l.getMessages()) {
+            assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, m.level);
         }
+    }
 
     @Test
     public void testAttributeGeneralization() throws SAXException {
         f.setContentHandler(new DefaultHandler());
         final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
         f.setLogger(l);
-        
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add(ATTRIBUTE_NAME_DOMAINS, "a(props person jobrole)")
-            .build());
-        assertEquals(0, l.getMessages().size());
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add("person", "jobrole(programmer)")
-            .add("jobrole", "admin")
-            .build());
-        assertEquals(1, l.getMessages().size());
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add("jobrole", "admin")
-            .build());
-        f.startElement(NULL_NS_URI, "x", "x", new AttributesBuilder()
-            .add("person", "jobrole(programmer)")
-            .build());
-        
-        assertEquals(1, l.getMessages().size());
-        assertEquals(TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
-    }
 
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder()
+                        .add(ATTRIBUTE_NAME_DOMAINS, "a(props person jobrole)")
+                        .build());
+        assertEquals(0, l.getMessages().size());
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder()
+                        .add("person", "jobrole(programmer)")
+                        .add("jobrole", "admin")
+                        .build());
+        assertEquals(1, l.getMessages().size());
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder().add("jobrole", "admin").build());
+        f.startElement(
+                NULL_NS_URI,
+                "x",
+                "x",
+                new AttributesBuilder().add("person", "jobrole(programmer)").build());
+
+        assertEquals(1, l.getMessages().size());
+        assertEquals(
+                TestUtils.CachingLogger.Message.Level.ERROR, l.getMessages().get(0).level);
+    }
 }

--- a/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
+++ b/src/test/java/org/dita/dost/writer/include/IncludeResolverTest.java
@@ -7,6 +7,18 @@
  */
 package org.dita.dost.writer.include;
 
+import static java.net.URI.create;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
+import static org.dita.dost.util.Constants.PR_D_CODEREF;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.store.StreamStore;
@@ -22,20 +34,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.xml.sax.InputSource;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.net.URI.create;
-import static org.dita.dost.TestUtils.assertXMLEqual;
-import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
-import static org.dita.dost.util.Constants.PR_D_CODEREF;
-
 @RunWith(Parameterized.class)
 public class IncludeResolverTest {
     private static final File resourceDir = TestUtils.getResourceDir(IncludeResolverTest.class);
@@ -44,11 +42,8 @@ public class IncludeResolverTest {
 
     @Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
-                {"coderef.dita"},
-                {"include_text.dita"},
-                {"include_xml.dita"},
-                {"include_xml_schema.dita"}
+        return Arrays.asList(new Object[][] {
+            {"coderef.dita"}, {"include_text.dita"}, {"include_xml.dita"}, {"include_xml_schema.dita"}
         });
     }
 
@@ -66,7 +61,7 @@ public class IncludeResolverTest {
 
         Files.copy(new File(srcDir, test).toPath(), new File(tempDir, test).toPath());
         Files.writeString(new File(tempDir, "topic.dita").toPath(), "dummy");
-        for (final String file : new String[]{"code.xml", "utf-8.xml", "plain.txt", "range.txt", "schema.xml"}) {
+        for (final String file : new String[] {"code.xml", "utf-8.xml", "plain.txt", "range.txt", "schema.xml"}) {
             Files.copy(new File(srcDir, file).toPath(), new File(tempDir, file).toPath());
         }
 
@@ -96,46 +91,47 @@ public class IncludeResolverTest {
 
         filter.write(f.getAbsoluteFile());
 
-//        assertEquals(Files.readLines(new File(expDir, test), StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")),
-//                Files.readLines(f, StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")));
-        assertXMLEqual(new InputSource(new File(expDir, test).toURI().toString()),
+        //        assertEquals(Files.readLines(new File(expDir, test),
+        // StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")),
+        //                Files.readLines(f, StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")));
+        assertXMLEqual(
+                new InputSource(new File(expDir, test).toURI().toString()),
                 new InputSource(f.toURI().toString()));
     }
-//
-//    @Test
-//    public void include_text() throws DITAOTException {
-//        final File f = new File(tempDir, "include_text.dita");
-//
-//        filter.write(f.getAbsoluteFile());
-//
-//        assertXMLEqual(new InputSource(new File(expDir, "include_text.dita").toURI().toString()),
-//                new InputSource(f.toURI().toString()));
-//    }
-//
-//    @Test
-//    public void include_xml() throws DITAOTException {
-//        final File f = new File(tempDir, "include_xml.dita");
-//
-//        filter.write(f.getAbsoluteFile());
-//
-//        assertXMLEqual(new InputSource(new File(expDir, "include_xml.dita").toURI().toString()),
-//                new InputSource(f.toURI().toString()));
-//    }
-//
-//    @Ignore
-//    @Test
-//    public void include_dita() throws DITAOTException {
-//        final File f = new File(tempDir, "include_dita.dita");
-//
-//        filter.write(f.getAbsoluteFile());
-//
-//        assertXMLEqual(new InputSource(new File(expDir, "include_dita.dita").toURI().toString()),
-//                new InputSource(f.toURI().toString()));
-//    }
+    //
+    //    @Test
+    //    public void include_text() throws DITAOTException {
+    //        final File f = new File(tempDir, "include_text.dita");
+    //
+    //        filter.write(f.getAbsoluteFile());
+    //
+    //        assertXMLEqual(new InputSource(new File(expDir, "include_text.dita").toURI().toString()),
+    //                new InputSource(f.toURI().toString()));
+    //    }
+    //
+    //    @Test
+    //    public void include_xml() throws DITAOTException {
+    //        final File f = new File(tempDir, "include_xml.dita");
+    //
+    //        filter.write(f.getAbsoluteFile());
+    //
+    //        assertXMLEqual(new InputSource(new File(expDir, "include_xml.dita").toURI().toString()),
+    //                new InputSource(f.toURI().toString()));
+    //    }
+    //
+    //    @Ignore
+    //    @Test
+    //    public void include_dita() throws DITAOTException {
+    //        final File f = new File(tempDir, "include_dita.dita");
+    //
+    //        filter.write(f.getAbsoluteFile());
+    //
+    //        assertXMLEqual(new InputSource(new File(expDir, "include_dita.dita").toURI().toString()),
+    //                new InputSource(f.toURI().toString()));
+    //    }
 
     @After
     public void teardown() throws IOException {
         TestUtils.forceDelete(tempDir);
     }
-
 }

--- a/src/test/java/org/dita/dost/writer/include/IncludeTextTest.java
+++ b/src/test/java/org/dita/dost/writer/include/IncludeTextTest.java
@@ -8,6 +8,19 @@
 
 package org.dita.dost.writer.include;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.dita.dost.TestUtils;
 import org.dita.dost.exception.UncheckedDITAOTException;
 import org.dita.dost.store.StreamStore;
@@ -20,20 +33,6 @@ import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.URI;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.dita.dost.util.Constants.*;
-import static org.junit.Assert.assertEquals;
 
 public class IncludeTextTest {
 
@@ -59,7 +58,6 @@ public class IncludeTextTest {
                 .src(tempDir.toURI().resolve("include.txt"))
                 .format(PR_D_CODEREF.localName)
                 .build());
-
     }
 
     @After
@@ -82,7 +80,7 @@ public class IncludeTextTest {
 
         // AllRange will normalize line feeds to '\n', so we cannot compare String directly
         try (BufferedReader act = new BufferedReader(new StringReader(characterBuffer.characters.toString()));
-             BufferedReader exp = new BufferedReader(new StringReader(DATA))) {
+                BufferedReader exp = new BufferedReader(new StringReader(DATA))) {
             String line;
             while ((line = exp.readLine()) != null) {
                 assertEquals(line, act.readLine());
@@ -116,6 +114,7 @@ public class IncludeTextTest {
 
     private static class CharacterBufferContentHandler extends DefaultHandler {
         StringBuilder characters = new StringBuilder();
+
         @Override
         public void characters(char[] ch, int start, int length) throws SAXException {
             characters.append(ch, start, length);


### PR DESCRIPTION
## Description
Add Java code formatter using [Palantir format](https://github.com/palantir/palantir-java-format).

## Motivation and Context
Using Spotless Gradle plug-in to format Java code allows consistent Java format to be used.

## Documentation and Compatibility
Coding conventions and PR contribution guidelines should be changed to mention formatting code before committing.
