### PR TITLE
add markers where named templates can be converted to moded templates

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -910,7 +910,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
                   <xsl:value-of select="normalize-space($grabbed-value)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:call-template name="linktext-fallback"/>
+                  <!--<xsl:apply-templates select="." mode="mappull:linktext-fallback"/>--><!-- #4207 -->
+                  <xsl:call-template name="linktext-fallback"/><!-- #4207 -->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:when>
@@ -926,7 +927,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
                   <xsl:value-of select="normalize-space($grabbed-value)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:call-template name="linktext-fallback"/>
+                  <!--<xsl:apply-templates select="." mode="mappull:linktext-fallback"/>--><!-- #4207 -->
+                  <xsl:call-template name="linktext-fallback"/><!-- #4207 -->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:when>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -910,8 +910,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
                   <xsl:value-of select="normalize-space($grabbed-value)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--<xsl:apply-templates select="." mode="mappull:linktext-fallback"/>--><!-- #4207 -->
-                  <xsl:call-template name="linktext-fallback"/><!-- #4207 -->
+                  <!-- TODO: Replace with mode="mappull:linktext-fallback" -->
+                  <xsl:call-template name="linktext-fallback"/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:when>
@@ -927,8 +927,8 @@ Other modes can be found within the code, and may or may not prove useful for ov
                   <xsl:value-of select="normalize-space($grabbed-value)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--<xsl:apply-templates select="." mode="mappull:linktext-fallback"/>--><!-- #4207 -->
-                  <xsl:call-template name="linktext-fallback"/><!-- #4207 -->
+                  <!-- TODO: Replace with mode="mappull:linktext-fallback" -->
+                  <xsl:call-template name="linktext-fallback"/>
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:when>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1136,8 +1136,8 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:param name="linkElement" as="element()" tunnel="yes"/>
     
     <xsl:for-each select="$linkElement">
-      <!--<xsl:apply-templates select="." mode="ditamsg:crossref-unordered-listitem"/>--><!-- #4207 -->
-      <xsl:call-template name="topicpull:referenced-invalid-list-item"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="ditamsg:crossref-unordered-listitem" -->
+      <xsl:call-template name="topicpull:referenced-invalid-list-item"/>
     </xsl:for-each>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1136,7 +1136,8 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     <xsl:param name="linkElement" as="element()" tunnel="yes"/>
     
     <xsl:for-each select="$linkElement">
-      <xsl:call-template name="topicpull:referenced-invalid-list-item"/>
+      <!--<xsl:apply-templates select="." mode="ditamsg:crossref-unordered-listitem"/>--><!-- #4207 -->
+      <xsl:call-template name="topicpull:referenced-invalid-list-item"/><!-- #4207 -->
     </xsl:for-each>
   </xsl:template>
   

--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -137,13 +137,17 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addAttributesToBody"/>
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
-      <xsl:call-template name="generateBreadcrumbs"/>
-      <xsl:call-template name="gen-user-header"/>
-      <xsl:call-template name="processHDR"/>
+      <!--<xsl:apply-templates select="." mode="generateBreadcrumbs"/>--><!-- #4207 -->
+      <xsl:call-template name="generateBreadcrumbs"/><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-header"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-header"/><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="processHDR"/>--><!-- #4207 -->
+      <xsl:call-template name="processHDR"/><!-- #4207 -->
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
       </xsl:if>
-      <xsl:call-template name="gen-user-sidetoc"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
       <xsl:choose>
         <xsl:when test="*[contains(@class, ' topic/title ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -156,30 +160,36 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="normalize-map"/>
       </xsl:variable>
       <xsl:apply-templates select="$map" mode="toc"/>
