### PR TITLE
In topicpull, update "copy-shortdesc" template to process all @href values

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1258,29 +1258,9 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
   <xsl:template match="*[contains(@class,' topic/fn ')]" mode="dita-ot:text-only"/>
 
   <xsl:template match="*[contains(@class,' topic/xref ')]" mode="copy-shortdesc">
-    <xsl:choose>
-      <xsl:when test="empty(@href) or @scope='peer' or @scope='external'">
-        <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="#current" />
-        </xsl:copy>
-      </xsl:when>
-      <xsl:when test="@format and not(@format='dita')">
-        <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="#current" />
-        </xsl:copy>
-      </xsl:when>
-      <xsl:when test="not(contains(@href,'/'))"><!-- May be DITA, but in the same directory -->
-        <xsl:copy>
-          <xsl:apply-templates select="@*|text()|*" mode="#current" />
-        </xsl:copy>
-      </xsl:when>
-      <xsl:when test="text()|*[not(contains(@class,' topic/desc '))]">
-        <xsl:apply-templates select="*[not(contains(@class,' topic/desc '))]|text()|comment()|processing-instruction()" mode="#current" />
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:text>***</xsl:text><!-- go get the target text -->
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:copy>
+      <xsl:apply-templates select="@*|text()|*" mode="#current"/>
+    </xsl:copy>
   </xsl:template>
   
   <xsl:template match="text()" mode="copy-shortdesc">


### PR DESCRIPTION
## Description
Updates `topicpull` processing to properly compute a topic link's description when the target topic contains a `<shortdesc>` containing another `<xref>` to a target file in a different directory.

## Motivation and Context
Fixes #4244.

The code in this template has been in place for at least 13 years, as shown by the following blame link:

https://github.com/dita-ot/dita-ot/blame/49975b0660689d34178612a930a3033f47f58c83/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl#L1251

Perhaps back then, the test for `/` in the `@href` value was because `topicpull` document path resolution was not as robust. It seems to work fine now. If we find a case where it doesn't, we should fix the issue instead of returning `***` as the inner link text.

Once the requirement for lack of `/` is removed,

* The test in the third branch of the `xsl:choose` simplifies to `true()`.
  * Because empty `@href` values are handled by the first branch, `@href` is always non-empty at the third branch.
  * If we also include `@href` values containing `/`, then `not(contains(@href,'/')) or contains(@href,'/')` simplifies to `true()`.
* The fourth and fifth branches are never used.
* The first three branches all apply the same processing, so the `xsl:choose` can be simplified to just that processing.

Side note - the `copy-shortdesc` template processing for `<xref>` elements is the same as the `copy-shortdesc` identity template:

```
  <xsl:template match="*|@*|processing-instruction()" mode="copy-shortdesc">
    <xsl:copy>
      <xsl:apply-templates select="@*|text()|*|processing-instruction()" mode="#current" />
    </xsl:copy>
  </xsl:template>
```

except that PIs are not copied.

## How Has This Been Tested?
I confirmed the fix with the #4244 testcase. I also ran the unit tests, although I don't think there is currently any test coverage of this `<xref>`-`<shortdesc>`-`<xref>` scenario, as I can replace it with

```
  <xsl:template match="*[contains(@class,' topic/xref ')]" mode="copy-shortdesc">
    <xsl:message terminate="yes">FAIL</xsl:message>
  </xsl:template>
```

and all tests still pass.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No documentation update is needed.

A release notes entry could be something like:

> For cross-references to a topic, the target topic’s short description is processed to create a link description. When that `<shortdesc>` element contained another cross-reference to a file in a different directory, the second link's description would contain `***` instead of the expected link text.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
