### PR TITLE
ignore `<fn>` elements when computing link text for a target element

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -1225,8 +1225,8 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
     </xsl:choose>
   </xsl:template>
 
+  <!-- use common "dita-ot:text-only" templates for link text computation -->
   <xsl:template match="*|text()|processing-instruction()" mode="text-only">
-    <!-- Redirect to common dita-ot module -->
     <xsl:apply-templates select="." mode="dita-ot:text-only"/>
   </xsl:template>
   <xsl:template match="*|@*|comment()|processing-instruction()|text()">
@@ -1234,6 +1234,10 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
       <xsl:apply-templates select="*|@*|comment()|processing-instruction()|text()"/>
     </xsl:copy>
   </xsl:template>
+
+  <!-- in link text computation, do not resolve footnote numbers
+       (the numbering space might differ between the source and target documents) -->
+  <xsl:template match="*[contains(@class,' topic/fn ')]" mode="dita-ot:text-only"/>
   
   
   <xsl:template match="*[contains(@class,' topic/xref ')]" mode="copy-shortdesc">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -266,6 +266,7 @@ See the accompanying LICENSE file for applicable license.
 
     <xsl:template match="*[contains(@class, ' topic/indexterm ')]" mode="insert-text"/>
     <xsl:template match="opentopic-index:*" mode="insert-text"/>
+    <xsl:template match="*[contains(@class, ' topic/fn ')]" mode="insert-text"/>
 
     <xsl:template match="text()[contains(., '[') and contains(., ']')][ancestor::*[contains(@class, ' topic/dl ')][contains(@otherprops,'sortable')]]" priority="10">
         <xsl:value-of select="substring-before(.,'[')"/>


### PR DESCRIPTION
## Description
For a link to a target element that has no explicit link text, the DITA-OT computes default link text from the target element. This link text computation should ignore any `<fn>` elements it encounters, as the footnote numbering in the target document has no meaning when the source document is different.

Note the following:

* For links to self-titled elements, the `<title>` element does not directly allow `<fn>` elements. But, they can "sneak into" the title when contained in other elements (such as `<ph>`).
  * This also applies to links to `<dt>` elements (and possibly others).
* For links to other elements, the `<fn>` element might exist in whatever target element content is used for link text computation.

## Motivation and Context
Fixes the link text aspect of #4269.

## How Has This Been Tested?
I ran the automated tests, plus the two testcases in #4269.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

In `topicpull`, `<fn>` elements are ignored during link text computation.

In PDF transformations, `<fn>` elements are ignored during link text recomputation.

## Documentation and Compatibility
No documentation update is needed. The fix should not affect any existing flows (unless they rely on this questionable behavior).

A release notes entry might be as follows:

> For a link to a target element that has no explicit link text, the DITA-OT computes default link text from the target element. This link text computation now ignores any `<fn>` elements it encounters, as the footnote numbering convention in the target document has no meaning when the source document is different.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
