### PR TITLE
Use correct cross-reference context when computing link description from `<shortdesc>` contents

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -714,7 +714,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
           <xsl:apply-templates select="." mode="topicpull:add-genshortdesc-PI"/>
           <desc class="- topic/desc ">
             <xsl:apply-templates select="$shortdesc">
-              <xsl:with-param name="baseContextElement" select="." tunnel="yes"/>
+              <xsl:with-param name="baseContextElement" select="$targetElement" tunnel="yes"/>
               <xsl:with-param name="inDescContent" as="xs:boolean" select="true()" tunnel="yes"/>
             </xsl:apply-templates>
           </desc>


### PR DESCRIPTION
## Description
During `topicpull`, when an `<xref>` or `<link>` is evaluated, the `@href` reference is evaluated relative to the current `$baseContextElement` base URI location.

When an `<xref>` or `<link>` processes a reference to a target topic, that target topic's `<shortdesc>` content is evaluated. During that evaluation, the `$baseContextElement` must be set to the target topic (or an element inside it) so that any second-level references inside the `<shortdesc>` are evaluated properly.

## Motivation and Context
Fixes [bug1](https://github.com/dita-ot/dita-ot/issues/4221#issuecomment-1625179925) from #4221.

## How Has This Been Tested?
* I ran the unit tests.
* I tested [bug1](https://github.com/dita-ot/dita-ot/issues/4221#issuecomment-1625179925) from #4221.
* I ran `dita --project docsrc/samples/project-files/html.xml`, which was originally how the bug was found.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
This fix should not cause compatibility issues in existing flows.

No documentation change is needed. A release notes writeup is sufficient. Perhaps something like:

> For cross-references to a topic, the target topic's `<shortdesc>` is processed to create a link description. When that `<shortdesc>` contained another cross-reference, sometimes it was not processed correctly. This issue is now fixed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>

I lack the Java knowledge to add a unit test, but I think this situation deserves to be tested. Here is an archive containing the "before" and "after" results for `topicpull`:

[4221_bug_before_and_after.zip](https://github.com/dita-ot/dita-ot/files/12065586/4221_bug_before_and_after.zip)

If someone wants to walk me through the process of adding a unit test, I am willing to learn.

Note that the test must have topic 2 and topic 3 in the same directory to avoid sensitizing [bug 2 here](https://github.com/dita-ot/dita-ot/issues/4221#issuecomment-1632779079). I will work on that next.