### PR TITLE
Support empty @specializations attribute value

### DIFF
--- a/src/main/java/org/dita/dost/util/StringUtils.java
+++ b/src/main/java/org/dita/dost/util/StringUtils.java
@@ -140,6 +140,7 @@ public final class StringUtils {
     // FIXME Dont' mix arrays and collections
     return Arrays
       .stream(specializations.trim().split("\\s+"))
+      .filter(s -> !s.isEmpty())
       .map(token ->
         Arrays
           .stream(token.substring(1).split("/"))

--- a/src/test/java/org/dita/dost/util/TestStringUtils.java
+++ b/src/test/java/org/dita/dost/util/TestStringUtils.java
@@ -69,6 +69,7 @@ public class TestStringUtils {
       new QName[][] { { props, QName.valueOf("foo") } },
       StringUtils.getExtPropsFromSpecializations("  @props/foo   ")
     );
+    assertArrayEquals(new QName[][] {}, StringUtils.getExtPropsFromSpecializations(""));
   }
 
   @Test


### PR DESCRIPTION
## Description
Support empty `@specializations` attribute value.

## Motivation and Context
Fix `StringIndexOutOfBoundsException` that is thrown when `@specializations` attribute has empty or all whitespace value.

## How Has This Been Tested?
New unit test.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
This is a bug that only manifested with DITA 2.0 content so it's unlikely that anyone outside the DITA-OT developers has encountered this. So a mention in release notes is enough.
