### PR TITLE
Use map-first preprocessing in HTML5 transtype

### DIFF
--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="dita2html5"
           depends="html5.init,
                    build-init,
-                   preprocess,
+                   preprocess2,
                    html5.topic,
                    html5.map,
                    html5.css"/>


### PR DESCRIPTION
## Description
Use map-first preprocessing in HTML5 transtype instead of old preprocessing.

## Motivation and Context
Preprocess2 is the way of the future and has been proven to work in PDF2.

## How Has This Been Tested?
Existing test.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
TBD