-      <xsl:call-template name="gen-endnotes"/>
-      <xsl:call-template name="gen-user-footer"/>
-      <xsl:call-template name="processFTR"/>
+      <!--<xsl:apply-templates select="." mode="gen-endnotes"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-endnotes"/><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-footer"/><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="processFTR"/>--><!-- #4207 -->
+      <xsl:call-template name="processFTR"/><!-- #4207 -->
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
     </body>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' map/map ')]/*[contains(@class, ' topic/title ')]">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:apply-templates/>
     </h1>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' map/map ')]/@title">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:value-of select="."/>
     </h1>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]" priority="10">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:apply-templates select="*[contains(@class, ' bookmap/mainbooktitle ')]/node()"/>
     </h1>
   </xsl:template>
@@ -188,15 +198,18 @@ See the accompanying LICENSE file for applicable license.
     <title>
       <xsl:choose>
         <xsl:when test="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/@title">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' map/map ')]/@title"/>
         </xsl:when>
       </xsl:choose>

--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -137,17 +137,17 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addAttributesToBody"/>
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
-      <!--<xsl:apply-templates select="." mode="generateBreadcrumbs"/>--><!-- #4207 -->
-      <xsl:call-template name="generateBreadcrumbs"/><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-header"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-header"/><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="processHDR"/>--><!-- #4207 -->
-      <xsl:call-template name="processHDR"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="generateBreadcrumbs" -->
+      <xsl:call-template name="generateBreadcrumbs"/>
+      <!-- TODO: Replace with mode="gen-user-header" -->
+      <xsl:call-template name="gen-user-header"/>
+      <!-- TODO: Replace with mode="processHDR" -->
+      <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
       </xsl:if>
-      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-sidetoc" -->
+      <xsl:call-template name="gen-user-sidetoc"/>
       <xsl:choose>
         <xsl:when test="*[contains(@class, ' topic/title ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -160,36 +160,36 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="normalize-map"/>
       </xsl:variable>
       <xsl:apply-templates select="$map" mode="toc"/>
-      <!--<xsl:apply-templates select="." mode="gen-endnotes"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-endnotes"/><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-footer"/><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="processFTR"/>--><!-- #4207 -->
-      <xsl:call-template name="processFTR"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-endnotes" -->
+      <xsl:call-template name="gen-endnotes"/>
+      <!-- TODO: Replace with mode="gen-user-footer" -->
+      <xsl:call-template name="gen-user-footer"/>
+      <!-- TODO: Replace with mode="processFTR" -->
+      <xsl:call-template name="processFTR"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
     </body>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' map/map ')]/*[contains(@class, ' topic/title ')]">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:apply-templates/>
     </h1>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' map/map ')]/@title">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:value-of select="."/>
     </h1>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]" priority="10">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:apply-templates select="*[contains(@class, ' bookmap/mainbooktitle ')]/node()"/>
     </h1>
   </xsl:template>
@@ -198,18 +198,18 @@ See the accompanying LICENSE file for applicable license.
     <title>
       <xsl:choose>
         <xsl:when test="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/@title">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' map/map ')]/@title"/>
         </xsl:when>
       </xsl:choose>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -66,8 +66,8 @@ See the accompanying LICENSE file for applicable license.
                     <!--use xref content-->
                   </xsl:when>
                   <xsl:otherwise>
-                    <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
-                    <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
+                    <!-- TODO: Replace with mode="determine-final-href" -->
+                    <xsl:call-template name="href"/><!--use href text-->
                   </xsl:otherwise>
                 </xsl:choose>
               </sup>
@@ -82,8 +82,8 @@ See the accompanying LICENSE file for applicable license.
                   <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
-                  <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
+                  <!-- TODO: Replace with mode="determine-final-href" -->
+                  <xsl:call-template name="href"/><!--use href text-->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>
@@ -463,8 +463,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
             </xsl:when>
             <xsl:otherwise>
               <!--use href-->
-              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-              <xsl:call-template name="href"/><!-- #4207 -->
+              <!-- TODO: Replace with mode="determine-final-href" -->
+              <xsl:call-template name="href"/>
             </xsl:otherwise>
           </xsl:choose>
         </a>
@@ -499,8 +499,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           </xsl:when>
           <xsl:otherwise>
             <!--use href-->
-            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-            <xsl:call-template name="href"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="determine-final-href" -->
+            <xsl:call-template name="href"/>
           </xsl:otherwise>
         </xsl:choose>
       </a>
@@ -574,8 +574,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
         </xsl:when>
         <xsl:otherwise>
           <!--use href-->
-          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-          <xsl:call-template name="href"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="determine-final-href" -->
+          <xsl:call-template name="href"/>
         </xsl:otherwise>
       </xsl:choose>
     </a>
@@ -717,8 +717,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           <xsl:value-of select="normalize-space(*[contains(@class, ' topic/linktext ')])"/>
         </xsl:when>
         <xsl:otherwise>
-          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-          <xsl:call-template name="href"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="determine-final-href" -->
+          <xsl:call-template name="href"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -66,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
                     <!--use xref content-->
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:call-template name="href"/><!--use href text-->
+                    <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
+                    <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
                   </xsl:otherwise>
                 </xsl:choose>
               </sup>
@@ -81,7 +82,8 @@ See the accompanying LICENSE file for applicable license.
                   <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:call-template name="href"/><!--use href text-->
+                  <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
+                  <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>
@@ -461,7 +463,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
             </xsl:when>
             <xsl:otherwise>
               <!--use href-->
-              <xsl:call-template name="href"/>
+              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+              <xsl:call-template name="href"/><!-- #4207 -->
             </xsl:otherwise>
           </xsl:choose>
         </a>
@@ -496,7 +499,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           </xsl:when>
           <xsl:otherwise>
             <!--use href-->
-            <xsl:call-template name="href"/>
+            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+            <xsl:call-template name="href"/><!-- #4207 -->
           </xsl:otherwise>
         </xsl:choose>
       </a>
@@ -570,7 +574,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
         </xsl:when>
         <xsl:otherwise>
           <!--use href-->
-          <xsl:call-template name="href"/>
+          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+          <xsl:call-template name="href"/><!-- #4207 -->
         </xsl:otherwise>
       </xsl:choose>
     </a>
@@ -712,7 +717,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           <xsl:value-of select="normalize-space(*[contains(@class, ' topic/linktext ')])"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:call-template name="href"/>
+          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+          <xsl:call-template name="href"/><!-- #4207 -->
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -597,8 +597,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="@href">
           <br/><div><a>
             <xsl:attribute name="href">
-              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-              <xsl:call-template name="href"/><!-- #4207 -->
+              <!-- TODO: Replace with mode="determine-final-href" -->
+              <xsl:call-template name="href"/>
             </xsl:attribute>
             <xsl:choose>
               <xsl:when test="@type = 'external'">
@@ -2329,12 +2329,12 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template name="chapter-setup">
 <html>
-  <!--<xsl:apply-templates select="." mode="setTopicLanguage"/>--><!-- #4207 -->
-  <xsl:call-template name="setTopicLanguage"/><!-- #4207 -->
-  <!--<xsl:apply-templates select="." mode="chapterHead"/>--><!-- #4207 -->
-  <xsl:call-template name="chapterHead"/><!-- #4207 -->
-  <!--<xsl:apply-templates select="." mode="chapterBody"/>--><!-- #4207 -->
-  <xsl:call-template name="chapterBody"/><!-- #4207 -->
+  <!-- TODO: Replace with mode="setTopicLanguage" -->
+  <xsl:call-template name="setTopicLanguage"/>
+  <!-- TODO: Replace with mode="chapterHead" -->
+  <xsl:call-template name="chapterHead"/>
+  <!-- TODO: Replace with mode="chapterBody" -->
+  <xsl:call-template name="chapterBody"/>
 </html>
 </xsl:template>
 
@@ -2361,26 +2361,26 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="chapterHead">
     <head>
       <!-- initial meta information -->
-      <!--<xsl:apply-templates select="." mode="generateCharset"/>-->      <!-- Set the character set to UTF-8 --><!-- #4207 -->
-      <xsl:call-template name="generateCharset"/>   <!-- Set the character set to UTF-8 --><!-- #4207 -->
+      <!-- TODO: Replace with mode="generateCharset" -->
+      <xsl:call-template name="generateCharset"/>   <!-- Set the character set to UTF-8 -->
       <xsl:apply-templates select="." mode="generateDefaultCopyright"/> <!-- Generate a default copyright, if needed -->
-      <!--<xsl:apply-templates select="." mode="generateDefaultMeta"/>-->  <!-- Standard meta for security, robots, etc --><!-- #4207 -->
-      <xsl:call-template name="generateDefaultMeta"/> <!-- Standard meta for security, robots, etc --><!-- #4207 -->
+      <!-- TODO: Replace with mode="generateDefaultMeta" -->
+      <xsl:call-template name="generateDefaultMeta"/> <!-- Standard meta for security, robots, etc -->
       <xsl:apply-templates select="." mode="getMeta"/> <!-- Process metadata from topic prolog -->
-      <!--<xsl:apply-templates select="." mode="copyright"/>-->            <!-- Generate copyright, if specified manually --><!-- #4207 -->
-      <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="generateChapterTitle"/>--> <!-- Generate the <title> element --><!-- #4207 -->
-      <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->        <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>-->     <!-- include user's XSL javascripts here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->      <!-- include user's XSL style element and content here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="processHDF"/>-->           <!-- Add user HDF file, if specified --><!-- #4207 -->
-      <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="generateCssLinks"/>-->     <!-- Generate links to CSS files --><!-- #4207 -->
-      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files --><!-- #4207 -->
+      <!-- TODO: Replace with mode="copyright" -->
+      <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
+      <!-- TODO: Replace with mode="generateChapterTitle" -->
+      <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element -->
+      <!-- TODO: Replace with mode="gen-user-head" -->
+      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
+      <!-- TODO: Replace with mode="gen-user-scripts" -->
+      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
+      <!-- TODO: Replace with mode="gen-user-styles" -->
+      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
+      <!-- TODO: Replace with mode="processHDF" -->
+      <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified -->
+      <!-- TODO: Replace with mode="generateCssLinks" -->
+      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
     </head>
   </xsl:template>
 
@@ -2481,8 +2481,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="/ | @* | node()" mode="generateChapterTitle">
     <!-- Title processing - special handling for short descriptions -->
     <title>
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
       <xsl:variable name="maintitle"><xsl:apply-templates select="/*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:variable name="ditamaintitle"><xsl:apply-templates select="/dita/*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:choose>
@@ -2516,8 +2516,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addHeaderToHtmlBodyElement"/>
 
       <!-- Include a user's XSL call here to generate a toc based on what's a child of topic -->
-      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-sidetoc" -->
+      <xsl:call-template name="gen-user-sidetoc"/>
 
       <xsl:apply-templates select="." mode="addContentToHtmlBodyElement"/>
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
@@ -2554,12 +2554,13 @@ See the accompanying LICENSE file for applicable license.
   <!-- Process <body> content that is appropriate for HTML5 header section. -->
   <xsl:template match="*" mode="addHeaderToHtmlBodyElement">
     <xsl:variable name="header-content" as="node()*">
-      <!--<xsl:apply-templates select="." mode="generateBreadcrumbs"/>--><!-- #4207 -->
-      <xsl:call-template name="generateBreadcrumbs"/><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-header"/>-->  <!-- include user's XSL running header here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="processHDR"/>--><!-- #4207 -->
-      <xsl:call-template name="processHDR"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="generateBreadcrumbs" -->
+      <xsl:call-template name="generateBreadcrumbs"/>
+        <!-- include user's XSL running header here -->
+      <!-- TODO: Replace with mode="gen-user-header" -->
+      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here -->
+      <!-- TODO: Replace with mode="processHDR" -->
+      <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')] |
                                      /dita/*[1]/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
@@ -2596,8 +2597,8 @@ See the accompanying LICENSE file for applicable license.
                                <!-- followed by body content, again by fall-through in document order -->
                                <!-- followed by related links -->
                                <!-- followed by child topics by fall-through -->
-        <!--<xsl:apply-templates select="." mode="gen-endnotes"/>-->    <!-- include footnote-endnotes --><!-- #4207 -->
-        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes --><!-- #4207 -->
+        <!-- TODO: Replace with mode="gen-endnotes" -->
+        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes -->
         <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
       </article>
     </main>
@@ -2610,10 +2611,10 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*" mode="addFooterToHtmlBodyElement">
     <xsl:variable name="footer-content" as="node()*">
-      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--> <!-- include user's XSL running footer here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="processFTR"/>-->      <!-- Include XHTML footer, if specified --><!-- #4207 -->
-      <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified --><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-footer" -->
+      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
+      <!-- TODO: Replace with mode="processFTR" -->
+      <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
     </xsl:variable>
     <xsl:if test="exists($footer-content)">
       <footer xsl:use-attribute-sets="footer">

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -597,7 +597,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="@href">
           <br/><div><a>
             <xsl:attribute name="href">
-              <xsl:call-template name="href"/>
+              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+              <xsl:call-template name="href"/><!-- #4207 -->
             </xsl:attribute>
             <xsl:choose>
               <xsl:when test="@type = 'external'">
@@ -2328,9 +2329,12 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template name="chapter-setup">
 <html>
-  <xsl:call-template name="setTopicLanguage"/>
-  <xsl:call-template name="chapterHead"/>
-  <xsl:call-template name="chapterBody"/> 
+  <!--<xsl:apply-templates select="." mode="setTopicLanguage"/>--><!-- #4207 -->
+  <xsl:call-template name="setTopicLanguage"/><!-- #4207 -->
+  <!--<xsl:apply-templates select="." mode="chapterHead"/>--><!-- #4207 -->
+  <xsl:call-template name="chapterHead"/><!-- #4207 -->
+  <!--<xsl:apply-templates select="." mode="chapterBody"/>--><!-- #4207 -->
+  <xsl:call-template name="chapterBody"/><!-- #4207 -->
 </html>
 </xsl:template>
 
@@ -2357,17 +2361,26 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="chapterHead">
     <head>
       <!-- initial meta information -->
-      <xsl:call-template name="generateCharset"/>   <!-- Set the character set to UTF-8 -->
+      <!--<xsl:apply-templates select="." mode="generateCharset"/>-->      <!-- Set the character set to UTF-8 --><!-- #4207 -->
+      <xsl:call-template name="generateCharset"/>   <!-- Set the character set to UTF-8 --><!-- #4207 -->
       <xsl:apply-templates select="." mode="generateDefaultCopyright"/> <!-- Generate a default copyright, if needed -->
-      <xsl:call-template name="generateDefaultMeta"/> <!-- Standard meta for security, robots, etc -->
+      <!--<xsl:apply-templates select="." mode="generateDefaultMeta"/>-->  <!-- Standard meta for security, robots, etc --><!-- #4207 -->
+      <xsl:call-template name="generateDefaultMeta"/> <!-- Standard meta for security, robots, etc --><!-- #4207 -->
       <xsl:apply-templates select="." mode="getMeta"/> <!-- Process metadata from topic prolog -->
-      <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
-      <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element -->
-      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
-      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
-      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
-      <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified -->
-      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
+      <!--<xsl:apply-templates select="." mode="copyright"/>-->            <!-- Generate copyright, if specified manually --><!-- #4207 -->
+      <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="generateChapterTitle"/>--> <!-- Generate the <title> element --><!-- #4207 -->
+      <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->        <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>-->     <!-- include user's XSL javascripts here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->      <!-- include user's XSL style element and content here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="processHDF"/>-->           <!-- Add user HDF file, if specified --><!-- #4207 -->
+      <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="generateCssLinks"/>-->     <!-- Generate links to CSS files --><!-- #4207 -->
+      <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files --><!-- #4207 -->
     </head>
   </xsl:template>
 
@@ -2468,7 +2481,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="/ | @* | node()" mode="generateChapterTitle">
     <!-- Title processing - special handling for short descriptions -->
     <title>
-      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
       <xsl:variable name="maintitle"><xsl:apply-templates select="/*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:variable name="ditamaintitle"><xsl:apply-templates select="/dita/*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:choose>
@@ -2502,7 +2516,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addHeaderToHtmlBodyElement"/>
 
       <!-- Include a user's XSL call here to generate a toc based on what's a child of topic -->
-      <xsl:call-template name="gen-user-sidetoc"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
 
       <xsl:apply-templates select="." mode="addContentToHtmlBodyElement"/>
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
@@ -2539,9 +2554,12 @@ See the accompanying LICENSE file for applicable license.
   <!-- Process <body> content that is appropriate for HTML5 header section. -->
   <xsl:template match="*" mode="addHeaderToHtmlBodyElement">
     <xsl:variable name="header-content" as="node()*">
-      <xsl:call-template name="generateBreadcrumbs"/>
-      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here -->
-      <xsl:call-template name="processHDR"/>
+      <!--<xsl:apply-templates select="." mode="generateBreadcrumbs"/>--><!-- #4207 -->
+      <xsl:call-template name="generateBreadcrumbs"/><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-header"/>-->  <!-- include user's XSL running header here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="processHDR"/>--><!-- #4207 -->
+      <xsl:call-template name="processHDR"/><!-- #4207 -->
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')] |
                                      /dita/*[1]/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
@@ -2578,7 +2596,8 @@ See the accompanying LICENSE file for applicable license.
                                <!-- followed by body content, again by fall-through in document order -->
                                <!-- followed by related links -->
                                <!-- followed by child topics by fall-through -->
-        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes -->
+        <!--<xsl:apply-templates select="." mode="gen-endnotes"/>-->    <!-- include footnote-endnotes --><!-- #4207 -->
+        <xsl:call-template name="gen-endnotes"/>    <!-- include footnote-endnotes --><!-- #4207 -->
         <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
       </article>
     </main>
@@ -2591,8 +2610,10 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*" mode="addFooterToHtmlBodyElement">
     <xsl:variable name="footer-content" as="node()*">
-      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
-      <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
+      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--> <!-- include user's XSL running footer here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="processFTR"/>-->      <!-- Include XHTML footer, if specified --><!-- #4207 -->
+      <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified --><!-- #4207 -->
     </xsl:variable>
     <xsl:if test="exists($footer-content)">
       <footer xsl:use-attribute-sets="footer">

--- a/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
@@ -114,8 +114,8 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- In the context of XREF - call it's HREF processor -->
   <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="imagemap-xref">
-   <!--<xsl:attribute name="href"><xsl:apply-templates select="." mode="determine-final-href"/></xsl:attribute>--><!-- #4207 -->
-   <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute><!-- #4207 -->
+   <!-- TODO: Replace with mode="determine-final-href" -->
+   <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute>
    <xsl:if test="@scope='external' or @type='external' or ((@format='PDF' or @format='pdf') and not(@scope='local'))">
      <xsl:apply-templates select="." mode="external-link"/>
    </xsl:if>

--- a/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
@@ -114,7 +114,8 @@ See the accompanying LICENSE file for applicable license.
   
   <!-- In the context of XREF - call it's HREF processor -->
   <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="imagemap-xref">
-   <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute>
+   <!--<xsl:attribute name="href"><xsl:apply-templates select="." mode="determine-final-href"/></xsl:attribute>--><!-- #4207 -->
+   <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute><!-- #4207 -->
    <xsl:if test="@scope='external' or @type='external' or ((@format='PDF' or @format='pdf') and not(@scope='local'))">
      <xsl:apply-templates select="." mode="external-link"/>
    </xsl:if>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -15,8 +15,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dt ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dt__content">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/dt ')])">
               <xsl:apply-templates select="../@id" mode="dlentry-id-for-fop"/>
               <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -15,7 +15,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dt ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dt__content">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:if test="not(preceding-sibling::*[contains(@class,' topic/dt ')])">
               <xsl:apply-templates select="../@id" mode="dlentry-id-for-fop"/>
               <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -254,8 +254,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicChapterInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:variable name="level" as="xs:integer">
               <xsl:apply-templates select="." mode="get-topic-level"/>
             </xsl:variable>
@@ -330,8 +330,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicAppendixInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:variable name="level" as="xs:integer">
               <xsl:apply-templates select="." mode="get-topic-level"/>
             </xsl:variable>
@@ -408,8 +408,8 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   <xsl:template match="*" mode="processTopicAppendicesInsideFlow">
     <fo:block xsl:use-attribute-sets="topic">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
         <fo:marker marker-class-name="current-topic-number">
           <xsl:variable name="topicref" 
@@ -491,8 +491,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicPartInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                 <fo:marker marker-class-name="current-topic-number">
                   <xsl:variable name="topicref" 
@@ -561,8 +561,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="insertPrefaceStaticContents"/>
             <fo:flow flow-name="xsl-region-body">
                 <fo:block xsl:use-attribute-sets="topic">
-                    <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                    <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                    <!-- TODO: Replace with mode="commonattributes" -->
+                    <xsl:call-template name="commonattributes"/>
                     <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                         <fo:marker marker-class-name="current-topic-number">
                           <xsl:variable name="topicref" 
@@ -633,8 +633,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicFrontMatterInsideFlow">
                  <fo:block xsl:use-attribute-sets="topic">
-                     <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                     <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                     <!-- TODO: Replace with mode="commonattributes" -->
+                     <xsl:call-template name="commonattributes"/>
                      <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
                          <fo:marker marker-class-name="current-topic-number">
                              <xsl:number format="1"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -254,7 +254,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicChapterInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:variable name="level" as="xs:integer">
               <xsl:apply-templates select="." mode="get-topic-level"/>
             </xsl:variable>
@@ -329,7 +330,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicAppendixInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:variable name="level" as="xs:integer">
               <xsl:apply-templates select="." mode="get-topic-level"/>
             </xsl:variable>
@@ -406,7 +408,8 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   <xsl:template match="*" mode="processTopicAppendicesInsideFlow">
     <fo:block xsl:use-attribute-sets="topic">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
         <fo:marker marker-class-name="current-topic-number">
           <xsl:variable name="topicref" 
@@ -488,7 +491,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicPartInsideFlow">
         <fo:block xsl:use-attribute-sets="topic">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                 <fo:marker marker-class-name="current-topic-number">
                   <xsl:variable name="topicref" 
@@ -557,7 +561,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:call-template name="insertPrefaceStaticContents"/>
             <fo:flow flow-name="xsl-region-body">
                 <fo:block xsl:use-attribute-sets="topic">
-                    <xsl:call-template name="commonattributes"/>
+                    <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                    <xsl:call-template name="commonattributes"/><!-- #4207 -->
                     <xsl:if test="empty(ancestor::*[contains(@class, ' topic/topic ')])">
                         <fo:marker marker-class-name="current-topic-number">
                           <xsl:variable name="topicref" 
@@ -628,7 +633,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
     <xsl:template match="*" mode="processTopicFrontMatterInsideFlow">
                  <fo:block xsl:use-attribute-sets="topic">
-                     <xsl:call-template name="commonattributes"/>
+                     <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                     <xsl:call-template name="commonattributes"/><!-- #4207 -->
                      <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
                          <fo:marker marker-class-name="current-topic-number">
                              <xsl:number format="1"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
@@ -61,19 +61,22 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="not(node())"/>
         <xsl:when test="$level = 1">
             <fo:block xsl:use-attribute-sets="body__toplevel conbody">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:when>
         <xsl:when test="$level = 2">
             <fo:block xsl:use-attribute-sets="body__secondLevel conbody">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:when>
         <xsl:otherwise>
             <fo:block xsl:use-attribute-sets="conbody">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:otherwise>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
@@ -61,22 +61,22 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="not(node())"/>
         <xsl:when test="$level = 1">
             <fo:block xsl:use-attribute-sets="body__toplevel conbody">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:when>
         <xsl:when test="$level = 2">
             <fo:block xsl:use-attribute-sets="body__secondLevel conbody">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:when>
         <xsl:otherwise>
             <fo:block xsl:use-attribute-sets="conbody">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <xsl:apply-templates/>
             </fo:block>
         </xsl:otherwise>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -35,7 +35,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="ot-placeholder:glossarylist//*[contains(@class, ' glossentry/glossentry ')]">
     <fo:block>
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <fo:block>
         <xsl:attribute name="id">
           <xsl:call-template name="generate-toc-id"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -35,8 +35,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="ot-placeholder:glossarylist//*[contains(@class, ' glossentry/glossentry ')]">
     <fo:block>
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <fo:block>
         <xsl:attribute name="id">
           <xsl:call-template name="generate-toc-id"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -14,8 +14,8 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:variable name="type" select="(@type, 'caution')[1]" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
     <fo:table xsl:use-attribute-sets="hazardstatement">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
         <xsl:with-param name="element" select="."/>
@@ -101,24 +101,24 @@ See the accompanying license.txt file for applicable licenses.
   
   <xsl:template match="*[contains(@class, ' hazard-d/typeofhazard ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' hazard-d/consequence ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' hazard-d/howtoavoid ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -14,7 +14,8 @@ See the accompanying license.txt file for applicable licenses.
     <xsl:variable name="type" select="(@type, 'caution')[1]" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
     <fo:table xsl:use-attribute-sets="hazardstatement">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
         <xsl:with-param name="element" select="."/>
@@ -100,21 +101,24 @@ See the accompanying license.txt file for applicable licenses.
   
   <xsl:template match="*[contains(@class, ' hazard-d/typeofhazard ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' hazard-d/consequence ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' hazard-d/howtoavoid ')]">
     <fo:block xsl:use-attribute-sets="p">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
@@ -37,64 +37,64 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' hi-d/b ')]">
         <fo:inline xsl:use-attribute-sets="b">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/i ')]">
       <fo:inline xsl:use-attribute-sets="i">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/u ')]">
       <fo:inline xsl:use-attribute-sets="u">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/tt ')]">
       <fo:inline xsl:use-attribute-sets="tt">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/sup ')]">
       <fo:inline xsl:use-attribute-sets="sup">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/sub ')]">
       <fo:inline xsl:use-attribute-sets="sub">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
   <xsl:template match="*[contains(@class,' hi-d/line-through ')]">
     <fo:inline xsl:use-attribute-sets="line-through">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' hi-d/overline ')]">
     <fo:inline xsl:use-attribute-sets="overline">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
@@ -37,56 +37,64 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' hi-d/b ')]">
         <fo:inline xsl:use-attribute-sets="b">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/i ')]">
       <fo:inline xsl:use-attribute-sets="i">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/u ')]">
       <fo:inline xsl:use-attribute-sets="u">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/tt ')]">
       <fo:inline xsl:use-attribute-sets="tt">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/sup ')]">
       <fo:inline xsl:use-attribute-sets="sup">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' hi-d/sub ')]">
       <fo:inline xsl:use-attribute-sets="sub">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
   <xsl:template match="*[contains(@class,' hi-d/line-through ')]">
     <fo:inline xsl:use-attribute-sets="line-through">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' hi-d/overline ')]">
     <fo:inline xsl:use-attribute-sets="overline">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -272,7 +272,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
 
     <fo:basic-link xsl:use-attribute-sets="xref">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:call-template name="buildBasicLinkDestination">
         <xsl:with-param name="scope" select="@scope"/>
         <xsl:with-param name="format" select="@format"/>
@@ -339,7 +340,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class,' topic/xref ')][empty(@href)]" priority="2">
     <fo:inline>
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))] | text()" />
     </fo:inline>
   </xsl:template>
@@ -420,7 +422,8 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ul">
         <xsl:for-each select="$children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])]">
           <fo:list-item xsl:use-attribute-sets="related-links.ul.li">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="related-links.ul.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ul.li__label__content">
                 <xsl:call-template name="getVariable">
@@ -449,7 +452,8 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ol">
         <xsl:for-each select="($children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])])">
           <fo:list-item xsl:use-attribute-sets="related-links.ol.li">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="related-links.ol.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ol.li__label__content">
                 <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -272,8 +272,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:variable>
 
     <fo:basic-link xsl:use-attribute-sets="xref">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="buildBasicLinkDestination">
         <xsl:with-param name="scope" select="@scope"/>
         <xsl:with-param name="format" select="@format"/>
@@ -340,8 +340,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class,' topic/xref ')][empty(@href)]" priority="2">
     <fo:inline>
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))] | text()" />
     </fo:inline>
   </xsl:template>
@@ -422,8 +422,8 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ul">
         <xsl:for-each select="$children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])]">
           <fo:list-item xsl:use-attribute-sets="related-links.ul.li">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="related-links.ul.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ul.li__label__content">
                 <xsl:call-template name="getVariable">
@@ -452,8 +452,8 @@ See the accompanying LICENSE file for applicable license.
       <fo:list-block xsl:use-attribute-sets="related-links.ol">
         <xsl:for-each select="($children[generate-id(.) = generate-id(key('link', related-links:link(.))[1])])">
           <fo:list-item xsl:use-attribute-sets="related-links.ol.li">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="related-links.ol.li__label">
               <fo:block xsl:use-attribute-sets="related-links.ol.li__label__content">
                 <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -42,8 +42,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ul ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ul">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -54,8 +54,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ol ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ol">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -66,8 +66,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ul ')]/*[contains(@class, ' topic/li ')]">
         <xsl:variable name="depth" select="count(ancestor::*[contains(@class, ' topic/ul ')])"/>
         <fo:list-item xsl:use-attribute-sets="ul.li">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ul.li__label">
                 <fo:block xsl:use-attribute-sets="ul.li__label__content">
                     <xsl:call-template name="getVariable">
@@ -91,8 +91,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="ol.li">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
                     <xsl:call-template name="getVariable">
@@ -115,8 +115,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/li ')]/*[contains(@class, ' topic/itemgroup ')]">
         <fo:block xsl:use-attribute-sets="li.itemgroup">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -124,8 +124,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/sl ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="sl">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -135,8 +135,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/sl ')]/*[contains(@class, ' topic/sli ')]">
         <fo:list-item xsl:use-attribute-sets="sl.sli">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="sl.sli__label">
                 <fo:block xsl:use-attribute-sets="sl.sli__label__content">
                 </fo:block>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -42,7 +42,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ul ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ul">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -53,7 +54,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ol ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="ol">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -64,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/ul ')]/*[contains(@class, ' topic/li ')]">
         <xsl:variable name="depth" select="count(ancestor::*[contains(@class, ' topic/ul ')])"/>
         <fo:list-item xsl:use-attribute-sets="ul.li">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="ul.li__label">
                 <fo:block xsl:use-attribute-sets="ul.li__label__content">
                     <xsl:call-template name="getVariable">
@@ -88,7 +91,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="ol.li">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
                     <xsl:call-template name="getVariable">
@@ -111,7 +115,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/li ')]/*[contains(@class, ' topic/itemgroup ')]">
         <fo:block xsl:use-attribute-sets="li.itemgroup">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -119,7 +124,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/sl ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:list-block xsl:use-attribute-sets="sl">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:list-block>
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -129,7 +135,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/sl ')]/*[contains(@class, ' topic/sli ')]">
         <fo:list-item xsl:use-attribute-sets="sl.sli">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="sl.sli__label">
                 <fo:block xsl:use-attribute-sets="sl.sli__label__content">
                 </fo:block>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
@@ -12,8 +12,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' markup-d/markupname ')]">
     <fo:inline xsl:use-attribute-sets="markupname">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
@@ -12,7 +12,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' markup-d/markupname ')]">
     <fo:inline xsl:use-attribute-sets="markupname">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -39,8 +39,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/codeph ')]">
         <fo:inline xsl:use-attribute-sets="codeph">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -66,8 +66,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/codeblock ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="codeblock">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -224,8 +224,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/var ') or contains(@class,' syntaxdiagram-d/var ')]">
         <fo:inline xsl:use-attribute-sets="var">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -238,32 +238,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/synph ') or contains(@class,' syntaxdiagram-d/synph ')]">
         <fo:inline xsl:use-attribute-sets="synph">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/oper ') or contains(@class,' syntaxdiagram-d/oper ')]">
         <fo:inline xsl:use-attribute-sets="oper">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/delim ') or contains(@class,' syntaxdiagram-d/delim ')]">
         <fo:inline xsl:use-attribute-sets="delim">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/sep ') or contains(@class,' syntaxdiagram-d/sep ')]">
         <fo:inline xsl:use-attribute-sets="sep">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -277,16 +277,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/parml ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="parml">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/plentry ')]">
         <fo:block xsl:use-attribute-sets="plentry">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -309,32 +309,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/pd ')]">
         <fo:block xsl:use-attribute-sets="pd">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synblk ') or contains(@class,' syntaxdiagram-d/synblk ')]">
         <fo:inline xsl:use-attribute-sets="synblk">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synnoteref ') or contains(@class,' syntaxdiagram-d/synnoteref ')]">
         <fo:inline xsl:use-attribute-sets="synnoteref">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         [<xsl:value-of select="@refid"/>] <!--TODO: synnoteref-->
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synnote ') or contains(@class,' syntaxdiagram-d/synnote ')]">
         <fo:inline xsl:use-attribute-sets="synnote"> <!--TODO: synnote-->
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:choose>
                 <xsl:when test="not(@id='')"> <!-- case of an explicit id -->
                     <xsl:value-of select="@id"/>
@@ -351,16 +351,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram"> <!--TODO: syntaxdiagram-->
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]">
         <fo:block xsl:use-attribute-sets="fragment">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:value-of select="*[contains(@class,' topic/title ')]"/>
             <xsl:text> </xsl:text>
             <xsl:apply-templates/>
@@ -369,8 +369,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
@@ -378,8 +378,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/kwd ') or contains(@class,' syntaxdiagram-d/kwd ')]">
         <fo:inline xsl:use-attribute-sets="kwd">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:if test="parent::*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]">
                 <xsl:if test="count(preceding-sibling::*)!=0"> | </xsl:if>
             </xsl:if>
@@ -400,8 +400,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/fragref ')]">
         <fo:inline xsl:use-attribute-sets="fragref">     <!--TODO: fragref-->
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:text>&lt;</xsl:text>
             <xsl:apply-templates/>
             <xsl:text>&gt;</xsl:text>
@@ -410,24 +410,24 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="fragment.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ')]|*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]|*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]">
         <fo:block xsl:use-attribute-sets="fragment.group">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="makeGroup"/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ')]|*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]|*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram.group">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="makeGroup"/>
         </fo:block>
     </xsl:template>
@@ -435,8 +435,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ') or contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]/
         *[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ') or contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]">
         <fo:inline>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="makeGroup"/>
         </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -39,7 +39,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/codeph ')]">
         <fo:inline xsl:use-attribute-sets="codeph">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -65,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/codeblock ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="codeblock">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -222,7 +224,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/var ') or contains(@class,' syntaxdiagram-d/var ')]">
         <fo:inline xsl:use-attribute-sets="var">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -235,28 +238,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/synph ') or contains(@class,' syntaxdiagram-d/synph ')]">
         <fo:inline xsl:use-attribute-sets="synph">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/oper ') or contains(@class,' syntaxdiagram-d/oper ')]">
         <fo:inline xsl:use-attribute-sets="oper">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/delim ') or contains(@class,' syntaxdiagram-d/delim ')]">
         <fo:inline xsl:use-attribute-sets="delim">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/sep ') or contains(@class,' syntaxdiagram-d/sep ')]">
         <fo:inline xsl:use-attribute-sets="sep">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -270,14 +277,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/parml ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="parml">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/plentry ')]">
         <fo:block xsl:use-attribute-sets="plentry">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -300,28 +309,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/pd ')]">
         <fo:block xsl:use-attribute-sets="pd">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synblk ') or contains(@class,' syntaxdiagram-d/synblk ')]">
         <fo:inline xsl:use-attribute-sets="synblk">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synnoteref ') or contains(@class,' syntaxdiagram-d/synnoteref ')]">
         <fo:inline xsl:use-attribute-sets="synnoteref">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         [<xsl:value-of select="@refid"/>] <!--TODO: synnoteref-->
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/synnote ') or contains(@class,' syntaxdiagram-d/synnote ')]">
         <fo:inline xsl:use-attribute-sets="synnote"> <!--TODO: synnote-->
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:choose>
                 <xsl:when test="not(@id='')"> <!-- case of an explicit id -->
                     <xsl:value-of select="@id"/>
@@ -338,14 +351,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram"> <!--TODO: syntaxdiagram-->
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]">
         <fo:block xsl:use-attribute-sets="fragment">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:value-of select="*[contains(@class,' topic/title ')]"/>
             <xsl:text> </xsl:text>
             <xsl:apply-templates/>
@@ -354,7 +369,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
@@ -362,7 +378,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/kwd ') or contains(@class,' syntaxdiagram-d/kwd ')]">
         <fo:inline xsl:use-attribute-sets="kwd">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:if test="parent::*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]">
                 <xsl:if test="count(preceding-sibling::*)!=0"> | </xsl:if>
             </xsl:if>
@@ -383,7 +400,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/fragref ')]">
         <fo:inline xsl:use-attribute-sets="fragref">     <!--TODO: fragref-->
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:text>&lt;</xsl:text>
             <xsl:apply-templates/>
             <xsl:text>&gt;</xsl:text>
@@ -392,21 +410,24 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="fragment.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ')]|*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]|*[contains(@class,' pr-d/fragment ') or contains(@class,' syntaxdiagram-d/fragment ')]/*[contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]">
         <fo:block xsl:use-attribute-sets="fragment.group">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="makeGroup"/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ')]|*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]|*[contains(@class,' pr-d/syntaxdiagram ') or contains(@class,' syntaxdiagram-d/syntaxdiagram ')]/*[contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ')]">
         <fo:block xsl:use-attribute-sets="syntaxdiagram.group">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="makeGroup"/>
         </fo:block>
     </xsl:template>
@@ -414,7 +435,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ') or contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]/
         *[contains(@class,' pr-d/groupcomp ') or contains(@class,' syntaxdiagram-d/groupcomp ') or contains(@class,' pr-d/groupchoice ') or contains(@class,' syntaxdiagram-d/groupchoice ') or contains(@class,' pr-d/groupseq ') or contains(@class,' syntaxdiagram-d/groupseq ')]">
         <fo:inline>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="makeGroup"/>
         </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -57,7 +57,8 @@ See the accompanying LICENSE file for applicable license.
      </xsl:template>
      <xsl:template match="*" mode="processTopicPrefaceInsideFlow">
          <fo:block xsl:use-attribute-sets="topic">
-             <xsl:call-template name="commonattributes"/>
+             <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+             <xsl:call-template name="commonattributes"/><!-- #4207 -->
              <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
                  <fo:marker marker-class-name="current-topic-number">
                      <xsl:number format="1"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -57,8 +57,8 @@ See the accompanying LICENSE file for applicable license.
      </xsl:template>
      <xsl:template match="*" mode="processTopicPrefaceInsideFlow">
          <fo:block xsl:use-attribute-sets="topic">
-             <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-             <xsl:call-template name="commonattributes"/><!-- #4207 -->
+             <!-- TODO: Replace with mode="commonattributes" -->
+             <xsl:call-template name="commonattributes"/>
              <xsl:if test="not(ancestor::*[contains(@class, ' topic/topic ')])">
                  <fo:marker marker-class-name="current-topic-number">
                      <xsl:number format="1"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -33,19 +33,22 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="not(node())"/>
       <xsl:when test="$level = 1">
         <fo:block xsl:use-attribute-sets="body__toplevel refbody">
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:apply-templates/>
         </fo:block>
       </xsl:when>
       <xsl:when test="$level = 2">
         <fo:block xsl:use-attribute-sets="body__secondLevel refbody">
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:apply-templates/>
         </fo:block>
       </xsl:when>
       <xsl:otherwise>
         <fo:block xsl:use-attribute-sets="refbody">
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:apply-templates/>
         </fo:block>
       </xsl:otherwise>
@@ -54,7 +57,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/refsyn ')]">
     <fo:block xsl:use-attribute-sets="refsyn">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
       <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
       <fo:block xsl:use-attribute-sets="refsyn__content">
@@ -71,7 +75,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/properties ')]">
     <fo:table xsl:use-attribute-sets="properties">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:call-template name="univAttrs"/>
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
@@ -131,7 +136,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/property ')]">
     <fo:table-row xsl:use-attribute-sets="property">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:variable name="valuePos">
         <xsl:apply-templates select="." mode="get-propvalue-position"/>
       </xsl:variable>
@@ -246,7 +252,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' reference/proptype ') or contains(@class, ' reference/propvalue ') or contains(@class, ' reference/propdesc ')]">
     <xsl:param name="entryCol"/>
     <fo:table-cell xsl:use-attribute-sets="property.entry">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>
@@ -287,7 +294,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/prophead ')]">
     <fo:table-header xsl:use-attribute-sets="prophead">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>
@@ -388,7 +396,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' reference/proptypehd ') or contains(@class, ' reference/propvaluehd ') or contains(@class, ' reference/propdeschd ')]">
     <xsl:param name="entryCol"/>
     <fo:table-cell xsl:use-attribute-sets="prophead.entry">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -33,22 +33,22 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="not(node())"/>
       <xsl:when test="$level = 1">
         <fo:block xsl:use-attribute-sets="body__toplevel refbody">
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:apply-templates/>
         </fo:block>
       </xsl:when>
       <xsl:when test="$level = 2">
         <fo:block xsl:use-attribute-sets="body__secondLevel refbody">
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:apply-templates/>
         </fo:block>
       </xsl:when>
       <xsl:otherwise>
         <fo:block xsl:use-attribute-sets="refbody">
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:apply-templates/>
         </fo:block>
       </xsl:otherwise>
@@ -57,8 +57,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/refsyn ')]">
     <fo:block xsl:use-attribute-sets="refsyn">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
       <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
       <fo:block xsl:use-attribute-sets="refsyn__content">
@@ -75,8 +75,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/properties ')]">
     <fo:table xsl:use-attribute-sets="properties">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="univAttrs"/>
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
@@ -136,8 +136,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/property ')]">
     <fo:table-row xsl:use-attribute-sets="property">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:variable name="valuePos">
         <xsl:apply-templates select="." mode="get-propvalue-position"/>
       </xsl:variable>
@@ -252,8 +252,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' reference/proptype ') or contains(@class, ' reference/propvalue ') or contains(@class, ' reference/propdesc ')]">
     <xsl:param name="entryCol"/>
     <fo:table-cell xsl:use-attribute-sets="property.entry">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>
@@ -294,8 +294,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' reference/prophead ')]">
     <fo:table-header xsl:use-attribute-sets="prophead">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>
@@ -396,8 +396,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' reference/proptypehd ') or contains(@class, ' reference/propvaluehd ') or contains(@class, ' reference/propdeschd ')]">
     <xsl:param name="entryCol"/>
     <fo:table-cell xsl:use-attribute-sets="prophead.entry">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:variable name="frame">
         <xsl:variable name="f" select="ancestor::*[contains(@class, ' reference/properties ')][1]/@frame"/>
         <xsl:choose>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -80,7 +80,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="topicNumbers">
         <xsl:for-each select="//*[contains(@class, ' topic/topic ')]">
             <topic guid="{generate-id()}">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
             </topic>
         </xsl:for-each>
     </xsl:variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -80,8 +80,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="topicNumbers">
         <xsl:for-each select="//*[contains(@class, ' topic/topic ')]">
             <topic guid="{generate-id()}">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
             </topic>
         </xsl:for-each>
     </xsl:variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
@@ -37,8 +37,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' sw-d/msgph ')]">
       <fo:inline xsl:use-attribute-sets="msgph">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
@@ -46,8 +46,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' sw-d/msgblock ')]">
       <xsl:call-template name="generateAttrLabel"/>
       <fo:block xsl:use-attribute-sets="msgblock">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:call-template name="setFrame"/>
         <xsl:call-template name="setScale"/>
         <xsl:call-template name="setExpanse"/>
@@ -75,24 +75,24 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' sw-d/filepath ')]">
       <fo:inline xsl:use-attribute-sets="filepath">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' sw-d/userinput ')]">
       <fo:inline xsl:use-attribute-sets="userinput">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' sw-d/systemoutput ')]">
       <fo:inline xsl:use-attribute-sets="systemoutput">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
@@ -37,7 +37,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' sw-d/msgph ')]">
       <fo:inline xsl:use-attribute-sets="msgph">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
@@ -45,7 +46,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' sw-d/msgblock ')]">
       <xsl:call-template name="generateAttrLabel"/>
       <fo:block xsl:use-attribute-sets="msgblock">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:call-template name="setFrame"/>
         <xsl:call-template name="setScale"/>
         <xsl:call-template name="setExpanse"/>
@@ -73,21 +75,24 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' sw-d/filepath ')]">
       <fo:inline xsl:use-attribute-sets="filepath">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' sw-d/userinput ')]">
       <fo:inline xsl:use-attribute-sets="userinput">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' sw-d/systemoutput ')]">
       <fo:inline xsl:use-attribute-sets="systemoutput">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:apply-templates/>
       </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -32,8 +32,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/dl ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:table xsl:use-attribute-sets="dl">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="*[contains(@class, ' topic/dlhead ')]"/>
             <fo:table-body xsl:use-attribute-sets="dl__body">
                 <xsl:choose>
@@ -56,8 +56,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dl ')]/*[contains(@class, ' topic/dlhead ')]">
         <fo:table-header xsl:use-attribute-sets="dl.dlhead">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:table-row xsl:use-attribute-sets="dl.dlhead__row">
                 <xsl:apply-templates/>
             </fo:table-row>
@@ -66,8 +66,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlhead ')]/*[contains(@class, ' topic/dthd ')]">
         <fo:table-cell xsl:use-attribute-sets="dlhead.dthd__cell">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:block xsl:use-attribute-sets="dlhead.dthd__content">
                 <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
                 <xsl:apply-templates/>
@@ -77,8 +77,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlhead ')]/*[contains(@class, ' topic/ddhd ')]">
         <fo:table-cell xsl:use-attribute-sets="dlhead.ddhd__cell">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:block xsl:use-attribute-sets="dlhead.ddhd__content">
                 <xsl:apply-templates/>
                 <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -88,8 +88,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlentry ')]">
         <fo:table-row xsl:use-attribute-sets="dlentry">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:table-cell xsl:use-attribute-sets="dlentry.dt">
                 <xsl:apply-templates select="*[contains(@class, ' topic/dt ')]"/>
                 <xsl:if test="empty(*[contains(@class, ' topic/dt ')])"><fo:block/></xsl:if>
@@ -112,8 +112,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dd ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dd__content">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
             <xsl:if test="not(following-sibling::*[contains(@class,' topic/dd ')])">
               <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -286,8 +286,8 @@ See the accompanying LICENSE file for applicable license.
 
         <fo:block-container xsl:use-attribute-sets="table__container">
             <fo:block xsl:use-attribute-sets="table">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <xsl:if test="not(@id)">
                   <xsl:attribute name="id">
                     <xsl:call-template name="get-id"/>
@@ -305,8 +305,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]">
         <fo:block xsl:use-attribute-sets="table.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Table.title'"/>
@@ -341,8 +341,8 @@ See the accompanying LICENSE file for applicable license.
 
         <xsl:variable name="table" as="element()">
             <fo:table xsl:use-attribute-sets="table.tgroup">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
 
                 <xsl:call-template name="displayAtts">
                     <xsl:with-param name="element" select=".."/>
@@ -400,32 +400,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/thead ')]">
         <fo:table-header xsl:use-attribute-sets="tgroup.thead">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:table-header>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tbody ')]">
         <fo:table-body xsl:use-attribute-sets="tgroup.tbody">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:table-body>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]">
         <fo:table-row xsl:use-attribute-sets="thead.row">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:table-row>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]">
         <fo:table-row xsl:use-attribute-sets="tbody.row">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:table-row>
     </xsl:template>
@@ -441,8 +441,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
         <xsl:apply-templates select="." mode="validate-entry-position"/>
         <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="applySpansAttrs"/>
             <xsl:call-template name="applyAlignAttrs"/>
             <xsl:call-template name="generateTableEntryBorder"/>
@@ -485,8 +485,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*" mode="processTableEntry">
-        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:call-template name="commonattributes"/>
         <xsl:call-template name="applySpansAttrs"/>
         <xsl:call-template name="applyAlignAttrs"/>
         <xsl:call-template name="generateTableEntryBorder"/>
@@ -927,8 +927,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <fo:table xsl:use-attribute-sets="simpletable">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="globalAtts"/>
             <xsl:call-template name="displayAtts">
                 <xsl:with-param name="element" select="."/>
@@ -973,8 +973,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]">
     <fo:block xsl:use-attribute-sets="table.title">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="." mode="customTitleAnchor"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'Table.title'"/>
@@ -1022,8 +1022,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:for-each select="1 to $fill-in-count">
           <xsl:for-each select="$current">
             <fo:table-cell xsl:use-attribute-sets="strow.stentry">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <xsl:variable name="frame" as="xs:string" select="(../@frame, $table.frame-default)[1]"/>
                 <xsl:if test="following-sibling::*[contains(@class, ' topic/strow ')]">
                     <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
@@ -1061,8 +1061,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="../*[1]" mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-header xsl:use-attribute-sets="sthead">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:table-row xsl:use-attribute-sets="sthead__row">
                 <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
                 <!--
@@ -1086,8 +1086,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="../*[1]" mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-row xsl:use-attribute-sets="strow">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
             <!--
             <xsl:variable name="row-cell-count" as="xs:integer">
@@ -1109,8 +1109,8 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="../.." mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-cell xsl:use-attribute-sets="sthead.stentry">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="@dita-ot:x"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
@@ -1156,8 +1156,8 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="../.." mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-cell xsl:use-attribute-sets="strow.stentry">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="@dita-ot:x"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -32,7 +32,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/dl ')]">
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <fo:table xsl:use-attribute-sets="dl">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="*[contains(@class, ' topic/dlhead ')]"/>
             <fo:table-body xsl:use-attribute-sets="dl__body">
                 <xsl:choose>
@@ -55,7 +56,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dl ')]/*[contains(@class, ' topic/dlhead ')]">
         <fo:table-header xsl:use-attribute-sets="dl.dlhead">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:table-row xsl:use-attribute-sets="dl.dlhead__row">
                 <xsl:apply-templates/>
             </fo:table-row>
@@ -64,7 +66,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlhead ')]/*[contains(@class, ' topic/dthd ')]">
         <fo:table-cell xsl:use-attribute-sets="dlhead.dthd__cell">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:block xsl:use-attribute-sets="dlhead.dthd__content">
                 <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
                 <xsl:apply-templates/>
@@ -74,7 +77,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlhead ')]/*[contains(@class, ' topic/ddhd ')]">
         <fo:table-cell xsl:use-attribute-sets="dlhead.ddhd__cell">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:block xsl:use-attribute-sets="dlhead.ddhd__content">
                 <xsl:apply-templates/>
                 <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -84,7 +88,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dlentry ')]">
         <fo:table-row xsl:use-attribute-sets="dlentry">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:table-cell xsl:use-attribute-sets="dlentry.dt">
                 <xsl:apply-templates select="*[contains(@class, ' topic/dt ')]"/>
                 <xsl:if test="empty(*[contains(@class, ' topic/dt ')])"><fo:block/></xsl:if>
@@ -107,7 +112,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/dd ')]">
         <fo:block xsl:use-attribute-sets="dlentry.dd__content">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
             <xsl:if test="not(following-sibling::*[contains(@class,' topic/dd ')])">
               <xsl:apply-templates select="../*[contains(@class,' ditaot-d/ditaval-endprop ')]" mode="outofline"/>
@@ -280,7 +286,8 @@ See the accompanying LICENSE file for applicable license.
 
         <fo:block-container xsl:use-attribute-sets="table__container">
             <fo:block xsl:use-attribute-sets="table">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <xsl:if test="not(@id)">
                   <xsl:attribute name="id">
                     <xsl:call-template name="get-id"/>
@@ -298,7 +305,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/table ')]/*[contains(@class, ' topic/title ')]">
         <fo:block xsl:use-attribute-sets="table.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Table.title'"/>
@@ -333,7 +341,8 @@ See the accompanying LICENSE file for applicable license.
 
         <xsl:variable name="table" as="element()">
             <fo:table xsl:use-attribute-sets="table.tgroup">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
 
                 <xsl:call-template name="displayAtts">
                     <xsl:with-param name="element" select=".."/>
@@ -391,28 +400,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/thead ')]">
         <fo:table-header xsl:use-attribute-sets="tgroup.thead">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:table-header>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tbody ')]">
         <fo:table-body xsl:use-attribute-sets="tgroup.tbody">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:table-body>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]">
         <fo:table-row xsl:use-attribute-sets="thead.row">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:table-row>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/tbody ')]/*[contains(@class, ' topic/row ')]">
         <fo:table-row xsl:use-attribute-sets="tbody.row">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:table-row>
     </xsl:template>
@@ -428,7 +441,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' topic/thead ')]/*[contains(@class, ' topic/row ')]/*[contains(@class, ' topic/entry ')]">
         <xsl:apply-templates select="." mode="validate-entry-position"/>
         <fo:table-cell xsl:use-attribute-sets="thead.row.entry">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="applySpansAttrs"/>
             <xsl:call-template name="applyAlignAttrs"/>
             <xsl:call-template name="generateTableEntryBorder"/>
@@ -471,7 +485,8 @@ See the accompanying LICENSE file for applicable license.
     </xsl:template>
 
     <xsl:template match="*" mode="processTableEntry">
-        <xsl:call-template name="commonattributes"/>
+        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+        <xsl:call-template name="commonattributes"/><!-- #4207 -->
         <xsl:call-template name="applySpansAttrs"/>
         <xsl:call-template name="applyAlignAttrs"/>
         <xsl:call-template name="generateTableEntryBorder"/>
@@ -912,7 +927,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="*[contains(@class,' ditaot-d/ditaval-startprop ')]" mode="outofline"/>
         <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
         <fo:table xsl:use-attribute-sets="simpletable">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="globalAtts"/>
             <xsl:call-template name="displayAtts">
                 <xsl:with-param name="element" select="."/>
@@ -957,7 +973,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]/*[contains(@class, ' topic/title ')]">
     <fo:block xsl:use-attribute-sets="table.title">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates select="." mode="customTitleAnchor"/>
       <xsl:call-template name="getVariable">
         <xsl:with-param name="id" select="'Table.title'"/>
@@ -1005,7 +1022,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:for-each select="1 to $fill-in-count">
           <xsl:for-each select="$current">
             <fo:table-cell xsl:use-attribute-sets="strow.stentry">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <xsl:variable name="frame" as="xs:string" select="(../@frame, $table.frame-default)[1]"/>
                 <xsl:if test="following-sibling::*[contains(@class, ' topic/strow ')]">
                     <xsl:apply-templates select="." mode="simpletableHorizontalBorders">
@@ -1043,7 +1061,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="../*[1]" mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-header xsl:use-attribute-sets="sthead">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:table-row xsl:use-attribute-sets="sthead__row">
                 <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
                 <!--
@@ -1067,7 +1086,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:apply-templates select="../*[1]" mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-row xsl:use-attribute-sets="strow">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="*[contains(@class, ' topic/stentry ')]"/>
             <!--
             <xsl:variable name="row-cell-count" as="xs:integer">
@@ -1089,7 +1109,8 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="../.." mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-cell xsl:use-attribute-sets="sthead.stentry">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="@dita-ot:x"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>
@@ -1135,7 +1156,8 @@ See the accompanying LICENSE file for applicable license.
           <xsl:apply-templates select="../.." mode="count-max-simpletable-cells"/>
         </xsl:param>
         <fo:table-cell xsl:use-attribute-sets="strow.stentry">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="simpletableApplySpansAttrs"/>
             <xsl:variable name="entryCol" select="@dita-ot:x"/>
             <xsl:variable name="frame" as="xs:string" select="(ancestor::*[contains(@class, ' topic/simpletable ')][1]/@frame, $table.frame-default)[1]"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -61,14 +61,16 @@ See the accompanying LICENSE file for applicable license.
   
     <xsl:template match="*[contains(@class, ' task/taskbody ')]">
         <fo:block xsl:use-attribute-sets="taskbody">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/prereq ')]">
         <fo:block xsl:use-attribute-sets="prereq">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                   <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -85,7 +87,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/context ')]">
         <fo:block xsl:use-attribute-sets="context">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -102,7 +105,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/cmd ')]" priority="1">
         <fo:block xsl:use-attribute-sets="cmd">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:if test="../@importance='optional'">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Optional Step'"/>
@@ -121,28 +125,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/info ')]">
         <fo:block xsl:use-attribute-sets="info">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/tutorialinfo ')]">
         <fo:block xsl:use-attribute-sets="tutorialinfo">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/stepresult ')]">
         <fo:block xsl:use-attribute-sets="stepresult">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/result ')]">
         <fo:block xsl:use-attribute-sets="result">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -160,7 +168,8 @@ See the accompanying LICENSE file for applicable license.
     <!-- If example has a title, process it first; otherwise, create default title (if needed) -->
     <xsl:template match="*[contains(@class, ' task/taskbody ')]/*[contains(@class, ' topic/example ')]">
         <fo:block xsl:use-attribute-sets="task.example">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:choose>
               <xsl:when test="*[contains(@class, ' topic/title ')]">
                 <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -184,7 +193,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/postreq ')]">
         <fo:block xsl:use-attribute-sets="postreq">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -201,7 +211,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepxmp ')]">
         <fo:block xsl:use-attribute-sets="stepxmp">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -219,13 +230,15 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="count(*[contains(@class, ' task/step ')]) eq 1 and
                         not(contains(parent::*/@class, ' task/step '))">
           <fo:block>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates mode="onestep"/>
           </fo:block>
         </xsl:when>
         <xsl:otherwise>
           <fo:list-block xsl:use-attribute-sets="steps">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
           </fo:list-block>
         </xsl:otherwise>
