### PR TITLE
Update reference to `commonvariables.xml` file

### DIFF
--- a/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
+++ b/src/main/plugins/org.dita.pdf2/cfg/common/vars/en.xml
@@ -39,9 +39,9 @@ See the accompanying LICENSE file for applicable license.
     it using the <locale ISO code>.xml format.
     
     Variables with no localized text, common to all (or nearly all)
-    languages, are stored in commonstrings.xml. Any common string
+    languages, are stored in commonvariables.xml. Any common string
     may be copied into <locale ISO code>.xml to provide a 
-    local-specific value for the common variable.
+    locale-specific value for the common variable.
     
   -->
 


### PR DESCRIPTION
This corrects the name of the [commonvariables.xml](https://github.com/dita-ot/dita-ot/blob/develop/src/main/plugins/org.dita.pdf2/cfg/common/vars/commonvariables.xml) as created in https://github.com/dita-ot/dita-ot/pull/2789.