### PR TITLE
Support alternative DITA formats as conref target

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -497,7 +497,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     final Set<Reference> nonCopytoResult = new LinkedHashSet<>(128);
     nonCopytoResult.addAll(listFilter.getNonConrefCopytoTargets());
     for (final URI f : listFilter.getConrefTargets()) {
-      nonCopytoResult.add(new Reference(stripFragment(f), listFilter.currentFileFormat()));
+      nonCopytoResult.add(new Reference(stripFragment(f), getFormatFromPath(stripFragment(f))));
     }
     for (final URI f : listFilter.getCopytoMap().values()) {
       nonCopytoResult.add(new Reference(stripFragment(f)));

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -365,11 +365,13 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     // Verify stub for current file is in Job
     final FileInfo fi = job.getFileInfo(currentFile);
     if (fi == null) {
+      final String extension = getExtension(currentFile.getPath());
       final FileInfo stub = new FileInfo.Builder()
         .src(currentFile)
         .uri(rel)
         .result(currentFile)
         .isInput(currentFile.equals(rootFile))
+        .format(isFormatDita(extension) ? extension : null)
         .build();
       job.add(stub);
     }
@@ -401,6 +403,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         logger.error(MessageUtils.getMessage("DOTJ021E", params).toString());
         failureList.add(currentFile);
       }
+    } catch (EarlyExitException e) {
+      failureList.add(currentFile);
     } catch (final RuntimeException e) {
       throw e;
     } catch (final SAXParseException sax) {

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -566,9 +566,9 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     }
 
     if (listFilter.isDitaTopic()) {
+      assert currentFile.getFragment() == null;
+      final URI f = currentFile.normalize();
       if (!isFormatDita(ref.format)) {
-        assert currentFile.getFragment() == null;
-        final URI f = currentFile.normalize();
         if (!fileinfos.containsKey(f)) {
           final FileInfo i = new FileInfo.Builder()
             .uri(tempFileNameScheme.generateTempFileName(currentFile))
@@ -576,6 +576,12 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             .format(ref.format)
             .build();
           fileinfos.put(i.src, Collections.singletonList(i));
+        }
+      } else {
+        final FileInfo fi = job.getFileInfo(f);
+        if (fi != null) {
+          final FileInfo i = new FileInfo.Builder(fi).format(ATTR_FORMAT_VALUE_DITA).build();
+          job.add(i);
         }
       }
       fullTopicSet.add(currentFile);

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -340,7 +340,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
    * @throws DITAOTException if processing failed
    */
   void readFile(final Reference ref, final URI parseFile) throws DITAOTException {
-    currentFile = ref.filename;
+    currentFile = ref.filename.normalize();
     assert currentFile.isAbsolute();
     final URI src = parseFile != null ? parseFile : currentFile;
     assert src.isAbsolute();
@@ -584,6 +584,11 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         hrefTopicSet.add(currentFile);
       }
     } else if (listFilter.isDitaMap()) {
+      final FileInfo fi = job.getFileInfo(currentFile);
+      if (fi != null && !Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITAMAP)) {
+        final FileInfo i = new FileInfo.Builder(fi).format(ATTR_FORMAT_VALUE_DITAMAP).build();
+        job.add(i);
+      }
       fullMapSet.add(currentFile);
     }
   }

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -489,7 +489,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     final Set<Reference> nonCopytoResult = new LinkedHashSet<>(128);
     nonCopytoResult.addAll(listFilter.getNonConrefCopytoTargets());
     for (final URI f : listFilter.getConrefTargets()) {
-      nonCopytoResult.add(new Reference(stripFragment(f), listFilter.currentFileFormat()));
+      nonCopytoResult.add(new Reference(stripFragment(f), getFormatFromPath(stripFragment(f))));
     }
     for (final URI f : listFilter.getCopytoMap().values()) {
       nonCopytoResult.add(new Reference(stripFragment(f)));

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -25,6 +25,7 @@ import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.NormalizeFilter;
 import org.dita.dost.writer.ProfilingFilter;
 import org.dita.dost.writer.ValidationFilter;
+import org.xml.sax.SAXException;
 import org.xml.sax.XMLFilter;
 
 /**
@@ -60,6 +61,12 @@ public final class MapReaderModule extends AbstractReaderModule {
     }
 
     return null;
+  }
+
+  @Override
+  void init() throws SAXException {
+    super.init();
+    listFilter.setForceType(MAP_MAP);
   }
 
   @Override

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -153,7 +153,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
 
   private Document getMapDocument() throws SAXException {
     final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
-    if (fi == null) {
+    if (fi == null || isFormatDita(fi.format)) {
       return null;
     }
     final URI currentFile = job.tempDirURI.resolve(fi.uri);


### PR DESCRIPTION
## Description
Support alternative DITA formats as conref target.

## Motivation and Context
When e.g. MDITA file is referenced only as a conref target, the format was set as DITA and parsing failed. Fix detecting format correctly


## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

