### PR TITLE
Update Logback and SLF4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
         exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.8'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.8'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'


### PR DESCRIPTION
## Description
Update to Logback 1.4.8 and SLF4J 2.0.7

## Motivation and Context
Update dependencies to fix security issues:

* [CVE-2022-23307](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23307)
* [CVE-2022-23305](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23305)
* [CVE-2022-23302](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23302)
* [CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550)
* [CVE-2021-4104](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4104)
* [CVE-2020-17521](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17521)
* [CVE-2020-10683](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10683)
* [CVE-2019-17571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17571)
* [CVE-2018-1000632](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000632)
* [CVE-2016-6814](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6814)
* [CVE-2015-3253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3253)

## How Has This Been Tested?
Existing tests.


