### PR TITLE
Fix DITA-OT 4.x compatibility with HTMLHelp

### DIFF
--- a/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
+++ b/src/main/plugins/org.dita.htmlhelp/build_dita2htmlhelp_template.xml
@@ -26,7 +26,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="dita2htmlhelp.init">
     <property name="html-version" value="html"/>
     <property name="temp.output.dir.name" value="temp_chm_dir"/>
-    <property name="preprocess.copy-image.skip" value="true"/>
+    <property name="build-step.copy-image" value="false"/>
   </target>
 
   <target name="use-init.envhhcdir" if="env.HHCDIR">


### PR DESCRIPTION
## Description
Fix bug in HTMLHelp that breaks compatibility with DITA-OT 4.x. The new build step properties required moving from `preprocess.copy-image.skip` to setting `build-step.copy-image`.

## Motivation and Context
Fixes #4181

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

