### PR TITLE
Improve some comments related to topicpull XSLT parameters

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -61,11 +61,11 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
 
   <!-- Set the format for generated text for links to tables and figures.   -->
   <!-- Recognized values are 'NUMBER' (Table 5) and 'TITLE' (Table Caption) -->
-  <xsl:param name="TABLELINK">NUMBER</xsl:param>
-  <xsl:param name="FIGURELINK">NUMBER</xsl:param>
-  <xsl:param name="remove-broken-links" as="xs:string?"/>
+  <xsl:param name="TABLELINK" as="xs:string" select="'NUMBER'"/>  <!-- DITA-OT parameter args.tablelink.style: 'NUMBER' or 'TITLE' -->
+  <xsl:param name="FIGURELINK" as="xs:string" select="'NUMBER'"/>  <!-- DITA-OT parameter args.figurelink.style: 'NUMBER' or 'TITLE' -->
+  <xsl:param name="remove-broken-links" as="xs:string" select="'false'"/>  <!-- DITA-OT parameter remove-broken-links: 'false' or 'true' -->
   <!-- Check whether the onlytopicinmap is turned on -->
-  <xsl:param name="ONLYTOPICINMAP" select="'false'"/>
+  <xsl:param name="ONLYTOPICINMAP" as="xs:string" select="'false'"/>  <!-- DITA-OT parameter onlytopic.in.map: 'false' or 'true' -->
   
   <!-- Establish keys for the counting of figures, tables, and anything else -->
   <!-- To remove something from the figure count, create the same key in an override.
@@ -943,18 +943,18 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:apply-templates select="." mode="ditamsg:cannot-retrieve-linktext"/>
   </xsl:template>
 
-  <!-- Determine the text for a link to a figure. Currently uses "Figure N". A node set
-       containing the figure's <title> element is also passed in, an override may choose
-       to use this in the figure's reference text. -->
+  <!-- Compute the text for a link to a figure:
+       * When $FIGURELINK = 'NUMBER', use "Figure N".
+       * When $FIGURELINK = 'TITLE', use "Figure Caption/Title". -->
   <xsl:template match="*" mode="topicpull:figure-linktext">
-    <xsl:param name="figtext"/>
-    <xsl:param name="figcount"/>
-    <xsl:param name="figtitle"/>
+    <xsl:param name="figtext"/>  <!-- for $FIGURELINK = 'NUMBER' -->
+    <xsl:param name="figcount"/>  <!-- for $FIGURELINK = 'NUMBER' -->
+    <xsl:param name="figtitle"/>  <!-- for $FIGURELINK = 'TITLE' -->
     <xsl:choose>
-      <xsl:when test="$FIGURELINK='TITLE'">
+      <xsl:when test="$FIGURELINK = 'TITLE'">
         <xsl:apply-templates select="$figtitle" mode="text-only"/>
       </xsl:when>
-      <xsl:otherwise> <!-- Default: FIGURELINK='NUMBER' -->
+      <xsl:otherwise>  <!-- $FIGURELINK = 'NUMBER' -->
         <xsl:value-of select="$figtext"/>
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'figure-number-separator'"/>
@@ -1035,16 +1035,18 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     </xsl:apply-templates>
   </xsl:template>
 
-  <!-- Determine the text for a link to a table. Currently uses table title. -->
+  <!-- Compute the text for a link to a table:
+       * When $TABLELINK = 'NUMBER', use "Table N".
+       * When $TABLELINK = 'TITLE', use "Table Caption/Title". -->
   <xsl:template match="*" mode="topicpull:table-linktext">
-    <xsl:param name="tbltext"/>
-    <xsl:param name="tblcount"/>
-    <xsl:param name="tbltitle"/> <!-- Currently unused, but may be picked up by an override -->
+    <xsl:param name="tbltext"/>  <!-- for $TABLELINK = 'NUMBER' -->
+    <xsl:param name="tblcount"/>  <!-- for $TABLELINK = 'NUMBER' -->
+    <xsl:param name="tbltitle"/>  <!-- for $TABLELINK = 'TITLE' -->
     <xsl:choose>
-      <xsl:when test="$TABLELINK='TITLE'">
+      <xsl:when test="$TABLELINK = 'TITLE'">
         <xsl:apply-templates select="$tbltitle" mode="text-only"/>
       </xsl:when>
-      <xsl:otherwise> <!-- Default: TABLELINK='NUMBER' -->
+      <xsl:otherwise>  <!-- $TABLELINK = 'NUMBER' -->
         <xsl:value-of select="$tbltext"/>
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'figure-number-separator'"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -53,19 +53,25 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="dita-ot topicpull ditamsg xs">
+
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>
+
   <!-- Deprecated since 2.4 -->
   <xsl:param name="DBG" select="'no'"/>
 
   <!-- Set the format for generated text for links to tables and figures.   -->
   <!-- Recognized values are 'NUMBER' (Table 5) and 'TITLE' (Table Caption) -->
