### PR TITLE
Bump xdita grammar to latest, v0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ def bundled = [
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
         "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20230426/org.oasis-open.dita.v2_0.zip",
         "dita20-techcomm": "https://github.com/dita-ot/dita-techcomm/releases/download/2.0.0-20230426/org.oasis-open.dita.techcomm.v2_0.zip",
-        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.2.2/org.oasis-open.xdita.v0_2_2.zip",
+        "xdita": "https://github.com/oasis-tcs/dita-lwdita/releases/download/v0.3.0.1/org.oasis-open.xdita.v0_3_0.zip",
         "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",
         "axf": "https://github.com/dita-ot/org.dita.pdf2.axf/releases/download/3.6.1/org.dita.pdf2.axf-3.6.1.zip",
         "xep": "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.3/org.dita.pdf2.xep-3.6.3.zip",


### PR DESCRIPTION
## Description

Bumps xdita grammar files to latest from lwdita OASIS repo

## Motivation and Context

Updates embedded lightweight dita grammars

## How Has This Been Tested?

Unit tests

## Type of Changes

Version bump for dependency

## Documentation and Compatibility

Covers all changes to grammar since 2018 package, which could be lengthy; may want to focus on latest?

This is technically backwards incompatible with previous one, they removed support for some elements

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
