### PR TITLE
Move teletype styling to Sass partial

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
+++ b/src/main/plugins/org.dita.html5/sass/domains/_hi-d.scss
@@ -26,6 +26,7 @@
 }
 
 .tt {
+  font-family: monospace;
 }
 
 .u {

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -36,8 +36,6 @@ See the accompanying LICENSE file for applicable license.
     <xsl:template match="*[contains(@class,' hi-d/tt ')]" name="topic.hi-d.tt">
       <span>
         <xsl:call-template name="commonattributes"/>
-          <!-- Combine TT style with style from ditaval, if present -->
-        <xsl:attribute name="style" select="('font-family: monospace', *[contains(@class,' ditaot-d/ditaval-startprop ')]/@style)" separator="; "/>
         <xsl:call-template name="setidaname"/>
         <xsl:apply-templates/>
       </span>


### PR DESCRIPTION
Per https://github.com/dita-ot/dita-ot/issues/4254#issuecomment-1679748417

- [x] Add teletype styling to Sass partial for highlighting domain
- [x] Remove hard-coded style attribute from `<tt>` element output

@jelovirt Can we safely remove [Lines 39-40 from `hi-d.xsl`](https://github.com/dita-ot/dita-ot/blob/feature/teletype-style/src/main/plugins/org.dita.html5/xsl/hi-d.xsl#L39-L40), or do we need to modify that to preserve DITAVAL styles?