-  <xsl:param name="TABLELINK" as="xs:string" select="'NUMBER'"/>  <!-- DITA-OT parameter args.tablelink.style: 'NUMBER' or 'TITLE' -->
-  <xsl:param name="FIGURELINK" as="xs:string" select="'NUMBER'"/>  <!-- DITA-OT parameter args.figurelink.style: 'NUMBER' or 'TITLE' -->
-  <xsl:param name="remove-broken-links" as="xs:string" select="'false'"/>  <!-- DITA-OT parameter remove-broken-links: 'false' or 'true' -->
+  <!-- DITA-OT parameter args.tablelink.style: 'NUMBER' or 'TITLE' -->
+  <xsl:param name="TABLELINK" as="xs:string" select="'NUMBER'"/>
+  <!-- DITA-OT parameter args.figurelink.style: 'NUMBER' or 'TITLE' -->
+  <xsl:param name="FIGURELINK" as="xs:string" select="'NUMBER'"/>
+  <!-- DITA-OT parameter remove-broken-links: 'false' or 'true' -->
+  <xsl:param name="remove-broken-links" as="xs:string" select="'false'"/>
   <!-- Check whether the onlytopicinmap is turned on -->
-  <xsl:param name="ONLYTOPICINMAP" as="xs:string" select="'false'"/>  <!-- DITA-OT parameter onlytopic.in.map: 'false' or 'true' -->
+  <!-- DITA-OT parameter onlytopic.in.map: 'false' or 'true' -->
+  <xsl:param name="ONLYTOPICINMAP" as="xs:string" select="'false'"/>
   
   <!-- Establish keys for the counting of figures, tables, and anything else -->
   <!-- To remove something from the figure count, create the same key in an override.
@@ -79,8 +85,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   
   <xsl:key name="nontopicElementsById" match="*[@id][not(dita-ot:is-topic(.))]" use="@id"/>
   <xsl:key name="topicsById" match="*[contains(@class, ' topic/topic ')][@id]" use="@id"/>
-  
-  
+
   <!-- ========================
        Functions
        ======================== -->
@@ -101,7 +106,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       select="if (exists($specifiedValue)) 
       then $specifiedValue 
       else $defaultValue"/>
-    
   </xsl:function>
   
   <xsl:function name="dita-ot:get-link-scope" as="xs:string?">
@@ -947,14 +951,19 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
        * When $FIGURELINK = 'NUMBER', use "Figure N".
        * When $FIGURELINK = 'TITLE', use "Figure Caption/Title". -->
   <xsl:template match="*" mode="topicpull:figure-linktext">
-    <xsl:param name="figtext"/>  <!-- for $FIGURELINK = 'NUMBER' -->
-    <xsl:param name="figcount"/>  <!-- for $FIGURELINK = 'NUMBER' -->
-    <xsl:param name="figtitle"/>  <!-- for $FIGURELINK = 'TITLE' -->
+    <!-- for $FIGURELINK = 'NUMBER' -->
+    <xsl:param name="figtext"/>
+    <!-- for $FIGURELINK = 'NUMBER' -->
+    <xsl:param name="figcount"/>
+    <!-- for $FIGURELINK = 'TITLE' -->
+    <xsl:param name="figtitle"/>
+
     <xsl:choose>
       <xsl:when test="$FIGURELINK = 'TITLE'">
         <xsl:apply-templates select="$figtitle" mode="text-only"/>
       </xsl:when>
-      <xsl:otherwise>  <!-- $FIGURELINK = 'NUMBER' -->
+      <!-- $FIGURELINK = 'NUMBER' -->
+      <xsl:otherwise>
         <xsl:value-of select="$figtext"/>
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'figure-number-separator'"/>
@@ -963,17 +972,21 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <!-- XXX: Remove I18N processing from here and move to transtype specific code -->
   <xsl:template match="*[lang('hu')]" mode="topicpull:figure-linktext">
     <!-- Hungarian: "1. Figure " -->
     <xsl:param name="figtext"/>
     <xsl:param name="figcount"/>
-    <xsl:param name="figtitle"/> <!-- Currently unused, but may be picked up by an override -->
+    <!-- Currently unused, but may be picked up by an override -->
+    <xsl:param name="figtitle"/>
+
     <xsl:choose>
       <xsl:when test="$FIGURELINK='TITLE'">
         <xsl:apply-templates select="$figtitle" mode="text-only"/>
       </xsl:when>
