### PR TITLE
Update Jackson to fix snakeyaml security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,9 @@ dependencies {
     }
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.8'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.0'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.13.4'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'
     implementation group: 'org.relaxng', name: 'jing', version: '20181222'
     implementation group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.13'
     testImplementation  group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'


### PR DESCRIPTION
## Description
Update Jackson dependencies to latest version.

## Motivation and Context
Fix Jackson and snakeyaml security vulnerabilities:

* [CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003)
* [CVE-2022-41854](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41854)
* [CVE-2022-38752](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-38752)
* [CVE-2022-1471](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1471)

Fixes #4216.

## How Has This Been Tested?
Existing tests.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_
-


