### PR TITLE
Throw exception In strict processing mode when error is logged from XSLT

### DIFF
--- a/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModule.java
@@ -16,6 +16,7 @@ import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.pipeline.PipelineHashIO;
+import org.dita.dost.util.Configuration.Mode;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -69,4 +70,6 @@ public interface AbstractPipelineModule {
   default void setProcessingPipe(List<XmlFilterModule.FilterPair> pipe) {}
 
   void setParallel(boolean parallel);
+
+  void setProcessingMode(Mode processingMode);
 }

--- a/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
+++ b/src/main/java/org/dita/dost/module/AbstractPipelineModuleImpl.java
@@ -13,6 +13,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Configuration.Mode;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -26,6 +27,7 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
   protected Job job;
   protected XMLUtils xmlUtils;
   protected boolean parallel;
+  protected Mode processingMode;
   Predicate<FileInfo> fileInfoFilter;
   List<XmlFilterModule.FilterPair> filters;
 
@@ -61,5 +63,9 @@ public abstract class AbstractPipelineModuleImpl implements AbstractPipelineModu
 
   public void setParallel(boolean parallel) {
     this.parallel = parallel;
+  }
+
+  public void setProcessingMode(Mode processingMode) {
+    this.processingMode = processingMode;
   }
 }

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -99,7 +99,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
       final XsltTransformer transformer = templates.load();
       transformer.setErrorReporter(toErrorReporter(logger));
       transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
-      transformer.setMessageListener(toMessageListener(logger));
+      transformer.setMessageListener(toMessageListener(logger, processingMode));
 
       transformer.setParameter(new QName("file-being-processed"), XdmItem.makeValue(inputFile.getName()));
 

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -63,7 +63,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
       final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
       transformer.setErrorReporter(toErrorReporter(logger));
       transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
-      transformer.setMessageListener(toMessageListener(logger));
+      transformer.setMessageListener(toMessageListener(logger, processingMode));
 
       if (input.getAttribute("include.rellinks") != null) {
         transformer.setParameter(

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -92,7 +92,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
         final XsltTransformer transformer = xsltExecutable.load();
         transformer.setErrorReporter(toErrorReporter(logger));
         transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
-        transformer.setMessageListener(toMessageListener(logger));
+        transformer.setMessageListener(toMessageListener(logger, processingMode));
 
         for (Entry<String, String> e : input.getAttributes().entrySet()) {
           logger.debug("Set parameter " + e.getKey() + " to '" + e.getValue() + "'");

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -114,7 +114,7 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
         final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(style)).load();
         transformer.setErrorReporter(toErrorReporter(logger));
         transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
-        transformer.setMessageListener(toMessageListener(logger));
+        transformer.setMessageListener(toMessageListener(logger, processingMode));
 
         final StreamSource source = new StreamSource(new ByteArrayInputStream(midBuffer.toByteArray()));
         final Destination result = processor.newSerializer(output);

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -192,7 +192,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
       //                    : uriResolver;
       transformer.setErrorReporter(toErrorReporter(logger));
       transformer.setURIResolver(uriResolver);
-      transformer.setMessageListener(toMessageListener(logger));
+      transformer.setMessageListener(toMessageListener(logger, processingMode));
       return transformer;
     } catch (final Exception e) {
       throw new DITAOTException("Failed to create Transformer: " + e.getMessage(), e);

--- a/src/test/java/org/dita/dost/module/DummyPipelineModule.java
+++ b/src/test/java/org/dita/dost/module/DummyPipelineModule.java
@@ -9,11 +9,10 @@ package org.dita.dost.module;
 
 import java.util.List;
 import java.util.function.Predicate;
-import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.module.AbstractPipelineModule;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Configuration.Mode;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -60,6 +59,11 @@ public class DummyPipelineModule implements AbstractPipelineModule {
 
   @Override
   public void setParallel(final boolean parallel) {
+    // Noop
+  }
+
+  @Override
+  public void setProcessingMode(final Mode processingMode) {
     // Noop
   }
 }

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -32,12 +32,14 @@ import net.sf.saxon.s9api.SaxonApiUncheckedException;
 import net.sf.saxon.s9api.XdmNode;
 import net.sf.saxon.sapling.Saplings;
 import net.sf.saxon.trans.SymbolicName;
+import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
 import net.sf.saxon.trans.XmlProcessingException;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.module.DelegatingCollationUriResolverTest;
+import org.dita.dost.util.Configuration.Mode;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -276,7 +278,7 @@ public class XMLUtilsTest {
   @Test
   public void toMessageListener() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()
@@ -293,7 +295,7 @@ public class XMLUtilsTest {
   @Test
   public void toMessageListener_withLevelAndErrorCode() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()
@@ -315,7 +317,7 @@ public class XMLUtilsTest {
   @Test
   public void toMessageListener_withErrorCode() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()
@@ -332,7 +334,7 @@ public class XMLUtilsTest {
   @Test
   public void toMessageListener_withFatalErrorCode() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()
@@ -357,7 +359,7 @@ public class XMLUtilsTest {
   @Test
   public void toMessageListener_withLevel() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()
@@ -372,9 +374,29 @@ public class XMLUtilsTest {
   }
 
   @Test
+  public void toMessageListener_withLevel_strictMode() throws SaxonApiException {
+    final CachingLogger logger = new CachingLogger();
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.STRICT);
+
+    final XdmNode msg = Saplings
+      .doc()
+      .withChild(Saplings.pi("level", "ERROR"), Saplings.text("message "), Saplings.elem("debug"))
+      .toXdmNode(new XMLUtils().getProcessor());
+
+    try {
+      listener.message(msg, null, false, null);
+      fail();
+    } catch (UncheckedXPathException e) {
+      assertEquals("message <debug/>", e.getMessage());
+    } catch (Throwable e) {
+      fail();
+    }
+  }
+
+  @Test
   public void toMessageListenerProperElemsSerialization() throws SaxonApiException {
     final CachingLogger logger = new CachingLogger();
-    final MessageListener2 listener = XMLUtils.toMessageListener(logger);
+    final MessageListener2 listener = XMLUtils.toMessageListener(logger, Mode.LAX);
 
     final XdmNode msg = Saplings
       .doc()


### PR DESCRIPTION
## Description
Throw exception In strict processing mode when error is logged from XSLT module.

## Motivation and Context
Match strict processing behaviour in Java code.

## How Has This Been Tested?
Unit tests and manual testing.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Strict mode will now work from messages thrown from XSLT.