-      <xsl:otherwise> <!-- Default: FIGURELINK='NUMBER' -->
+      <!-- Default: FIGURELINK='NUMBER' -->
+      <xsl:otherwise>
         <xsl:value-of select="$figcount"/>
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'figure-number-separator'"/>
@@ -982,6 +995,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <!-- If the figure is unavailable or we're not sure what to do with it, generate fallback text -->
   <xsl:template match="*" mode="topicpull:figure-linktext-fallback">
     <xsl:choose>
@@ -1039,14 +1053,19 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
        * When $TABLELINK = 'NUMBER', use "Table N".
        * When $TABLELINK = 'TITLE', use "Table Caption/Title". -->
   <xsl:template match="*" mode="topicpull:table-linktext">
-    <xsl:param name="tbltext"/>  <!-- for $TABLELINK = 'NUMBER' -->
-    <xsl:param name="tblcount"/>  <!-- for $TABLELINK = 'NUMBER' -->
-    <xsl:param name="tbltitle"/>  <!-- for $TABLELINK = 'TITLE' -->
+    <!-- for $TABLELINK = 'NUMBER' -->
+    <xsl:param name="tbltext"/>
+    <!-- for $TABLELINK = 'NUMBER' -->
+    <xsl:param name="tblcount"/>
+    <!-- for $TABLELINK = 'TITLE' -->
+    <xsl:param name="tbltitle"/>
+
     <xsl:choose>
       <xsl:when test="$TABLELINK = 'TITLE'">
         <xsl:apply-templates select="$tbltitle" mode="text-only"/>
       </xsl:when>
-      <xsl:otherwise>  <!-- $TABLELINK = 'NUMBER' -->
+      <!-- $TABLELINK = 'NUMBER' -->
+      <xsl:otherwise>
         <xsl:value-of select="$tbltext"/>
         <xsl:call-template name="getVariable">
           <xsl:with-param name="id" select="'figure-number-separator'"/>
@@ -1055,11 +1074,14 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <xsl:template match="*[lang('hu')]" mode="topicpull:table-linktext">
     <!-- Hungarian: "1. Table" -->
     <xsl:param name="tbltext"/>
     <xsl:param name="tblcount"/>
-    <xsl:param name="tbltitle"/> <!-- Currently unused, but may be picked up by an override -->
+    <!-- Currently unused, but may be picked up by an override -->
+    <xsl:param name="tbltitle"/>
+
     <xsl:choose>
       <xsl:when test="$TABLELINK='TITLE'">
         <xsl:apply-templates select="$tbltitle" mode="text-only"/>
@@ -1073,6 +1095,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <!-- Fallback text if a table target cannot be found, or there is some other problem -->
   <xsl:template match="*" mode="topicpull:table-linktext-fallback">
     <xsl:choose>
@@ -1105,7 +1128,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template mode="topicpull:resolvelinktext" priority="10" 
     match="*[contains(@class, ' topic/ol ')]/*[contains(@class, ' topic/li ')]" 
     >
-    
     <xsl:apply-templates mode="topicpull:li-linktext" 
       select="."/>
   </xsl:template>  
@@ -1123,6 +1145,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:number level="multiple"
       count="*[contains(@class,' topic/ol ')]/*[contains(@class,' topic/li ')]" format="1.a.i.1.a.i.1.a.i"/>
   </xsl:template>
+
   <!-- Instead of matching an unordered list item, we will call this template; that way
      the error points to the XREF, not to the list item. -->
   <xsl:template name="topicpull:referenced-invalid-list-item">
@@ -1133,7 +1156,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="*[contains(@class,' topic/fn ')]" mode="topicpull:resolvelinktext">
     <xsl:apply-templates mode="topicpull:fn-linktext" 
       select="."/>
-    
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' topic/fn ')]" mode="topicpull:fn-linktext">
@@ -1173,6 +1195,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       has been determined to be appropriate-->
   <xsl:template match="*" mode="topicpull:getshortdesc">
     <xsl:param name="targetElement" as="element()?"/>
+
     <xsl:choose>
       <xsl:when test="not(dita-ot:is-topic($targetElement))">
         <xsl:apply-templates select="." mode="topicpull:getshortdesc_element">
@@ -1206,6 +1229,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <!-- Get the shortdesc from a specific topic in another file -->
   <xsl:template match="*" mode="topicpull:getshortdesc_topic">
     <xsl:param name="targetElement" as="element()?"/>
