### PR TITLE
Fix conref in keydef value in preprocess2

### DIFF
--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -131,7 +131,7 @@ public class TopicReaderModuleTest {
     reader.readStartFile();
 
     assertEquals(1, reader.nonConrefCopytoTargetSet.size());
-    assertEquals(0, reader.conrefTargetSet.size());
-    assertEquals(1, reader.waitList.size());
+    assertEquals(1, reader.conrefTargetSet.size());
+    assertEquals(2, reader.waitList.size());
   }
 }

--- a/src/test/resources/org/dita/dost/module/reader/TopicReaderModuleTest/src/root.ditamap
+++ b/src/test/resources/org/dita/dost/module/reader/TopicReaderModuleTest/src/root.ditamap
@@ -1,0 +1,13 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
+     domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+     ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Test Conref and Keyref</title>
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="product-keyword" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword " conref="mysite.dita#mysite/keyword"/>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref class="- map/topicref " href="myproduct.dita"/>
+</map>


### PR DESCRIPTION
## Description
Fix the case where a map uses a topic as a conref target but the topic is not referenced with a topicref. 

## Motivation and Context
Partial fix for #2420.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

