### PR TITLE
Fix for #4184, avoid creating nested <desc> elements

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -691,11 +691,11 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <!-- Get the short description for a link or xref -->
   <xsl:template match="*" mode="topicpull:get-stuff_get-shortdesc">
     <xsl:param name="targetElement" as="element()?"/>
-    <xsl:param name="in-desc-content" as="xs:boolean" select="false()" tunnel="yes"/>
+    <xsl:param name="inDescContent" as="xs:boolean" select="false()" tunnel="yes"/>
     
     <xsl:choose>
       <!-- if already creating content inside a <desc>, do not create a lower-level <desc> -->
-      <xsl:when test="$in-desc-content"/>
+      <xsl:when test="$inDescContent"/>
       <!--if there's already a desc, copy it-->
       <xsl:when test="*[contains(@class, ' topic/desc ')]">
         <xsl:apply-templates select="." mode="topicpull:add-usershortdesc-PI"/>
@@ -715,7 +715,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
           <desc class="- topic/desc ">
             <xsl:apply-templates select="$shortdesc">
               <xsl:with-param name="baseContextElement" select="." tunnel="yes"/>
-              <xsl:with-param name="in-desc-content" as="xs:boolean" select="true()" tunnel="yes"/>
+              <xsl:with-param name="inDescContent" as="xs:boolean" select="true()" tunnel="yes"/>
             </xsl:apply-templates>
           </desc>
         </xsl:if>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -691,8 +691,12 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <!-- Get the short description for a link or xref -->
   <xsl:template match="*" mode="topicpull:get-stuff_get-shortdesc">
     <xsl:param name="targetElement" as="element()?"/>
+    <xsl:param name="in-desc-content" as="xs:boolean" select="false()" tunnel="yes"/>
     
     <xsl:choose>
+      <!-- if already creating content inside a <desc>, do not create a lower-level <desc>
+           (see #4184 for details on how this can occur) -->
+      <xsl:when test="$in-desc-content"/>
       <!--if there's already a desc, copy it-->
       <xsl:when test="*[contains(@class, ' topic/desc ')]">
         <xsl:apply-templates select="." mode="topicpull:add-usershortdesc-PI"/>
@@ -712,6 +716,8 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
           <desc class="- topic/desc ">
             <xsl:apply-templates select="$shortdesc">
               <xsl:with-param name="baseContextElement" select="." tunnel="yes"/>
+              <!-- remember that we are now creating content inside a <desc> element -->
+              <xsl:with-param name="in-desc-content" as="xs:boolean" select="true()" tunnel="yes"/>
             </xsl:apply-templates>
           </desc>
         </xsl:if>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -694,8 +694,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:param name="in-desc-content" as="xs:boolean" select="false()" tunnel="yes"/>
     
     <xsl:choose>
-      <!-- if already creating content inside a <desc>, do not create a lower-level <desc>
-           (see #4184 for details on how this can occur) -->
+      <!-- if already creating content inside a <desc>, do not create a lower-level <desc> -->
       <xsl:when test="$in-desc-content"/>
       <!--if there's already a desc, copy it-->
       <xsl:when test="*[contains(@class, ' topic/desc ')]">
@@ -716,7 +715,6 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
           <desc class="- topic/desc ">
             <xsl:apply-templates select="$shortdesc">
               <xsl:with-param name="baseContextElement" select="." tunnel="yes"/>
-              <!-- remember that we are now creating content inside a <desc> element -->
               <xsl:with-param name="in-desc-content" as="xs:boolean" select="true()" tunnel="yes"/>
             </xsl:apply-templates>
           </desc>


### PR DESCRIPTION
## Description
Update `topicpull` to avoid attempting to create a lower-level `<desc>` element inside higher-level `<desc>` element. This can occur when:

* An `<xref>` or `<link>` element points to topic 1.
* Topic 1 contains a `<shortdesc>` with a link to topic 2.
* Topic 2 contains a `<shortdesc>`.

## Motivation and Context
Fixes #4184.

## How Has This Been Tested?
I ran the testcase from #4184. I also ran `gradlew test`, `gradlew integrationtest`, and `gradlew e2etest`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

A tunneling parameter is set to `true()` when creating content in a `<desc>` element. Further attempts to create a `<desc>` element inside this scope will return an empty sequence.

An interesting technical note here is that the tunneling parameter is applied to and checked within different templates.

The risk of breaking an existing processing flow is low. All changes are contained within the single `mode="topicpull:get-stuff_get-shortdesc"` template. If a user overrides this template, the changes would not affect their processing.

## Documentation and Compatibility
No documentation update is needed.

A release notes entry could be something like this:

> When topic `<shortdesc>` descriptions contained cross-reference links in circular reference loops across topics, an infinite-recursion stylesheet loop could result. Now, `<shortdesc>` descriptions in referenced elements are processed only one level deep.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
