### PR TITLE
Fix validating network file URI

### DIFF
--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -198,7 +198,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
       try {
         final URI uri = new URI(href);
         final URI abs = currentFile.resolve(uri).normalize();
-        if (Objects.equals(abs.getScheme(), "file")) {
+        if (Objects.equals(abs.getScheme(), "file") && (abs.getAuthority() == null || abs.getAuthority().isEmpty())) {
           final File p = new File(URLUtils.setQuery(URLUtils.stripFragment(abs), null));
           try {
             final File canFile = p.getCanonicalFile();

--- a/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ValidationFilterTest.java
@@ -63,7 +63,7 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testHref() throws SAXException, URISyntaxException {
+  public void testHref() throws SAXException {
     final List<String> res = new ArrayList<>();
     f.setContentHandler(
       new DefaultHandler() {
@@ -103,7 +103,35 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testConref() throws SAXException, URISyntaxException {
+  public void testHref_networkFile() throws SAXException {
+    final List<String> res = new ArrayList<>();
+    f.setContentHandler(
+      new DefaultHandler() {
+        @Override
+        public void startElement(final String uri, final String localName, final String qName, final Attributes atts) {
+          res.add(atts.getValue(ATTRIBUTE_NAME_HREF));
+        }
+      }
+    );
+    final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
+    f.setLogger(l);
+
+    f.startElement(
+      NULL_NS_URI,
+      TOPIC_XREF.localName,
+      TOPIC_XREF.localName,
+      new AttributesBuilder()
+        .add(ATTRIBUTE_NAME_HREF, "file://example.com/foo")
+        .add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL)
+        .build()
+    );
+
+    assertTrue(l.getMessages().isEmpty());
+    assertEquals("file://example.com/foo", res.get(0));
+  }
+
+  @Test
+  public void testConref() throws SAXException {
     final List<String> res = new ArrayList<>();
     f.setContentHandler(
       new DefaultHandler() {
@@ -137,7 +165,7 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testScope() throws SAXException, URISyntaxException {
+  public void testScope() throws SAXException {
     final List<String> res = new ArrayList<>();
     f.setContentHandler(
       new DefaultHandler() {
@@ -173,7 +201,7 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testId() throws SAXException, URISyntaxException {
+  public void testId() throws SAXException {
     f.setContentHandler(new DefaultHandler());
     final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
     f.setLogger(l);
@@ -221,7 +249,7 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testKeys() throws SAXException, URISyntaxException {
+  public void testKeys() throws SAXException {
     f.setContentHandler(new DefaultHandler());
     final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
     f.setLogger(l);
@@ -268,7 +296,7 @@ public class ValidationFilterTest {
   }
 
   @Test
-  public void testKeyscope() throws SAXException, URISyntaxException {
+  public void testKeyscope() throws SAXException {
     f.setContentHandler(new DefaultHandler());
     final TestUtils.CachingLogger l = new TestUtils.CachingLogger();
     f.setLogger(l);


### PR DESCRIPTION
## Description
Fix validating network file URI, i.e. file that has authority part. For example `file://authority/path`.

## Motivation and Context
Fixes #3718
## How Has This Been Tested?
New unit test.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

