### PR TITLE
In README.markdown, use `--recurse-submodules` option to clone submodules

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,19 +72,15 @@ See the [documentation][docs] for arguments and [options].
 
 Building the toolkit from source code and compiling the distribution package
 
-1.  Clone the DITA-OT Git repository:
+1.  Clone the DITA-OT Git repository, including submodules:
     ```shell
-    git clone git://github.com/dita-ot/dita-ot.git
+    git clone --recurse-submodules git://github.com/dita-ot/dita-ot.git
     ```
 2.  Change to the DITA-OT directory:
     ```shell
     cd dita-ot
     ```
-3.  Fetch the submodules:
-    ```shell
-    git submodule update --init --recursive
-    ```
-4.  In the root directory, run Gradle to compile the Java code and install plugins:
+3.  In the root directory, run Gradle to compile the Java code and install plugins:
     ```shell
     ./gradlew
     ```


### PR DESCRIPTION
## Description
In the README file, use `git clone --recurse-submodules` instead of manual submodule initialization and cloning.

## Motivation and Context
The `--recurse-submodules` cloning option is the contemporary method of including submodules in a cloned repository. It is an alias for the `--recursive` option, which was [introduced in Git 1.6.5](https://github.com/git/git/blob/master/Documentation/RelNotes/1.6.5.txt#L102) in October 2009.

## How Has This Been Tested?
I use this every time I clone the DITA-OT repository.

## Type of Changes
Documentation change

## Documentation and Compatibility
No documentation change is needed.

A release notes description could be something like:

> In the "Development" section of the main README.markdown file, the repository cloning instructions now use the `--recurse-submodules` option instead of manual submodule initialization and cloning.
