### PR TITLE
Show development content in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,7 @@ For information on additional DITA and DITA-OT resources, see [SUPPORT]. To repo
 - [Installing](#installing)
 - [Building output](#building-output)
 - [Development](#development)
+    - [Running tests](#running-tests)
     - [Formatting code](#formatting-code)
     - [Distribution builds](#distribution-builds)
 - [License](#license)
@@ -88,6 +89,15 @@ Building the toolkit from source code and compiling the distribution package
     ./gradlew
     ```
 
+### Running tests
+
+```shell
+./gradlew check
+```
+
+All tests are run by GitHub Actions [test workflow] on each push and
+for every pull request. 
+
 ### Formatting code
 
 Requirements:
@@ -135,3 +145,4 @@ DITA Open Toolkit is licensed for use under the [Apache License 2.0][apache].
 [apache]: http://www.apache.org/licenses/LICENSE-2.0
 [issue]: https://github.com/dita-ot/dita-ot/issues/new/choose
 [contributing]: https://github.com/dita-ot/.github/blob/master/CONTRIBUTING.md
+[test workflow]: https://github.com/dita-ot/dita-ot/actions/workflows/test.yml

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,9 @@ For information on additional DITA and DITA-OT resources, see [SUPPORT]. To repo
 - [Prerequisites: Java 17](#prerequisites-java-17)
 - [Installing](#installing)
 - [Building output](#building-output)
-- [For developers](#for-developers)
+- [Development](#development)
+    - [Formatting code](#formatting-code)
+    - [Distribution builds](#distribution-builds)
 - [License](#license)
 
 ## Prerequisites: Java 17
@@ -65,10 +67,9 @@ You can generate output using the `dita` command-line tool included with DITA Op
 
 See the [documentation][docs] for arguments and [options].
 
-## For developers
+## Development
 
-<details>
-<summary>Building the toolkit from source code and compiling the distribution package</summary>
+Building the toolkit from source code and compiling the distribution package
 
 1.  Clone the DITA-OT Git repository:
     ```shell
@@ -117,8 +118,6 @@ Prettier is used retain consistent Java formatting.
     If Gradle throws an error like `java.lang.OutOfMemoryError: Java heap space`, you probably need to increase the maximum Java heap size. One way to do this is to set the `GRADLE_OPTS` environment variable to a value like `-Xmx1024m`.
 
     For more information on the `-Xmx` option, see the [Java SE Documentation][javadoc].
-
-</details>
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,10 @@ task integrationTest(type: Test, dependsOn: 'buildLocal') {
     systemProperties = integrationTestSystemProperties
     include '**/IntegrationTest*.class'
 }
+tasks.named('check') {
+    dependsOn('integrationTest')
+}
+
 
 // End to end test
 
@@ -135,6 +139,9 @@ task e2eTest(type: Test, dependsOn: 'buildLocal') {
     maxParallelForks = 4
     systemProperties = e2eTestSystemProperties
     include '**/EndToEndTest*.class'
+}
+tasks.named('check') {
+    dependsOn('e2eTest')
 }
 
 // Install


### PR DESCRIPTION
## Description
Show development content in README

## Motivation and Context
Hiding development content in README makes is more difficult to find development related info. Our end user documentation is as dita-ot.org, whereas developer documentation is at GitHub. 

Fixes #4150

