### PR TITLE
Process map conref during preprocess2 topic stage before keyref

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -43,6 +43,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="preprocess2.topics"
           depends="topic-reader,
                   topic-branch-filter,
+                  topic-map-conref,
                   topic-keyref,
                   topic-copy-to,
                   topic-conrefpush,
@@ -306,6 +307,26 @@ See the accompanying LICENSE file for applicable license.
       <module class="org.dita.dost.module.CopyToModule">
         <param name="force-unique" value="${force-unique}" if:set="force-unique"/>
       </module>
+    </pipeline>
+  </target>
+
+  <target name="topic-map-conref"
+          unless="preprocess.conref.skip"
+          description="Resolve conref in input map files">
+    <property name="dita.preprocess.reloadstylesheet.conref" value="${dita.preprocess.reloadstylesheet}"/>
+    <makeurl property="exportfile.url" file="${dita.temp.dir}/export.xml" validate="false"/>
+    <pipeline message="Resolve conref in input files" taskname="conref">
+      <xslt basedir="${dita.temp.dir}"
+            reloadstylesheet="${dita.preprocess.reloadstylesheet.conref}"
+            style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/conref.xsl"
+            filenameparameter="file-being-processed"
+            parallel="${parallel}">
+        <ditafileset format="ditamap" conref="true" input="true"/>
+        <ditafileset format="ditamap" conref="true" inputResource="true"/>
+        <param name="EXPORTFILE" expression="${exportfile.url}"/>
+        <param name="TRANSTYPE" expression="${transtype}"/>
+        <dita:extension id="dita.preprocess.conref.param" behavior="org.dita.dost.platform.InsertAction"/>
+      </xslt>
     </pipeline>
   </target>
 

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -254,7 +254,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:variable name="domains" select="($target-doc/*/@domains | $target-doc/dita/*[@domains][1]/@domains)[1]" as="xs:string?"/>
         <xsl:choose>
           <xsl:when test="empty($target-doc)">
-            <xsl:apply-templates select="$current-element" mode="ditamsg:missing-conref-target-error"/>
+            <xsl:apply-templates select="$current-element" mode="missing-conref-target-file"/>
           </xsl:when>
           <xsl:when test="conref:isValid($domains,false())">
             <xsl:if test="not(conref:isValid($domains,true()))">
@@ -329,6 +329,10 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="." mode="ditamsg:malformedConref"/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*" mode="missing-conref-target-file">
+    <xsl:apply-templates select="." mode="ditamsg:missing-conref-target-error"/>
   </xsl:template>
 
   <!-- When an element is the target of a conref, treat everything the same as any other element EXCEPT the attributes.
@@ -746,7 +750,7 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <!--copy everything else-->
-  <xsl:template match="@* | node()">
+  <xsl:template match="@* | node()" name="copy">
     <xsl:param name="current-relative-path" tunnel="yes" as="xs:string" select="''"/>
     <xsl:param name="WORKDIR" tunnel="yes" as="xs:string">
       <xsl:apply-templates select="/processing-instruction('workdir-uri')[1]" mode="get-work-dir"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/map-conref_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/map-conref_template.xsl
@@ -10,11 +10,10 @@ See the accompanying LICENSE file for applicable license.
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/conrefImpl.xsl"/>
   <dita:extension id="dita.xsl.conref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />
-  
-  <xsl:template match="*[@conref and contains(@class, ' topic/')]">
-    <xsl:copy>
-      <xsl:apply-templates select="@* | node()"/>
-    </xsl:copy>
+
+  <!-- Ignore missing conref target and retain conref for future processing -->
+  <xsl:template match="*" mode="missing-conref-target-file">
+    <xsl:call-template name="copy"/>
   </xsl:template>
   
 </xsl:stylesheet>

--- a/src/test/java/org/dita/dost/IntegrationTest.java
+++ b/src/test/java/org/dita/dost/IntegrationTest.java
@@ -301,6 +301,11 @@ public abstract class IntegrationTest extends AbstractIntegrationTest {
   }
 
   @Test