@@ -242,7 +255,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:with-param>
     </xsl:apply-templates>
     <fo:list-block xsl:use-attribute-sets="steps-unordered">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:list-block>
   </xsl:template>
@@ -255,7 +269,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="steps.step">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="steps.step__label">
                 <fo:block xsl:use-attribute-sets="steps.step__label__content">
                     <xsl:if test="$depth > 1 or 
@@ -283,7 +298,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/steps-unordered ')]/*[contains(@class, ' task/step ')]">
         <fo:list-item xsl:use-attribute-sets="steps-unordered.step">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="steps-unordered.step__label">
                 <fo:block xsl:use-attribute-sets="steps-unordered.step__label__content">
                     <xsl:call-template name="getVariable">
@@ -303,7 +319,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/step ')]" mode="onestep">
     <fo:block xsl:use-attribute-sets="steps.step__content--onestep">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
@@ -311,7 +328,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepsection ')]">
         <fo:list-item xsl:use-attribute-sets="stepsection">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="stepsection__label">
               <fo:block xsl:use-attribute-sets="stepsection__label__content">
               </fo:block>
@@ -331,7 +349,8 @@ See the accompanying LICENSE file for applicable license.
   
     <xsl:template match="*[contains(@class, ' task/substeps ')]">
         <fo:list-block xsl:use-attribute-sets="substeps">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:list-block>
     </xsl:template>
