### PR TITLE
Update bundled LwDITA plug-in to 5.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
                    "${cleanVersion}"
 def bundled = [
         "eclipsehelp": "https://github.com/dita-ot/org.dita.eclipsehelp/releases/download/3.4/org.dita.eclipsehelp-3.4.0.zip",
-        "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/5.1.0/org.lwdita-5.1.0.zip",
+        "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/5.2.1/org.lwdita-5.2.1.zip",
         "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/1.1.0.zip",
         "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",


### PR DESCRIPTION
## Description
Update bundled LwDITA plug-in to 5.2.1.

## Motivation and Context
Latest version of LwDITA plug-in that contains support for MDITA maps.

## How Has This Been Tested?
Manual testing.
## Type of Changes

- New feature _(non-breaking change which adds functionality)_
