### PR TITLE
Support custom parse for start map

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -11,6 +11,7 @@ package org.dita.dost.module.reader;
 import static org.dita.dost.reader.GenListModuleReader.*;
 import static org.dita.dost.util.Configuration.*;
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.FileUtils.getExtension;
 import static org.dita.dost.util.Job.FileInfo;
 import static org.dita.dost.util.Job.USER_INPUT_FILE_LIST_FILE;
 import static org.dita.dost.util.URLUtils.*;
@@ -135,6 +136,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   final Set<URI> additionalResourcesSet = ConcurrentHashMap.newKeySet();
 
   public abstract void readStartFile() throws DITAOTException;
+
+  String getFormatFromPath(URI file) {
+    final String ext = getExtension(file.getPath());
+    if (parserMap.containsKey(ext)) {
+      return ext;
+    }
+    return null;
+  }
 
   void readResourceFiles() throws DITAOTException {
     if (!resources.isEmpty()) {

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -64,7 +64,7 @@ public final class MapReaderModule extends AbstractReaderModule {
 
   @Override
   public void readStartFile() throws DITAOTException {
-    addToWaitList(new Reference(rootFile));
+    addToWaitList(new Reference(rootFile, getFormatFromPath(rootFile)));
   }
 
   @Override

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -168,8 +168,9 @@ public final class TopicReaderModule extends AbstractReaderModule {
   @Override
   public void readStartFile() throws DITAOTException {
     final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
+    final URI rootFile = job.getInputFile();
     if (fi == null) {
-      addToWaitList(new Reference(job.getInputFile()));
+      addToWaitList(new Reference(rootFile, getFormatFromPath(rootFile)));
     } else {
       if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
         getStartDocuments(fi).forEach(this::addToWaitList);
@@ -178,7 +179,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
           fi.format = ATTR_FORMAT_VALUE_DITA;
           job.add(fi);
         }
-        addToWaitList(new Reference(job.getInputFile(), fi.format));
+        addToWaitList(new Reference(rootFile, fi.format));
       }
     }
   }


### PR DESCRIPTION
## Description
Support parsing the start map using a custom parser, e.g. a Markdown parser.

## Motivation and Context
Previously only files referenced from the start map could be parser using custom parser. This allows also the start map use a custom parser.

## How Has This Been Tested?
Tests pass.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Mention in release notes.