+
     <xsl:choose>
       <xsl:when test="$targetElement/*[contains(@class, ' topic/shortdesc ')] |
                       $targetElement/*[contains(@class, ' topic/abstract ')]/*[contains(@class, ' topic/shortdesc ')]">
@@ -1222,6 +1246,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="*|text()|processing-instruction()" mode="text-only">
     <xsl:apply-templates select="." mode="dita-ot:text-only"/>
   </xsl:template>
+
   <xsl:template match="*|@*|comment()|processing-instruction()|text()">
     <xsl:copy>
       <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()"/>
@@ -1231,8 +1256,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <!-- in link text computation, do not resolve footnote numbers
        (the numbering space might differ between the source and target documents) -->
   <xsl:template match="*[contains(@class,' topic/fn ')]" mode="dita-ot:text-only"/>
-  
-  
+
   <xsl:template match="*[contains(@class,' topic/xref ')]" mode="copy-shortdesc">
     <xsl:choose>
       <xsl:when test="empty(@href) or @scope='peer' or @scope='external'">
@@ -1279,6 +1303,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="@id" mode="copy-shortdesc" />
   
   <xsl:template match="*[contains(@class,' topic/indexterm ')]" mode="copy-shortdesc" />
+
   <xsl:template match="*[contains(@class,' topic/draft-comment ') or contains(@class,' topic/required-cleanup ')]" mode="copy-shortdesc"/>
   
   <xsl:template match="*|@*|processing-instruction()" mode="copy-shortdesc">
@@ -1291,6 +1316,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template name="compute-number">
     <xsl:param name="except"/>
     <xsl:param name="all"/>
+
     <xsl:choose>
       <xsl:when test="$except != ''">
         <xsl:value-of select="number($all) - number($except)"/>
@@ -1312,38 +1338,46 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:empty-href">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX017E'"/>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:missing-href">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX028E'"/>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:type-attribute-not-specific">
     <xsl:param name="elem-name" select="name()"/>
     <xsl:param name="targetting"/>
     <xsl:param name="type"/>
     <xsl:param name="actual-name"/>
+
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX029I'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$elem-name"/>;%2=<xsl:value-of select="$targetting"/>;%3=<xsl:value-of select="$type"/>;%4=<xsl:value-of select="$actual-name"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:type-attribute-incorrect">
     <xsl:param name="elem-name" select="name()"/>
     <xsl:param name="targetting"/>
     <xsl:param name="type"/>
     <xsl:param name="actual-name"/>
+
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX030W'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="$elem-name"/>;%2=<xsl:value-of select="$targetting"/>;%3=<xsl:value-of select="$type"/>;%4=<xsl:value-of select="$actual-name"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:missing-href-target">
     <xsl:param name="file"/>
+
     <xsl:choose>
        <xsl:when test="$ONLYTOPICINMAP='true'">
           <xsl:call-template name="output-message">
@@ -1359,30 +1393,35 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
          </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:cannot-retrieve-linktext">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX032E'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:cannot-retrieve-list-number">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX033E'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:crossref-unordered-listitem">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX034E'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:cannot-retrieve-footnote-number">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX035E'"/>
       <xsl:with-param name="msgparams">%1=<xsl:value-of select="@href"/></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
+
   <xsl:template match="*" mode="ditamsg:cannot-find-dlentry-target">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX036E'"/>
@@ -1408,6 +1447,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
   <xsl:template match="*" mode="topicpull:add-usertext-PI">
     <xsl:choose>
       <xsl:when test="processing-instruction()[name()='ditaot'][.='usertext' or .='gentext']">
@@ -1422,12 +1462,14 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <!-- Added for RFE 3001750. -->
   <!-- Returns a <?ditaot dita-ot:genshortdesc?> if context element does not already have a *shortdesc PI -->
   <xsl:template match="*" mode="topicpull:add-genshortdesc-PI"/>
+
   <xsl:template match="*[not(processing-instruction('ditaot')[. = ('usershortdesc' ,'genshortdesc')])]" mode="topicpull:add-genshortdesc-PI" priority="10">
     <xsl:processing-instruction name="ditaot">genshortdesc</xsl:processing-instruction>
   </xsl:template>
 
   <!-- Returns a <?ditaot dita-ot:usershortdesc?> if context element does not already have a *shortdesc PI -->
   <xsl:template match="*" mode="topicpull:add-usershortdesc-PI"/>
+
   <xsl:template match="*[not(processing-instruction('ditaot')[. = ('usershortdesc' ,'genshortdesc')])]" mode="topicpull:add-usershortdesc-PI" priority="10">
     <xsl:processing-instruction name="ditaot">usershortdesc</xsl:processing-instruction>
   </xsl:template>


### PR DESCRIPTION
## Description
This pull request adds/updates some parameter-related comments in the topicpullImpl.xsl file.

## Motivation and Context
This started when I noticed an outdated comment that a `$tbltitle` template parameter was not used (it is). After fixing that, I also added/updated some other parameter-related comments while tracing through the code.

## How Has This Been Tested?
All tests pass. I also manually tested `<xref>` and `<link>` references to `<table>` and `<figure>` elements with the parameters set to both values.

## Type of Changes
These are comments only; no functionality is affected.

## Documentation and Compatibility
No documentation or release notes are needed.

## Checklist
I tried to follow the format of existing comments in other preprocessing stylesheets.