### PR TITLE
Support SAX properties for custom parsers

### DIFF
--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -149,7 +149,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     try {
       reader.setErrorHandler(new DITAOTXMLErrorHandler(currentFile.toString(), logger, processingMode));
 
-      XMLReader parser = XMLUtils.getXmlReader(f.format).orElse(reader);
+      XMLReader parser = XMLUtils.getXmlReader(f.format, processingMode).orElse(reader);
       XMLReader xmlSource = parser;
       for (final XMLFilter filter : getProcessingPipe(currentFile)) {
         filter.setParent(xmlSource);

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -406,7 +406,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     final String[] params = { currentFile.toString() };
 
     try {
-      XMLReader xmlSource = XMLUtils.getXmlReader(ref.format).orElse(reader);
+      XMLReader xmlSource = XMLUtils.getXmlReader(ref.format, processingMode).orElse(reader);
       for (final XMLFilter f : getProcessingPipe(currentFile)) {
         f.setParent(xmlSource);
         f.setEntityResolver(CatalogUtils.getCatalogResolver());

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -29,7 +29,7 @@ import org.xmlresolver.Resolver;
 /**
  * Common functionality for modules that read source documents.
  */
-abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
+public abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
 
   private static final String FEATURE_GRAMMAR_POOL = "http://apache.org/xml/properties/internal/grammar-pool";
 
@@ -62,6 +62,16 @@ abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
         } catch (final SAXNotRecognizedException e) {
           // Not Xerces, ignore exception
         }
+      }
+      try {
+        reader.setProperty(PROPERTY_FORMATS, parserMap.keySet());
+      } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+        // Ignore
+      }
+      try {
+        reader.setProperty(PROPERTY_PROCESSING_MODE, processingMode.name().toLowerCase());
+      } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+        // Ignore
       }
     } else {
       reader = XMLUtils.getXMLReader();

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -377,7 +377,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     }
 
     try {
-      XMLReader parser = XMLUtils.getXmlReader(ref.format).orElse(reader);
+      XMLReader parser = XMLUtils.getXmlReader(ref.format, processingMode).orElse(reader);
       XMLReader xmlSource = parser;
       for (final XMLFilter f : getProcessingPipe(currentFile)) {
         f.setParent(xmlSource);

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1716,6 +1716,11 @@ public final class Constants {
 
   public static final String PI_WORKDIR_TARGET_URI = "workdir-uri";
 
+  /** SAX property for processing mode as lowercase {@link String} name of {@link Configuration.Mode Mode}. */
+  public static final String PROPERTY_PROCESSING_MODE = "https://dita-ot.org/property/processing-mode";
+  /** SAX property for supported DITA formats as a {@link java.util.Collection Collection}<code>&lt;</code>{@link String}<code>></code>. */
+  public static final String PROPERTY_FORMATS = "https://dita-ot.org/property/formats";
+
   /**
    * Instances should NOT be constructed in standard programming.
    */

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -913,11 +913,13 @@ public final class XMLUtils {
   /**
    * Get reader for input format
    *
-   * @param format input document format
+   * @param format         input document format
+   * @param processingMode
    * @return reader for given forma
    * @throws SAXException if creating reader failed
    */
-  public static Optional<XMLReader> getXmlReader(final String format) throws SAXException {
+  public static Optional<XMLReader> getXmlReader(final String format, Configuration.Mode processingMode)
+    throws SAXException {
     if (format == null || format.equals(ATTR_FORMAT_VALUE_DITA) || format.equals(ATTR_FORMAT_VALUE_DITAMAP)) {
       return Optional.empty();
     }
@@ -933,6 +935,16 @@ public final class XMLUtils {
             } catch (final SAXNotRecognizedException ex) {
               // Not Xerces, ignore exception
             }
+          }
+          try {
+            r.setProperty(PROPERTY_FORMATS, parserMap.keySet());
+          } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
+            // Ignore
+          }
+          try {
+            r.setProperty(PROPERTY_PROCESSING_MODE, processingMode.name().toLowerCase());
+          } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
+            // Ignore
           }
           return Optional.of(r);
         } catch (final InstantiationException | ClassNotFoundException | IllegalAccessException ex) {

--- a/src/test/java/org/dita/dost/reader/CustomXMLReader.java
+++ b/src/test/java/org/dita/dost/reader/CustomXMLReader.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.reader;
+
+import java.util.Collection;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+public class CustomXMLReader extends XMLFilterImpl {
+
+  private Collection<String> formats;
+  private String processingMode;
+
+  public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
+    switch (name) {
+      case "https://dita-ot.org/property/formats":
+        formats = (Collection<String>) value;
+        break;
+      case "https://dita-ot.org/property/processing-mode":
+        processingMode =
+          switch ((String) value) {
+            case "skip" -> throw new SAXNotRecognizedException();
+            case "strict" -> throw new SAXNotSupportedException();
+            default -> (String) value;
+          };
+        break;
+      default:
+        throw new IllegalArgumentException("%s=%s".formatted(name, value));
+    }
+  }
+
+  public Collection<String> getFormats() {
+    return formats;
+  }
+
+  public String getProcessingMode() {
+    return processingMode;
+  }
+}

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import net.sf.saxon.Configuration;
@@ -39,6 +40,7 @@ import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.CachingLogger;
 import org.dita.dost.TestUtils.CachingLogger.Message;
 import org.dita.dost.module.DelegatingCollationUriResolverTest;
+import org.dita.dost.reader.CustomXMLReader;
 import org.dita.dost.util.Configuration.Mode;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,6 +50,8 @@ import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.LocatorImpl;
 
@@ -529,6 +533,30 @@ public class XMLUtilsTest {
   //        TestUtils.assertXMLEqual(new InputSource(new File(expDir, "identity.dita").toURI().toString()),
   //                       new InputSource(new File(tempDir, "identity.dita").toURI().toString()));
   //    }
+
+  @Test
+  void getXmlReader() throws SAXException {
+    final Optional<XMLReader> act = XMLUtils.getXmlReader("custom", Mode.LAX);
+    final CustomXMLReader reader = (CustomXMLReader) act.get();
+    assertEquals("lax", reader.getProcessingMode());
+    assertEquals(List.of("custom"), List.copyOf(reader.getFormats()));
+  }
+
+  @Test
+  void getXmlReader_notRecognized() throws SAXException {
+    final Optional<XMLReader> act = XMLUtils.getXmlReader("custom", Mode.SKIP);
+    final CustomXMLReader reader = (CustomXMLReader) act.get();
+    assertNull(reader.getProcessingMode());
+    assertEquals(List.of("custom"), List.copyOf(reader.getFormats()));
+  }
+
+  @Test
+  void getXmlReader_notSupported() throws SAXException {
+    final Optional<XMLReader> act = XMLUtils.getXmlReader("custom", Mode.STRICT);
+    final CustomXMLReader reader = (CustomXMLReader) act.get();
+    assertNull(reader.getProcessingMode());
+    assertEquals(List.of("custom"), List.copyOf(reader.getFormats()));
+  }
 
   @AfterAll
   public static void tearDown() throws IOException {

--- a/src/test/resources/org.dita.dost.platform/plugin.properties
+++ b/src/test/resources/org.dita.dost.platform/plugin.properties
@@ -21,3 +21,4 @@ plugin.org.dita.javahelp.dir=plugins/org.dita.javahelp
 plugin.org.dita.troff.dir=plugins/org.dita.troff
 plugin.org.dita.eclipsecontent.dir=plugins/org.dita.eclipsecontent
 plugin.org.dita.htmlhelp.dir=plugins/org.dita.htmlhelp
+parser.custom=org.dita.dost.reader.CustomXMLReader


### PR DESCRIPTION
## Description
Set SAX properties on custom parsers:
 * `https://dita-ot.org/property/processing-mode` — processing mode as lowercase `String`.
 * `https://dita-ot.org/property/formats` — supported DITA formats as `Collection<String>`.

## Motivation and Context
Allow custom parsers to match processing with rest of DITA-OT.

## How Has This Been Tested?
Unit tests.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
A new feature for developers of plug-ins that add custom parsers and it's only visible to them.

