### PR TITLE
Fix XSD validation configuration

### DIFF
--- a/src/main/java/org/ditang/relaxng/defaults/RelaxDefaultsParserConfiguration.java
+++ b/src/main/java/org/ditang/relaxng/defaults/RelaxDefaultsParserConfiguration.java
@@ -163,9 +163,8 @@ public class RelaxDefaultsParserConfiguration extends XIncludeAwareParserConfigu
   public void setFeature(String featureId, boolean state) throws XMLConfigurationException {
     if (XERCES_SCHEMA_VALIDATION.equals(featureId)) {
       relaxNGValidation = state;
-    } else {
-      super.setFeature(featureId, state);
     }
+    super.setFeature(featureId, state);
   }
 
   @Override


### PR DESCRIPTION
## Description
Fix configuration bug to enable XSD validation of input documents.

## Motivation and Context
RELAX NG grammar caching PR #3926 introduced a configuration bug in DITA-OT 4.0 that disabled XSD validation.

## How Has This Been Tested?
Manual testing with source files that use XSD.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