@@ -343,7 +362,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="substeps.substep">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="substeps.substep__label">
                 <fo:block xsl:use-attribute-sets="substeps.substep__label__content">
                     <xsl:call-template name="getVariable">
@@ -368,14 +388,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' task/choices ')][empty(*[contains(@class,' task/choice ')])]" priority="10"/>
     <xsl:template match="*[contains(@class, ' task/choices ')]">
         <fo:list-block xsl:use-attribute-sets="choices">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:list-block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/choice ')]">
         <fo:list-item xsl:use-attribute-sets="choices.choice">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="choices.choice__label">
                 <fo:block xsl:use-attribute-sets="choices.choice__label__content">
                     <xsl:call-template name="getVariable">
@@ -398,7 +420,8 @@ See the accompanying LICENSE file for applicable license.
     [empty(*[contains(@class,' task/choption ') or contains(@class,' task/chdesc ')])]" priority="10"/>
   <xsl:template match="*[contains(@class, ' task/choicetable ')]">
     <fo:table xsl:use-attribute-sets="choicetable">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:call-template name="univAttrs"/>
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
@@ -464,7 +487,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]">
     <fo:table-header xsl:use-attribute-sets="chhead">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <fo:table-row xsl:use-attribute-sets="chhead__row">
         <xsl:if test="empty(*[contains(@class,' task/choptionhd ')])">
           <xsl:apply-templates select="." mode="emptyChoptionHd"/>
