### PR TITLE
Insert <?ditaot dita-ot:usershortdesc?> in cases where it was missing

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -402,6 +402,14 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     </xsl:choose>
   </xsl:template>
 
+  <!-- Insert a <?ditaot usershortdesc?> processing instruction to indicate preexisting <desc> elements in the input document
+       * This behavior applies only to <desc> elements contained in <xref> and <link> elements
+       * The "topicpull:add-usershortdesc-PI" mode does not add a *shortdesc PI if one already exists -->
+  <xsl:template match="*[contains(@class,' topic/xref ') or contains(@class,' topic/link ')]/*[contains(@class,' topic/desc ')]">
+    <xsl:apply-templates select=".." mode="topicpull:add-usershortdesc-PI"/>
+    <xsl:next-match/>  <!-- process the element as usual -->
+  </xsl:template>
+
   <!-- 2007.03.13: Update inheritance to check specific elements and attributes.
        Similar to the inheritance template in mappull, except that it stops at related links. -->
   <xsl:template name="topicpull:inherit">
@@ -698,7 +706,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       <xsl:when test="$inDescContent"/>
       <!--if there's already a desc, copy it-->
       <xsl:when test="*[contains(@class, ' topic/desc ')]">
-        <xsl:apply-templates select="." mode="topicpull:add-usershortdesc-PI"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/desc ')]"/>
       </xsl:when>
       <!--if the target is inaccessible, don't do anything - shortdesc is optional -->
@@ -1416,25 +1423,16 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   </xsl:template>
   
   <!-- Added for RFE 3001750. -->
-  <xsl:template match="*" mode="topicpull:add-genshortdesc-PI">
-    <xsl:choose>
-      <xsl:when test="processing-instruction()[name()='ditaot'][.='usershortdesc' or .='genshortdesc']">
-        <xsl:copy-of select="processing-instruction()[name()='ditaot'][.='usershortdesc' or .='genshortdesc']"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:processing-instruction name="ditaot">genshortdesc</xsl:processing-instruction>
-      </xsl:otherwise>
-    </xsl:choose>
+  <!-- Returns a <?ditaot dita-ot:genshortdesc?> if context element does not already have a *shortdesc PI -->
+  <xsl:template match="*" mode="topicpull:add-genshortdesc-PI"/>
+  <xsl:template match="*[not(processing-instruction('ditaot')[. = ('usershortdesc' ,'genshortdesc')])]" mode="topicpull:add-genshortdesc-PI" priority="10">
+    <xsl:processing-instruction name="ditaot">genshortdesc</xsl:processing-instruction>
   </xsl:template>
-  <xsl:template match="*" mode="topicpull:add-usershortdesc-PI">
-    <xsl:choose>
-      <xsl:when test="processing-instruction()[name()='ditaot'][.='usershortdesc' or .='genshortdesc']">
-        <xsl:copy-of select="processing-instruction()[name()='ditaot'][.='usershortdesc' or .='genshortdesc']"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:processing-instruction name="ditaot">usershortdesc</xsl:processing-instruction>
-      </xsl:otherwise>
-    </xsl:choose>
+
+  <!-- Returns a <?ditaot dita-ot:usershortdesc?> if context element does not already have a *shortdesc PI -->
+  <xsl:template match="*" mode="topicpull:add-usershortdesc-PI"/>
+  <xsl:template match="*[not(processing-instruction('ditaot')[. = ('usershortdesc' ,'genshortdesc')])]" mode="topicpull:add-usershortdesc-PI" priority="10">
+    <xsl:processing-instruction name="ditaot">usershortdesc</xsl:processing-instruction>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
## Description
This pull request updates the `topicpull` preprocessing stage to add `<?ditaot usershortdesc?>` processing instructions to indicate user-defined `<desc>` elements in cases where they were missing.

The existing implementation added the PI in various deeper code branches that could be followed. Rather than fill in the holes by adding PI insertions to additional code branches, I opted to simplify the implementation to create a `<desc>` template that adds the PI whenever the element is within a `<link>` or `<xref>` element. Because all the code branches apply `<xsl:apply-templates>` to any `<desc>` child elements, the PI is reliably created where needed.

The easiest way to understand the change is to view a graphical diff of the original and updated `topicpull` preprocessing results from the #4153 testcase, which are available in the following archive:

[4155-results.zip](https://github.com/dita-ot/dita-ot/files/11128976/4155-results.zip)

Note that `<?ditaot usershortdesc?>` is added only before `<desc>` elements that contain the text "RELATED-LINKS DESC", which indicates user-provided `<desc>` text in the input document, as opposed to generated text pulled from a topic's `<shortdesc>`.

## Motivation and Context
Fixes part of #4153 (only the `<?ditaot usershortdesc?>` behavior is corrected).

## How Has This Been Tested?
I tested the fix using the testcase from #4153 and confirmed that `<?ditaot usershortdesc?>` is added in the cases where it was expected but missing. The testcase also contains an "other.dita" topic with non-link uses of the `<desc>` element, and I confirmed these were unchanged.

I also ran `gradlew test`, `gradlew e2etest`, and `gradlew integrationtest`.

## Type of Changes
- Breaking change _(fix that changes existing functionality)_

## Documentation and Compatibility
It cannot be ruled out that existing processing code relies on the existing incorrect behavior. However, the issue cannot be fixed unless the incorrect behavior is corrected.

A release notes entry should be included, something along the lines of:

In previous releases, there were some cases in which a `<desc>` element inside an `<xref>` or `<link>` element did not get the expected `<?ditaot usershortdesc?>` processing instruction during preprocessing. These omissions have been corrected. (This change is relevant only within preprocessing, as these processing instructions are deleted when preprocessing completes.)

No documentation changes are needed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>

The existing unit tests pass. I did not add or update any tests because I lack the Java experience needed to do so, but it might be a good idea to have a test that covers the expected `<?ditaot genshortdesc?>` and `<?ditaot usershortdesc?>` behaviors.