+  public void testkeyrefKeywordConref() throws Throwable {
+    builder().name(Paths.get("keyref", "keyword_conref")).transtype(PREPROCESS).input(Paths.get("test.ditamap")).test();
+  }
+
+  @Test
   public void testmapref() throws Throwable {
     builder()
       .name(Paths.get("mapref", "basic"))

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess/a.dita
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess/a.dita
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic class="- topic/topic " id="a">
+  <title class="- topic/title ">a</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " id="keyword">Keyword</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess/b.dita
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess/b.dita
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic class="- topic/topic " id="a">
+  <title class="- topic/title ">a</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="author"/>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess/test.ditamap
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess/test.ditamap
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map cascade="nomerge" class="- map/map " id="test" title="Key reference test">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="author" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">Keyword</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref class="- map/topicref " href="b.dita" type="topic">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">a</navtitle>
+      <?ditaot gentext?>
+      <linktext class="- map/linktext ">a</linktext>
+    </topicmeta>
+  </topicref>
+</map>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess2/a.dita
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess2/a.dita
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic class="- topic/topic " id="a">
+  <title class="- topic/title ">a</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " id="keyword">Keyword</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess2/b.dita
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess2/b.dita
@@ -3,7 +3,7 @@
   <title class="- topic/title ">a</title>
   <body class="- topic/body ">
     <p class="- topic/p ">
-      <keyword class="- topic/keyword " keyref="author"/>
+      <keyword class="- topic/keyword " keyref="author">Keyword</keyword>
     </p>
   </body>
 </topic>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess2/b.dita
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess2/b.dita
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic class="- topic/topic " id="a">
+  <title class="- topic/title ">a</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="author"/>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/exp/preprocess2/test.ditamap
+++ b/src/test/resources/keyref/keyword_conref/exp/preprocess2/test.ditamap
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map cascade="nomerge" class="- map/map " id="test" title="Key reference test">
+  <keydef class="+ map/topicref mapgroup-d/keydef " keys="author" processing-role="resource-only">
+    <topicmeta class="- map/topicmeta ">
+      <keywords class="- topic/keywords ">
+        <keyword class="- topic/keyword ">Keyword</keyword>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref class="- map/topicref " href="b.dita" type="topic">
+    <topicmeta class="- map/topicmeta ">
+      <navtitle class="- topic/navtitle ">a</navtitle>
+      <?ditaot gentext?>
+      <linktext class="- map/linktext ">a</linktext>
+    </topicmeta>
+  </topicref>
+</map>

--- a/src/test/resources/keyref/keyword_conref/src/a.dita
+++ b/src/test/resources/keyref/keyword_conref/src/a.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="a">
+  <title>a</title>
+  <body>
+    <p>
+      <keyword id="keyword">Keyword</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/src/b.dita
+++ b/src/test/resources/keyref/keyword_conref/src/b.dita
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="a">
+  <title>a</title>
+  <body>
+    <p>
+      <keyword keyref="author"/>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/keyref/keyword_conref/src/test.ditamap
+++ b/src/test/resources/keyref/keyword_conref/src/test.ditamap
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map title="Key reference test" id="test">
+  <keydef keys="author">
+    <topicmeta>
+      <keywords>
+        <keyword conref="a.dita#a/keyword"/>
+      </keywords>
+    </topicmeta>
+  </keydef>
+  <topicref href="b.dita"/>
+</map>


### PR DESCRIPTION
## Description
When `@conref` in a DITA map references a DITA topic, preprocess2 is unable to process is because topics are not available when the map is processed. To enable this, a new target `topic-map-conref` is added to preprocess2 topic stage to process the map conref. The normal map conref target `map-conref` will process all conrefs it can and will retain all `@conref` where the target resource is not available. When `topic-map-conref` processes the maps again for conrefs, it will try to process all retaining `@conref` in case they were targeting a DITA topic.

## Motivation and Context
Fixes #2420

## How Has This Been Tested?
Manual testing

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Doesn't require any changes from custom plug-ins.