@@ -479,14 +503,16 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chrow ')]">
     <fo:table-row xsl:use-attribute-sets="chrow">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:table-row>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/choptionhd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <xsl:apply-templates select="." mode="simpletableVerticalBorders"/>
@@ -498,7 +524,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/chdeschd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
@@ -510,7 +537,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chrow ')]/*[contains(@class, ' task/choption ')]">
     <xsl:variable name="keyCol" select="ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.choption">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
         <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       </xsl:if>
@@ -533,7 +561,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chrow ')]/*[contains(@class, ' task/chdesc ')]">
     <xsl:variable name="keyCol" select="number(ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol)"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.chdesc">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
         <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       </xsl:if>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -61,16 +61,16 @@ See the accompanying LICENSE file for applicable license.
   
     <xsl:template match="*[contains(@class, ' task/taskbody ')]">
         <fo:block xsl:use-attribute-sets="taskbody">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/prereq ')]">
         <fo:block xsl:use-attribute-sets="prereq">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                   <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -87,8 +87,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/context ')]">
         <fo:block xsl:use-attribute-sets="context">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -105,8 +105,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/cmd ')]" priority="1">
         <fo:block xsl:use-attribute-sets="cmd">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:if test="../@importance='optional'">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Optional Step'"/>
@@ -125,32 +125,32 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/info ')]">
         <fo:block xsl:use-attribute-sets="info">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/tutorialinfo ')]">
         <fo:block xsl:use-attribute-sets="tutorialinfo">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/stepresult ')]">
         <fo:block xsl:use-attribute-sets="stepresult">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/result ')]">
         <fo:block xsl:use-attribute-sets="result">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -168,8 +168,8 @@ See the accompanying LICENSE file for applicable license.
     <!-- If example has a title, process it first; otherwise, create default title (if needed) -->
     <xsl:template match="*[contains(@class, ' task/taskbody ')]/*[contains(@class, ' topic/example ')]">
         <fo:block xsl:use-attribute-sets="task.example">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:choose>
               <xsl:when test="*[contains(@class, ' topic/title ')]">
                 <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -193,8 +193,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/postreq ')]">
         <fo:block xsl:use-attribute-sets="postreq">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:task-heading">
                 <xsl:with-param name="use-label">
                     <xsl:apply-templates select="." mode="dita2xslfo:retrieve-task-heading">
@@ -211,8 +211,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepxmp ')]">
         <fo:block xsl:use-attribute-sets="stepxmp">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -230,15 +230,15 @@ See the accompanying LICENSE file for applicable license.
         <xsl:when test="count(*[contains(@class, ' task/step ')]) eq 1 and
                         not(contains(parent::*/@class, ' task/step '))">
           <fo:block>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates mode="onestep"/>
           </fo:block>
         </xsl:when>
         <xsl:otherwise>
           <fo:list-block xsl:use-attribute-sets="steps">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
           </fo:list-block>
         </xsl:otherwise>
@@ -255,8 +255,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:with-param>
     </xsl:apply-templates>
     <fo:list-block xsl:use-attribute-sets="steps-unordered">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:list-block>
   </xsl:template>
@@ -269,8 +269,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="steps.step">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps.step__label">
                 <fo:block xsl:use-attribute-sets="steps.step__label__content">
                     <xsl:if test="$depth > 1 or 
@@ -298,8 +298,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/steps-unordered ')]/*[contains(@class, ' task/step ')]">
         <fo:list-item xsl:use-attribute-sets="steps-unordered.step">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="steps-unordered.step__label">
                 <fo:block xsl:use-attribute-sets="steps-unordered.step__label__content">
                     <xsl:call-template name="getVariable">
@@ -319,8 +319,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/step ')]" mode="onestep">
     <fo:block xsl:use-attribute-sets="steps.step__content--onestep">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
@@ -328,8 +328,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' task/stepsection ')]">
         <fo:list-item xsl:use-attribute-sets="stepsection">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="stepsection__label">
               <fo:block xsl:use-attribute-sets="stepsection__label__content">
               </fo:block>
@@ -349,8 +349,8 @@ See the accompanying LICENSE file for applicable license.
   
     <xsl:template match="*[contains(@class, ' task/substeps ')]">
         <fo:list-block xsl:use-attribute-sets="substeps">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
     </xsl:template>
@@ -362,8 +362,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:call-template>
         </xsl:variable>
         <fo:list-item xsl:use-attribute-sets="substeps.substep">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="substeps.substep__label">
                 <fo:block xsl:use-attribute-sets="substeps.substep__label__content">
                     <xsl:call-template name="getVariable">
@@ -388,16 +388,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class, ' task/choices ')][empty(*[contains(@class,' task/choice ')])]" priority="10"/>
     <xsl:template match="*[contains(@class, ' task/choices ')]">
         <fo:list-block xsl:use-attribute-sets="choices">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:list-block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class, ' task/choice ')]">
         <fo:list-item xsl:use-attribute-sets="choices.choice">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="choices.choice__label">
                 <fo:block xsl:use-attribute-sets="choices.choice__label__content">
                     <xsl:call-template name="getVariable">
@@ -420,8 +420,8 @@ See the accompanying LICENSE file for applicable license.
     [empty(*[contains(@class,' task/choption ') or contains(@class,' task/chdesc ')])]" priority="10"/>
   <xsl:template match="*[contains(@class, ' task/choicetable ')]">
     <fo:table xsl:use-attribute-sets="choicetable">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:call-template name="univAttrs"/>
       <xsl:call-template name="globalAtts"/>
       <xsl:call-template name="displayAtts">
@@ -487,8 +487,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]">
     <fo:table-header xsl:use-attribute-sets="chhead">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <fo:table-row xsl:use-attribute-sets="chhead__row">
         <xsl:if test="empty(*[contains(@class,' task/choptionhd ')])">
           <xsl:apply-templates select="." mode="emptyChoptionHd"/>
@@ -503,16 +503,16 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chrow ')]">
     <fo:table-row xsl:use-attribute-sets="chrow">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:table-row>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/choptionhd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.choptionhd">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <xsl:apply-templates select="." mode="simpletableVerticalBorders"/>
