### PR TITLE
Log exception with location

### DIFF
--- a/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
@@ -45,10 +45,11 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
    */
   @Override
   public void error(final SAXParseException saxException) throws SAXException {
+    final SAXExceptionWrapper ex = new SAXExceptionWrapper(filePath, saxException);
     if (mode == Configuration.Mode.STRICT) {
-      throw new SAXExceptionWrapper(filePath, saxException);
+      throw ex;
     } else {
-      logger.error(saxException.getMessage(), saxException);
+      logger.error(ex.getMessage(), ex);
     }
   }
 


### PR DESCRIPTION
## Description
Log exception with location.

## Motivation and Context
Fixes #4240. When logging was changed to use processing mode, the change logged the exception without location. This changes the code to add location to the exception before logging.

## How Has This Been Tested?
Existing tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