@@ -524,8 +524,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' task/chhead ')]/*[contains(@class, ' task/chdeschd ')]">
     <fo:table-cell xsl:use-attribute-sets="chhead.chdeschd">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       <xsl:apply-templates select="." mode="simpletableTopBorder"/>
       <fo:block xsl:use-attribute-sets="chhead.chdeschd__content">
@@ -537,8 +537,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chrow ')]/*[contains(@class, ' task/choption ')]">
     <xsl:variable name="keyCol" select="ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.choption">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
         <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       </xsl:if>
@@ -561,8 +561,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' task/chrow ')]/*[contains(@class, ' task/chdesc ')]">
     <xsl:variable name="keyCol" select="number(ancestor::*[contains(@class, ' task/choicetable ')][1]/@keycol)"/>
     <fo:table-cell xsl:use-attribute-sets="chrow.chdesc">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:if test="../following-sibling::*[contains(@class, ' task/chrow ')]">
         <xsl:apply-templates select="." mode="simpletableHorizontalBorders"/>
       </xsl:if>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -76,8 +76,8 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
         </xsl:variable>
         <fo:block>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="get-attributes">
               <xsl:with-param name="element" as="element()">
                 <xsl:choose>
@@ -196,8 +196,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/section ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="section.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates select="." mode="getTitle"/>
         </fo:block>
@@ -205,8 +205,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/example ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="example.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
@@ -214,8 +214,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/fig ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="fig.title">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Figure.title'"/>
@@ -240,8 +240,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="tm-scope"/>
       </xsl:variable>
         <fo:inline xsl:use-attribute-sets="tm">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
             <xsl:choose>
               <xsl:when test="not($generate-symbol)"/>
@@ -280,16 +280,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:choose>
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref term">
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:call-template name="buildBasicLinkDestination"/>
           <xsl:copy-of select="$contents"/>
         </fo:basic-link>
       </xsl:when>
       <xsl:otherwise>
         <fo:inline xsl:use-attribute-sets="term">
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:copy-of select="$contents"/>
         </fo:inline>
       </xsl:otherwise>
@@ -534,8 +534,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:if test="$DRAFT='yes'">
         <xsl:if test="*">
           <fo:block xsl:use-attribute-sets="titlealts">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
           </fo:block>
         </xsl:if>
@@ -544,8 +544,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/navtitle ')]">
         <fo:block xsl:use-attribute-sets="navtitle">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:inline xsl:use-attribute-sets="navtitle__label">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Navigation title'"/>
@@ -558,8 +558,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/titlealts ')]/*[dita-ot:matches-searchtitle-class(@class)]">
         <fo:block xsl:use-attribute-sets="searchtitle">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:inline xsl:use-attribute-sets="searchtitle__label">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Search title'"/>
@@ -572,8 +572,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/abstract ')]">
         <fo:block xsl:use-attribute-sets="abstract">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -625,8 +625,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="format-shortdesc-as-block">
         <!--compare the length of shortdesc with the got max chars-->
         <fo:block xsl:use-attribute-sets="topic__shortdesc">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <!-- If the shortdesc is sufficiently short, add keep-with-next. -->
             <xsl:if test="string-length(.) lt $maxCharsInShortDesc">
                 <!-- Low-strength keep to avoid conflict with keeps on titles. -->
@@ -641,8 +641,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*" mode="format-shortdesc-as-inline">
         <fo:inline xsl:use-attribute-sets="shortdesc">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:if test="preceding-sibling::* | preceding-sibling::text()">
                 <xsl:text> </xsl:text>
             </xsl:if>
@@ -719,8 +719,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/bodydiv ')]">
         <fo:block>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -730,8 +730,8 @@ See the accompanying LICENSE file for applicable license.
                 mode="dita2xslfo:section-heading"
                 priority="10">
     <fo:block xsl:use-attribute-sets="section.title">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:variable name="spectitleValue" as="xs:string" select="string(@spectitle)"/>
       <xsl:variable name="resolvedVariable">
         <xsl:call-template name="getVariable">
@@ -753,8 +753,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/section ')]">
         <fo:block xsl:use-attribute-sets="section">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
             <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
             <fo:block xsl:use-attribute-sets="section__content">
@@ -765,16 +765,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/sectiondiv ')]">
         <fo:block>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/example ')]">
         <fo:block xsl:use-attribute-sets="example">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
             <fo:block xsl:use-attribute-sets="example__content">
                 <xsl:apply-templates select="node() except (*[contains(@class,' topic/title ')])"/>
@@ -784,8 +784,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/desc ')]">
         <fo:inline xsl:use-attribute-sets="desc">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -837,24 +837,24 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' topic/div ')]">
     <fo:block xsl:use-attribute-sets="div">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/p ')]">
         <fo:block xsl:use-attribute-sets="p">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*" mode="placeNoteContent">
         <fo:block xsl:use-attribute-sets="note">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:inline xsl:use-attribute-sets="note__label">
                 <xsl:choose>
                     <xsl:when test="@type='note' or not(@type)">
@@ -1013,8 +1013,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/lq ')]">
         <fo:block xsl:use-attribute-sets="lq">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:choose>
                 <xsl:when test="@href or @reftitle">
                   <xsl:call-template name="get-attributes">
@@ -1070,8 +1070,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/q ')]">
         <fo:inline xsl:use-attribute-sets="q">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'#quote-start'"/>
             </xsl:call-template>
@@ -1084,8 +1084,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/fig ')]">
         <fo:block xsl:use-attribute-sets="fig">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setExpanse"/>
             <xsl:call-template name="setScale"/>
@@ -1101,8 +1101,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/figgroup ')]">
         <fo:block xsl:use-attribute-sets="figgroup">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -1110,8 +1110,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/pre ')]">
         <xsl:call-template name="setSpecTitle"/>
         <fo:block xsl:use-attribute-sets="pre">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -1182,8 +1182,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/lines ')]">
         <xsl:call-template name="setSpecTitle"/>
         <fo:block xsl:use-attribute-sets="lines">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -1194,8 +1194,8 @@ See the accompanying LICENSE file for applicable license.
     <!-- The text element has no default semantics or formatting -->
     <xsl:template match="*[contains(@class,' topic/text ')]">
         <fo:inline>
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -1220,8 +1220,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref">
           <xsl:sequence select="$copyAttributes/@*"/>
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:call-template name="buildBasicLinkDestination"/>
           <xsl:copy-of select="$contents"/>
         </fo:basic-link>
@@ -1229,8 +1229,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:otherwise>
         <fo:inline>
           <xsl:sequence select="$copyAttributes/@*"/>
-          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-          <xsl:call-template name="commonattributes"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="commonattributes" -->
+          <xsl:call-template name="commonattributes"/>
           <xsl:copy-of select="$contents"/>
         </fo:inline>
       </xsl:otherwise>
@@ -1251,8 +1251,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/boolean ')]">
         <fo:inline xsl:use-attribute-sets="boolean">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:value-of select="name()"/>
             <xsl:text>: </xsl:text>
             <xsl:value-of select="@state"/>
@@ -1261,8 +1261,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/state ')]">
         <fo:inline xsl:use-attribute-sets="state">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:value-of select="name()"/>
             <xsl:text>: </xsl:text>
             <xsl:value-of select="@name"/>
@@ -1280,8 +1280,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:when test="empty(@href)"/>
             <xsl:when test="@placement = 'break'">
                     <fo:block xsl:use-attribute-sets="image__block">
-                        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                        <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                        <!-- TODO: Replace with mode="commonattributes" -->
+                        <xsl:call-template name="commonattributes"/>
                         <xsl:apply-templates select="." mode="placeImage">
                             <xsl:with-param name="imageAlign" select="@align"/>
                           <xsl:with-param name="href">
@@ -1309,8 +1309,8 @@ See the accompanying LICENSE file for applicable license.
             </xsl:when>
             <xsl:otherwise>
                 <fo:inline xsl:use-attribute-sets="image__inline">
-                    <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                    <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                    <!-- TODO: Replace with mode="commonattributes" -->
+                    <xsl:call-template name="commonattributes"/>
                     <xsl:apply-templates select="." mode="placeImage">
                         <xsl:with-param name="imageAlign" select="@align"/>
                       <xsl:with-param name="href">
@@ -1457,15 +1457,15 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/object ')]">
         <fo:inline xsl:use-attribute-sets="object">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/param ')]">
         <fo:inline xsl:use-attribute-sets="param">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
         </fo:inline>
     </xsl:template>
 
@@ -1475,8 +1475,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/draft-comment ')]">
         <xsl:if test="$publishRequiredCleanup = 'yes' or $DRAFT='yes'">
             <fo:block xsl:use-attribute-sets="draft-comment">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <fo:block xsl:use-attribute-sets="draft-comment__label">
                     <xsl:text>Disposition: </xsl:text>
                     <xsl:value-of select="@disposition"/>
@@ -1492,8 +1492,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/required-cleanup ')]">
         <xsl:if test="$publishRequiredCleanup = 'yes' or $DRAFT='yes'">
             <fo:inline xsl:use-attribute-sets="required-cleanup">
-                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-                <xsl:call-template name="commonattributes"/><!-- #4207 -->
+                <!-- TODO: Replace with mode="commonattributes" -->
+                <xsl:call-template name="commonattributes"/>
                 <fo:inline xsl:use-attribute-sets="required-cleanup__label">
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="'Required-Cleanup'"/>
@@ -1573,8 +1573,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/indextermref ')]">
         <fo:inline xsl:use-attribute-sets="indextermref">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -76,7 +76,8 @@ See the accompanying LICENSE file for applicable license.
             </xsl:apply-templates>
         </xsl:variable>
         <fo:block>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="get-attributes">
               <xsl:with-param name="element" as="element()">
                 <xsl:choose>
@@ -195,7 +196,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/section ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="section.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates select="." mode="getTitle"/>
         </fo:block>
@@ -203,7 +205,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/example ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="example.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:apply-templates/>
         </fo:block>
@@ -211,7 +214,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/fig ')]/*[contains(@class,' topic/title ')]">
         <fo:block xsl:use-attribute-sets="fig.title">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="customTitleAnchor"/>
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'Figure.title'"/>
@@ -236,7 +240,8 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="tm-scope"/>
       </xsl:variable>
         <fo:inline xsl:use-attribute-sets="tm">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
             <xsl:choose>
               <xsl:when test="not($generate-symbol)"/>
@@ -275,14 +280,16 @@ See the accompanying LICENSE file for applicable license.
     <xsl:choose>
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref term">
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:call-template name="buildBasicLinkDestination"/>
           <xsl:copy-of select="$contents"/>
         </fo:basic-link>
       </xsl:when>
       <xsl:otherwise>
         <fo:inline xsl:use-attribute-sets="term">
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:copy-of select="$contents"/>
         </fo:inline>
       </xsl:otherwise>
@@ -527,7 +534,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:if test="$DRAFT='yes'">
         <xsl:if test="*">
           <fo:block xsl:use-attribute-sets="titlealts">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
           </fo:block>
         </xsl:if>
@@ -536,7 +544,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/navtitle ')]">
         <fo:block xsl:use-attribute-sets="navtitle">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:inline xsl:use-attribute-sets="navtitle__label">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Navigation title'"/>
@@ -549,7 +558,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/titlealts ')]/*[dita-ot:matches-searchtitle-class(@class)]">
         <fo:block xsl:use-attribute-sets="searchtitle">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:inline xsl:use-attribute-sets="searchtitle__label">
                 <xsl:call-template name="getVariable">
                     <xsl:with-param name="id" select="'Search title'"/>
@@ -562,7 +572,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/abstract ')]">
         <fo:block xsl:use-attribute-sets="abstract">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -614,7 +625,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*" mode="format-shortdesc-as-block">
         <!--compare the length of shortdesc with the got max chars-->
         <fo:block xsl:use-attribute-sets="topic__shortdesc">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <!-- If the shortdesc is sufficiently short, add keep-with-next. -->
             <xsl:if test="string-length(.) lt $maxCharsInShortDesc">
                 <!-- Low-strength keep to avoid conflict with keeps on titles. -->
@@ -629,7 +641,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*" mode="format-shortdesc-as-inline">
         <fo:inline xsl:use-attribute-sets="shortdesc">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:if test="preceding-sibling::* | preceding-sibling::text()">
                 <xsl:text> </xsl:text>
             </xsl:if>
@@ -706,7 +719,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/bodydiv ')]">
         <fo:block>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -716,7 +730,8 @@ See the accompanying LICENSE file for applicable license.
                 mode="dita2xslfo:section-heading"
                 priority="10">
     <fo:block xsl:use-attribute-sets="section.title">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:variable name="spectitleValue" as="xs:string" select="string(@spectitle)"/>
       <xsl:variable name="resolvedVariable">
         <xsl:call-template name="getVariable">
@@ -738,7 +753,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/section ')]">
         <fo:block xsl:use-attribute-sets="section">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="." mode="dita2xslfo:section-heading"/>
             <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
             <fo:block xsl:use-attribute-sets="section__content">
@@ -749,14 +765,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/sectiondiv ')]">
         <fo:block>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/example ')]">
         <fo:block xsl:use-attribute-sets="example">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="*[contains(@class,' topic/title ')]"/>
             <fo:block xsl:use-attribute-sets="example__content">
                 <xsl:apply-templates select="node() except (*[contains(@class,' topic/title ')])"/>
@@ -766,7 +784,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/desc ')]">
         <fo:inline xsl:use-attribute-sets="desc">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -818,21 +837,24 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' topic/div ')]">
     <fo:block xsl:use-attribute-sets="div">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:block>
   </xsl:template>
 
     <xsl:template match="*[contains(@class, ' topic/p ')]">
         <fo:block xsl:use-attribute-sets="p">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
 
     <xsl:template match="*" mode="placeNoteContent">
         <fo:block xsl:use-attribute-sets="note">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:inline xsl:use-attribute-sets="note__label">
                 <xsl:choose>
                     <xsl:when test="@type='note' or not(@type)">
@@ -991,7 +1013,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/lq ')]">
         <fo:block xsl:use-attribute-sets="lq">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:choose>
                 <xsl:when test="@href or @reftitle">
                   <xsl:call-template name="get-attributes">
@@ -1047,7 +1070,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/q ')]">
         <fo:inline xsl:use-attribute-sets="q">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="getVariable">
                 <xsl:with-param name="id" select="'#quote-start'"/>
             </xsl:call-template>
@@ -1060,7 +1084,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/fig ')]">
         <fo:block xsl:use-attribute-sets="fig">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setExpanse"/>
             <xsl:call-template name="setScale"/>
@@ -1076,7 +1101,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/figgroup ')]">
         <fo:block xsl:use-attribute-sets="figgroup">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:block>
     </xsl:template>
@@ -1084,7 +1110,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/pre ')]">
         <xsl:call-template name="setSpecTitle"/>
         <fo:block xsl:use-attribute-sets="pre">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -1155,7 +1182,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/lines ')]">
         <xsl:call-template name="setSpecTitle"/>
         <fo:block xsl:use-attribute-sets="lines">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>
@@ -1166,7 +1194,8 @@ See the accompanying LICENSE file for applicable license.
     <!-- The text element has no default semantics or formatting -->
     <xsl:template match="*[contains(@class,' topic/text ')]">
         <fo:inline>
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -1191,7 +1220,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="$keys and @href and not($topicref/ancestor-or-self::*[@linking][1]/@linking = ('none', 'sourceonly'))">
         <fo:basic-link xsl:use-attribute-sets="xref">
           <xsl:sequence select="$copyAttributes/@*"/>
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:call-template name="buildBasicLinkDestination"/>
           <xsl:copy-of select="$contents"/>
         </fo:basic-link>
@@ -1199,7 +1229,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:otherwise>
         <fo:inline>
           <xsl:sequence select="$copyAttributes/@*"/>
-          <xsl:call-template name="commonattributes"/>
+          <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+          <xsl:call-template name="commonattributes"/><!-- #4207 -->
           <xsl:copy-of select="$contents"/>
         </fo:inline>
       </xsl:otherwise>
@@ -1220,7 +1251,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/boolean ')]">
         <fo:inline xsl:use-attribute-sets="boolean">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:value-of select="name()"/>
             <xsl:text>: </xsl:text>
             <xsl:value-of select="@state"/>
@@ -1229,7 +1261,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/state ')]">
         <fo:inline xsl:use-attribute-sets="state">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:value-of select="name()"/>
             <xsl:text>: </xsl:text>
             <xsl:value-of select="@name"/>
@@ -1247,7 +1280,8 @@ See the accompanying LICENSE file for applicable license.
             <xsl:when test="empty(@href)"/>
             <xsl:when test="@placement = 'break'">
                     <fo:block xsl:use-attribute-sets="image__block">
-                        <xsl:call-template name="commonattributes"/>
+                        <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                        <xsl:call-template name="commonattributes"/><!-- #4207 -->
                         <xsl:apply-templates select="." mode="placeImage">
                             <xsl:with-param name="imageAlign" select="@align"/>
                           <xsl:with-param name="href">
@@ -1275,7 +1309,8 @@ See the accompanying LICENSE file for applicable license.
             </xsl:when>
             <xsl:otherwise>
                 <fo:inline xsl:use-attribute-sets="image__inline">
-                    <xsl:call-template name="commonattributes"/>
+                    <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                    <xsl:call-template name="commonattributes"/><!-- #4207 -->
                     <xsl:apply-templates select="." mode="placeImage">
                         <xsl:with-param name="imageAlign" select="@align"/>
                       <xsl:with-param name="href">
@@ -1422,13 +1457,15 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/object ')]">
         <fo:inline xsl:use-attribute-sets="object">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' topic/param ')]">
         <fo:inline xsl:use-attribute-sets="param">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
         </fo:inline>
     </xsl:template>
 
@@ -1438,7 +1475,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/draft-comment ')]">
         <xsl:if test="$publishRequiredCleanup = 'yes' or $DRAFT='yes'">
             <fo:block xsl:use-attribute-sets="draft-comment">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <fo:block xsl:use-attribute-sets="draft-comment__label">
                     <xsl:text>Disposition: </xsl:text>
                     <xsl:value-of select="@disposition"/>
@@ -1454,7 +1492,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' topic/required-cleanup ')]">
         <xsl:if test="$publishRequiredCleanup = 'yes' or $DRAFT='yes'">
             <fo:inline xsl:use-attribute-sets="required-cleanup">
-                <xsl:call-template name="commonattributes"/>
+                <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+                <xsl:call-template name="commonattributes"/><!-- #4207 -->
                 <fo:inline xsl:use-attribute-sets="required-cleanup__label">
                     <xsl:call-template name="getVariable">
                         <xsl:with-param name="id" select="'Required-Cleanup'"/>
@@ -1534,7 +1573,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' topic/indextermref ')]">
         <fo:inline xsl:use-attribute-sets="indextermref">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
@@ -58,16 +58,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' ui-d/menucascade ')]">
         <fo:inline xsl:use-attribute-sets="menucascade">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates select="* | processing-instruction() | comment()"/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' ui-d/shortcut ')]">
         <fo:inline xsl:use-attribute-sets="shortcut">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -75,8 +75,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' ui-d/screen ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="screen">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
@@ -58,14 +58,16 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' ui-d/menucascade ')]">
         <fo:inline xsl:use-attribute-sets="menucascade">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates select="* | processing-instruction() | comment()"/>
         </fo:inline>
     </xsl:template>
 
     <xsl:template match="*[contains(@class,' ui-d/shortcut ')]">
         <fo:inline xsl:use-attribute-sets="shortcut">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:apply-templates/>
         </fo:inline>
     </xsl:template>
@@ -73,7 +75,8 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' ui-d/screen ')]">
         <xsl:call-template name="generateAttrLabel"/>
         <fo:block xsl:use-attribute-sets="screen">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <xsl:call-template name="setFrame"/>
             <xsl:call-template name="setScale"/>
             <xsl:call-template name="setExpanse"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
@@ -11,8 +11,8 @@ See the accompanying LICENSE file for applicable license.
     version="3.0">
 
     <xsl:template match="*[contains(@class,' ut-d/imagemap ')]">
-        <!--<xsl:variable name="attributes" as="attribute()*"><xsl:apply-templates select="." mode="commonattributes"/></xsl:variable>--><!-- #4207 -->
-        <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable><!-- #4207 -->
+        <!-- TODO: Replace with mode="commonattributes" -->
+        <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable>
         <xsl:if test="exists($attributes)">
             <fo:inline><xsl:sequence select="$attributes"/></fo:inline>
         </xsl:if>
@@ -24,8 +24,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' ut-d/area ')]">
         <fo:list-item xsl:use-attribute-sets="ol.li">
-            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-            <xsl:call-template name="commonattributes"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="commonattributes" -->
+            <xsl:call-template name="commonattributes"/>
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
                     <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
@@ -11,7 +11,8 @@ See the accompanying LICENSE file for applicable license.
     version="3.0">
 
     <xsl:template match="*[contains(@class,' ut-d/imagemap ')]">
-        <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable>
+        <!--<xsl:variable name="attributes" as="attribute()*"><xsl:apply-templates select="." mode="commonattributes"/></xsl:variable>--><!-- #4207 -->
+        <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable><!-- #4207 -->
         <xsl:if test="exists($attributes)">
             <fo:inline><xsl:sequence select="$attributes"/></fo:inline>
         </xsl:if>
@@ -23,7 +24,8 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class,' ut-d/area ')]">
         <fo:list-item xsl:use-attribute-sets="ol.li">
-            <xsl:call-template name="commonattributes"/>
+            <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+            <xsl:call-template name="commonattributes"/><!-- #4207 -->
             <fo:list-item-label xsl:use-attribute-sets="ol.li__label">
                 <fo:block xsl:use-attribute-sets="ol.li__label__content">
                     <xsl:call-template name="getVariable">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
@@ -12,8 +12,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlelement ')]">
     <fo:inline xsl:use-attribute-sets="xmlelement">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>&lt;</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>&gt;</xsl:text>
@@ -22,8 +22,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlatt ')]">
     <fo:inline xsl:use-attribute-sets="xmlatt">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>@</xsl:text>
       <xsl:apply-templates/>
     </fo:inline>
@@ -31,8 +31,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/textentity ')]">
     <fo:inline xsl:use-attribute-sets="textentity">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>&amp;</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -41,8 +41,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/parameterentity ')]">
     <fo:inline xsl:use-attribute-sets="parameterentity">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>%</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -51,8 +51,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/numcharref ')]">
     <fo:inline xsl:use-attribute-sets="numcharref">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>&amp;#</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -61,16 +61,16 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlnsname ')]">
     <fo:inline xsl:use-attribute-sets="xmlnsname">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlpi ')]">
     <fo:inline xsl:use-attribute-sets="xmlpi">
-      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
-      <xsl:call-template name="commonattributes"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="commonattributes" -->
+      <xsl:call-template name="commonattributes"/>
       <xsl:text>&lt;?</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>?&gt;</xsl:text>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
@@ -12,7 +12,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlelement ')]">
     <fo:inline xsl:use-attribute-sets="xmlelement">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>&lt;</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>&gt;</xsl:text>
@@ -21,7 +22,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlatt ')]">
     <fo:inline xsl:use-attribute-sets="xmlatt">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>@</xsl:text>
       <xsl:apply-templates/>
     </fo:inline>
@@ -29,7 +31,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/textentity ')]">
     <fo:inline xsl:use-attribute-sets="textentity">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>&amp;</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -38,7 +41,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/parameterentity ')]">
     <fo:inline xsl:use-attribute-sets="parameterentity">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>%</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -47,7 +51,8 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/numcharref ')]">
     <fo:inline xsl:use-attribute-sets="numcharref">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>&amp;#</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>;</xsl:text>
@@ -56,14 +61,16 @@ See the accompanying LICENSE file for applicable license.
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlnsname ')]">
     <fo:inline xsl:use-attribute-sets="xmlnsname">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:apply-templates/>
     </fo:inline>
   </xsl:template>
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlpi ')]">
     <fo:inline xsl:use-attribute-sets="xmlpi">
-      <xsl:call-template name="commonattributes"/>
+      <!--<xsl:apply-templates select="." mode="commonattributes"/>--><!-- #4207 -->
+      <xsl:call-template name="commonattributes"/><!-- #4207 -->
       <xsl:text>&lt;?</xsl:text>
       <xsl:apply-templates/>
       <xsl:text>?&gt;</xsl:text>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -30,12 +30,14 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
       <xsl:call-template name="generateBreadcrumbs"/>
-      <xsl:call-template name="gen-user-header"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-header"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-header"/><!-- #4207 -->
       <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
       </xsl:if>
-      <xsl:call-template name="gen-user-sidetoc"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
       <xsl:choose>
         <xsl:when test="*[contains(@class, ' topic/title ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -49,7 +51,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:variable>
       <xsl:apply-templates select="$map" mode="toc"/>
       <xsl:call-template name="gen-endnotes"/>
-      <xsl:call-template name="gen-user-footer"/>
+      <!--<xsl:apply-templates select="." name="gen-user-footer"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-footer"/><!-- #4207 -->
       <xsl:call-template name="processFTR"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
     </body>
@@ -57,21 +60,24 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' map/map ')]/*[contains(@class, ' topic/title ')]">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:apply-templates/>
     </h1>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' map/map ')]/@title">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:value-of select="."/>
     </h1>
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]" priority="10">
     <h1 class="title topictitle1">
-      <xsl:call-template name="gen-user-panel-title-pfx"/>
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
       <xsl:apply-templates select="*[contains(@class, ' bookmap/mainbooktitle ')]/node()"/>
     </h1>
   </xsl:template>
@@ -80,15 +86,18 @@ See the accompanying LICENSE file for applicable license.
     <title>
       <xsl:choose>
         <xsl:when test="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/@title">
-          <xsl:call-template name="gen-user-panel-title-pfx"/>
+          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
           <xsl:value-of select="/*[contains(@class,' map/map ')]/@title"/>
         </xsl:when>
       </xsl:choose>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -30,14 +30,14 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
       <xsl:call-template name="generateBreadcrumbs"/>
-      <!--<xsl:apply-templates select="." mode="gen-user-header"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-header"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-header" -->
+      <xsl:call-template name="gen-user-header"/>
       <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')]"/>
       </xsl:if>
-      <!--<xsl:apply-templates select="." mode="gen-user-sidetoc"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-sidetoc" -->
+      <xsl:call-template name="gen-user-sidetoc"/>
       <xsl:choose>
         <xsl:when test="*[contains(@class, ' topic/title ')]">
           <xsl:apply-templates select="*[contains(@class, ' topic/title ')]"/>
@@ -51,8 +51,8 @@ See the accompanying LICENSE file for applicable license.
       </xsl:variable>
       <xsl:apply-templates select="$map" mode="toc"/>
       <xsl:call-template name="gen-endnotes"/>
-      <!--<xsl:apply-templates select="." name="gen-user-footer"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-footer"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-footer" -->
+      <xsl:call-template name="gen-user-footer"/>
       <xsl:call-template name="processFTR"/>
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
     </body>
@@ -60,24 +60,24 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' map/map ')]/*[contains(@class, ' topic/title ')]">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:apply-templates/>
     </h1>
   </xsl:template>
 
   <xsl:template match="*[contains(@class, ' map/map ')]/@title">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:value-of select="."/>
     </h1>
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]" priority="10">
     <h1 class="title topictitle1">
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/>
       <xsl:apply-templates select="*[contains(@class, ' bookmap/mainbooktitle ')]/node()"/>
     </h1>
   </xsl:template>
@@ -86,18 +86,18 @@ See the accompanying LICENSE file for applicable license.
     <title>
       <xsl:choose>
         <xsl:when test="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' bookmap/bookmap ')]/*[contains(@class,' bookmap/booktitle ')]/*[contains(@class, ' bookmap/mainbooktitle ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]"/>
         </xsl:when>
         <xsl:when test="/*[contains(@class,' map/map ')]/@title">
-          <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--><!-- #4207 -->
-          <xsl:call-template name="gen-user-panel-title-pfx"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+          <xsl:call-template name="gen-user-panel-title-pfx"/>
           <xsl:value-of select="/*[contains(@class,' map/map ')]/@title"/>
         </xsl:when>
       </xsl:choose>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
@@ -50,12 +50,12 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
     <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
     <xsl:call-template name="generateMapTitle"/> <!-- Generate the <title> element -->
-    <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-    <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-    <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>--> <!-- include user's XSL javascripts here --><!-- #4207 -->
-    <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
-    <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->  <!-- include user's XSL style element and content here --><!-- #4207 -->
-    <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
+    <!-- TODO: Replace with mode="gen-user-head" -->
+    <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
+    <!-- TODO: Replace with mode="gen-user-scripts" -->
+    <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
+    <!-- TODO: Replace with mode="gen-user-styles" -->
+    <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
   </head><xsl:value-of select="$newline"/>
 
   <body>
@@ -115,8 +115,8 @@ See the accompanying LICENSE file for applicable license.
   <!-- Title processing - special handling for short descriptions -->
   <xsl:if test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')] or /*[contains(@class,' map/map ')]/@title">
   <title>
-    <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
-    <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+    <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+    <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
     <xsl:choose>
       <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
         <xsl:value-of select="normalize-space(/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')])"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
@@ -50,9 +50,12 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
     <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
     <xsl:call-template name="generateMapTitle"/> <!-- Generate the <title> element -->
-    <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
-    <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
-    <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
+    <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+    <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+    <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>--> <!-- include user's XSL javascripts here --><!-- #4207 -->
+    <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
+    <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->  <!-- include user's XSL style element and content here --><!-- #4207 -->
+    <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
   </head><xsl:value-of select="$newline"/>
 
   <body>
@@ -112,7 +115,8 @@ See the accompanying LICENSE file for applicable license.
   <!-- Title processing - special handling for short descriptions -->
   <xsl:if test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')] or /*[contains(@class,' map/map ')]/@title">
   <title>
-    <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
+    <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+    <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
     <xsl:choose>
       <xsl:when test="/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')]">
         <xsl:value-of select="normalize-space(/*[contains(@class,' map/map ')]/*[contains(@class,' topic/title ')])"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -745,7 +745,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="@href">
         <br/><div style="text-align:right"><a>
           <xsl:attribute name="href">
-            <xsl:call-template name="href"/>
+            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+            <xsl:call-template name="href"/><!-- #4207 -->
           </xsl:attribute>
           <xsl:choose>
             <xsl:when test="@type = 'external'">
@@ -1107,7 +1108,8 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Test for TM area's language -->
     <xsl:variable name="tmtest">
-      <xsl:call-template name="tm-area"/>
+      <!--<xsl:apply-templates select="." mode="mark-tm-in-this-area"/>--><!-- #4207 -->
+      <xsl:call-template name="tm-area"/><!-- #4207 -->
     </xsl:variable>
 
     <!-- If this language should get trademark markers, continue... -->
@@ -2562,8 +2564,10 @@ See the accompanying LICENSE file for applicable license.
 <html>
   <xsl:call-template name="setTopicLanguage"/>
   <xsl:value-of select="$newline"/>
-  <xsl:call-template name="chapterHead"/>
-  <xsl:call-template name="chapterBody"/> 
+  <!--<xsl:apply-templates select="." mode="chapterHead"/>--><!-- #4207 -->
+  <xsl:call-template name="chapterHead"/><!-- #4207 -->
+  <!--<xsl:apply-templates select="." mode="chapterBody"/>--><!-- #4207 -->
+  <xsl:call-template name="chapterBody"/><!-- #4207 -->
 </html>
 </xsl:template>
 
@@ -2597,9 +2601,12 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
       <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
       <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element -->
-      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
-      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
-      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
+      <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>--> <!-- include user's XSL javascripts here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
+      <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->  <!-- include user's XSL style element and content here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
       <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified -->
     </head>
     <xsl:value-of select="$newline"/>
@@ -2698,7 +2705,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template name="generateChapterTitle">
     <!-- Title processing - special handling for short descriptions -->
     <title>
-      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
+      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
       <xsl:variable name="maintitle"><xsl:apply-templates select="/*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:variable name="ditamaintitle"><xsl:apply-templates select="/dita/*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:choose>
@@ -2729,7 +2737,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addHeaderToHtmlBodyElement"/>
 
       <!-- Include a user's XSL call here to generate a toc based on what's a child of topic -->
-      <xsl:call-template name="gen-user-sidetoc"/>
+      <!--<xsl:apply-templates select="." name="gen-user-sidetoc"/>--><!-- #4207 -->
+      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
 
       <xsl:apply-templates select="." mode="addContentToHtmlBodyElement"/>
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
@@ -2764,7 +2773,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="addHeaderToHtmlBodyElement">
     <xsl:variable name="header-content" as="node()*">
       <xsl:call-template name="generateBreadcrumbs"/>
-      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here -->
+      <!--<xsl:apply-templates select="." mode="gen-user-header"/>-->  <!-- include user's XSL running header here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here --><!-- #4207 -->
       <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')] |
@@ -2801,7 +2811,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*" mode="addFooterToHtmlBodyElement">
     <xsl:variable name="footer-content" as="node()*">
-      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
+      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--> <!-- include user's XSL running footer here --><!-- #4207 -->
+      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here --><!-- #4207 -->
       <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
     </xsl:variable>
     <xsl:if test="exists($footer-content)">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -745,8 +745,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="@href">
         <br/><div style="text-align:right"><a>
           <xsl:attribute name="href">
-            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-            <xsl:call-template name="href"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="determine-final-href" -->
+            <xsl:call-template name="href"/>
           </xsl:attribute>
           <xsl:choose>
             <xsl:when test="@type = 'external'">
@@ -1108,8 +1108,8 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Test for TM area's language -->
     <xsl:variable name="tmtest">
-      <!--<xsl:apply-templates select="." mode="mark-tm-in-this-area"/>--><!-- #4207 -->
-      <xsl:call-template name="tm-area"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="mark-tm-in-this-area" -->
+      <xsl:call-template name="tm-area"/>
     </xsl:variable>
 
     <!-- If this language should get trademark markers, continue... -->
@@ -2564,10 +2564,10 @@ See the accompanying LICENSE file for applicable license.
 <html>
   <xsl:call-template name="setTopicLanguage"/>
   <xsl:value-of select="$newline"/>
-  <!--<xsl:apply-templates select="." mode="chapterHead"/>--><!-- #4207 -->
-  <xsl:call-template name="chapterHead"/><!-- #4207 -->
-  <!--<xsl:apply-templates select="." mode="chapterBody"/>--><!-- #4207 -->
-  <xsl:call-template name="chapterBody"/><!-- #4207 -->
+  <!-- TODO: Replace with mode="chapterHead" -->
+  <xsl:call-template name="chapterHead"/>
+  <!-- TODO: Replace with mode="chapterBody" -->
+  <xsl:call-template name="chapterBody"/>
 </html>
 </xsl:template>
 
@@ -2601,12 +2601,12 @@ See the accompanying LICENSE file for applicable license.
       <xsl:call-template name="copyright"/>         <!-- Generate copyright, if specified manually -->
       <xsl:call-template name="generateCssLinks"/>  <!-- Generate links to CSS files -->
       <xsl:call-template name="generateChapterTitle"/> <!-- Generate the <title> element -->
-      <!--<xsl:apply-templates select="." mode="gen-user-head"/>-->    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-scripts"/>--> <!-- include user's XSL javascripts here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here --><!-- #4207 -->
-      <!--<xsl:apply-templates select="." mode="gen-user-styles"/>-->  <!-- include user's XSL style element and content here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here --><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-head" -->
+      <xsl:call-template name="gen-user-head" />    <!-- include user's XSL HEAD processing here -->
+      <!-- TODO: Replace with mode="gen-user-scripts" -->
+      <xsl:call-template name="gen-user-scripts" /> <!-- include user's XSL javascripts here -->
+      <!-- TODO: Replace with mode="gen-user-styles" -->
+      <xsl:call-template name="gen-user-styles" />  <!-- include user's XSL style element and content here -->
       <xsl:call-template name="processHDF"/>        <!-- Add user HDF file, if specified -->
     </head>
     <xsl:value-of select="$newline"/>
@@ -2705,8 +2705,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template name="generateChapterTitle">
     <!-- Title processing - special handling for short descriptions -->
     <title>
-      <!--<xsl:apply-templates select="." mode="gen-user-panel-title-pfx"/>--> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
-      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix --><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-panel-title-pfx" -->
+      <xsl:call-template name="gen-user-panel-title-pfx"/> <!-- hook for a user-XSL title prefix -->
       <xsl:variable name="maintitle"><xsl:apply-templates select="/*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:variable name="ditamaintitle"><xsl:apply-templates select="/dita/*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]" mode="text-only"/></xsl:variable>
       <xsl:choose>
@@ -2737,8 +2737,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="." mode="addHeaderToHtmlBodyElement"/>
 
       <!-- Include a user's XSL call here to generate a toc based on what's a child of topic -->
-      <!--<xsl:apply-templates select="." name="gen-user-sidetoc"/>--><!-- #4207 -->
-      <xsl:call-template name="gen-user-sidetoc"/><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-sidetoc" -->
+      <xsl:call-template name="gen-user-sidetoc"/>
 
       <xsl:apply-templates select="." mode="addContentToHtmlBodyElement"/>
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
@@ -2773,8 +2773,9 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="addHeaderToHtmlBodyElement">
     <xsl:variable name="header-content" as="node()*">
       <xsl:call-template name="generateBreadcrumbs"/>
-      <!--<xsl:apply-templates select="." mode="gen-user-header"/>-->  <!-- include user's XSL running header here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here --><!-- #4207 -->
+        <!-- include user's XSL running header here -->
+      <!-- TODO: Replace with mode="gen-user-header" -->
+      <xsl:call-template name="gen-user-header"/>  <!-- include user's XSL running header here -->
       <xsl:call-template name="processHDR"/>
       <xsl:if test="$INDEXSHOW = 'yes'">
         <xsl:apply-templates select="/*/*[contains(@class, ' topic/prolog ')]/*[contains(@class, ' topic/metadata ')]/*[contains(@class, ' topic/keywords ')]/*[contains(@class, ' topic/indexterm ')] |
@@ -2811,8 +2812,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*" mode="addFooterToHtmlBodyElement">
     <xsl:variable name="footer-content" as="node()*">
-      <!--<xsl:apply-templates select="." mode="gen-user-footer"/>--> <!-- include user's XSL running footer here --><!-- #4207 -->
-      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here --><!-- #4207 -->
+      <!-- TODO: Replace with mode="gen-user-footer" -->
+      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
       <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
     </xsl:variable>
     <xsl:if test="exists($footer-content)">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -70,7 +70,8 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:call-template name="href"/><!--use href text-->
+                    <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
+                    <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
                   </xsl:otherwise>
                 </xsl:choose>
               </sup>
@@ -82,7 +83,8 @@ See the accompanying LICENSE file for applicable license.
                   <!--use xref content-->
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:call-template name="href"/><!--use href text-->
+                  <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
+                  <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>
@@ -472,7 +474,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
             </xsl:when>
             <xsl:otherwise>
               <!--use href-->
-              <xsl:call-template name="href"/>
+              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+              <xsl:call-template name="href"/><!-- #4207 -->
             </xsl:otherwise>
           </xsl:choose>
         </a>
@@ -509,7 +512,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           </xsl:when>
           <xsl:otherwise>
             <!--use href-->
-            <xsl:call-template name="href"/>
+            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+            <xsl:call-template name="href"/><!-- #4207 -->
           </xsl:otherwise>
         </xsl:choose>
       </a>
@@ -588,7 +592,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
         </xsl:when>
         <xsl:otherwise>
           <!--use href-->
-          <xsl:call-template name="href"/>
+          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+          <xsl:call-template name="href"/><!-- #4207 -->
         </xsl:otherwise>
       </xsl:choose>
     </a>
@@ -737,7 +742,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           <xsl:value-of select="normalize-space(*[contains(@class, ' topic/linktext ')])"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:call-template name="href"/>
+          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
+          <xsl:call-template name="href"/><!-- #4207 -->
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -70,8 +70,8 @@ See the accompanying LICENSE file for applicable license.
                     <xsl:value-of select="replace(@href, '^mailto:', '')"/><!--remove mailto: prefix from href text-->
                   </xsl:when>
                   <xsl:otherwise>
-                    <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
-                    <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
+                    <!-- TODO: Replace with mode="determine-final-href" -->
+                    <xsl:call-template name="href"/><!--use href text-->
                   </xsl:otherwise>
                 </xsl:choose>
               </sup>
@@ -83,8 +83,8 @@ See the accompanying LICENSE file for applicable license.
                   <!--use xref content-->
                 </xsl:when>
                 <xsl:otherwise>
-                  <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!--use href text--><!-- #4207 -->
-                  <xsl:call-template name="href"/><!--use href text--><!-- #4207 -->
+                  <!-- TODO: Replace with mode="determine-final-href" -->
+                  <xsl:call-template name="href"/><!--use href text-->
                 </xsl:otherwise>
               </xsl:choose>
             </xsl:otherwise>
@@ -474,8 +474,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
             </xsl:when>
             <xsl:otherwise>
               <!--use href-->
-              <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-              <xsl:call-template name="href"/><!-- #4207 -->
+              <!-- TODO: Replace with mode="determine-final-href" -->
+              <xsl:call-template name="href"/>
             </xsl:otherwise>
           </xsl:choose>
         </a>
@@ -512,8 +512,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           </xsl:when>
           <xsl:otherwise>
             <!--use href-->
-            <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-            <xsl:call-template name="href"/><!-- #4207 -->
+            <!-- TODO: Replace with mode="determine-final-href" -->
+            <xsl:call-template name="href"/>
           </xsl:otherwise>
         </xsl:choose>
       </a>
@@ -592,8 +592,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
         </xsl:when>
         <xsl:otherwise>
           <!--use href-->
-          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-          <xsl:call-template name="href"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="determine-final-href" -->
+          <xsl:call-template name="href"/>
         </xsl:otherwise>
       </xsl:choose>
     </a>
@@ -742,8 +742,8 @@ Each child is indented, the linktext is bold, and the shortdesc appears in norma
           <xsl:value-of select="normalize-space(*[contains(@class, ' topic/linktext ')])"/>
         </xsl:when>
         <xsl:otherwise>
-          <!--<xsl:apply-templates select="." mode="determine-final-href"/>--><!-- #4207 -->
-          <xsl:call-template name="href"/><!-- #4207 -->
+          <!-- TODO: Replace with mode="determine-final-href" -->
+          <xsl:call-template name="href"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
@@ -124,7 +124,8 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- In the context of XREF - call it's HREF processor -->
 <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="imagemap-xref">
- <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute>
+ <!--<xsl:attribute name="href"><xsl:apply-templates select="." mode="determine-final-href"/></xsl:attribute>--><!-- #4207 -->
+ <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute><!-- #4207 -->
  <xsl:if test="@scope='external' or @type='external' or ((@format='PDF' or @format='pdf') and not(@scope='local'))">
   <xsl:attribute name="target">_blank</xsl:attribute>
  </xsl:if>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
@@ -124,8 +124,9 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- In the context of XREF - call it's HREF processor -->
 <xsl:template match="*[contains(@class, ' topic/xref ')]" mode="imagemap-xref">
- <!--<xsl:attribute name="href"><xsl:apply-templates select="." mode="determine-final-href"/></xsl:attribute>--><!-- #4207 -->
- <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute><!-- #4207 -->
+ <!-- TODO: Replace with mode="determine-final-href" -->
+
+ <xsl:attribute name="href"><xsl:call-template name="href"/></xsl:attribute>
  <xsl:if test="@scope='external' or @type='external' or ((@format='PDF' or @format='pdf') and not(@scope='local'))">
   <xsl:attribute name="target">_blank</xsl:attribute>
  </xsl:if>


### PR DESCRIPTION
## Description
Add `<!-- #4207 -->` comment markers where XSLT named templates can be converted to moded templates.

## Motivation and Context
Marks where #4207 can be implemented in the future.

Each original named template call becomes a pair of lines - the equivalent moded template call, followed by the original named template call. (The mode names don't always match the template names.) Both lines have an end-of-line comment marker.

The Perl script below can be used to switch the marked code between named and moded templates as follows:

```
# to use named templates:
grep --files-with-matches -r 4207 --include='*.xsl' src/main/ | xargs ./4207.pl 0

# to use moded templates:
grep --files-with-matches -r 4207 --include='*.xsl' src/main/ | xargs ./4207.pl 1
```

[4207.pl.zip](https://github.com/dita-ot/dita-ot/files/11643297/4207.pl.zip)

## How Has This Been Tested?
Using the Perl script, I switched all the calls to moded template calls, then I ran `./gradlew test`, `integrationtest`, and `e2etest`.

## Type of Changes
XSLT comments were added. No code was changed.

## Documentation and Compatibility
There is no code change or behavior change, so no release notes are needed (unless we want to use this opportunity to mention something about the deprecated named templates).

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
