### PR TITLE
Revise log messages for #3973

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -31,12 +31,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA011W" type="WARN">
-    <reason>Argument '%1' is deprecated.</reason>
-    <response>This argument is no longer supported in the toolkit.</response>
+    <reason>The '%1' argument is deprecated.</reason>
+    <response>This argument is no longer supported.</response>
   </message>
 
   <message id="DOTA012W" type="WARN">
-    <reason>Argument '%1' is deprecated.</reason>
+    <reason>The '%1' argument is deprecated.</reason>
     <response>Please use the argument '%2' instead.</response>
   </message>
 
@@ -46,13 +46,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA014W" type="WARN">
-    <reason>Attribute @%1 is deprecated.</reason>
-    <response>Use attribute @%2 instead.</response>
+    <reason>The @%1 attribute is deprecated.</reason>
+    <response>Use @%2 instead.</response>
   </message>
 
   <message id="DOTA015F" type="FATAL">
-    <reason>Internal property '%1' may not be set directly.</reason>
-    <response>Use property'%2'instead.</response>
+    <reason>The internal property '%1' may not be set directly.</reason>
+    <response>Use the '%2' property instead.</response>
   </message>
 
   <message id="DOTA069F" type="FATAL">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -335,7 +335,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ065I" type="INFO">
-    <reason>Branch filter generated topic '%1' used more than once.</reason>
+    <reason>Branch filter generated topic '%1' is used more than once.</reason>
     <response>Renaming '%1' to '%2'.</response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -16,7 +16,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA002F" type="FATAL">
-    <reason>Input file is not specified, or is specified using the wrong parameter.</reason>
+    <reason>Input not specified, or specified using the wrong parameter.</reason>
     <response></response>
   </message>
 
@@ -56,8 +56,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA069F" type="FATAL">
-    <reason>Input file '%1' cannot be located or read.</reason>
-    <response>Ensure that file was specified properly and that you have permission to access it.</response>
+    <reason>The input resource '%1' cannot be located or read.</reason>
+    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- Start of Java Messages -->
@@ -90,17 +90,17 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Would like to improve / shorten DOTJ009E but not sure how to modify. -->
   <message id="DOTJ009E" type="ERROR">
-    <reason>Cannot overwrite file '%1' with file '%2'. The modified result may not be consumed by the following steps in the transform pipeline.</reason>
-    <response>Check to see whether the file is locked by some other application during the transformation process.</response>
+    <reason>Cannot overwrite the '%1' resource with '%2'. The modified result may not be available to the following steps in the transformation.</reason>
+    <response>Check if the resource is locked by some other application during the transformation process.</response>
   </message>
 
   <message id="DOTJ012F" type="FATAL">
-    <reason>Failed to parse the input file '%1'.</reason>
+    <reason>Failed to parse the input resource '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ013E" type="ERROR">
-    <reason>Failed to parse the referenced file '%1'.</reason>
+    <reason>Failed to parse the referenced resource '%1'.</reason>
     <response></response>
   </message>
 
@@ -120,24 +120,24 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ021E" type="ERROR">
-    <reason>File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.</reason>
-    <response></response>
+    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
+    <response>Please check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
-    <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the DITAVAL file.</reason>
-    <response>Please check the '%1' file and the DITAVAL file to see if this is the intended result.</response>
+    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
+    <response>Please check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <message id="DOTJ022F" type="FATAL">
-    <reason>Failed to parse the input file '%1' because all of its content has been filtered out.</reason>
-    <response>This will happen if the input file has filter conditions on the root element, and a DITAVAL file excludes all content based on those conditions.</response>
+    <reason>Failed to parse the input resource '%1' because all of its content has been filtered out.</reason>
+    <response>This will happen if the resource has filter conditions on the root element, and a DITAVAL file excludes all content based on those conditions.</response>
   </message>
 
   <message id="DOTJ023E" type="ERROR">
-    <reason>Failed to get the specified image file '%1', so it will not be included with your output.</reason>
-    <response></response>
+    <reason>The specified image file '%1' is not available. It will not be included in the output.</reason>
+    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ025E" type="ERROR">
@@ -151,8 +151,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ028E" type="ERROR">
-    <reason>No @format attribute was found on a reference to file '%1', which does not appear to be a DITA file.</reason>
-    <response>If this is not a DITA file, set the @format attribute to an appropriate value, otherwise set the @format attribute to "dita".</response>
+    <reason>No @format attribute was found on a reference to the '%1' resource, which does not appear to be DITA.</reason>
+    <response>If this is not a DITA resource, set the @format attribute to an appropriate value; otherwise set the @format attribute to "dita".</response>
   </message>
 
   <!-- Deprecated since 3.5 -->
@@ -179,18 +179,17 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ034F" type="FATAL">
-    <reason>Failed to parse the input file '%1' (the content of the file is not valid).</reason>
-    <response>If the input file '%1' does not have a DOCTYPE declaration, please make sure that all @class attributes are present in the file.</response>
+    <reason>Failed to parse the input resource '%1' (the content is not valid).</reason>
+    <response>If '%1' does not have a DOCTYPE declaration, please make sure that all @class attributes are present.</response>
   </message>
 
-  <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ035F" type="FATAL">
-    <reason>The file '%1' is outside the scope of the input resource directory.</reason>
-    <response>To lower the severity level, use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file '%1' into the directory where the input map or topic is stored.</response>
+    <reason>The '%1' resource is outside the scope of the input directory.</reason>
+    <response>To lower the severity level, use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the '%1' resource to the directory where the input map or topic is stored.</response>
   </message>
 
   <message id="DOTJ036W" type="WARN">
-    <reason>The file '%1' is outside the scope of the input resource directory.</reason>
+    <reason>The '%1' resource is outside the scope of the input directory.</reason>
     <response></response>
   </message>
 
@@ -227,7 +226,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ043W" type="WARN">
-    <reason>The conref push function is trying to replace an element that does not exist (element '%1' in file '%2').</reason>
+    <reason>The conref push function is trying to replace an element that does not exist ('%1' element in the '%2' resource).</reason>
     <response></response>
   </message>
 
@@ -238,7 +237,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ045I" type="INFO">
-    <reason>The key '%1' is defined more than once in the same map file.</reason>
+    <reason>The key '%1' is defined more than once in the same map.</reason>
     <response></response>
   </message>
 
@@ -270,17 +269,17 @@ See the accompanying LICENSE file for applicable license.
   <!-- Long term, would like to split this into two messages. One for file not found, another for file outside the scope of the map. -->
   <message id="DOTJ051E" type="ERROR">
     <reason>Unable to load target for coderef '%1'.</reason>
-    <response></response>
+    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ052E" type="ERROR">
     <reason>Code reference charset '%1' not supported.</reason>
-    <response>See the DITA-OT documentation for supported charset values on the @format attribute.</response>
+    <response>See the DITA-OT documentation for supported character set values on the @format attribute.</response>
   </message>
 
   <!-- Obsolete since 2.3 -->
   <message id="DOTJ053W" type="WARN">
-    <reason>Input file '%1' is not valid DITA file name.</reason>
+    <reason>The input resource '%1' is not a valid DITA filename.</reason>
     <response>Please check '%1' to see if it is correct. The extensions ".dita" or ".xml" are supported for DITA topics.</response>
   </message>
 
@@ -405,12 +404,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ078F" type="FATAL">
-    <reason>Input file '%1' could not be loaded.</reason>
+    <reason>The input resource '%1' could not be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
   </message>
 
   <message id="DOTJ079E" type="ERROR">
-    <reason>File '%1' could not be loaded.</reason>
+    <reason>The '%1' resource could not be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
   </message>
 
@@ -475,7 +474,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX004I" type="INFO">
     <reason>Found a &lt;navref&gt; element that does not reference anything.</reason>
-    <response>The &lt;navref&gt; element should either reference another DITA map or an Eclipse XML file.</response>
+    <response>The &lt;navref&gt; element should either reference another DITA map or an Eclipse XML TOC file.</response>
   </message>
 
   <message id="DOTX005E" type="ERROR">
@@ -484,7 +483,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX006E" type="ERROR">
-    <reason>Unknown file extension in href='%1'.</reason>
+    <reason>Unknown file name extension in @href attribute value '%1'.</reason>
     <response>References to non-DITA resources should set the @format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
 
@@ -495,13 +494,13 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
   <message id="DOTX008E" type="ERROR">
-    <reason>File '%1' does not exist or cannot be loaded.</reason>
-    <response></response>
+    <reason>The resource '%1' cannot be loaded.</reason>
+    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- As of 2012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->
   <message id="DOTX008W" type="WARN">
-    <reason>File '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
+    <reason>The resource '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
     <response></response>
   </message>
 
@@ -517,8 +516,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX011W" type="WARN">
-    <reason>There is more than one possible target for the @conref="%1" reference. Only the first will be used.</reason>
-    <response>Remove the duplicate ID in the referenced file.</response>
+    <reason>There is more than one possible target for the @conref attribute value "%1". Only the first will be used.</reason>
+    <response>Remove the duplicate ID in the referenced resource.</response>
   </message>
 
   <!-- This message can no longer appear, though the template for producing it remains in conrefImpl.xsl.
@@ -622,7 +621,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX031E" type="ERROR">
-    <reason>The file '%1' is not available to resolve link information.</reason>
+    <reason>The '%1' resource is not available to resolve link information.</reason>
     <response></response>
   </message>
 
@@ -717,7 +716,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX052W" type="WARN">
-    <reason>No string named '%1' was found when creating generated text; using the value '%1' in your output file.</reason>
+    <reason>No string named '%1' was found when creating generated text; using the value '%1' in the output.</reason>
     <response></response>
   </message>
 
@@ -737,12 +736,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX056W" type="WARN">
-    <reason>The file '%1' is not available to resolve link information.</reason>
+    <reason>The '%1' resource is not available to resolve link information.</reason>
     <response></response>
   </message>
 
   <message id="DOTX057W" type="WARN">
-    <reason>The link or cross reference target '%1' cannot be found, which may cause errors creating links or cross references in your output file.</reason>
+    <reason>The link or cross-reference target '%1' cannot be found, which may cause errors in the output.</reason>
     <response></response>
   </message>
 
@@ -768,11 +767,11 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX063W" type="WARN">
     <reason>The DITA document '%1' is linked to from your content, but not referenced by a &lt;topicref&gt; element in the map.</reason>
-    <response>Include the topic in your map file to avoid a broken link.</response>
+    <response>Include the topic in your map to avoid a broken link.</response>
   </message>
 
   <message id="DOTX064W" type="WARN">
-    <reason>The @copy-to attribute value '%1' uses the name of a file that already exists, so this attribute is ignored.</reason>
+    <reason>The @copy-to attribute value '%1' uses the name of a resource that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA003F" type="FATAL">
-    <reason>Cannot find the user specified XSLT stylesheet '%1'.</reason>
+    <reason>Cannot find the user-specified XSLT stylesheet '%1'.</reason>
     <response></response>
   </message>
 
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA013F" type="FATAL">
-    <reason>Cannot find the specified DITAVAL '%1'.</reason>
+    <reason>Cannot find the specified DITAVAL file '%1'.</reason>
     <response></response>
   </message>
 
@@ -88,9 +88,8 @@ See the accompanying LICENSE file for applicable license.
     <response>The first encountered condition will be used.</response>
   </message>
 
-  <!-- Would like to improve / shorten DOTJ009E but not sure how to modify. -->
   <message id="DOTJ009E" type="ERROR">
-    <reason>Cannot overwrite the '%1' resource with '%2'. The modified result may not be available to the following steps in the transformation.</reason>
+    <reason>Cannot overwrite the '%1' resource with '%2'. The modified result may not be available to the following transformation steps.</reason>
     <response>Check if the resource is locked by some other application during the transformation process.</response>
   </message>
 
@@ -111,7 +110,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ018I" type="INFO">
     <reason>Log file '%1' was generated successfully in directory '%2'.</reason>
-    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT documentation.</response>
+    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the documentation.</response>
   </message>
 
   <message id="DOTJ020W" type="WARN">
@@ -141,13 +140,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ025E" type="ERROR">
-    <reason>The input to the "topic merge" transform process cannot be found.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
+    <reason>The input to the "topic merge" process cannot be found.</reason>
+    <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
   </message>
 
   <message id="DOTJ026E" type="ERROR">
-    <reason>The "topic merge" did not generate any output.</reason>
-    <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
+    <reason>The "topic merge" process did not generate any output.</reason>
+    <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
   </message>
 
   <message id="DOTJ028E" type="ERROR">
@@ -167,14 +166,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ031I" type="INFO">
-    <reason>No specified rule for '%1' was found in the DITAVAL file. This value will use the default action, or a parent prop action if specified.</reason>
-    <response>To remove this message, you can specify a rule for '%1' in the DITAVAL file.</response>
+    <reason>No rule for '%1' was found in the DITAVAL file. This value will use the default action, or a parent prop action if specified.</reason>
+    <response>To remove this message, specify a rule for '%1' in the DITAVAL file.</response>
   </message>
 
-  <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ033E" type="ERROR">
-    <reason>No valid content is found in topicref '%1' during chunk processing.</reason>
-    <response>Please specify an existing and valid topic for the topicref.</response>
+    <reason>No valid content found in topicref '%1' during chunk processing.</reason>
+    <response>Please specify an existing and valid topic for the topic reference.</response>
   </message>
 
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
@@ -274,7 +272,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ052E" type="ERROR">
     <reason>Code reference charset '%1' not supported.</reason>
-    <response>See the DITA-OT documentation for supported character set values on the @format attribute.</response>
+    <response>See the documentation for supported character set values on the @format attribute.</response>
   </message>
 
   <!-- Obsolete since 2.3 -->
@@ -315,7 +313,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ060W" type="WARN">
     <reason>Key '%1' was used in conkeyref but is not bound to a DITA topic or map.</reason>
-    <response>Cannot resolve conkeyref value '%2' as a valid conref reference.</response>
+    <response>Cannot resolve conkeyref value '%2' as a valid content reference.</response>
   </message>
 
   <message id="DOTJ061E" type="ERROR">
@@ -330,7 +328,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ063E" type="ERROR">
     <reason>The @cols attribute is set to '%1' but the number of &lt;colspec&gt; elements was '%2'.</reason>
-    <response></response>
+    <response>Please verify the number of columns in the table.</response>
   </message>
 
   <message id="DOTJ064W" type="WARN">
@@ -345,7 +343,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ066E" type="ERROR">
     <reason>No @id attribute on topic type element '%1'.</reason>
-    <response>Using generated id '%2'.</response>
+    <response>Using generated ID '%2'.</response>
   </message>
 
   <message id="DOTJ067E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -739,7 +739,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX057W" type="WARN">
-    <reason>The link or cross-reference target '%1' cannot be found, which may cause errors in the output.</reason>
+    <reason>The link or cross reference target '%1' cannot be found, which may cause errors in the output.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -552,13 +552,13 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- 018 currently not used, commented out due to SF bug 1771123 -->
   <message id="DOTX018I" type="INFO">
-    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
-    <response></response>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic.</reason>
+    <response>Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</response>
   </message>
 
   <message id="DOTX019W" type="WARN">
-    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
-    <response></response>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a '%2' topic.</reason>
+    <response>This may cause links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</response>
   </message>
 
   <message id="DOTX020E" type="ERROR">
@@ -607,13 +607,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX029I" type="INFO">
-    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause links to sort incorrectly in the output.</reason>
-    <response></response>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'.</reason>
+    <response>This may cause links to sort incorrectly in the output.</response>
   </message>
 
   <message id="DOTX030W" type="WARN">
-    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a '%4' '%2'. This may cause links to sort incorrectly in the output.</reason>
-    <response></response>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a '%4' '%2'.</reason>
+    <response>This may cause links to sort incorrectly in the output.</response>
   </message>
 
   <message id="DOTX031E" type="ERROR">
@@ -717,8 +717,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX053E" type="ERROR">
-    <reason>A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to '%1'.</reason>
-    <response></response>
+    <reason>A element that references another map indirectly includes itself, which results in an infinite loop.</reason>
+    <response>The original map reference is to '%1'.</response>
   </message>
 
   <message id="DOTX054W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -572,8 +572,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX022W" type="WARN">
-    <reason>Unable to retrieve navtitle from target: '%1'. Using topicmeta linktext as the navigation title.</reason>
-    <response></response>
+    <reason>Unable to retrieve navtitle from target: '%1'.</reason>
+    <response>Using topicmeta linktext as the navigation title.</response>
   </message>
 
   <message id="DOTX023W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -7,8 +7,9 @@ Copyright 2005, 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <messages xmlns:dita="http://dita-ot.sourceforge.net">
-  
+
   <!-- Start of Ant Messages -->
+
   <message id="DOTA001F" type="FATAL">
     <reason>"%1" is not a recognized transformation type.</reason>
     <response>Supported transformation types are <dita:extension id="dita.conductor.transtype.check" behavior="org.dita.dost.platform.ListTranstypeAction" separator=", "/>.</response>
@@ -38,18 +39,22 @@ See the accompanying LICENSE file for applicable license.
     <reason>Argument "%1" is deprecated.</reason>
     <response>This argument is no longer supported in the toolkit.</response>
   </message>
+
   <message id="DOTA012W" type="WARN">
     <reason>Argument "%1" is deprecated.</reason>
     <response>Please use the argument "%2" instead.</response>
   </message>
+
   <message id="DOTA013F" type="FATAL">
     <reason>Cannot find the specified DITAVAL '%1'.</reason>
     <response></response>
   </message>
+
   <message id="DOTA014W" type="WARN">
     <reason>Attribute @%1 is deprecated.</reason>
     <response>Use attribute @%2 instead.</response>
   </message>
+
   <message id="DOTA015F" type="FATAL">
     <reason>Internal property %1 may not be set directly.</reason>
     <response>Use property %2 instead.</response>
@@ -448,8 +453,9 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <!-- End of Java Messages -->
-    
-  <!-- Start of XSL Messages -->  
+
+  <!-- Start of XSL Messages -->
+
   <message id="DOTX001W" type="WARN">
     <reason>No string named '%1' was found for language '%2'. Using the default language '%3'.</reason>
     <response>Add a mapping between default language and desired language for the string '%1'.</response>
@@ -838,9 +844,8 @@ See the accompanying LICENSE file for applicable license.
     <response>Rewriting resolved version to '%2'.</response>
   </message>
 
+  <!-- End of XSL Messages -->
 
-  <!-- End of XSL Messages --> 
-      
   <!-- Add any messages defined by plugins. -->
   <dita:extension xmlns:dita="http://dita-ot.sourceforge.net"
     behavior="org.dita.dost.platform.InsertAction" id="dita.xsl.messages"/>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -105,17 +105,17 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ014W" type="WARN">
     <reason>Found an &lt;indexterm&gt; element with no content.</reason>
-    <response>Setting the term to ***.</response>
+    <response>Setting the term to '***'.</response>
   </message>
 
   <message id="DOTJ018I" type="INFO">
-    <reason>Log file '%1' was generated successfully in directory '%2'.</reason>
-    <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the documentation.</response>
+    <reason>The '%1' log file was written to the '%2' directory.</reason>
+    <response>Any messages from the transformation process are available in the log; additional details about each message may be available in the documentation.</response>
   </message>
 
   <message id="DOTJ020W" type="WARN">
-    <reason>At least one plug-in in '%1' is required by plug-in '%2'. Plug-in '%2' cannot be loaded.</reason>
-    <response>Check if all prerequisite plug-ins are properly installed.</response>
+    <reason>The '%2' plug-in cannot be loaded because it requires at least one plug-in in '%1'.</reason>
+    <response>Make sure all prerequisite plug-ins are properly installed.</response>
   </message>
 
   <message id="DOTJ021E" type="ERROR">
@@ -219,7 +219,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ042E" type="ERROR">
     <reason>Two elements both use conref push to replace the target '%1'.</reason>
-    <response>Delete one of the duplicate 'replace' actions.</response>
+    <response>Delete one of the duplicate 'pushreplace' actions.</response>
   </message>
 
   <message id="DOTJ043W" type="WARN">
@@ -254,7 +254,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ049W" type="WARN">
     <reason>The @%1 attribute value '%3' on the &lt;%2&gt; element does not comply with the specified subject scheme.</reason>
-    <response>According to the subject scheme map, the following values are valid for the @%1 attribute: '%4'</response>
+    <response>According to the subject scheme map, the following values are valid for the @%1 attribute: '%4'.</response>
   </message>
 
   <message id="DOTJ050W" type="WARN">
@@ -300,7 +300,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ058E" type="ERROR">
-    <reason>Both '%1' and '%2' attributes defined.</reason>
+    <reason>Both the @%1 and @%2 attributes are defined.</reason>
     <response>A single element may not contain both generalized and specialized values for the same attribute.</response>
   </message>
 
@@ -310,8 +310,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ060W" type="WARN">
-    <reason>Key '%1' was used in conkeyref but is not bound to a DITA topic or map.</reason>
-    <response>Cannot resolve conkeyref value '%2' as a valid content reference.</response>
+    <reason>The '%1' key is used in a @conkeyref attribute but it is not bound to a DITA topic or map.</reason>
+    <response>Cannot resolve '%2' as a valid content key reference.</response>
   </message>
 
   <message id="DOTJ061E" type="ERROR">
@@ -360,7 +360,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ070I" type="INFO">
-    <reason>An invalid @class attribute '%1' for was found for the &lt;%2&gt; element.</reason>
+    <reason>An invalid @class attribute '%1' was found for the &lt;%2&gt; element.</reason>
     <response>Processing as an unknown or non-DITA element.</response>
   </message>
 
@@ -401,12 +401,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ078F" type="FATAL">
     <reason>The input resource '%1' cannot be loaded.</reason>
-    <response>Check if grammar files for this document type are properly referenced and installed.</response>
+    <response>Make sure the grammar files for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ079E" type="ERROR">
     <reason>The '%1' resource cannot be loaded.</reason>
-    <response>Check if grammar files for this document type are properly referenced and installed.</response>
+    <response>Make sure the grammar files for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ080W" type="WARN">
@@ -520,7 +520,7 @@ See the accompanying LICENSE file for applicable license.
        Support for mismatched domains was added in release 1.5 or earlier. -->
   <message id="DOTX012W" type="WARN">
     <reason>When you conref another topic or an item in another topic, the @domains attribute of the target topic must be equal to or a subset of the current topic's @domains attribute.</reason>
-    <response>Put the target under an appropriate domain. You can see the messages guide for more help.</response>
+    <response>Put the target under an appropriate domain.</response>
   </message>
 
   <message id="DOTX013E" type="ERROR">
@@ -563,16 +563,16 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX020E" type="ERROR">
     <reason>Missing @navtitle attribute or element for peer topic '%1'.</reason>
-    <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
+    <response>References must provide a navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX021E" type="ERROR">
     <reason>Missing @navtitle attribute or element for non-DITA resource '%1'.</reason>
-    <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
+    <response>References must provide a navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX022W" type="WARN">
-    <reason>Unable to retrieve navtitle from target: '%1'. Using linktext (specified in topicmeta) as the navigation title.</reason>
+    <reason>Unable to retrieve navtitle from target: '%1'. Using topicmeta linktext as the navigation title.</reason>
     <response></response>
   </message>
 
@@ -583,12 +583,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX024E" type="ERROR">
     <reason>Missing linktext and navtitle for peer topic '%1'.</reason>
-    <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
+    <response>References must provide a navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX025E" type="ERROR">
     <reason>Missing linktext and navtitle for non-DITA resource '%1'.</reason>
-    <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
+    <response>References must provide a navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX026W" type="WARN">
@@ -747,12 +747,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX060W" type="WARN">
-    <reason>The '%1' key was used in an &lt;abbreviated-form&gt; element, but the key is not associated with a glossary entry.</reason>
-    <response>Abbreviated-form should ONLY be used to reference to a glossary entry.</response>
+    <reason>The '%1' key is used in an &lt;abbreviated-form&gt; element, but the key is not associated with a glossary entry.</reason>
+    <response>Abbreviated-form should ONLY be used to reference a glossary entry.</response>
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>The @id attribute value '%1' was used on a &lt;topicref&gt; element, but it did not reference a topic element.</reason>
+    <reason>The @id attribute value '%1' is defined on a &lt;topicref&gt; element, but it does not reference a topic element.</reason>
     <response>The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</response>
   </message>
 
@@ -777,7 +777,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX066W" type="WARN">
-    <reason>Template '%1' is deprecated.</reason>
+    <reason>The '%1' template is deprecated.</reason>
     <response>Remove references to this template from the custom XSLT or plug-ins.</response>
   </message>
 
@@ -788,27 +788,27 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX068W" type="WARN">
     <reason>A &lt;topicref&gt; element that references a map contains child &lt;topicref&gt; elements.</reason>
-    <response>Child &lt;topicref&gt; elements are ignored.</response>
+    <response>Ignoring child topic references.</response>
   </message>
 
   <message id="DOTX069W" type="WARN">
-    <reason>Template mode '%1' is deprecated.</reason>
-    <response>Remove references to this template mode from the custom XSLT or plug-ins.</response>
+    <reason>The '%1' template mode is deprecated.</reason>
+    <response>Remove references to this template mode from custom XSLT or plug-ins.</response>
   </message>
 
   <message id="DOTX070W" type="WARN">
-    <reason>Target '%1' is deprecated.</reason>
-    <response>Remove references to this target from the custom Ant files.</response>
+    <reason>The '%1' target is deprecated.</reason>
+    <response>Remove references to this target from custom Ant files.</response>
   </message>
 
   <message id="DOTX071E" type="ERROR">
-    <reason>Conref range: Unable to find conref range end element with ID '%1'.</reason>
+    <reason>Unable to find conref range end element with ID '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTX071W" type="WARN">
-    <reason>Parameter '%1' on template '%2' is deprecated.</reason>
-    <response>Use parameter '%3' instead.</response>
+    <reason>The '%1' parameter on the '%2' template is deprecated.</reason>
+    <response>Use the '%3' parameter instead.</response>
   </message>
 
   <message id="DOTX072I" type="INFO">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -744,7 +744,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX058W" type="WARN">
-    <reason>No glossary entry found for the '%1' key on the '%2' element.</reason>
+    <reason>No glossary entry found for the '%1' key on the &lt;%2&gt; element.</reason>
     <response>Check display text and hover text for terms and abbreviations.</response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -671,6 +671,7 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTX042I" type="INFO">
     <reason>DITAVAL-based flagging is not currently supported for inline phrases in XHTML; ignoring flag value on '%1' attribute.</reason>
     <response></response>
@@ -726,6 +727,7 @@ See the accompanying LICENSE file for applicable license.
     <response>Check the DITAVAL and DITA source files to make sure there is no style conflict on the element that needs to be flagged.</response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTX055W" type="WARN">
     <reason>A customized stylesheet uses the deprecated 'flagit' template. Conditional processing is no longer supported using this template.</reason>
     <response>Update the stylesheet to use the 'start-flagit' template instead of the 'flagit' template.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -286,7 +286,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ055E" type="ERROR">
     <reason>Invalid key name '%1'.</reason>
-    <response>Check the reference to see if the target exists.</response>
+    <response>Key names consist of URI characters and may not contain '{', '}', '[', ']', '/', '#', '?' or whitespace.</response>
   </message>
 
   <message id="DOTJ056E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -71,6 +71,7 @@ See the accompanying LICENSE file for applicable license.
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTJ007E" type="ERROR">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
@@ -81,6 +82,7 @@ See the accompanying LICENSE file for applicable license.
     <response>The first encountered condition will be used.</response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTJ007W" type="WARN">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -211,13 +211,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ040E" type="ERROR">
-    <reason>An element uses conaction="replace", but a @conref attribute is not found in the expected location.</reason>
+    <reason>An element uses @conaction="replace", but a @conref attribute is not found in the expected location.</reason>
     <response></response>
   </message>
 
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
   <message id="DOTJ041E" type="ERROR">
-    <reason>The attribute conref="%1" uses invalid syntax.</reason>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
@@ -243,7 +243,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ046E" type="ERROR">
-    <reason>Conkeyref="%1" can not be resolved because it does not contain a key or the key is not defined.</reason>
+    <reason>The @conkeyref attribute value '%1' cannot be resolved because it does not contain a key or the key is not defined.</reason>
     <response>The build will use the @conref attribute for fallback, if one exists.</response>
   </message>
 
@@ -258,8 +258,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ049W" type="WARN">
-    <reason>The attribute value %1="%3" on element '%2' does not comply with the specified subject scheme.</reason>
-    <response>According to the subject scheme map, the following values are valid for the '%1' attribute: '%4'</response>
+    <reason>The @%1 attribute value '%3' on element '%2' does not comply with the specified subject scheme.</reason>
+    <response>According to the subject scheme map, the following values are valid for the @%1 attribute: '%4'</response>
   </message>
 
   <message id="DOTJ050W" type="WARN">
@@ -285,7 +285,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ054E" type="ERROR">
-    <reason>Unable to parse invalid '%1' attribute value '%2'.</reason>
+    <reason>Unable to parse invalid @%1 attribute value '%2'.</reason>
     <response></response>
   </message>
 
@@ -490,7 +490,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX007I" type="INFO">
     <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to '%1' will be ignored.</reason>
-    <response>To remove this message, you can set the toc="no" or processing-role="resource-only" attribute on your topicref.</response>
+    <response>To remove this message, you can set @toc="no" or @processing-role="resource-only" on the topicref.</response>
   </message>
 
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
@@ -512,13 +512,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX010E" type="ERROR">
-    <reason>Unable to find target for conref="%1".</reason>
+    <reason>Unable to find target for @conref="%1".</reason>
     <response></response>
   </message>
 
   <message id="DOTX011W" type="WARN">
-    <reason>There is more than one possible target for the reference conref="%1". Only the first will be used.</reason>
-    <response>Remove the duplicate id in the referenced file.</response>
+    <reason>There is more than one possible target for the @conref="%1" reference. Only the first will be used.</reason>
+    <response>Remove the duplicate ID in the referenced file.</response>
   </message>
 
   <!-- This message can no longer appear, though the template for producing it remains in conrefImpl.xsl.
@@ -534,12 +534,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX014E" type="ERROR">
-    <reason>The conref="%1" attribute setting uses invalid syntax.</reason>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
     <response>Conref references to a map element should contain '#' followed by an ID, such as mymap.ditamap#mytopicrefid.</response>
   </message>
 
   <message id="DOTX015E" type="ERROR">
-    <reason>The attribute conref="%1" uses invalid syntax.</reason>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
@@ -772,12 +772,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX064W" type="WARN">
-    <reason>The @copy-to attribute [copy-to="%1"] uses the name of a file that already exists, so this attribute is ignored.</reason>
+    <reason>The @copy-to attribute value '%1' uses the name of a file that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
 
   <message id="DOTX065W" type="WARN">
-    <reason>Two unique source files each specify copy-to="%2", which results in a collision. The value associated with href="%1" is ignored.</reason>
+    <reason>Two unique source files each specify @copy-to="%2", which results in a collision. The value associated with
+      @href="%1" is ignored.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -214,7 +214,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
   <message id="DOTJ041E" type="ERROR">
-    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
+    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
@@ -240,7 +240,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ046E" type="ERROR">
-    <reason>The @conkeyref attribute value '%1' cannot be resolved because it does not contain a key or the key is not defined.</reason>
+    <reason>The @conkeyref attribute value "%1" cannot be resolved because it does not contain a key or the key is not defined.</reason>
     <response>The build will use the @conref attribute for fallback, if one exists.</response>
   </message>
 
@@ -297,7 +297,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ057E" type="ERROR">
-    <reason>The @id attribute value '%1' is not unique within the topic that contains it.</reason>
+    <reason>The @id attribute value "%1" is not unique within the topic that contains it.</reason>
     <response></response>
   </message>
 
@@ -373,12 +373,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ072E" type="ERROR">
     <reason>Email link without correct @format attribute.</reason>
-    <response>Using @format attribute value 'email'.</response>
+    <response>Using @format attribute value "email".</response>
   </message>
 
   <message id="DOTJ073E" type="ERROR">
     <reason>Email link without correct @scope attribute.</reason>
-    <response>Using @scope attribute value 'external'.</response>
+    <response>Using @scope attribute value "external".</response>
   </message>
 
   <message id="DOTJ074W" type="WARN">
@@ -388,7 +388,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ075W" type="WARN">
     <reason>Absolute link '%1' without correct @scope attribute.</reason>
-    <response>Using @scope attribute value 'external'.</response>
+    <response>Using @scope attribute value "external".</response>
   </message>
 
   <message id="DOTJ076W" type="WARN">
@@ -447,7 +447,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ087W" type="WARN">
-    <reason>Found @chunk attribute with value '%1' inside combine chunk.</reason>
+    <reason>Found @chunk attribute with value "%1" inside combine chunk.</reason>
     <response>Ignoring chunk operation.</response>
   </message>
 
@@ -467,7 +467,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX003I" type="INFO">
     <reason>The @anchorref attribute should either reference another DITA map or an Eclipse XML TOC file.</reason>
-    <response>The value '%1' does not appear to reference either.</response>
+    <response>The value "%1" does not appear to reference either.</response>
   </message>
 
   <message id="DOTX004I" type="INFO">
@@ -481,7 +481,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX006E" type="ERROR">
-    <reason>Unknown file name extension in @href attribute value '%1'.</reason>
+    <reason>Unknown file name extension in @href attribute value "%1".</reason>
     <response>References to non-DITA resources should set the @format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
 
@@ -531,12 +531,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX014E" type="ERROR">
-    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
+    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
     <response>Conref references to a map element should contain '#' followed by an ID, such as mymap.ditamap#mytopicrefid.</response>
   </message>
 
   <message id="DOTX015E" type="ERROR">
-    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
+    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
@@ -554,12 +554,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- 018 currently not used, commented out due to SF bug 1771123 -->
   <message id="DOTX018I" type="INFO">
-    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
   <message id="DOTX019W" type="WARN">
-    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
@@ -754,7 +754,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>The @id attribute value '%1' was used on a &lt;topicref&gt; element, but it did not reference a topic element. The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</reason>
+    <reason>The @id attribute value "%1" was used on a &lt;topicref&gt; element, but it did not reference a topic element. The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</reason>
     <response></response>
   </message>
 
@@ -769,7 +769,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX064W" type="WARN">
-    <reason>The @copy-to attribute value '%1' uses the name of a resource that already exists, so this attribute is ignored.</reason>
+    <reason>The @copy-to attribute value "%1" uses the name of a resource that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
 
@@ -825,7 +825,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX074W" type="WARN">
-    <reason>No formatting defined for unknown @class attribute value '%1'.</reason>
+    <reason>No formatting defined for unknown @class attribute value "%1".</reason>
     <response/>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -540,7 +540,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX016W" type="WARN">
     <reason>'%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'.</reason>
-    <response>Processing as a non-DITA element. To process as DITA, set the @format attribute to 'dita'.</response>
+    <response>Processing as a non-DITA resource. To process as DITA, set the @format attribute to 'dita'.</response>
   </message>
 
   <!-- Should likely be "warning" instead of "error", as related toolkit problems were fixed in very early releases.

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -157,7 +157,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 3.5 -->
   <message id="DOTJ029I" type="INFO">
     <reason>No @domains attribute was found for the &lt;%1&gt; element.</reason>
-    <response>This generally indicates that your DTD or schema was not developed properly according to the DITA specification.</response>
+    <response>This generally indicates that the DTD or schema was not developed properly according to the DITA specification.</response>
   </message>
 
   <message id="DOTJ030I" type="INFO">
@@ -486,7 +486,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX007I" type="INFO">
-    <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to '%1' will be ignored.</reason>
+    <reason>Only DITA topics, HTML files, and images may be included in the compiled CHM file. The reference to '%1' will be ignored.</reason>
     <response>To remove this message, set the @toc attribute to "no" or the @processing-role attribute to "resource-only" on the topic reference.</response>
   </message>
 
@@ -522,7 +522,7 @@ See the accompanying LICENSE file for applicable license.
        Support for mismatched domains was added in release 1.5 or earlier. -->
   <message id="DOTX012W" type="WARN">
     <reason>When you conref another topic or an item in another topic, the @domains attribute of the target topic must be equal to or a subset of the current topic's @domains attribute.</reason>
-    <response>Put your target under an appropriate domain. You can see the messages guide for more help.</response>
+    <response>Put the target under an appropriate domain. You can see the messages guide for more help.</response>
   </message>
 
   <message id="DOTX013E" type="ERROR">
@@ -559,7 +559,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX019W" type="WARN">
-    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a '%2' topic. This may cause links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
@@ -609,12 +609,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX029I" type="INFO">
-    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX030W" type="WARN">
-    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a '%4' '%2'. This may cause links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
@@ -660,12 +660,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX039W" type="WARN">
     <reason>Required cleanup area found.</reason>
-    <response>To remove this message and hide the content, build your content without using the DRAFT parameter.</response>
+    <response>To remove this message and hide the content, build without the DRAFT parameter.</response>
   </message>
 
   <message id="DOTX040I" type="INFO">
     <reason>Draft comment area found.</reason>
-    <response>To remove this message and hide the comments, build your content without using the DRAFT parameter.</response>
+    <response>To remove this message and hide the comments, build without the DRAFT parameter.</response>
   </message>
 
   <message id="DOTX041W" type="WARN">
@@ -709,8 +709,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX050W" type="WARN">
-    <reason>Default ID "org.sample.help.doc" is used for Eclipse plug-in.</reason>
-    <response>If you want to use your own plug-in ID, please specify it using the @id attribute on your map.</response>
+    <reason>The default ID "org.sample.help.doc" is used for the Eclipse plug-in.</reason>
+    <response>To use your own plug-in ID, specify it using the @id attribute on the map.</response>
   </message>
 
   <message id="DOTX052W" type="WARN">
@@ -764,8 +764,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX063W" type="WARN">
-    <reason>The DITA document '%1' is linked to from your content, but not referenced by a &lt;topicref&gt; element in the map.</reason>
-    <response>Include the topic in your map to avoid a broken link.</response>
+    <reason>The DITA document '%1' is linked to from the content, but not referenced by a &lt;topicref&gt; element in the map.</reason>
+    <response>Include the topic in the map to avoid a broken link.</response>
   </message>
 
   <message id="DOTX064W" type="WARN">
@@ -781,7 +781,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX066W" type="WARN">
     <reason>Template '%1' is deprecated.</reason>
-    <response>Remove references to this template from your custom XSLT or plug-ins.</response>
+    <response>Remove references to this template from the custom XSLT or plug-ins.</response>
   </message>
 
   <message id="DOTX067E" type="ERROR">
@@ -796,12 +796,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX069W" type="WARN">
     <reason>Template mode '%1' is deprecated.</reason>
-    <response>Remove references to this template mode from your custom XSLT or plug-ins.</response>
+    <response>Remove references to this template mode from the custom XSLT or plug-ins.</response>
   </message>
 
   <message id="DOTX070W" type="WARN">
     <reason>Target '%1' is deprecated.</reason>
-    <response>Remove references to this target from your custom Ant files.</response>
+    <response>Remove references to this target from the custom Ant files.</response>
   </message>
 
   <message id="DOTX071E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -507,8 +507,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX010E" type="ERROR">
-    <reason>Unable to find the @conref attribute value '%1'.</reason>
-    <response>Check '%1' to see if the target exists.</response>
+    <reason>Unable to find the @conref target '%1'.</reason>
+    <response>Check '%1' to see if the target resource exists.</response>
   </message>
 
   <message id="DOTX011W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -157,7 +157,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 3.5 -->
   <message id="DOTJ029I" type="INFO">
     <reason>No @domains attribute was found for the &lt;%1&gt; element.</reason>
-    <response>This generally indicates that the DTD or schema was not developed properly according to the DITA specification.</response>
+    <response>This generally indicates that the grammar files (such as DTDs or schemas) were not developed properly according to the DITA specification.</response>
   </message>
 
   <message id="DOTJ030I" type="INFO">
@@ -401,12 +401,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ078F" type="FATAL">
     <reason>The input resource '%1' cannot be loaded.</reason>
-    <response>Make sure the grammar files for this document type are properly referenced and installed.</response>
+    <response>Make sure the grammar files (such as DTDs or schemas) for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ079E" type="ERROR">
     <reason>The '%1' resource cannot be loaded.</reason>
-    <response>Make sure the grammar files for this document type are properly referenced and installed.</response>
+    <response>Make sure the grammar files (such as DTDs or schemas) for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ080W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -26,8 +26,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA004F" type="FATAL">
-    <reason>Invalid DITA topic extension '%1'.</reason>
-    <response>Supported values are '.dita' and '.xml'.</response>
+    <reason>Invalid file name extension '%1'.</reason>
+    <response>The '.dita' and '.xml' file name extensions are supported for DITA topics.</response>
   </message>
 
   <message id="DOTA011W" type="WARN">
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA012W" type="WARN">
     <reason>The '%1' argument is deprecated.</reason>
-    <response>Use the argument '%2' instead.</response>
+    <response>Use the '%2' argument instead.</response>
   </message>
 
   <message id="DOTA013F" type="FATAL">
@@ -47,7 +47,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA014W" type="WARN">
     <reason>The @%1 attribute is deprecated.</reason>
-    <response>Use @%2 instead.</response>
+    <response>Use the @%2 attribute instead.</response>
   </message>
 
   <message id="DOTA015F" type="FATAL">
@@ -223,8 +223,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ043W" type="WARN">
-    <reason>The conref push function is trying to replace an element that does not exist ('%1' element in the '%2' resource).</reason>
-    <response></response>
+    <reason>The conref push function is trying to replace an element &lt;%1&gt; that does not exist in the '%2' resource.</reason>
+    <response>Update the reference to point to a valid target.</response>
   </message>
 
   <message id="DOTJ044W" type="WARN">
@@ -269,14 +269,14 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ052E" type="ERROR">
-    <reason>Code reference charset '%1' not supported.</reason>
+    <reason>Unsupported code reference charset '%1'.</reason>
     <response>See the documentation for supported character set values on the @format attribute.</response>
   </message>
 
   <!-- Obsolete since 2.3 -->
   <message id="DOTJ053W" type="WARN">
     <reason>The input resource '%1' is not a valid DITA filename.</reason>
-    <response>Check '%1' to see if it is correct. The '.dita' and '.xml' extensions are supported for DITA topics.</response>
+    <response>Check '%1' to see if it is correct. The '.dita' and '.xml' file name extensions are supported for DITA topics.</response>
   </message>
 
   <message id="DOTJ054E" type="ERROR">
@@ -286,12 +286,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ055E" type="ERROR">
     <reason>Invalid key name '%1'.</reason>
-    <response></response>
+    <response>Check the reference to see if the target exists.</response>
   </message>
 
   <message id="DOTJ056E" type="ERROR">
-    <reason>Invalid xml:lang '%1'.</reason>
-    <response></response>
+    <reason>Invalid @xml:lang attribute value '%1'.</reason>
+    <response>Check the correct value for the target language.</response>
   </message>
 
   <message id="DOTJ057E" type="ERROR">
@@ -326,7 +326,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ063E" type="ERROR">
     <reason>The @cols attribute is set to '%1' but the number of &lt;colspec&gt; elements was '%2'.</reason>
-    <response>Verify the number of columns in the table.</response>
+    <response>Check the number of columns in the table.</response>
   </message>
 
   <message id="DOTJ064W" type="WARN">
@@ -743,7 +743,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX058W" type="WARN">
     <reason>No glossary entry found for the '%1' key on the '%2' element.</reason>
-    <response>Verify display text and hover text for terms and abbreviations.</response>
+    <response>Check display text and hover text for terms and abbreviations.</response>
   </message>
 
   <message id="DOTX060W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -141,7 +141,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ025E" type="ERROR">
-    <reason>The input to the "topic merge" transform process could not be found.</reason>
+    <reason>The input to the "topic merge" transform process cannot be found.</reason>
     <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
 
@@ -404,12 +404,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ078F" type="FATAL">
-    <reason>The input resource '%1' could not be loaded.</reason>
+    <reason>The input resource '%1' cannot be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
   </message>
 
   <message id="DOTJ079E" type="ERROR">
-    <reason>The '%1' resource could not be loaded.</reason>
+    <reason>The '%1' resource cannot be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
   </message>
 
@@ -434,7 +434,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ084E" type="ERROR">
-    <reason>Couldn’t read '%1' with the '%2' character set.</reason>
+    <reason>Cannot read '%1' with the '%2' character set.</reason>
     <response>Save the file with '%2' encoding.</response>
   </message>
 
@@ -506,7 +506,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- As of 2012-06-13, DOTX009W is only called for HTML Help and map2htmtoc -->
   <message id="DOTX009W" type="WARN">
-    <reason>Could not retrieve a title from '%1'. Using '%2' instead.</reason>
+    <reason>Cannot retrieve a title from '%1'. Using '%2' instead.</reason>
     <response></response>
   </message>
 
@@ -646,7 +646,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX036E" type="ERROR">
-    <reason>Unable to generate link text for a cross reference to a dlentry (the dlentry or term could not be found): '%1'.</reason>
+    <reason>Unable to generate link text for a cross reference to a dlentry (the dlentry or term cannot be found): '%1'.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -119,13 +119,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ021E" type="ERROR">
-    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
+    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
     <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
-    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
+    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
     <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
@@ -140,18 +140,18 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ025E" type="ERROR">
-    <reason>The input to the "topic merge" process cannot be found.</reason>
+    <reason>The input to the 'topic merge' process cannot be found.</reason>
     <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
   </message>
 
   <message id="DOTJ026E" type="ERROR">
-    <reason>The "topic merge" process did not generate any output.</reason>
+    <reason>The 'topic merge' process did not generate any output.</reason>
     <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
   </message>
 
   <message id="DOTJ028E" type="ERROR">
     <reason>No @format attribute was found on a reference to the '%1' resource, which does not appear to be DITA.</reason>
-    <response>If this is not a DITA resource, set the @format attribute to an appropriate value; otherwise set the @format attribute to "dita".</response>
+    <response>If this is not a DITA resource, set the @format attribute to an appropriate value; otherwise set the @format attribute to 'dita'.</response>
   </message>
 
   <!-- Deprecated since 3.5 -->
@@ -183,7 +183,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ035F" type="FATAL">
     <reason>The '%1' resource is outside the scope of the input directory.</reason>
-    <response>To lower the severity level, use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the '%1' resource to the directory where the input map or topic is stored.</response>
+    <response>To lower the severity level, use the Ant parameter 'outer.control', and set the value to 'warn' or 'quiet'. Otherwise, move the '%1' resource to the directory where the input map or topic is stored.</response>
   </message>
 
   <message id="DOTJ036W" type="WARN">
@@ -203,24 +203,24 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ039E" type="ERROR">
-    <reason>There is no target specified for the conref push action "pushafter".</reason>
+    <reason>There is no target specified for the conref push action 'pushafter'.</reason>
     <response>Please specify @conref="pushtarget" and @conaction="mark" on the element that precedes the current element.</response>
   </message>
 
   <message id="DOTJ040E" type="ERROR">
-    <reason>An element uses @conaction="replace", but a @conref attribute is not found in the expected location.</reason>
+    <reason>An element uses the conref action 'pushreplace', but no @conref attribute is found in the expected location.</reason>
     <response></response>
   </message>
 
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
   <message id="DOTJ041E" type="ERROR">
-    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
-    <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
+    <response>The value must contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
   <message id="DOTJ042E" type="ERROR">
     <reason>Two elements both use conref push to replace the target '%1'.</reason>
-    <response>Please delete one of the duplicate "replace" actions.</response>
+    <response>Please delete one of the duplicate 'replace' actions.</response>
   </message>
 
   <message id="DOTJ043W" type="WARN">
@@ -228,10 +228,9 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
-  <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ044W" type="WARN">
-    <reason>There is a redundant conref action "pushbefore".</reason>
-    <response>Please make sure that "mark" and "pushbefore" occur in pairs.</response>
+    <reason>There is a redundant conref action 'pushbefore'.</reason>
+    <response>Please make sure that 'mark' and 'pushbefore' occur in pairs.</response>
   </message>
 
   <message id="DOTJ045I" type="INFO">
@@ -240,7 +239,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ046E" type="ERROR">
-    <reason>The @conkeyref attribute value "%1" cannot be resolved because it does not contain a key or the key is not defined.</reason>
+    <reason>The @conkeyref attribute value '%1' cannot be resolved because it does not contain a key or the key is not defined.</reason>
     <response>The build will use the @conref attribute for fallback, if one exists.</response>
   </message>
 
@@ -278,7 +277,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Obsolete since 2.3 -->
   <message id="DOTJ053W" type="WARN">
     <reason>The input resource '%1' is not a valid DITA filename.</reason>
-    <response>Check '%1' to see if it is correct. The extensions ".dita" or ".xml" are supported for DITA topics.</response>
+    <response>Check '%1' to see if it is correct. The '.dita' and '.xml' extensions are supported for DITA topics.</response>
   </message>
 
   <message id="DOTJ054E" type="ERROR">
@@ -297,7 +296,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ057E" type="ERROR">
-    <reason>The @id attribute value "%1" is not unique within the topic that contains it.</reason>
+    <reason>The @id attribute value '%1' is not unique within the topic that contains it.</reason>
     <response></response>
   </message>
 
@@ -318,7 +317,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ061E" type="ERROR">
     <reason>Topic reference target is a DITA map but the @format attribute has not been set.</reason>
-    <response>Set the @format attribute value to "ditamap".</response>
+    <response>Set the @format attribute value to 'ditamap'.</response>
   </message>
 
   <message id="DOTJ062E" type="ERROR">
@@ -332,8 +331,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ064W" type="WARN">
-    <reason>The @chunk attribute uses both "to-content" and "by-topic" that conflict with each other.</reason>
-    <response>Ignoring the "by-topic" token.</response>
+    <reason>The @chunk attribute uses both 'to-content' and 'by-topic' that conflict with each other.</reason>
+    <response>Ignoring the 'by-topic' token.</response>
   </message>
 
   <message id="DOTJ065I" type="INFO">
@@ -352,7 +351,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ068E" type="ERROR">
-    <reason>Conref action "mark" without conref target.</reason>
+    <reason>Conref action 'mark' without conref target.</reason>
     <response></response>
   </message>
 
@@ -373,12 +372,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ072E" type="ERROR">
     <reason>Email link without correct @format attribute.</reason>
-    <response>Using @format attribute value "email".</response>
+    <response>Using @format attribute value 'email'.</response>
   </message>
 
   <message id="DOTJ073E" type="ERROR">
     <reason>Email link without correct @scope attribute.</reason>
-    <response>Using @scope attribute value "external".</response>
+    <response>Using @scope attribute value 'external'.</response>
   </message>
 
   <message id="DOTJ074W" type="WARN">
@@ -388,7 +387,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ075W" type="WARN">
     <reason>Absolute link '%1' without correct @scope attribute.</reason>
-    <response>Using @scope attribute value "external".</response>
+    <response>Using @scope attribute value 'external'.</response>
   </message>
 
   <message id="DOTJ076W" type="WARN">
@@ -417,7 +416,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ081W" type="WARN">
-    <reason>Ignoring empty @conref attribute: conref="".</reason>
+    <reason>Ignoring empty @conref attribute.</reason>
     <response></response>
   </message>
 
@@ -447,7 +446,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ087W" type="WARN">
-    <reason>Found @chunk attribute with value "%1" inside combine chunk.</reason>
+    <reason>Found @chunk attribute with value '%1' inside combine chunk.</reason>
     <response>Ignoring chunk operation.</response>
   </message>
 
@@ -467,7 +466,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX003I" type="INFO">
     <reason>The @anchorref attribute should either reference another DITA map or an Eclipse XML TOC file.</reason>
-    <response>The value "%1" does not appear to reference either.</response>
+    <response>The value '%1' does not appear to reference either.</response>
   </message>
 
   <message id="DOTX004I" type="INFO">
@@ -481,13 +480,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX006E" type="ERROR">
-    <reason>Unknown file name extension in @href attribute value "%1".</reason>
+    <reason>Unknown file name extension in @href attribute value '%1'.</reason>
     <response>References to non-DITA resources should set the @format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
 
   <message id="DOTX007I" type="INFO">
     <reason>Only DITA topics, HTML files, and images may be included in the compiled CHM file. The reference to '%1' will be ignored.</reason>
-    <response>To remove this message, set the @toc attribute to "no" or the @processing-role attribute to "resource-only" on the topic reference.</response>
+    <response>To remove this message, set the @toc attribute to 'no' or the @processing-role attribute to 'resource-only' on the topic reference.</response>
   </message>
 
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
@@ -509,12 +508,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX010E" type="ERROR">
-    <reason>Unable to find target for @conref="%1".</reason>
-    <response></response>
+    <reason>Unable to find the @conref attribute value '%1'.</reason>
+    <response>Check '%1' to see if the target exists.</response>
   </message>
 
   <message id="DOTX011W" type="WARN">
-    <reason>There is more than one possible target for the @conref attribute value "%1". Only the first will be used.</reason>
+    <reason>There is more than one possible target for the @conref attribute value '%1'. Only the first will be used.</reason>
     <response>Remove the duplicate ID in the referenced resource.</response>
   </message>
 
@@ -531,13 +530,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX014E" type="ERROR">
-    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
     <response>Conref references to a map element should contain '#' followed by an ID, such as 'mymap.ditamap#mytopicrefid'.</response>
   </message>
 
   <message id="DOTX015E" type="ERROR">
-    <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
-    <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
+    <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
+    <response>The value must contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
 
   <message id="DOTX016W" type="WARN">
@@ -548,18 +547,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- Should likely be "warning" instead of "error", as related toolkit problems were fixed in very early releases.
        Now this serves only to catch likely problems with the source content. Keeping as "error" to avoid meaningless churn. -->
   <message id="DOTX017E" type="ERROR">
-    <reason>Found a link or cross reference with an empty @href attribute: href="".</reason>
+    <reason>Found a link or cross reference with an empty @href attribute.</reason>
     <response>Remove the empty @href attribute or provide a value.</response>
   </message>
 
   <!-- 018 currently not used, commented out due to SF bug 1771123 -->
   <message id="DOTX018I" type="INFO">
-    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
   <message id="DOTX019W" type="WARN">
-    <reason>The @type attribute on a topicref was set to "%1", but the topicref references a '%2' topic. This may cause links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value "%1" may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
@@ -649,7 +648,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX037W" type="WARN">
-    <reason>No title found for this document; using "***" as HTML page title.</reason>
+    <reason>No title found for this document; using '***' as HTML page title.</reason>
     <response></response>
   </message>
 
@@ -709,7 +708,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX050W" type="WARN">
-    <reason>The default ID "org.sample.help.doc" is used for the Eclipse plug-in.</reason>
+    <reason>The default ID 'org.sample.help.doc' is used for the Eclipse plug-in.</reason>
     <response>To use your own plug-in ID, specify it using the @id attribute on the map.</response>
   </message>
 
@@ -729,8 +728,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX055W" type="WARN">
-    <reason>A customized stylesheet uses the deprecated "flagit" template. Conditional processing is no longer supported using this template.</reason>
-    <response>Please update the stylesheet to use the "start-flagit" template instead of the "flagit" template.</response>
+    <reason>A customized stylesheet uses the deprecated 'flagit' template. Conditional processing is no longer supported using this template.</reason>
+    <response>Please update the stylesheet to use the 'start-flagit' template instead of the 'flagit' template.</response>
   </message>
 
   <message id="DOTX056W" type="WARN">
@@ -754,7 +753,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>The @id attribute value "%1" was used on a &lt;topicref&gt; element, but it did not reference a topic element.</reason>
+    <reason>The @id attribute value '%1' was used on a &lt;topicref&gt; element, but it did not reference a topic element.</reason>
     <response>The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</response>
   </message>
 
@@ -769,13 +768,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX064W" type="WARN">
-    <reason>The @copy-to attribute value "%1" uses the name of a resource that already exists, so this attribute is ignored.</reason>
+    <reason>The @copy-to attribute value '%1' uses the name of a resource that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
 
   <message id="DOTX065W" type="WARN">
-    <reason>Two unique source files each specify a @copy-to attribute value "%2", which results in a collision. The value associated with
-      @href value "%1" will be ignored.</reason>
+    <reason>Two unique source files each specify a @copy-to attribute value '%2', which results in a collision. The value associated with
+      @href value '%1' will be ignored.</reason>
     <response></response>
   </message>
 
@@ -811,7 +810,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX071W" type="WARN">
     <reason>Parameter '%1' on template '%2' is deprecated.</reason>
-    <response>Use parameter "%3" instead.</response>
+    <response>Use parameter '%3' instead.</response>
   </message>
 
   <message id="DOTX072I" type="INFO">
@@ -825,7 +824,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX074W" type="WARN">
-    <reason>No formatting defined for unknown @class attribute value "%1".</reason>
+    <reason>No formatting defined for unknown @class attribute value '%1'.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -754,7 +754,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>The @id attribute value '%1' is defined on a &lt;topicref&gt; element, but it does not reference a topic element.</reason>
+    <reason>The @href attribute value '%1' contains a fragment identifier, but it does not reference a topic element.</reason>
     <response>The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -283,7 +283,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ054E" type="ERROR">
-    <reason>Unable to parse invalid %1 attribute value "%2"</reason>
+    <reason>Unable to parse invalid %1 attribute value "%2".</reason>
     <response></response>
   </message>
 
@@ -428,7 +428,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ083E" type="ERROR">
-    <reason>The resource referenced as %1 is capitalized differently on disk</reason>
+    <reason>The resource referenced as %1 is capitalized differently on disk.</reason>
     <response></response>
   </message>
 
@@ -630,22 +630,22 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX033E" type="ERROR">
-    <reason>Unable to generate link text for a cross reference to a list item: '%1'</reason>
+    <reason>Unable to generate link text for a cross reference to a list item: '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTX034E" type="ERROR">
-    <reason>Unable to generate link text for a cross reference to an unordered list item: '%1'</reason>
+    <reason>Unable to generate link text for a cross reference to an unordered list item: '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTX035E" type="ERROR">
-    <reason>Unable to generate the correct number for a cross reference to a footnote: '%1'</reason>
+    <reason>Unable to generate the correct number for a cross reference to a footnote: '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTX036E" type="ERROR">
-    <reason>Unable to generate link text for a cross reference to a dlentry (the dlentry or term could not be found): '%1'</reason>
+    <reason>Unable to generate link text for a cross reference to a dlentry (the dlentry or term could not be found): '%1'.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -806,7 +806,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX071E" type="ERROR">
     <reason>Conref range: Unable to find conref range end element with ID '%1'.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="DOTX071W" type="WARN">
@@ -816,17 +816,17 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX072I" type="INFO">
     <reason>Ignoring navtitle within topicgroup.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="DOTX073I" type="INFO">
     <reason>Removing broken link to '%1'.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="DOTX074W" type="WARN">
     <reason>No formatting defined for unknown @class attribute value "%1".</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="DOTX075W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -105,7 +105,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ014W" type="WARN">
-    <reason>Found an indexterm element with no content.</reason>
+    <reason>Found an &lt;indexterm&gt; element with no content.</reason>
     <response>Setting the term to ***.</response>
   </message>
 
@@ -157,12 +157,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Deprecated since 3.5 -->
   <message id="DOTJ029I" type="INFO">
-    <reason>No @domains attribute was found for element '&lt;%1&gt;'.</reason>
-    <response>This generally indicates that your DTD or Schema was not developed properly according to the DITA specification.</response>
+    <reason>No @domains attribute was found for the &lt;%1&gt; element.</reason>
+    <response>This generally indicates that your DTD or schema was not developed properly according to the DITA specification.</response>
   </message>
 
   <message id="DOTJ030I" type="INFO">
-    <reason>No @class attribute for was found for element '&lt;%1&gt;'.</reason>
+    <reason>No @class attribute was found for the &lt;%1&gt; element.</reason>
     <response>The element will be processed as an unknown or non-DITA element.</response>
   </message>
 
@@ -258,7 +258,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ049W" type="WARN">
-    <reason>The @%1 attribute value '%3' on element '%2' does not comply with the specified subject scheme.</reason>
+    <reason>The @%1 attribute value '%3' on the &lt;%2&gt; element does not comply with the specified subject scheme.</reason>
     <response>According to the subject scheme map, the following values are valid for the @%1 attribute: '%4'</response>
   </message>
 
@@ -330,7 +330,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ063E" type="ERROR">
-    <reason>The @cols attribute is set to '%1' but the number of colspec elements was '%2'.</reason>
+    <reason>The @cols attribute is set to '%1' but the number of &lt;colspec&gt; elements was '%2'.</reason>
     <response></response>
   </message>
 
@@ -365,7 +365,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ070I" type="INFO">
-    <reason>Invalid 'class' attribute '%1' for was found for element '&lt;%2&gt;'.</reason>
+    <reason>An invalid @class attribute '%1' for was found for the &lt;%2&gt; element.</reason>
     <response>The element will be processed as an unknown or non-DITA element.</response>
   </message>
 
@@ -445,7 +445,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ086W" type="WARN">
-    <reason>Split @chunk attribute found on '&lt;%1>' element that does not reference a topic.</reason>
+    <reason>Split @chunk attribute found on &lt;%1&gt; element that does not reference a topic.</reason>
     <response>Ignoring chunk operation.</response>
   </message>
 
@@ -474,8 +474,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX004I" type="INFO">
-    <reason>Found a navref element that does not reference anything.</reason>
-    <response>The navref element should either reference another dita map or an Eclipse XML file.</response>
+    <reason>Found a &lt;navref&gt; element that does not reference anything.</reason>
+    <response>The &lt;navref&gt; element should either reference another DITA map or an Eclipse XML file.</response>
   </message>
 
   <message id="DOTX005E" type="ERROR">
@@ -529,7 +529,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX013E" type="ERROR">
-    <reason>A element with the @conref attribute set to '%1' indirectly includes itself, which results in an infinite loop.</reason>
+    <reason>An element with the @conref attribute set to '%1' indirectly includes itself, which results in an infinite loop.</reason>
     <response></response>
   </message>
 
@@ -612,12 +612,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX029I" type="INFO">
-    <reason>The @type attribute on a '%1' element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX030W" type="WARN">
-    <reason>The @type attribute on a '%1' element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
@@ -657,8 +657,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX038I" type="INFO">
-    <reason>The @longdescref attribute on tag '%1' will be ignored. Accessibility for object elements needs to be handled another way.</reason>
-    <response></response>
+    <reason>The @longdescref attribute on the &lt;%1&gt; element will be ignored.</reason>
+    <response>Accessibility for object elements needs to be handled another way.</response>
   </message>
 
   <message id="DOTX039W" type="WARN">
@@ -672,7 +672,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX041W" type="WARN">
-    <reason>Found more than one title element in a '%1' element. Using the first one for the %1's title.</reason>
+    <reason>Found more than one &lt;title&gt; element in a &lt;%1&gt; element. Using the first one as the element title.</reason>
     <response></response>
   </message>
 
@@ -687,12 +687,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX044E" type="ERROR">
-    <reason>The area element in an image map does not specify a link target.</reason>
-    <response>Please add an xref element with a link target to the area element.</response>
+    <reason>The &lt;area&gt; element in an image map does not specify a link target.</reason>
+    <response>Please add an &lt;xref&gt; element with a link target to the &lt;area&gt; element.</response>
   </message>
 
   <message id="DOTX045W" type="WARN">
-    <reason>The area element in an image map should specify link text for greater accessibility.</reason>
+    <reason>The &lt;area&gt; element in an image map should specify link text for better accessibility.</reason>
     <response>Link text should be specified directly when the target is not a local DITA resource.</response>
   </message>
 
@@ -752,12 +752,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX060W" type="WARN">
-    <reason>Key '%1' was used in an abbreviated-form element, but the key is not associated with a glossary entry.</reason>
+    <reason>The '%1' key was used in an &lt;abbreviated-form&gt; element, but the key is not associated with a glossary entry.</reason>
     <response>Abbreviated-form should ONLY be used to reference to a glossary entry.</response>
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>ID '%1' was used in topicref tag but did not reference a topic element. The @href attribute on a topicref element should only reference topic level elements.</reason>
+    <reason>The @id attribute value '%1' was used on a &lt;topicref&gt; element, but it did not reference a topic element. The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</reason>
     <response></response>
   </message>
 
@@ -793,8 +793,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX068W" type="WARN">
-    <reason>A topicref element that references a map contains child topicref elements.</reason>
-    <response>Child topicref elements are ignored.</response>
+    <reason>A &lt;topicref&gt; element that references a map contains child &lt;topicref&gt; elements.</reason>
+    <response>Child &lt;topicref&gt; elements are ignored.</response>
   </message>
 
   <message id="DOTX069W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -126,13 +126,13 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
-    <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file.</reason>
-    <response>Please check the file '%1' and the ditaval file to see if this is the intended result.</response>
+    <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the DITAVAL file.</reason>
+    <response>Please check the '%1' file and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <message id="DOTJ022F" type="FATAL">
     <reason>Failed to parse the input file '%1' because all of its content has been filtered out.</reason>
-    <response>This will happen if the input file has filter conditions on the root element, and a ditaval excludes all content based on those conditions.</response>
+    <response>This will happen if the input file has filter conditions on the root element, and a DITAVAL file excludes all content based on those conditions.</response>
   </message>
 
   <message id="DOTJ023E" type="ERROR">
@@ -167,8 +167,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ031I" type="INFO">
-    <reason>No specified rule for '%1' was found in the ditaval file. This value will use the default action, or a parent prop action if specified.</reason>
-    <response>To remove this message, you can specify a rule for '%1' in the ditaval file.</response>
+    <reason>No specified rule for '%1' was found in the DITAVAL file. This value will use the default action, or a parent prop action if specified.</reason>
+    <response>To remove this message, you can specify a rule for '%1' in the DITAVAL file.</response>
   </message>
 
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
@@ -185,12 +185,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ035F" type="FATAL">
-    <reason>The file '%1' is outside the scope of the input dita/map directory.</reason>
-    <response>If you want to lower the severity level, please use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file '%1' into the input dita/map directory.</response>
+    <reason>The file '%1' is outside the scope of the input resource directory.</reason>
+    <response>To lower the severity level, use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file '%1' into the directory where the input map or topic is stored.</response>
   </message>
 
   <message id="DOTJ036W" type="WARN">
-    <reason>The file '%1' is outside the scope of the input dita/map directory.</reason>
+    <reason>The file '%1' is outside the scope of the input resource directory.</reason>
     <response></response>
   </message>
 
@@ -464,7 +464,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX002W" type="WARN">
-    <reason>The @title attribute or element in the ditamap is required for Eclipse output.</reason>
+    <reason>The @title attribute or element in the DITA map is required for Eclipse output.</reason>
     <response></response>
   </message>
 
@@ -707,7 +707,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX049I" type="INFO">
-    <reason>References to non-dita files will be ignored by the PDF, ODT, and RTF output transforms.</reason>
+    <reason>References to non-DITA files will be ignored by the PDF, ODT, and RTF output transforms.</reason>
     <response></response>
   </message>
 
@@ -728,7 +728,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX054W" type="WARN">
     <reason>Conflict text style is applied on the current element based on DITAVAL flagging rules.</reason>
-    <response>Please check ditaval and dita source to make sure there is no style conflict on the element which needs to be flagged.</response>
+    <response>Please check the DITAVAL and DITA source files to make sure there is no style conflict on the element that needs to be flagged.</response>
   </message>
 
   <message id="DOTX055W" type="WARN">
@@ -767,8 +767,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX063W" type="WARN">
-    <reason>The dita document '%1' is linked to from your content, but is not referenced by a topicref tag in the ditamap file.</reason>
-    <response>Include the topic in your map to avoid a broken link.</response>
+    <reason>The DITA document '%1' is linked to from your content, but not referenced by a &lt;topicref&gt; element in the map.</reason>
+    <response>Include the topic in your map file to avoid a broken link.</response>
   </message>
 
   <message id="DOTX064W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -204,12 +204,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ039E" type="ERROR">
     <reason>There is no target specified for the conref push action 'pushafter'.</reason>
-    <response>Please specify @conref="pushtarget" and @conaction="mark" on the element that precedes the current element.</response>
+    <response>Please specify a @conref target and set the 'mark' @conaction on the element that precedes the current element.</response>
   </message>
 
   <message id="DOTJ040E" type="ERROR">
-    <reason>An element uses the conref action 'pushreplace', but no @conref attribute is found in the expected location.</reason>
-    <response></response>
+    <reason>An element uses the conref push action 'pushreplace', but no @conref attribute is defined.</reason>
+    <response>Please specify a @conref target with the ID of the content you want to replace.</response>
   </message>
 
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
@@ -229,7 +229,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ044W" type="WARN">
-    <reason>There is a redundant conref action 'pushbefore'.</reason>
+    <reason>There is a redundant conref push action 'pushbefore'.</reason>
     <response>Please make sure that 'mark' and 'pushbefore' occur in pairs.</response>
   </message>
 
@@ -531,7 +531,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX014E" type="ERROR">
     <reason>The @conref attribute value '%1' uses invalid syntax.</reason>
-    <response>Conref references to a map element should contain '#' followed by an ID, such as 'mymap.ditamap#mytopicrefid'.</response>
+    <response>Content references to a map element should contain '#' followed by an ID, such as 'mymap.ditamap#mytopicrefid'.</response>
   </message>
 
   <message id="DOTX015E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -20,11 +20,6 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
-  <message id="DOTA069F" type="FATAL">
-    <reason>Input file '%1' cannot be located or read.</reason>
-    <response>Ensure that file was specified properly and that you have permission to access it.</response>
-  </message>
-
   <message id="DOTA003F" type="FATAL">
     <reason>Cannot find the user specified XSLT stylesheet '%1'.</reason>
     <response></response>
@@ -60,6 +55,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Use property %2 instead.</response>
   </message>
 
+  <message id="DOTA069F" type="FATAL">
+    <reason>Input file '%1' cannot be located or read.</reason>
+    <response>Ensure that file was specified properly and that you have permission to access it.</response>
+  </message>
+
   <!-- Start of Java Messages -->
 
   <!-- DOTJ005F appears to indicate an internal programming error, failed to create
@@ -71,17 +71,17 @@ See the accompanying LICENSE file for applicable license.
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
+  <message id="DOTJ007E" type="ERROR">
+    <reason>Duplicate condition in filter file for rule '%1'.</reason>
+    <response>The first encountered condition will be used.</response>
+  </message>
+
   <message id="DOTJ007I" type="INFO">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
   </message>
 
   <message id="DOTJ007W" type="WARN">
-    <reason>Duplicate condition in filter file for rule '%1'.</reason>
-    <response>The first encountered condition will be used.</response>
-  </message>
-
-  <message id="DOTJ007E" type="ERROR">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
   </message>
@@ -117,15 +117,15 @@ See the accompanying LICENSE file for applicable license.
     <response>Check and see whether all prerequisite plug-ins are installed in toolkit.</response>
   </message>
 
+  <message id="DOTJ021E" type="ERROR">
+    <reason>File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.</reason>
+    <response></response>
+  </message>
+
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
     <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file.</reason>
     <response>Please check the file '%1' and the ditaval file to see if this is the intended result.</response>
-  </message>
-
-  <message id="DOTJ021E" type="ERROR">
-    <reason>File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.</reason>
-    <response></response>
   </message>
 
   <message id="DOTJ022F" type="FATAL">
@@ -491,19 +491,19 @@ See the accompanying LICENSE file for applicable license.
     <response>To remove this message, you can set the toc="no" or processing-role="resource-only" attribute on your topicref.</response>
   </message>
 
-  <!-- As of 20012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->
-  <message id="DOTX008W" type="WARN">
-    <reason>File '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
-    <response></response>
-  </message>
-
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
   <message id="DOTX008E" type="ERROR">
     <reason>File '%1' does not exist or cannot be loaded.</reason>
     <response></response>
   </message>
 
-  <!-- As of 20012-06-13, 009W is only called for HTML Help and map2htmtoc -->
+  <!-- As of 2012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->
+  <message id="DOTX008W" type="WARN">
+    <reason>File '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
+    <response></response>
+  </message>
+
+  <!-- As of 2012-06-13, DOTX009W is only called for HTML Help and map2htmtoc -->
   <message id="DOTX009W" type="WARN">
     <reason>Could not retrieve a title from '%1'. Using '%2' instead.</reason>
     <response></response>
@@ -804,14 +804,14 @@ See the accompanying LICENSE file for applicable license.
     <response>Remove references to this target from your custom Ant files.</response>
   </message>
 
-  <message id="DOTX071W" type="WARN">
-    <reason>Parameter "%1" on template "%2" is deprecated.</reason>
-    <response>Use parameter "%3" instead.</response>
-  </message>
-
   <message id="DOTX071E" type="ERROR">
     <reason>Conref range: Unable to find conref range end element with ID "%1".</reason>
     <response/>
+  </message>
+
+  <message id="DOTX071W" type="WARN">
+    <reason>Parameter "%1" on template "%2" is deprecated.</reason>
+    <response>Use parameter "%3" instead.</response>
   </message>
 
   <message id="DOTX072I" type="INFO">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -367,7 +367,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ071E" type="ERROR">
-    <reason>Cannot find the specified DITAVAL '%1'.</reason>
+    <reason>Cannot find the specified DITAVAL file '%1'.</reason>
     <response></response>
   </message>
 
@@ -382,7 +382,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ074W" type="WARN">
-    <reason>The @rev attribute cannot be used with prop filter.</reason>
+    <reason>The @rev attribute cannot be used with the &lt;prop&gt; filter.</reason>
     <response></response>
   </message>
 
@@ -413,7 +413,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ080W" type="WARN">
     <reason>Integrator configuration '%1' has been deprecated.</reason>
-    <response>Use plugin configuration '%1' instead.</response>
+    <response>Use plug-in configuration '%1' instead.</response>
   </message>
 
   <message id="DOTJ081W" type="WARN">
@@ -532,7 +532,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX014E" type="ERROR">
     <reason>The @conref attribute value "%1" uses invalid syntax.</reason>
-    <response>Conref references to a map element should contain '#' followed by an ID, such as mymap.ditamap#mytopicrefid.</response>
+    <response>Conref references to a map element should contain '#' followed by an ID, such as 'mymap.ditamap#mytopicrefid'.</response>
   </message>
 
   <message id="DOTX015E" type="ERROR">
@@ -674,7 +674,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX042I" type="INFO">
-    <reason>DITAVAL based flagging is not currently supported for inline phrases in XHTML; ignoring flag value on '%1' attribute.</reason>
+    <reason>DITAVAL-based flagging is not currently supported for inline phrases in XHTML; ignoring flag value on '%1' attribute.</reason>
     <response></response>
   </message>
 
@@ -694,7 +694,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX046W" type="WARN">
-    <reason>Area shape should be: default, rect, circle, poly, or blank (no value). The value '%1' is not recognized.</reason>
+    <reason>Area shape should be one of: default, rect, circle, poly, or blank (no value). The value '%1' is not recognized.</reason>
     <response></response>
   </message>
 
@@ -729,8 +729,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX055W" type="WARN">
-    <reason>Customized stylesheet uses deprecated template "flagit". Conditional processing is no longer supported using this template.</reason>
-    <response>Please update your stylesheet to use template "start-flagit" instead of deprecated template "flagit".</response>
+    <reason>A customized stylesheet uses the deprecated "flagit" template. Conditional processing is no longer supported using this template.</reason>
+    <response>Please update the stylesheet to use the "start-flagit" template instead of the "flagit" template.</response>
   </message>
 
   <message id="DOTX056W" type="WARN">
@@ -754,8 +754,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>The @id attribute value "%1" was used on a &lt;topicref&gt; element, but it did not reference a topic element. The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</reason>
-    <response></response>
+    <reason>The @id attribute value "%1" was used on a &lt;topicref&gt; element, but it did not reference a topic element.</reason>
+    <response>The @href attribute on a &lt;topicref&gt; element should only reference topic-level elements.</response>
   </message>
 
   <message id="DOTX062I" type="INFO">
@@ -774,8 +774,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX065W" type="WARN">
-    <reason>Two unique source files each specify @copy-to="%2", which results in a collision. The value associated with
-      @href="%1" is ignored.</reason>
+    <reason>Two unique source files each specify a @copy-to attribute value "%2", which results in a collision. The value associated with
+      @href value "%1" will be ignored.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 
@@ -14,27 +14,27 @@ See the accompanying LICENSE file for applicable license.
     <reason>"%1" is not a recognized transformation type.</reason>
     <response>Supported transformation types are <dita:extension id="dita.conductor.transtype.check" behavior="org.dita.dost.platform.ListTranstypeAction" separator=", "/>.</response>
   </message>
-  
+
   <message id="DOTA002F" type="FATAL">
     <reason>Input file is not specified, or is specified using the wrong parameter.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTA069F" type="FATAL">
     <reason>Input file '%1' cannot be located or read.</reason>
     <response>Ensure that file was specified properly and that you have permission to access it.</response>
   </message>
-  
+
   <message id="DOTA003F" type="FATAL">
     <reason>Cannot find the user specified XSLT stylesheet '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTA004F" type="FATAL">
     <reason>Invalid DITA topic extension '%1'.</reason>
     <response>Supported values are '.dita' and '.xml'.</response>
   </message>
-    
+
   <message id="DOTA011W" type="WARN">
     <reason>Argument "%1" is deprecated.</reason>
     <response>This argument is no longer supported in the toolkit.</response>
@@ -61,7 +61,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <!-- Start of Java Messages -->
-  
+
   <!-- DOTJ005F appears to indicate an internal programming error, failed to create
        a new module in ModuleFactory.java. This message should be updated
        to indicate it is an internal programming error and should be reported to the
@@ -70,12 +70,12 @@ See the accompanying LICENSE file for applicable license.
     <reason>Failed to create new instance for '%1'.</reason>
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>
   </message>
-  
+
   <message id="DOTJ007I" type="INFO">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
   </message>
-  
+
   <message id="DOTJ007W" type="WARN">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
@@ -85,49 +85,49 @@ See the accompanying LICENSE file for applicable license.
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
     <response>The first encountered condition will be used.</response>
   </message>
-  
+
   <!-- Would like to improve / shorten DOTJ009E but not sure how to modify. -->
   <message id="DOTJ009E" type="ERROR">
     <reason>Cannot overwrite file '%1' with file '%2'. The modified result may not be consumed by the following steps in the transform pipeline.</reason>
     <response>Check to see whether the file is locked by some other application during the transformation process.</response>
   </message>
-  
+
   <message id="DOTJ012F" type="FATAL">
     <reason>Failed to parse the input file '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ013E" type="ERROR">
     <reason>Failed to parse the referenced file '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ014W" type="WARN">
     <reason>Found an indexterm element with no content.</reason>
     <response>Setting the term to ***.</response>
   </message>
-  
+
   <message id="DOTJ018I" type="INFO">
     <reason>Log file '%1' was generated successfully in directory '%2'.</reason>
     <response>Any messages from the transformation process are available in the log file; additional details about each message are available in the DITA-OT documentation.</response>
   </message>
-  
+
   <message id="DOTJ020W" type="WARN">
     <reason>At least one plug-in in '%1' is required by plug-in '%2'. Plug-in '%2' cannot be loaded.</reason>
     <response>Check and see whether all prerequisite plug-ins are installed in toolkit.</response>
   </message>
-  
+
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
     <reason>File '%1' will not generate output since it is invalid or all of its content has been filtered out by the ditaval file.</reason>
     <response>Please check the file '%1' and the ditaval file to see if this is the intended result.</response>
   </message>
-  
+
   <message id="DOTJ021E" type="ERROR">
     <reason>File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ022F" type="FATAL">
     <reason>Failed to parse the input file '%1' because all of its content has been filtered out.</reason>
     <response>This will happen if the input file has filter conditions on the root element, and a ditaval excludes all content based on those conditions.</response>
@@ -137,12 +137,12 @@ See the accompanying LICENSE file for applicable license.
     <reason>Failed to get the specified image file '%1', so it will not be included with your output.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ025E" type="ERROR">
     <reason>The input to the "topic merge" transform process could not be found.</reason>
     <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
   </message>
-  
+
   <message id="DOTJ026E" type="ERROR">
     <reason>The "topic merge" did not generate any output.</reason>
     <response>Correct any earlier transform errors and try the build again, or see the DITA-OT documentation for additional causes.</response>
@@ -157,114 +157,114 @@ See the accompanying LICENSE file for applicable license.
   <message id="DOTJ029I" type="INFO">
     <reason>No 'domains' attribute was found for element '&lt;%1&gt;'.</reason>
     <response>This generally indicates that your DTD or Schema was not developed properly according to the DITA specification.</response>
-  </message> 
-  
+  </message>
+
   <message id="DOTJ030I" type="INFO">
     <reason>No 'class' attribute for was found for element '&lt;%1&gt;'.</reason>
     <response>The element will be processed as an unknown or non-DITA element.</response>
-  </message> 
-  
+  </message>
+
   <message id="DOTJ031I" type="INFO">
     <reason>No specified rule for '%1' was found in the ditaval file. This value will use the default action, or a parent prop action if specified.</reason>
     <response>To remove this message, you can specify a rule for '%1' in the ditaval file.</response>
-  </message> 
-  
+  </message>
+
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ033E" type="ERROR">
     <reason>No valid content is found in topicref '%1' during chunk processing.</reason>
     <response>Please specify an existing and valid topic for the topicref.</response>
-  </message> 
-  
+  </message>
+
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ034F" type="FATAL">
     <reason>Failed to parse the input file '%1' (the content of the file is not valid).</reason>
     <response>If the input file '%1' does not have a DOCTYPE declaration, please make sure that all class attributes are present in the file.</response>
   </message>
-  
+
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ035F" type="FATAL">
     <reason>The file "%1" is outside the scope of the input dita/map directory.</reason>
     <response>If you want to lower the severity level, please use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file "%1" into the input dita/map directory.</response>
   </message>
-  
+
   <message id="DOTJ036W" type="WARN">
     <reason>The file "%1" is outside the scope of the input dita/map directory.</reason>
     <response></response>
   </message>
-  
+
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ037W" type="WARN">
     <reason>The XML schema and DTD validation function of the parser is turned off.</reason>
     <response>Please make sure the input is normalized DITA with class attributes included, otherwise it will not be processed correctly.</response>
   </message>
-  
+
   <message id="DOTJ038E" type="ERROR">
     <reason>The tag "%1" is specialized from unrecognized metadata.</reason>
     <response>Please make sure that tag "%1" is specialized from an existing metadata tag in the core DITA vocabulary.</response>
   </message>
-  
+
   <message id="DOTJ039E" type="ERROR">
     <reason>There is no target specified for conref push action "pushafter".</reason>
     <response>Please add &lt;elementname conref="pushtarget" conaction="mark"&gt; before current element.</response>
   </message>
-  
+
   <message id="DOTJ040E" type="ERROR">
     <reason>An element uses the attribute conaction="replace", but a conref attribute is not found in the expected location.</reason>
     <response></response>
   </message>
-  
+
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
   <message id="DOTJ041E" type="ERROR">
     <reason>The attribute conref="%1" uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
-  
+
   <message id="DOTJ042E" type="ERROR">
     <reason>Two elements both use conref push to replace the target "%1".</reason>
     <response>Please delete one of the duplicate "replace" actions.</response>
   </message>
-  
+
   <message id="DOTJ043W" type="WARN">
     <reason>The conref push function is trying to replace an element that does not exist (element "%1" in file "%2").</reason>
     <response></response>
   </message>
-  
+
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ044W" type="WARN">
     <reason>There is a redundant conref action "pushbefore".</reason>
     <response>Please make sure that "mark" and "pushbefore" occur in pairs.</response>
   </message>
-  
+
   <message id="DOTJ045I" type="INFO">
     <reason>The key "%1" is defined more than once in the same map file.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ046E" type="ERROR">
     <reason>Conkeyref="%1" can not be resolved because it does not contain a key or the key is not defined.</reason>
     <response>The build will use the conref attribute for fallback, if one exists.</response>
   </message>
-  
+
   <message id="DOTJ047I" type="INFO">
     <reason>Unable to find key definition for key reference "%1" in root scope.</reason>
     <response>The href attribute may be used as fallback if it exists</response>
   </message>
-  
+
   <message id="DOTJ048I" type="INFO">
     <reason>Unable to find key definition for key reference "%1" in scope "%2".</reason>
     <response>The href attribute may be used as fallback if it exists</response>
   </message>
-  
+
   <message id="DOTJ049W" type="WARN">
     <reason>The attribute value %1="%3" on element "%2" does not comply with the specified subject scheme.</reason>
     <response>According to the subject scheme map, the following values are valid for the %1 attribute: %4</response>
   </message>
-  
+
   <message id="DOTJ050W" type="WARN">
     <reason>Found an &lt;index-see&gt; or &lt;index-see-also&gt; reference to the term '%1', but that term is not defined in the index.</reason>
     <response></response>
   </message>
-  
+
   <!-- Long term, would like to split this into two messages. One for file not found, another for file outside the scope of the map. -->
   <message id="DOTJ051E" type="ERROR">
     <reason>Unable to load target for coderef "%1".</reason>
@@ -281,37 +281,37 @@ See the accompanying LICENSE file for applicable license.
     <reason>Input file '%1' is not valid DITA file name.</reason>
     <response>Please check '%1' to see if it is correct. The extensions ".dita" or ".xml" are supported for DITA topics.</response>
   </message>
-  
+
   <message id="DOTJ054E" type="ERROR">
     <reason>Unable to parse invalid %1 attribute value "%2"</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ055E" type="ERROR">
     <reason>Invalid key name "%1".</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ056E" type="ERROR">
     <reason>Invalid xml:lang "%1".</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ057E" type="ERROR">
     <reason>The id attribute value "%1" is not unique within the topic that contains it.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ058E" type="ERROR">
     <reason>Both %1 and %2 attributes defined.</reason>
     <response>A single element may not contain both generalized and specialized values for the same attribute.</response>
   </message>
-  
+
   <message id="DOTJ059E" type="ERROR">
     <reason>Invalid key scope name "%1".</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ060W" type="WARN">
     <reason>Key "%1" was used in conkeyref but is not bound to a DITA topic or map.</reason>
     <response>Cannot resolve conkeyref value "%2" as a valid conref reference.</response>
@@ -321,7 +321,7 @@ See the accompanying LICENSE file for applicable license.
     <reason>Topic reference target is a DITA map but format attribute has not been set.</reason>
     <response>Set format attribute value to "ditamap".</response>
   </message>
-    
+
   <message id="DOTJ062E" type="ERROR">
     <reason>Invalid %1 attribute value "%2".</reason>
     <response></response>
@@ -341,12 +341,12 @@ See the accompanying LICENSE file for applicable license.
     <reason>Branch filter generated topic %1 used more than once.</reason>
     <response>Renaming %1 to %2.</response>
   </message>
-  
+
   <message id="DOTJ066E" type="ERROR">
     <reason>No id attribute on topic type element %1.</reason>
     <response>Using generated id %2.</response>
   </message>
-  
+
   <message id="DOTJ067E" type="ERROR">
     <reason>No id attribute on topic type element %1.</reason>
     <response></response>
@@ -396,17 +396,17 @@ See the accompanying LICENSE file for applicable license.
     <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ077F" type="FATAL">
     <reason>Invalid action attribute '%1' on DITAVAL property.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTJ078F" type="FATAL">
     <reason>Input file '%1' could not be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
   </message>
-  
+
   <message id="DOTJ079E" type="ERROR">
     <reason>File '%1' could not be loaded.</reason>
     <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
@@ -460,37 +460,37 @@ See the accompanying LICENSE file for applicable license.
     <reason>No string named '%1' was found for language '%2'. Using the default language '%3'.</reason>
     <response>Add a mapping between default language and desired language for the string '%1'.</response>
   </message>
-  
+
   <message id="DOTX002W" type="WARN">
     <reason>The title element or attribute in the ditamap is required for Eclipse output.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX003I" type="INFO">
     <reason>The anchorref attribute should either reference another dita map or an Eclipse XML TOC file. The value '%1' does not appear to reference either.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX004I" type="INFO">
     <reason>Found a navref element that does not reference anything.</reason>
     <response>The navref element should either reference another dita map or an Eclipse XML file.</response>
   </message>
-  
+
   <message id="DOTX005E" type="ERROR">
     <reason>Unable to find navigation title for reference to '%1'.</reason>
     <response>The build will use '%1' as the title in the Eclipse Table of Contents.</response>
   </message>
-  
+
   <message id="DOTX006E" type="ERROR">
     <reason>Unknown file extension in href="%1".</reason>
     <response>References to non-DITA resources should set the format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
-  
+
   <message id="DOTX007I" type="INFO">
     <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to "%1" will be ignored.</reason>
     <response>To remove this message, you can set the toc="no" or processing-role="resource-only" attribute on your topicref.</response>
   </message>
-  
+
   <!-- As of 20012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->
   <message id="DOTX008W" type="WARN">
     <reason>File '%1' cannot be loaded, and no navigation title is specified for the table of contents.</reason>
@@ -508,302 +508,302 @@ See the accompanying LICENSE file for applicable license.
     <reason>Could not retrieve a title from '%1'. Using '%2' instead.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX010E" type="ERROR">
     <reason>Unable to find target for conref="%1".</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX011W" type="WARN">
     <reason>There is more than one possible target for the reference conref="%1". Only the first will be used.</reason>
     <response>Remove the duplicate id in the referenced file.</response>
   </message>
-  
+
   <!-- This message can no longer appear, though the template for producing it remains in conrefImpl.xsl.
        Support for mismatched domains was added in release 1.5 or earlier. -->
   <message id="DOTX012W" type="WARN">
     <reason>When you conref another topic or an item in another topic, the domains attribute of the target topic must be equal to or a subset of the current topic's domains attribute.</reason>
     <response>Put your target under an appropriate domain. You can see the messages guide for more help.</response>
   </message>
-  
+
   <message id="DOTX013E" type="ERROR">
     <reason>A element with attribute conref="%1" indirectly includes itself, which results in an infinite loop.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX014E" type="ERROR">
     <reason>The attribute conref="%1" uses invalid syntax.</reason>
     <response>Conref references to a map element should contain '#' followed by an ID, such as mymap.ditamap#mytopicrefid.</response>
   </message>
-  
+
   <message id="DOTX015E" type="ERROR">
     <reason>The attribute conref="%1" uses invalid syntax.</reason>
     <response>The value should contain '#' followed by a topic or map ID, optionally followed by '/elemID' for a sub-topic element.</response>
   </message>
-  
+
   <message id="DOTX016W" type="WARN">
     <reason>A reference to "%2" appears to reference a DITA document, but the format attribute has inherited a value of "%1". The document will not be processed as DITA.</reason>
     <response></response>
   </message>
-  
+
   <!-- Should likely be "warning" instead of "error", as related toolkit problems were fixed in very early releases.
        Now this serves only to catch likely problems with the source content. Keeping as "error" to avoid meaningless churn. -->
   <message id="DOTX017E" type="ERROR">
     <reason>Found a link or cross reference with an empty href attribute (href="").</reason>
     <response>Remove the empty href attribute or provide a value.</response>
   </message>
-  
+
   <!-- 018 currently not used, commented out due to SF bug 1771123 -->
   <message id="DOTX018I" type="INFO">
     <reason>The type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX019W" type="WARN">
     <reason>The type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX020E" type="ERROR">
     <reason>Missing navtitle attribute or element for peer topic "%1".</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
-  
+
   <message id="DOTX021E" type="ERROR">
     <reason>Missing navtitle attribute or element for non-DITA resource "%1".</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
-  
+
   <message id="DOTX022W" type="WARN">
     <reason>Unable to retrieve navtitle from target: '%1'. Using linktext (specified in topicmeta) as the navigation title.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX023W" type="WARN">
     <reason>Unable to retrieve navtitle from target: '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX024E" type="ERROR">
     <reason>Missing linktext and navtitle for peer topic "%1".</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
-  
+
   <message id="DOTX025E" type="ERROR">
     <reason>Missing linktext and navtitle for non-DITA resource "%1".</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
-  
+
   <message id="DOTX026W" type="WARN">
     <reason>Unable to retrieve linktext from target: '%1'. Using navigation title as fallback.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX027W" type="WARN">
     <reason>Unable to retrieve linktext from target: '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX028E" type="ERROR">
     <reason>Link or cross reference must contain a valid href or keyref attribute; no link target is specified.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX029I" type="INFO">
     <reason>The type attribute on a %1 element was set to %3, but the reference is to a more specific %4 %2. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX030W" type="WARN">
     <reason>The type attribute on a %1 element was set to %3, but the reference is to a %4 %2. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX031E" type="ERROR">
     <reason>The file %1 is not available to resolve link information.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX032E" type="ERROR">
     <reason>Unable to retrieve link text from target: '%1'.</reason>
     <response>If the target is not accessible at build time, or does not have a title, provide the link text inside the reference.</response>
   </message>
-  
+
   <message id="DOTX033E" type="ERROR">
     <reason>Unable to generate link text for a cross reference to a list item: '%1'</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX034E" type="ERROR">
     <reason>Unable to generate link text for a cross reference to an unordered list item: '%1'</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX035E" type="ERROR">
     <reason>Unable to generate the correct number for a cross reference to a footnote: '%1'</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX036E" type="ERROR">
     <reason>Unable to generate link text for a cross reference to a dlentry (the dlentry or term could not be found): '%1'</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX037W" type="WARN">
     <reason>No title found for this document; using "***" as HTML page title.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX038I" type="INFO">
     <reason>The longdescref attribute on tag '%1' will be ignored. Accessibility for object elements needs to be handled another way.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX039W" type="WARN">
     <reason>Required cleanup area found.</reason>
     <response>To remove this message and hide the content, build your content without using the DRAFT parameter.</response>
   </message>
-  
+
   <message id="DOTX040I" type="INFO">
     <reason>Draft comment area found.</reason>
     <response>To remove this message and hide the comments, build your content without using the DRAFT parameter.</response>
   </message>
-  
+
   <message id="DOTX041W" type="WARN">
     <reason>Found more than one title element in a %1 element. Using the first one for the %1's title.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX042I" type="INFO">
     <reason>DITAVAL based flagging is not currently supported for inline phrases in XHTML; ignoring flag value on '%1' attribute.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX043I" type="INFO">
     <reason>The link to '%1' may appear more than once in '%2'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX044E" type="ERROR">
     <reason>The area element in an image map does not specify a link target.</reason>
     <response>Please add an xref element with a link target to the area element.</response>
   </message>
-  
+
   <message id="DOTX045W" type="WARN">
     <reason>The area element in an image map should specify link text for greater accessibility.</reason>
     <response>Link text should be specified directly when the target is not a local DITA resource.</response>
   </message>
-  
+
   <message id="DOTX046W" type="WARN">
     <reason>Area shape should be: default, rect, circle, poly, or blank (no value). The value '%1' is not recognized.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX047W" type="WARN">
     <reason>Area coordinates are blank. Coordinate points for the shape need to be specified.</reason>
     <response></response>
   </message>
-    
+
   <message id="DOTX049I" type="INFO">
     <reason>References to non-dita files will be ignored by the PDF, ODT, and RTF output transforms.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX050W" type="WARN">
     <reason>Default id "org.sample.help.doc" is used for Eclipse plug-in.</reason>
     <response>If you want to use your own plug-in id, please specify it using the id attribute on your map.</response>
   </message>
-  
+
   <message id="DOTX052W" type="WARN">
     <reason>No string named '%1' was found when creating generated text; using the value '%1' in your output file.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX053E" type="ERROR">
     <reason>A element that references another map indirectly includes itself, which results in an infinite loop. The original map reference is to '%1'.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX054W" type="WARN">
     <reason>Conflict text style is applied on the current element based on DITAVAL flagging rules.</reason>
     <response>Please check ditaval and dita source to make sure there is no style conflict on the element which needs to be flagged.</response>
   </message>
-  
+
   <message id="DOTX055W" type="WARN">
     <reason>Customized stylesheet uses deprecated template "flagit". Conditional processing is no longer supported using this template.</reason>
     <response>Please update your stylesheet to use template "start-flagit" instead of deprecated template "flagit".</response>
   </message>
-  
+
   <message id="DOTX056W" type="WARN">
     <reason>The file '%1' is not available to resolve link information.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX057W" type="WARN">
     <reason>The link or cross reference target '%1' cannot be found, which may cause errors creating links or cross references in your output file.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX058W" type="WARN">
     <reason>No glossary entry was found associated with key '%1' on %2 element. The build will try to determine the best display text and hover text for terms and abbreviations.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX060W" type="WARN">
     <reason>Key '%1' was used in an abbreviated-form element, but the key is not associated with a glossary entry.</reason>
     <response>Abbreviated-form should ONLY be used to reference to a glossary entry.</response>
   </message>
-  
+
   <message id="DOTX061W" type="WARN">
     <reason>ID '%1' was used in topicref tag but did not reference a topic element. The href attribute on a topicref element should only reference topic level elements.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX062I" type="INFO">
     <reason>It appears that this document uses constraints, but the conref processor cannot validate that the target of a conref is valid.</reason>
     <response>To enable constraint checking, please upgrade to an XSLT 2.0 processor.</response>
   </message>
-  
+
   <message id="DOTX063W" type="WARN">
     <reason>The dita document '%1' is linked to from your content, but is not referenced by a topicref tag in the ditamap file.</reason>
     <response>Include the topic in your map to avoid a broken link.</response>
   </message>
-  
+
   <message id="DOTX064W" type="WARN">
     <reason>The copy-to attribute [copy-to="%1"] uses the name of a file that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX065W" type="WARN">
     <reason>Two unique source files each specify copy-to="%2", which results in a collision. The value associated with href="%1" is ignored.</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX066W" type="WARN">
     <reason>Template "%1" is deprecated.</reason>
     <response>Remove references to this template from your custom XSLT or plug-ins.</response>
   </message>
-  
+
   <message id="DOTX067E" type="ERROR">
     <reason>No string named '%1' was found for language '%2'.</reason>
     <response>Add a mapping for the string '%1'.</response>
   </message>
-  
+
   <message id="DOTX068W" type="WARN">
     <reason>A topicref element that references a map contains child topicref elements.</reason>
     <response>Child topicref elements are ignored.</response>
   </message>
-  
+
   <message id="DOTX069W" type="WARN">
     <reason>Template mode "%1" is deprecated.</reason>
     <response>Remove references to this template mode from your custom XSLT or plug-ins.</response>
   </message>
-  
+
   <message id="DOTX070W" type="WARN">
     <reason>Target "%1" is deprecated.</reason>
     <response>Remove references to this target from your custom Ant files.</response>
   </message>
-  
+
   <message id="DOTX071W" type="WARN">
     <reason>Parameter "%1" on template "%2" is deprecated.</reason>
     <response>Use parameter "%3" instead.</response>
@@ -813,7 +813,7 @@ See the accompanying LICENSE file for applicable license.
     <reason>Conref range: Unable to find conref range end element with ID "%1".</reason>
     <response/>
   </message>
-  
+
   <message id="DOTX072I" type="INFO">
     <reason>Ignoring navtitle within topicgroup.</reason>
     <response/>
@@ -823,7 +823,7 @@ See the accompanying LICENSE file for applicable license.
     <reason>Removing broken link to "%1".</reason>
     <response/>
   </message>
-  
+
   <message id="DOTX074W" type="WARN">
     <reason>No formatting defined for unknown class attribute value "%1".</reason>
     <response/>
@@ -833,12 +833,12 @@ See the accompanying LICENSE file for applicable license.
     <reason>A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in "%1".</reason>
     <response></response>
   </message>
-  
+
   <message id="DOTX076E" type="ERROR">
     <reason>A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints "%1".</reason>
     <response>The current constrained document may only reuse content from documents with equivalent constraints.</response>
   </message>
-  
+
   <message id="DOTX077I" type="INFO">
     <reason>Resolving content references results in duplicate ID '%1'.</reason>
     <response>Rewriting resolved version to '%2'.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA012W" type="WARN">
     <reason>The '%1' argument is deprecated.</reason>
-    <response>Please use the argument '%2' instead.</response>
+    <response>Use the argument '%2' instead.</response>
   </message>
 
   <message id="DOTA013F" type="FATAL">
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA069F" type="FATAL">
     <reason>The input resource '%1' cannot be located or read.</reason>
-    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- Start of Java Messages -->
@@ -68,7 +68,7 @@ See the accompanying LICENSE file for applicable license.
        toolkit development team. -->
   <message id="DOTJ005F" type="FATAL">
     <reason>Failed to create new instance for '%1'.</reason>
-    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- Deprecated since 4.2 -->
@@ -136,7 +136,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ023E" type="ERROR">
     <reason>The specified image file '%1' is not available. It will not be included in the output.</reason>
-    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ025E" type="ERROR">
@@ -172,13 +172,13 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ033E" type="ERROR">
     <reason>No valid content found in topicref '%1' during chunk processing.</reason>
-    <response>Please specify an existing and valid topic for the topic reference.</response>
+    <response>Specify an existing and valid topic for the topic reference.</response>
   </message>
 
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ034F" type="FATAL">
     <reason>Failed to parse the input resource '%1' (the content is not valid).</reason>
-    <response>If '%1' does not have a DOCTYPE declaration, please make sure that all @class attributes are present.</response>
+    <response>If '%1' does not have a DOCTYPE declaration, make sure that all @class attributes are present.</response>
   </message>
 
   <message id="DOTJ035F" type="FATAL">
@@ -194,22 +194,22 @@ See the accompanying LICENSE file for applicable license.
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ037W" type="WARN">
     <reason>The XML schema and DTD validation function of the parser is turned off.</reason>
-    <response>Please make sure the input is normalized DITA with @class attributes included, otherwise it will not be processed correctly.</response>
+    <response>Make sure the input is normalized DITA with @class attributes included, otherwise it will not be processed correctly.</response>
   </message>
 
   <message id="DOTJ038E" type="ERROR">
     <reason>The &lt;%1&gt; element is specialized from unrecognized metadata.</reason>
-    <response>Please make sure that the &lt;%1&gt; element is specialized from an existing metadata element in the core DITA vocabulary.</response>
+    <response>Make sure that the &lt;%1&gt; element is specialized from an existing metadata element in the core DITA vocabulary.</response>
   </message>
 
   <message id="DOTJ039E" type="ERROR">
     <reason>There is no target specified for the conref push action 'pushafter'.</reason>
-    <response>Please specify a @conref target and set the 'mark' @conaction on the element that precedes the current element.</response>
+    <response>Specify a @conref target and set the 'mark' @conaction on the element that precedes the current element.</response>
   </message>
 
   <message id="DOTJ040E" type="ERROR">
     <reason>An element uses the conref push action 'pushreplace', but no @conref attribute is defined.</reason>
-    <response>Please specify a @conref target with the ID of the content you want to replace.</response>
+    <response>Specify a @conref target with the ID of the content you want to replace.</response>
   </message>
 
   <!-- Note, the following message comes from the Java conref-push module, XSL based message later catches regular conref (DOTX014E and DOTX015)-->
@@ -220,7 +220,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ042E" type="ERROR">
     <reason>Two elements both use conref push to replace the target '%1'.</reason>
-    <response>Please delete one of the duplicate 'replace' actions.</response>
+    <response>Delete one of the duplicate 'replace' actions.</response>
   </message>
 
   <message id="DOTJ043W" type="WARN">
@@ -230,7 +230,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ044W" type="WARN">
     <reason>There is a redundant conref push action 'pushbefore'.</reason>
-    <response>Please make sure that 'mark' and 'pushbefore' occur in pairs.</response>
+    <response>Make sure that 'mark' and 'pushbefore' occur in pairs.</response>
   </message>
 
   <message id="DOTJ045I" type="INFO">
@@ -266,7 +266,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Long term, would like to split this into two messages. One for file not found, another for file outside the scope of the map. -->
   <message id="DOTJ051E" type="ERROR">
     <reason>Unable to load target for coderef '%1'.</reason>
-    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ052E" type="ERROR">
@@ -327,7 +327,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ063E" type="ERROR">
     <reason>The @cols attribute is set to '%1' but the number of &lt;colspec&gt; elements was '%2'.</reason>
-    <response>Please verify the number of columns in the table.</response>
+    <response>Verify the number of columns in the table.</response>
   </message>
 
   <message id="DOTJ064W" type="WARN">
@@ -492,7 +492,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
   <message id="DOTX008E" type="ERROR">
     <reason>The resource '%1' cannot be loaded.</reason>
-    <response>Please ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- As of 2012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->
@@ -540,7 +540,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX016W" type="WARN">
-    <reason>A reference to '%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
+    <reason>'%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
     <response></response>
   </message>
 
@@ -684,7 +684,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX044E" type="ERROR">
     <reason>The &lt;area&gt; element in an image map does not specify a link target.</reason>
-    <response>Please add an &lt;xref&gt; element with a link target to the &lt;area&gt; element.</response>
+    <response>Add an &lt;xref&gt; element with a link target to the &lt;area&gt; element.</response>
   </message>
 
   <message id="DOTX045W" type="WARN">
@@ -729,7 +729,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX055W" type="WARN">
     <reason>A customized stylesheet uses the deprecated 'flagit' template. Conditional processing is no longer supported using this template.</reason>
-    <response>Please update the stylesheet to use the 'start-flagit' template instead of the 'flagit' template.</response>
+    <response>Update the stylesheet to use the 'start-flagit' template instead of the 'flagit' template.</response>
   </message>
 
   <message id="DOTX056W" type="WARN">
@@ -759,7 +759,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX062I" type="INFO">
     <reason>It appears that this document uses constraints, but the conref processor cannot validate that the target of a conref is valid.</reason>
-    <response>To enable constraint checking, please upgrade to an XSLT 2.0 processor.</response>
+    <response>To enable constraint checking, upgrade to an XSLT 2.0 processor.</response>
   </message>
 
   <message id="DOTX063W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -151,8 +151,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ028E" type="ERROR">
-    <reason>No format attribute was found on a reference to file '%1', which does not appear to be a DITA file.</reason>
-    <response>If this is not a DITA file, set the format attribute to an appropriate value, otherwise set the format attribute to "dita".</response>
+    <reason>No @format attribute was found on a reference to file '%1', which does not appear to be a DITA file.</reason>
+    <response>If this is not a DITA file, set the @format attribute to an appropriate value, otherwise set the @format attribute to "dita".</response>
   </message>
 
   <!-- Deprecated since 3.5 -->
@@ -180,7 +180,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- 2012-06-12: Still need to reproduce and edit this message -->
   <message id="DOTJ034F" type="FATAL">
     <reason>Failed to parse the input file '%1' (the content of the file is not valid).</reason>
-    <response>If the input file '%1' does not have a DOCTYPE declaration, please make sure that all class attributes are present in the file.</response>
+    <response>If the input file '%1' does not have a DOCTYPE declaration, please make sure that all @class attributes are present in the file.</response>
   </message>
 
   <!-- 2012-06-12: Still need to edit this message -->
@@ -197,7 +197,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ037W" type="WARN">
     <reason>The XML schema and DTD validation function of the parser is turned off.</reason>
-    <response>Please make sure the input is normalized DITA with class attributes included, otherwise it will not be processed correctly.</response>
+    <response>Please make sure the input is normalized DITA with @class attributes included, otherwise it will not be processed correctly.</response>
   </message>
 
   <message id="DOTJ038E" type="ERROR">
@@ -211,7 +211,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ040E" type="ERROR">
-    <reason>An element uses the attribute conaction="replace", but a conref attribute is not found in the expected location.</reason>
+    <reason>An element uses conaction="replace", but a @conref attribute is not found in the expected location.</reason>
     <response></response>
   </message>
 
@@ -244,17 +244,17 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ046E" type="ERROR">
     <reason>Conkeyref="%1" can not be resolved because it does not contain a key or the key is not defined.</reason>
-    <response>The build will use the conref attribute for fallback, if one exists.</response>
+    <response>The build will use the @conref attribute for fallback, if one exists.</response>
   </message>
 
   <message id="DOTJ047I" type="INFO">
     <reason>Unable to find key definition for key reference '%1' in root scope.</reason>
-    <response>The href attribute may be used as fallback if it exists</response>
+    <response>The @href attribute may be used as fallback if it exists.</response>
   </message>
 
   <message id="DOTJ048I" type="INFO">
     <reason>Unable to find key definition for key reference '%1' in scope '%2'.</reason>
-    <response>The href attribute may be used as fallback if it exists</response>
+    <response>The @href attribute may be used as fallback if it exists.</response>
   </message>
 
   <message id="DOTJ049W" type="WARN">
@@ -275,7 +275,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ052E" type="ERROR">
     <reason>Code reference charset '%1' not supported.</reason>
-    <response>See the DITA-OT documentation for supported charset values on the format attribute.</response>
+    <response>See the DITA-OT documentation for supported charset values on the @format attribute.</response>
   </message>
 
   <!-- Obsolete since 2.3 -->
@@ -300,7 +300,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ057E" type="ERROR">
-    <reason>The id attribute value '%1' is not unique within the topic that contains it.</reason>
+    <reason>The @id attribute value '%1' is not unique within the topic that contains it.</reason>
     <response></response>
   </message>
 
@@ -320,17 +320,17 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ061E" type="ERROR">
-    <reason>Topic reference target is a DITA map but format attribute has not been set.</reason>
-    <response>Set format attribute value to "ditamap".</response>
+    <reason>Topic reference target is a DITA map but the @format attribute has not been set.</reason>
+    <response>Set the @format attribute value to "ditamap".</response>
   </message>
 
   <message id="DOTJ062E" type="ERROR">
-    <reason>Invalid '%1' attribute value '%2'.</reason>
+    <reason>Invalid @%1 attribute value '%2'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ063E" type="ERROR">
-    <reason>The cols attribute is '%1' but number of colspec elements was '%2'.</reason>
+    <reason>The @cols attribute is set to '%1' but the number of colspec elements was '%2'.</reason>
     <response></response>
   </message>
 
@@ -345,12 +345,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ066E" type="ERROR">
-    <reason>No id attribute on topic type element '%1'.</reason>
+    <reason>No @id attribute on topic type element '%1'.</reason>
     <response>Using generated id '%2'.</response>
   </message>
 
   <message id="DOTJ067E" type="ERROR">
-    <reason>No id attribute on topic type element '%1'.</reason>
+    <reason>No @id attribute on topic type element '%1'.</reason>
     <response></response>
   </message>
 
@@ -400,7 +400,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ077F" type="FATAL">
-    <reason>Invalid action attribute '%1' on DITAVAL property.</reason>
+    <reason>Invalid @action attribute '%1' on DITAVAL property.</reason>
     <response></response>
   </message>
 
@@ -420,7 +420,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ081W" type="WARN">
-    <reason>Ignoring empty conref attribute conref="".</reason>
+    <reason>Ignoring empty @conref attribute: conref="".</reason>
     <response></response>
   </message>
 
@@ -445,12 +445,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ086W" type="WARN">
-    <reason>Split chunk attribute found on '&lt;%1>' element that does not reference a topic.</reason>
+    <reason>Split @chunk attribute found on '&lt;%1>' element that does not reference a topic.</reason>
     <response>Ignoring chunk operation.</response>
   </message>
 
   <message id="DOTJ087W" type="WARN">
-    <reason>Found chunk attribute with value '%1' inside combine chunk.</reason>
+    <reason>Found @chunk attribute with value '%1' inside combine chunk.</reason>
     <response>Ignoring chunk operation.</response>
   </message>
 
@@ -464,13 +464,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX002W" type="WARN">
-    <reason>The title element or attribute in the ditamap is required for Eclipse output.</reason>
+    <reason>The @title attribute or element in the ditamap is required for Eclipse output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX003I" type="INFO">
-    <reason>The anchorref attribute should either reference another dita map or an Eclipse XML TOC file. The value '%1' does not appear to reference either.</reason>
-    <response></response>
+    <reason>The @anchorref attribute should either reference another DITA map or an Eclipse XML TOC file.</reason>
+    <response>The value '%1' does not appear to reference either.</response>
   </message>
 
   <message id="DOTX004I" type="INFO">
@@ -485,7 +485,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX006E" type="ERROR">
     <reason>Unknown file extension in href='%1'.</reason>
-    <response>References to non-DITA resources should set the format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
+    <response>References to non-DITA resources should set the @format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
 
   <message id="DOTX007I" type="INFO">
@@ -524,17 +524,17 @@ See the accompanying LICENSE file for applicable license.
   <!-- This message can no longer appear, though the template for producing it remains in conrefImpl.xsl.
        Support for mismatched domains was added in release 1.5 or earlier. -->
   <message id="DOTX012W" type="WARN">
-    <reason>When you conref another topic or an item in another topic, the domains attribute of the target topic must be equal to or a subset of the current topic's domains attribute.</reason>
+    <reason>When you conref another topic or an item in another topic, the @domains attribute of the target topic must be equal to or a subset of the current topic's @domains attribute.</reason>
     <response>Put your target under an appropriate domain. You can see the messages guide for more help.</response>
   </message>
 
   <message id="DOTX013E" type="ERROR">
-    <reason>A element with attribute conref="%1" indirectly includes itself, which results in an infinite loop.</reason>
+    <reason>A element with the @conref attribute set to '%1' indirectly includes itself, which results in an infinite loop.</reason>
     <response></response>
   </message>
 
   <message id="DOTX014E" type="ERROR">
-    <reason>The attribute conref="%1" uses invalid syntax.</reason>
+    <reason>The conref="%1" attribute setting uses invalid syntax.</reason>
     <response>Conref references to a map element should contain '#' followed by an ID, such as mymap.ditamap#mytopicrefid.</response>
   </message>
 
@@ -544,35 +544,35 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX016W" type="WARN">
-    <reason>A reference to '%2' appears to reference a DITA document, but the format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
+    <reason>A reference to '%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
     <response></response>
   </message>
 
   <!-- Should likely be "warning" instead of "error", as related toolkit problems were fixed in very early releases.
        Now this serves only to catch likely problems with the source content. Keeping as "error" to avoid meaningless churn. -->
   <message id="DOTX017E" type="ERROR">
-    <reason>Found a link or cross reference with an empty href attribute (href="").</reason>
-    <response>Remove the empty href attribute or provide a value.</response>
+    <reason>Found a link or cross reference with an empty @href attribute: href="".</reason>
+    <response>Remove the empty @href attribute or provide a value.</response>
   </message>
 
   <!-- 018 currently not used, commented out due to SF bug 1771123 -->
   <message id="DOTX018I" type="INFO">
-    <reason>The type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a more specific '%2' topic. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
   <message id="DOTX019W" type="WARN">
-    <reason>The type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
+    <reason>The @type attribute on a topicref was set to '%1', but the topicref references a '%2' topic. This may cause your links to sort incorrectly in the output. Note that the @type attribute cascades in maps, so the value '%1' may come from an ancestor topicref.</reason>
     <response></response>
   </message>
 
   <message id="DOTX020E" type="ERROR">
-    <reason>Missing navtitle attribute or element for peer topic '%1'.</reason>
+    <reason>Missing @navtitle attribute or element for peer topic '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX021E" type="ERROR">
-    <reason>Missing navtitle attribute or element for non-DITA resource '%1'.</reason>
+    <reason>Missing @navtitle attribute or element for non-DITA resource '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
@@ -607,17 +607,17 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX028E" type="ERROR">
-    <reason>Link or cross reference must contain a valid href or keyref attribute; no link target is specified.</reason>
+    <reason>Link or cross reference must contain a valid @href or @keyref attribute; no link target is specified.</reason>
     <response></response>
   </message>
 
   <message id="DOTX029I" type="INFO">
-    <reason>The type attribute on a '%1' element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a '%1' element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX030W" type="WARN">
-    <reason>The type attribute on a '%1' element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The @type attribute on a '%1' element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
@@ -657,7 +657,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX038I" type="INFO">
-    <reason>The longdescref attribute on tag '%1' will be ignored. Accessibility for object elements needs to be handled another way.</reason>
+    <reason>The @longdescref attribute on tag '%1' will be ignored. Accessibility for object elements needs to be handled another way.</reason>
     <response></response>
   </message>
 
@@ -712,8 +712,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX050W" type="WARN">
-    <reason>Default id "org.sample.help.doc" is used for Eclipse plug-in.</reason>
-    <response>If you want to use your own plug-in id, please specify it using the id attribute on your map.</response>
+    <reason>Default ID "org.sample.help.doc" is used for Eclipse plug-in.</reason>
+    <response>If you want to use your own plug-in ID, please specify it using the @id attribute on your map.</response>
   </message>
 
   <message id="DOTX052W" type="WARN">
@@ -757,7 +757,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX061W" type="WARN">
-    <reason>ID '%1' was used in topicref tag but did not reference a topic element. The href attribute on a topicref element should only reference topic level elements.</reason>
+    <reason>ID '%1' was used in topicref tag but did not reference a topic element. The @href attribute on a topicref element should only reference topic level elements.</reason>
     <response></response>
   </message>
 
@@ -772,7 +772,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX064W" type="WARN">
-    <reason>The copy-to attribute [copy-to="%1"] uses the name of a file that already exists, so this attribute is ignored.</reason>
+    <reason>The @copy-to attribute [copy-to="%1"] uses the name of a file that already exists, so this attribute is ignored.</reason>
     <response></response>
   </message>
 
@@ -827,7 +827,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX074W" type="WARN">
-    <reason>No formatting defined for unknown class attribute value '%1'.</reason>
+    <reason>No formatting defined for unknown @class attribute value '%1'.</reason>
     <response/>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -224,7 +224,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ043W" type="WARN">
     <reason>The conref push function is trying to replace an element &lt;%1&gt; that does not exist in the '%2' resource.</reason>
-    <response>Update the reference to point to a valid target.</response>
+    <response>Update the reference to refer to a valid target.</response>
   </message>
 
   <message id="DOTJ044W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ020W" type="WARN">
     <reason>At least one plug-in in '%1' is required by plug-in '%2'. Plug-in '%2' cannot be loaded.</reason>
-    <response>Check and see whether all prerequisite plug-ins are installed in toolkit.</response>
+    <response>Check and see whether all prerequisite plug-ins are installed.</response>
   </message>
 
   <message id="DOTJ021E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -171,7 +171,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ033E" type="ERROR">
-    <reason>No valid content found in topicref '%1' during chunk processing.</reason>
+    <reason>No valid content found in the referenced resource '%1' during chunk processing.</reason>
     <response>Specify an existing and valid topic for the topic reference.</response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -120,13 +120,13 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ021E" type="ERROR">
     <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
-    <response>Please check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
+    <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
     <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL "exclude" conditions, or the resource is not valid DITA.</reason>
-    <response>Please check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
+    <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <message id="DOTJ022F" type="FATAL">
@@ -278,7 +278,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Obsolete since 2.3 -->
   <message id="DOTJ053W" type="WARN">
     <reason>The input resource '%1' is not a valid DITA filename.</reason>
-    <response>Please check '%1' to see if it is correct. The extensions ".dita" or ".xml" are supported for DITA topics.</response>
+    <response>Check '%1' to see if it is correct. The extensions ".dita" or ".xml" are supported for DITA topics.</response>
   </message>
 
   <message id="DOTJ054E" type="ERROR">
@@ -725,7 +725,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX054W" type="WARN">
     <reason>Conflict text style is applied on the current element based on DITAVAL flagging rules.</reason>
-    <response>Please check the DITAVAL and DITA source files to make sure there is no style conflict on the element that needs to be flagged.</response>
+    <response>Check the DITAVAL and DITA source files to make sure there is no style conflict on the element that needs to be flagged.</response>
   </message>
 
   <message id="DOTX055W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -489,7 +489,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX007I" type="INFO">
     <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to '%1' will be ignored.</reason>
-    <response>To remove this message, you can set @toc="no" or @processing-role="resource-only" on the topicref.</response>
+    <response>To remove this message, set the @toc attribute to "no" or the @processing-role attribute to "resource-only" on the topic reference.</response>
   </message>
 
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Start of Ant Messages -->
 
   <message id="DOTA001F" type="FATAL">
-    <reason>"%1" is not a recognized transformation type.</reason>
+    <reason>'%1' is not a recognized transformation type.</reason>
     <response>Supported transformation types are <dita:extension id="dita.conductor.transtype.check" behavior="org.dita.dost.platform.ListTranstypeAction" separator=", "/>.</response>
   </message>
 
@@ -31,13 +31,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA011W" type="WARN">
-    <reason>Argument "%1" is deprecated.</reason>
+    <reason>Argument '%1' is deprecated.</reason>
     <response>This argument is no longer supported in the toolkit.</response>
   </message>
 
   <message id="DOTA012W" type="WARN">
-    <reason>Argument "%1" is deprecated.</reason>
-    <response>Please use the argument "%2" instead.</response>
+    <reason>Argument '%1' is deprecated.</reason>
+    <response>Please use the argument '%2' instead.</response>
   </message>
 
   <message id="DOTA013F" type="FATAL">
@@ -51,8 +51,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA015F" type="FATAL">
-    <reason>Internal property %1 may not be set directly.</reason>
-    <response>Use property %2 instead.</response>
+    <reason>Internal property '%1' may not be set directly.</reason>
+    <response>Use property'%2'instead.</response>
   </message>
 
   <message id="DOTA069F" type="FATAL">
@@ -183,12 +183,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ035F" type="FATAL">
-    <reason>The file "%1" is outside the scope of the input dita/map directory.</reason>
-    <response>If you want to lower the severity level, please use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file "%1" into the input dita/map directory.</response>
+    <reason>The file '%1' is outside the scope of the input dita/map directory.</reason>
+    <response>If you want to lower the severity level, please use the Ant parameter 'outer.control', and set the value to "warn" or "quiet". Otherwise, move the referenced file '%1' into the input dita/map directory.</response>
   </message>
 
   <message id="DOTJ036W" type="WARN">
-    <reason>The file "%1" is outside the scope of the input dita/map directory.</reason>
+    <reason>The file '%1' is outside the scope of the input dita/map directory.</reason>
     <response></response>
   </message>
 
@@ -199,8 +199,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ038E" type="ERROR">
-    <reason>The tag "%1" is specialized from unrecognized metadata.</reason>
-    <response>Please make sure that tag "%1" is specialized from an existing metadata tag in the core DITA vocabulary.</response>
+    <reason>The tag '%1' is specialized from unrecognized metadata.</reason>
+    <response>Please make sure that tag '%1' is specialized from an existing metadata tag in the core DITA vocabulary.</response>
   </message>
 
   <message id="DOTJ039E" type="ERROR">
@@ -220,12 +220,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ042E" type="ERROR">
-    <reason>Two elements both use conref push to replace the target "%1".</reason>
+    <reason>Two elements both use conref push to replace the target '%1'.</reason>
     <response>Please delete one of the duplicate "replace" actions.</response>
   </message>
 
   <message id="DOTJ043W" type="WARN">
-    <reason>The conref push function is trying to replace an element that does not exist (element "%1" in file "%2").</reason>
+    <reason>The conref push function is trying to replace an element that does not exist (element '%1' in file '%2').</reason>
     <response></response>
   </message>
 
@@ -236,7 +236,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ045I" type="INFO">
-    <reason>The key "%1" is defined more than once in the same map file.</reason>
+    <reason>The key '%1' is defined more than once in the same map file.</reason>
     <response></response>
   </message>
 
@@ -246,18 +246,18 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ047I" type="INFO">
-    <reason>Unable to find key definition for key reference "%1" in root scope.</reason>
+    <reason>Unable to find key definition for key reference '%1' in root scope.</reason>
     <response>The href attribute may be used as fallback if it exists</response>
   </message>
 
   <message id="DOTJ048I" type="INFO">
-    <reason>Unable to find key definition for key reference "%1" in scope "%2".</reason>
+    <reason>Unable to find key definition for key reference '%1' in scope '%2'.</reason>
     <response>The href attribute may be used as fallback if it exists</response>
   </message>
 
   <message id="DOTJ049W" type="WARN">
-    <reason>The attribute value %1="%3" on element "%2" does not comply with the specified subject scheme.</reason>
-    <response>According to the subject scheme map, the following values are valid for the %1 attribute: %4</response>
+    <reason>The attribute value %1="%3" on element '%2' does not comply with the specified subject scheme.</reason>
+    <response>According to the subject scheme map, the following values are valid for the '%1' attribute: '%4'</response>
   </message>
 
   <message id="DOTJ050W" type="WARN">
@@ -267,12 +267,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Long term, would like to split this into two messages. One for file not found, another for file outside the scope of the map. -->
   <message id="DOTJ051E" type="ERROR">
-    <reason>Unable to load target for coderef "%1".</reason>
+    <reason>Unable to load target for coderef '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ052E" type="ERROR">
-    <reason>Code reference charset "%1" not supported.</reason>
+    <reason>Code reference charset '%1' not supported.</reason>
     <response>See the DITA-OT documentation for supported charset values on the format attribute.</response>
   </message>
 
@@ -283,38 +283,38 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ054E" type="ERROR">
-    <reason>Unable to parse invalid %1 attribute value "%2".</reason>
+    <reason>Unable to parse invalid '%1' attribute value '%2'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ055E" type="ERROR">
-    <reason>Invalid key name "%1".</reason>
+    <reason>Invalid key name '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ056E" type="ERROR">
-    <reason>Invalid xml:lang "%1".</reason>
+    <reason>Invalid xml:lang '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ057E" type="ERROR">
-    <reason>The id attribute value "%1" is not unique within the topic that contains it.</reason>
+    <reason>The id attribute value '%1' is not unique within the topic that contains it.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ058E" type="ERROR">
-    <reason>Both %1 and %2 attributes defined.</reason>
+    <reason>Both '%1' and '%2' attributes defined.</reason>
     <response>A single element may not contain both generalized and specialized values for the same attribute.</response>
   </message>
 
   <message id="DOTJ059E" type="ERROR">
-    <reason>Invalid key scope name "%1".</reason>
+    <reason>Invalid key scope name '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ060W" type="WARN">
-    <reason>Key "%1" was used in conkeyref but is not bound to a DITA topic or map.</reason>
-    <response>Cannot resolve conkeyref value "%2" as a valid conref reference.</response>
+    <reason>Key '%1' was used in conkeyref but is not bound to a DITA topic or map.</reason>
+    <response>Cannot resolve conkeyref value '%2' as a valid conref reference.</response>
   </message>
 
   <message id="DOTJ061E" type="ERROR">
@@ -323,12 +323,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ062E" type="ERROR">
-    <reason>Invalid %1 attribute value "%2".</reason>
+    <reason>Invalid '%1' attribute value '%2'.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ063E" type="ERROR">
-    <reason>The cols attribute is "%1" but number of colspec elements was %2.</reason>
+    <reason>The cols attribute is '%1' but number of colspec elements was '%2'.</reason>
     <response></response>
   </message>
 
@@ -338,17 +338,17 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ065I" type="INFO">
-    <reason>Branch filter generated topic %1 used more than once.</reason>
-    <response>Renaming %1 to %2.</response>
+    <reason>Branch filter generated topic '%1' used more than once.</reason>
+    <response>Renaming '%1' to '%2'.</response>
   </message>
 
   <message id="DOTJ066E" type="ERROR">
-    <reason>No id attribute on topic type element %1.</reason>
-    <response>Using generated id %2.</response>
+    <reason>No id attribute on topic type element '%1'.</reason>
+    <response>Using generated id '%2'.</response>
   </message>
 
   <message id="DOTJ067E" type="ERROR">
-    <reason>No id attribute on topic type element %1.</reason>
+    <reason>No id attribute on topic type element '%1'.</reason>
     <response></response>
   </message>
 
@@ -358,7 +358,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ069E" type="ERROR">
-    <reason>Circular key definition %1.</reason>
+    <reason>Circular key definition '%1'.</reason>
     <response></response>
   </message>
 
@@ -428,13 +428,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ083E" type="ERROR">
-    <reason>The resource referenced as %1 is capitalized differently on disk.</reason>
+    <reason>The resource referenced as '%1' is capitalized differently on disk.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ084E" type="ERROR">
-    <reason>Couldn’t read '%1' with the %2 character set.</reason>
-    <response>Save the file with %2 encoding.</response>
+    <reason>Couldn’t read '%1' with the '%2' character set.</reason>
+    <response>Save the file with '%2' encoding.</response>
   </message>
 
   <message id="DOTJ085E" type="ERROR">
@@ -482,12 +482,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX006E" type="ERROR">
-    <reason>Unknown file extension in href="%1".</reason>
+    <reason>Unknown file extension in href='%1'.</reason>
     <response>References to non-DITA resources should set the format attribute to match the resource (for example, 'txt', 'pdf', or 'html').</response>
   </message>
 
   <message id="DOTX007I" type="INFO">
-    <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to "%1" will be ignored.</reason>
+    <reason>Only DITA topics, HTML files, and images may be included in your compiled CHM file. The reference to '%1' will be ignored.</reason>
     <response>To remove this message, you can set the toc="no" or processing-role="resource-only" attribute on your topicref.</response>
   </message>
 
@@ -542,7 +542,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX016W" type="WARN">
-    <reason>A reference to "%2" appears to reference a DITA document, but the format attribute has inherited a value of "%1". The document will not be processed as DITA.</reason>
+    <reason>A reference to '%2' appears to reference a DITA document, but the format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
     <response></response>
   </message>
 
@@ -565,12 +565,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX020E" type="ERROR">
-    <reason>Missing navtitle attribute or element for peer topic "%1".</reason>
+    <reason>Missing navtitle attribute or element for peer topic '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX021E" type="ERROR">
-    <reason>Missing navtitle attribute or element for non-DITA resource "%1".</reason>
+    <reason>Missing navtitle attribute or element for non-DITA resource '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
@@ -585,12 +585,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX024E" type="ERROR">
-    <reason>Missing linktext and navtitle for peer topic "%1".</reason>
+    <reason>Missing linktext and navtitle for peer topic '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
   <message id="DOTX025E" type="ERROR">
-    <reason>Missing linktext and navtitle for non-DITA resource "%1".</reason>
+    <reason>Missing linktext and navtitle for non-DITA resource '%1'.</reason>
     <response>References must provide a local navigation title when the target is not a local DITA resource.</response>
   </message>
 
@@ -610,17 +610,17 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX029I" type="INFO">
-    <reason>The type attribute on a %1 element was set to %3, but the reference is to a more specific %4 %2. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The type attribute on a '%1' element was set to '%3', but the reference is to a more specific '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX030W" type="WARN">
-    <reason>The type attribute on a %1 element was set to %3, but the reference is to a %4 %2. This may cause your links to sort incorrectly in the output.</reason>
+    <reason>The type attribute on a '%1' element was set to '%3', but the reference is to a '%4' '%2'. This may cause your links to sort incorrectly in the output.</reason>
     <response></response>
   </message>
 
   <message id="DOTX031E" type="ERROR">
-    <reason>The file %1 is not available to resolve link information.</reason>
+    <reason>The file '%1' is not available to resolve link information.</reason>
     <response></response>
   </message>
 
@@ -670,7 +670,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX041W" type="WARN">
-    <reason>Found more than one title element in a %1 element. Using the first one for the %1's title.</reason>
+    <reason>Found more than one title element in a '%1' element. Using the first one for the %1's title.</reason>
     <response></response>
   </message>
 
@@ -745,7 +745,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX058W" type="WARN">
-    <reason>No glossary entry was found associated with key '%1' on %2 element. The build will try to determine the best display text and hover text for terms and abbreviations.</reason>
+    <reason>No glossary entry was found associated with key '%1' on '%2' element. The build will try to determine the best display text and hover text for terms and abbreviations.</reason>
     <response></response>
   </message>
 
@@ -780,7 +780,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX066W" type="WARN">
-    <reason>Template "%1" is deprecated.</reason>
+    <reason>Template '%1' is deprecated.</reason>
     <response>Remove references to this template from your custom XSLT or plug-ins.</response>
   </message>
 
@@ -795,22 +795,22 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX069W" type="WARN">
-    <reason>Template mode "%1" is deprecated.</reason>
+    <reason>Template mode '%1' is deprecated.</reason>
     <response>Remove references to this template mode from your custom XSLT or plug-ins.</response>
   </message>
 
   <message id="DOTX070W" type="WARN">
-    <reason>Target "%1" is deprecated.</reason>
+    <reason>Target '%1' is deprecated.</reason>
     <response>Remove references to this target from your custom Ant files.</response>
   </message>
 
   <message id="DOTX071E" type="ERROR">
-    <reason>Conref range: Unable to find conref range end element with ID "%1".</reason>
+    <reason>Conref range: Unable to find conref range end element with ID '%1'.</reason>
     <response/>
   </message>
 
   <message id="DOTX071W" type="WARN">
-    <reason>Parameter "%1" on template "%2" is deprecated.</reason>
+    <reason>Parameter '%1' on template '%2' is deprecated.</reason>
     <response>Use parameter "%3" instead.</response>
   </message>
 
@@ -820,22 +820,22 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX073I" type="INFO">
-    <reason>Removing broken link to "%1".</reason>
+    <reason>Removing broken link to '%1'.</reason>
     <response/>
   </message>
 
   <message id="DOTX074W" type="WARN">
-    <reason>No formatting defined for unknown class attribute value "%1".</reason>
+    <reason>No formatting defined for unknown class attribute value '%1'.</reason>
     <response/>
   </message>
 
   <message id="DOTX075W" type="WARN">
-    <reason>A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in "%1".</reason>
+    <reason>A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in '%1'.</reason>
     <response></response>
   </message>
 
   <message id="DOTX076E" type="ERROR">
-    <reason>A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints "%1".</reason>
+    <reason>A content reference in a constrained document type cannot be resolved because it would violate one of the document constraints '%1'.</reason>
     <response>The current constrained document may only reuse content from documents with equivalent constraints.</response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -115,7 +115,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ020W" type="WARN">
     <reason>At least one plug-in in '%1' is required by plug-in '%2'. Plug-in '%2' cannot be loaded.</reason>
-    <response>Check and see whether all prerequisite plug-ins are installed.</response>
+    <response>Check if all prerequisite plug-ins are properly installed.</response>
   </message>
 
   <message id="DOTJ021E" type="ERROR">
@@ -403,12 +403,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ078F" type="FATAL">
     <reason>The input resource '%1' cannot be loaded.</reason>
-    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+    <response>Check if grammar files for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ079E" type="ERROR">
     <reason>The '%1' resource cannot be loaded.</reason>
-    <response>Ensure that grammar files for this document type are referenced and installed properly.</response>
+    <response>Check if grammar files for this document type are properly referenced and installed.</response>
   </message>
 
   <message id="DOTJ080W" type="WARN">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -141,12 +141,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ025E" type="ERROR">
     <reason>The input to the 'topic merge' process cannot be found.</reason>
-    <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
+    <response>Correct any earlier errors and try the build again, or see the documentation for additional details.</response>
   </message>
 
   <message id="DOTJ026E" type="ERROR">
     <reason>The 'topic merge' process did not generate any output.</reason>
-    <response>Correct any earlier errors and try the build again, or see the documentation for additional causes.</response>
+    <response>Correct any earlier errors and try the build again, or see the documentation for additional details.</response>
   </message>
 
   <message id="DOTJ028E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -206,8 +206,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ039E" type="ERROR">
-    <reason>There is no target specified for conref push action "pushafter".</reason>
-    <response>Please add &lt;elementname conref="pushtarget" conaction="mark"&gt; before current element.</response>
+    <reason>There is no target specified for the conref push action "pushafter".</reason>
+    <response>Please specify @conref="pushtarget" and @conaction="mark" on the element that precedes the current element.</response>
   </message>
 
   <message id="DOTJ040E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -196,6 +196,7 @@ See the accompanying LICENSE file for applicable license.
     <response>For correct processing, make sure the input is normalized DITA with @class attributes included.</response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTJ038E" type="ERROR">
     <reason>The &lt;%1&gt; element is specialized from unrecognized metadata.</reason>
     <response>Make sure that the &lt;%1&gt; element is specialized from an existing metadata element in the core DITA vocabulary.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -57,7 +57,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA069F" type="FATAL">
     <reason>The input resource '%1' cannot be located or read.</reason>
-    <response>Ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Make sure '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- Start of Java Messages -->
@@ -68,7 +68,7 @@ See the accompanying LICENSE file for applicable license.
        toolkit development team. -->
   <message id="DOTJ005F" type="FATAL">
     <reason>Failed to create new instance for '%1'.</reason>
-    <response>Ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Make sure '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- Deprecated since 4.2 -->
@@ -136,7 +136,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ023E" type="ERROR">
     <reason>The specified image file '%1' is not available. It is not included in the output.</reason>
-    <response>Ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Make sure '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ025E" type="ERROR">
@@ -265,7 +265,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Long term, would like to split this into two messages. One for file not found, another for file outside the scope of the map. -->
   <message id="DOTJ051E" type="ERROR">
     <reason>Unable to load target for coderef '%1'.</reason>
-    <response>Ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Make sure '%1' exists and that you have permission to access it.</response>
   </message>
 
   <message id="DOTJ052E" type="ERROR">
@@ -491,7 +491,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- DOTX008E uses the XSLT prefix DOTX, but generated only from Java code. -->
   <message id="DOTX008E" type="ERROR">
     <reason>The resource '%1' cannot be loaded.</reason>
-    <response>Ensure that '%1' exists and that you have permission to access it.</response>
+    <response>Make sure '%1' exists and that you have permission to access it.</response>
   </message>
 
   <!-- As of 2012-06-13, DOTX008W is only called for HTML Help and map2htmtoc -->

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -60,7 +60,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- DOTJ005F appears to indicate an internal programming error, failed to create
        a new module in ModuleFactory.java. This message should be updated
        to indicate it is an internal programming error and should be reported to the
-       toolkit development team. -->>
+       toolkit development team. -->
   <message id="DOTJ005F" type="FATAL">
     <reason>Failed to create new instance for '%1'.</reason>
     <response>Please ensure that '%1' exists and that you have permission to access it.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -201,8 +201,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ038E" type="ERROR">
-    <reason>The tag '%1' is specialized from unrecognized metadata.</reason>
-    <response>Please make sure that tag '%1' is specialized from an existing metadata tag in the core DITA vocabulary.</response>
+    <reason>The &lt;%1&gt; element is specialized from unrecognized metadata.</reason>
+    <response>Please make sure that the &lt;%1&gt; element is specialized from an existing metadata element in the core DITA vocabulary.</response>
   </message>
 
   <message id="DOTJ039E" type="ERROR">

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -808,6 +808,7 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <!-- Deprecated since 4.2 -->
   <message id="DOTX071W" type="WARN">
     <reason>The '%1' parameter on the '%2' template is deprecated.</reason>
     <response>Use the '%3' parameter instead.</response>

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -157,12 +157,12 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Deprecated since 3.5 -->
   <message id="DOTJ029I" type="INFO">
-    <reason>No 'domains' attribute was found for element '&lt;%1&gt;'.</reason>
+    <reason>No @domains attribute was found for element '&lt;%1&gt;'.</reason>
     <response>This generally indicates that your DTD or Schema was not developed properly according to the DITA specification.</response>
   </message>
 
   <message id="DOTJ030I" type="INFO">
-    <reason>No 'class' attribute for was found for element '&lt;%1&gt;'.</reason>
+    <reason>No @class attribute for was found for element '&lt;%1&gt;'.</reason>
     <response>The element will be processed as an unknown or non-DITA element.</response>
   </message>
 
@@ -335,8 +335,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ064W" type="WARN">
-    <reason>Chunk attribute uses both "to-content" and "by-topic" that conflict with each other.</reason>
-    <response>Ignoring "by-topic" token.</response>
+    <reason>The @chunk attribute uses both "to-content" and "by-topic" that conflict with each other.</reason>
+    <response>Ignoring the "by-topic" token.</response>
   </message>
 
   <message id="DOTJ065I" type="INFO">
@@ -375,27 +375,27 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ072E" type="ERROR">
-    <reason>Email link without correct 'format' attribute.</reason>
-    <response>Using 'format' attribute value 'email'.</response>
+    <reason>Email link without correct @format attribute.</reason>
+    <response>Using @format attribute value 'email'.</response>
   </message>
 
   <message id="DOTJ073E" type="ERROR">
-    <reason>Email link without correct 'scope' attribute.</reason>
-    <response>Using 'scope' attribute value 'external'.</response>
+    <reason>Email link without correct @scope attribute.</reason>
+    <response>Using @scope attribute value 'external'.</response>
   </message>
 
   <message id="DOTJ074W" type="WARN">
-    <reason>Rev attribute cannot be used with prop filter.</reason>
+    <reason>The @rev attribute cannot be used with prop filter.</reason>
     <response></response>
   </message>
 
   <message id="DOTJ075W" type="WARN">
-    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
-    <response>Using 'scope' attribute value 'external'.</response>
+    <reason>Absolute link '%1' without correct @scope attribute.</reason>
+    <response>Using @scope attribute value 'external'.</response>
   </message>
 
   <message id="DOTJ076W" type="WARN">
-    <reason>Absolute link '%1' without correct 'scope' attribute.</reason>
+    <reason>Absolute link '%1' without correct @scope attribute.</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -74,18 +74,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 4.2 -->
   <message id="DOTJ007E" type="ERROR">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
-    <response>The first encountered condition will be used.</response>
+    <response>Using the first condition found.</response>
   </message>
 
   <message id="DOTJ007I" type="INFO">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
-    <response>The first encountered condition will be used.</response>
+    <response>Using the first condition found.</response>
   </message>
 
   <!-- Deprecated since 4.2 -->
   <message id="DOTJ007W" type="WARN">
     <reason>Duplicate condition in filter file for rule '%1'.</reason>
-    <response>The first encountered condition will be used.</response>
+    <response>Using the first condition found.</response>
   </message>
 
   <message id="DOTJ009E" type="ERROR">
@@ -119,23 +119,23 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ021E" type="ERROR">
-    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
+    <reason>No output generated for '%1' because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
     <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <!-- Message DOTJ021W deprecated in 3.4, replaced with DOTJ021E -->
   <message id="DOTJ021W" type="WARN">
-    <reason>The '%1' resource will not generate output because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
+    <reason>No output generated for '%1' because all content has been filtered out by DITAVAL 'exclude' conditions, or the resource is not valid DITA.</reason>
     <response>Check the '%1' resource and the DITAVAL file to see if this is the intended result.</response>
   </message>
 
   <message id="DOTJ022F" type="FATAL">
     <reason>Failed to parse the input resource '%1' because all of its content has been filtered out.</reason>
-    <response>This will happen if the resource has filter conditions on the root element, and a DITAVAL file excludes all content based on those conditions.</response>
+    <response>This can happen if the resource has filter conditions on the root element, and a DITAVAL file excludes all content based on those conditions.</response>
   </message>
 
   <message id="DOTJ023E" type="ERROR">
-    <reason>The specified image file '%1' is not available. It will not be included in the output.</reason>
+    <reason>The specified image file '%1' is not available. It is not included in the output.</reason>
     <response>Ensure that '%1' exists and that you have permission to access it.</response>
   </message>
 
@@ -162,11 +162,11 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ030I" type="INFO">
     <reason>No @class attribute was found for the &lt;%1&gt; element.</reason>
-    <response>The element will be processed as an unknown or non-DITA element.</response>
+    <response>Processing as an unknown or non-DITA element.</response>
   </message>
 
   <message id="DOTJ031I" type="INFO">
-    <reason>No rule for '%1' was found in the DITAVAL file. This value will use the default action, or a parent prop action if specified.</reason>
+    <reason>No rule for '%1' was found in the DITAVAL file. Using the default action, or a parent prop action if specified.</reason>
     <response>To remove this message, specify a rule for '%1' in the DITAVAL file.</response>
   </message>
 
@@ -191,10 +191,9 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
-  <!-- 2012-06-12: Still need to edit this message -->
   <message id="DOTJ037W" type="WARN">
     <reason>The XML schema and DTD validation function of the parser is turned off.</reason>
-    <response>Make sure the input is normalized DITA with @class attributes included, otherwise it will not be processed correctly.</response>
+    <response>For correct processing, make sure the input is normalized DITA with @class attributes included.</response>
   </message>
 
   <message id="DOTJ038E" type="ERROR">
@@ -240,17 +239,17 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ046E" type="ERROR">
     <reason>The @conkeyref attribute value '%1' cannot be resolved because it does not contain a key or the key is not defined.</reason>
-    <response>The build will use the @conref attribute for fallback, if one exists.</response>
+    <response>Using the @conref attribute as fallback if it exists.</response>
   </message>
 
   <message id="DOTJ047I" type="INFO">
     <reason>Unable to find key definition for key reference '%1' in root scope.</reason>
-    <response>The @href attribute may be used as fallback if it exists.</response>
+    <response>Using the @href attribute as fallback if it exists.</response>
   </message>
 
   <message id="DOTJ048I" type="INFO">
     <reason>Unable to find key definition for key reference '%1' in scope '%2'.</reason>
-    <response>The @href attribute may be used as fallback if it exists.</response>
+    <response>Using the @href attribute as fallback if it exists.</response>
   </message>
 
   <message id="DOTJ049W" type="WARN">
@@ -362,7 +361,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTJ070I" type="INFO">
     <reason>An invalid @class attribute '%1' for was found for the &lt;%2&gt; element.</reason>
-    <response>The element will be processed as an unknown or non-DITA element.</response>
+    <response>Processing as an unknown or non-DITA element.</response>
   </message>
 
   <message id="DOTJ071E" type="ERROR">
@@ -476,7 +475,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTX005E" type="ERROR">
     <reason>Unable to find navigation title for reference to '%1'.</reason>
-    <response>The build will use '%1' as the title in the Eclipse Table of Contents.</response>
+    <response>Using '%1' as the title in the Eclipse Table of Contents.</response>
   </message>
 
   <message id="DOTX006E" type="ERROR">
@@ -485,7 +484,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX007I" type="INFO">
-    <reason>Only DITA topics, HTML files, and images may be included in the compiled CHM file. The reference to '%1' will be ignored.</reason>
+    <reason>Only DITA topics, HTML files, and images may be included in the compiled CHM file. Ignoring reference to '%1'.</reason>
     <response>To remove this message, set the @toc attribute to 'no' or the @processing-role attribute to 'resource-only' on the topic reference.</response>
   </message>
 
@@ -513,7 +512,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX011W" type="WARN">
-    <reason>There is more than one possible target for the @conref attribute value '%1'. Only the first will be used.</reason>
+    <reason>There is more than one possible target for the @conref attribute value '%1'. Using the first value found.</reason>
     <response>Remove the duplicate ID in the referenced resource.</response>
   </message>
 
@@ -540,8 +539,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX016W" type="WARN">
-    <reason>'%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'. The document will not be processed as DITA.</reason>
-    <response></response>
+    <reason>'%2' appears to reference a DITA document, but the @format attribute has inherited a value of '%1'.</reason>
+    <response>Processing as a non-DITA element. To process as DITA, set the @format attribute to 'dita'.</response>
   </message>
 
   <!-- Should likely be "warning" instead of "error", as related toolkit problems were fixed in very early releases.
@@ -653,7 +652,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX038I" type="INFO">
-    <reason>The @longdescref attribute on the &lt;%1&gt; element will be ignored.</reason>
+    <reason>Ignoring the @longdescref attribute on the &lt;%1&gt; element.</reason>
     <response>Accessibility for object elements needs to be handled another way.</response>
   </message>
 
@@ -703,7 +702,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX049I" type="INFO">
-    <reason>References to non-DITA files will be ignored by the PDF, ODT, and RTF output transforms.</reason>
+    <reason>References to non-DITA files are ignored by the PDF, ODT, and RTF transformations.</reason>
     <response></response>
   </message>
 
@@ -743,8 +742,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX058W" type="WARN">
-    <reason>No glossary entry was found associated with key '%1' on '%2' element. The build will try to determine the best display text and hover text for terms and abbreviations.</reason>
-    <response></response>
+    <reason>No glossary entry found for the '%1' key on the '%2' element.</reason>
+    <response>Verify display text and hover text for terms and abbreviations.</response>
   </message>
 
   <message id="DOTX060W" type="WARN">
@@ -773,9 +772,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX065W" type="WARN">
-    <reason>Two unique source files each specify a @copy-to attribute value '%2', which results in a collision. The value associated with
-      @href value '%1' will be ignored.</reason>
-    <response></response>
+    <reason>Two unique source files each specify a @copy-to attribute value '%2', which results in a collision.</reason>
+    <response>Ignoring the @copy-to value associated with the @href value '%1'.</response>
   </message>
 
   <message id="DOTX066W" type="WARN">
@@ -829,8 +827,8 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTX075W" type="WARN">
-    <reason>A content reference in a constrained document type is pulling content from an unconstrained document type. The reference will resolve, but may result in content that violates one of the document constraints in '%1'.</reason>
-    <response></response>
+    <reason>A content reference in a constrained document type is pulling content from an unconstrained document type.</reason>
+    <response>Resolving this reference may result in content that violates one of the document constraints in '%1'.</response>
   </message>
 
   <message id="DOTX076E" type="ERROR">

--- a/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
+++ b/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <messages>
 
   <message id="DOTX048I" type="INFO">
-    <reason>In order to include peer or external topic '%1' in your help file, you may need to recompile the CHM file after making the file available.</reason>
+    <reason>To include the peer or external topic '%1' in your help file, you may need to recompile the CHM file after making the resource available.</reason>
     <response></response>
   </message>
 

--- a/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
+++ b/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
+++ b/src/main/plugins/org.dita.htmlhelp/resource/messages.xml
@@ -7,8 +7,10 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <messages>
+
   <message id="DOTX048I" type="INFO">
     <reason>In order to include peer or external topic '%1' in your help file, you may need to recompile the CHM file after making the file available.</reason>
     <response></response>
   </message>
+
 </messages>

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -63,12 +63,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFX004F" type="ERROR">
     <reason>A topic reference was found with href="".</reason>
-    <response>Please specify a target or remove the href attribute.</response>
+    <response>Please specify a target or remove the @href attribute.</response>
   </message>
 
   <message id="PDFX005F" type="ERROR">
     <reason>The topic reference href="%1" could not be found.</reason>
-    <response>Please correct the reference, or set the scope or format attribute if the target is not a local DITA topic.</response>
+    <response>Please correct the reference, or set the @scope or @format attribute if the target is not a local DITA topic.</response>
   </message>
 
   <!-- PDFX006E cannot appear with version 2.2; commenting out. Should be removed when it is removed from the code.

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -107,4 +107,4 @@ See the accompanying LICENSE file for applicable license.
     <response/>
   </message>
 
-</messages>  
+</messages>

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Start of Ant Messages -->
 
   <message id="DOTA066F" type="FATAL">
-    <reason>Cannot find the user specified XSLT stylesheet '%1'.</reason>
+    <reason>Cannot find the user-specified XSLT stylesheet '%1'.</reason>
     <response></response>
   </message>
 

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -88,12 +88,12 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="PDFX009E" type="ERROR">
-    <reason>Attribute set reflection cannot handle XSLT element %1.</reason>
+    <reason>Attribute set reflection cannot handle XSLT element '%1'.</reason>
     <response/>
   </message>
 
   <message id="PDFX011E" type="ERROR">
-    <reason>The index term '%2' uses both an index-see element and %1 element.</reason>
+    <reason>The index term '%2' uses both an index-see element and '%1' element.</reason>
     <response>Convert the index-see element to index-see-also.</response>
   </message>
 

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -7,82 +7,104 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <messages>
-  <!-- Ant -->
+
+  <!-- Start of Ant Messages -->
+
   <message id="DOTA066F" type="FATAL">
     <reason>Cannot find the user specified XSLT stylesheet '%1'.</reason>
     <response></response>
   </message>
-  <!-- Java -->
+
+  <!-- Start of Java Messages -->
+
   <message id="PDFJ001E" type="ERROR">
     <reason>The PDF indexing process could not find the proper sort location for '%1', so the term has been dropped from the index.</reason>
     <response/>
   </message>
+
   <message id="PDFJ002E" type="ERROR">
     <reason>The build failed due to problems encountered when sorting the PDF index.</reason>
     <response>Please address any messages located earlier in the log.</response>
   </message>
+
   <message id="PDFJ003I" type="INFO">
     <reason>Index entry '%1' will be sorted under the "Special characters" heading.</reason>
     <response/>
   </message>
+
   <!-- DOTA067W and DOTA068W actually come from Java code inside the PDF plug-in.
        DOTA prefix is innacurate. No reason to change at this point. -->
   <message id="DOTA067W" type="WARN">
     <reason>Ignoring index-see '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
     <response></response>
   </message>
+
   <message id="DOTA068W" type="WARN">
     <reason>Ignoring index-see-also '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
     <response></response>
   </message>
-  <!-- XSLT -->
+
+  <!-- Start of XSL Messages -->
+
   <message id="PDFX001W" type="WARN">
     <reason>There is an index term specified with start="%1", but there is no matching end for this term.</reason>
     <response>Add an index term in a valid location with end="%1".</response>
   </message>
+
   <message id="PDFX002W" type="WARN">
     <reason>There are multiple index terms specified with start="%1", but there is only one term to end this range, or the ranges for this term overlap.</reason>
     <response>Ensure that each term with this start value has a matching end value, and that the specified ranges for this value do not overlap</response>
   </message>
+
   <message id="PDFX003W" type="WARN">
     <reason>There are multiple index entries found to close the index range for "%1".</reason>
     <response>Ensure that any index term with start="%1" has only one matching end term with end="%1".</response>
   </message>
+
   <message id="PDFX004F" type="ERROR">
     <reason>A topic reference was found with href="".</reason>
     <response>Please specify a target or remove the href attribute.</response>
   </message>
+
   <message id="PDFX005F" type="ERROR">
     <reason>The topic reference href="%1" could not be found.</reason>
     <response>Please correct the reference, or set the scope or format attribute if the target is not a local DITA topic.</response>
   </message>
+
   <!-- PDFX006E cannot appear with version 2.2; commenting out. Should be removed when it is removed from the code.
   <message id="PDFX006E" type="ERROR">
     <reason>Number of columns must be specified.</reason>
     <response/>
   </message>-->
+
   <message id="PDFX007W" type="WARN">
     <reason>Found an index term with end="%1", but no starting term was found for this entry.</reason>
     <response/>
   </message>
+
   <message id="PDFX008W" type="WARN">
     <reason>Font definition not found for the logical name or alias '%1'.</reason>
     <response/>
   </message>
+
   <message id="PDFX009E" type="ERROR">
     <reason>Attribute set reflection cannot handle XSLT element %1.</reason>
     <response/>
   </message>
+
   <message id="PDFX011E" type="ERROR">
     <reason>The index term '%2' uses both an index-see element and %1 element.</reason>
     <response>Convert the index-see element to index-see-also.</response>
   </message>
+
   <message id="PDFX012E" type="ERROR">
     <reason>Found a table row with more entries than allowed.</reason>
     <response/>
   </message>
+
   <message id="PDFX013F" type="FATAL">
     <reason>The PDF file '%1' could not be generated.</reason>
     <response/>
   </message>
+
 </messages>  

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -99,7 +99,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFX012E" type="ERROR">
     <reason>Found a table row with more entries than allowed.</reason>
-    <response></response>
+    <response>Check the number of columns in the table.</response>
   </message>
 
   <message id="PDFX013F" type="FATAL">

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -88,13 +88,13 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="PDFX009E" type="ERROR">
-    <reason>Attribute set reflection cannot handle XSLT element '%1'.</reason>
+    <reason>Attribute set reflection cannot handle the XSLT element &lt;%1&gt;.</reason>
     <response/>
   </message>
 
   <message id="PDFX011E" type="ERROR">
-    <reason>The index term '%2' uses both an index-see element and '%1' element.</reason>
-    <response>Convert the index-see element to index-see-also.</response>
+    <reason>The index term '%2' uses both an &lt;index-see&gt; element and an &lt;%1&gt; element.</reason>
+    <response>Convert the &lt;index-see&gt; element to &lt;index-see-also&gt;.</response>
   </message>
 
   <message id="PDFX012E" type="ERROR">

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -30,7 +30,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- Start of Java Messages -->
 
   <message id="PDFJ001E" type="ERROR">
-    <reason>The PDF indexing process could not find the proper sort location for '%1', so the term has been dropped from the index.</reason>
+    <reason>The PDF indexing process cannot find the proper sort location for '%1', so the term has been dropped from the index.</reason>
     <response/>
   </message>
 
@@ -67,7 +67,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="PDFX005F" type="ERROR">
-    <reason>The topic reference href="%1" could not be found.</reason>
+    <reason>The topic reference href="%1" cannot be found.</reason>
     <response>Please correct the reference, or set the @scope or @format attribute if the target is not a local DITA topic.</response>
   </message>
 
@@ -103,7 +103,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="PDFX013F" type="FATAL">
-    <reason>The PDF file '%1' could not be generated.</reason>
+    <reason>The PDF file '%1' cannot be generated.</reason>
     <response/>
   </message>
 

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -31,7 +31,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFJ001E" type="ERROR">
     <reason>The PDF indexing process cannot find the proper sort location for '%1', so the term has been dropped from the index.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="PDFJ002E" type="ERROR">
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFJ003I" type="INFO">
     <reason>Index entry '%1' will be sorted under the "Special characters" heading.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <!-- Start of XSL Messages -->
@@ -74,22 +74,22 @@ See the accompanying LICENSE file for applicable license.
   <!-- PDFX006E cannot appear with version 2.2; commenting out. Should be removed when it is removed from the code.
   <message id="PDFX006E" type="ERROR">
     <reason>Number of columns must be specified.</reason>
-    <response/>
+    <response></response>
   </message>-->
 
   <message id="PDFX007W" type="WARN">
     <reason>Found an index term with end="%1", but no starting term was found for this entry.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="PDFX008W" type="WARN">
     <reason>Font definition not found for the logical name or alias '%1'.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="PDFX009E" type="ERROR">
     <reason>Attribute set reflection cannot handle the XSLT element &lt;%1&gt;.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="PDFX011E" type="ERROR">
@@ -99,12 +99,12 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFX012E" type="ERROR">
     <reason>Found a table row with more entries than allowed.</reason>
-    <response/>
+    <response></response>
   </message>
 
   <message id="PDFX013F" type="FATAL">
     <reason>The PDF file '%1' cannot be generated.</reason>
-    <response/>
+    <response></response>
   </message>
 
 </messages>

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -36,11 +36,11 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFJ002E" type="ERROR">
     <reason>The build failed due to problems encountered when sorting the PDF index.</reason>
-    <response>Please address any messages located earlier in the log.</response>
+    <response>Address any messages located earlier in the log.</response>
   </message>
 
   <message id="PDFJ003I" type="INFO">
-    <reason>Index entry '%1' will be sorted under the "Special characters" heading.</reason>
+    <reason>Index entry '%1' will be sorted under the 'Special characters' heading.</reason>
     <response></response>
   </message>
 
@@ -58,17 +58,17 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="PDFX003W" type="WARN">
     <reason>Multiple index entries close the index range '%1'.</reason>
-    <response>Make sure that each index term with with a @start attribute value of '%1' has only one matching term with an @end attribute value of '%1'.</response>
+    <response>Make sure that each index term with a @start attribute value of '%1' has only one matching term with a corresponding @end attribute value.</response>
   </message>
 
   <message id="PDFX004F" type="ERROR">
-    <reason>A topic reference was found with href="".</reason>
+    <reason>Found a topic reference with an empty @href attribute value.</reason>
     <response>Please specify a target or remove the @href attribute.</response>
   </message>
 
   <message id="PDFX005F" type="ERROR">
-    <reason>The topic reference href="%1" cannot be found.</reason>
-    <response>Please correct the reference, or set the @scope or @format attribute if the target is not a local DITA topic.</response>
+    <reason>The '%1' topic reference cannot be found.</reason>
+    <response>Please correct the @href attribute value, or set the @scope or @format attribute if the target is not a local DITA topic.</response>
   </message>
 
   <!-- PDFX006E cannot appear with version 2.2; commenting out. Should be removed when it is removed from the code.
@@ -78,7 +78,7 @@ See the accompanying LICENSE file for applicable license.
   </message>-->
 
   <message id="PDFX007W" type="WARN">
-    <reason>Found an index term with end="%1", but no starting term was found for this entry.</reason>
+    <reason>Found an index term with @end attribute value '%1', but no start term was found for this entry.</reason>
     <response></response>
   </message>
 

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -18,12 +18,12 @@ See the accompanying LICENSE file for applicable license.
   <!-- DOTA067W and DOTA068W actually come from Java code inside the PDF plug-in.
        DOTA prefix is innacurate. No reason to change at this point. -->
   <message id="DOTA067W" type="WARN">
-    <reason>Ignoring index-see '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
+    <reason>Ignoring &lt;index-see&gt; '%1' inside parent index entry '%2' because the parent term contains term children.</reason>
     <response></response>
   </message>
 
   <message id="DOTA068W" type="WARN">
-    <reason>Ignoring index-see-also '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
+    <reason>Ignoring &lt;index-see-also&gt; '%1' inside parent index entry '%2' because the parent term contains term children.</reason>
     <response></response>
   </message>
 
@@ -47,18 +47,18 @@ See the accompanying LICENSE file for applicable license.
   <!-- Start of XSL Messages -->
 
   <message id="PDFX001W" type="WARN">
-    <reason>There is an index term specified with start="%1", but there is no matching end for this term.</reason>
-    <response>Add an index term in a valid location with end="%1".</response>
+    <reason>An index term range is specified with a @start attribute value of '%1', but there is no matching @end attribute.</reason>
+    <response>To end the range, add an index term in a valid location with the @end attribute set to '%1'.</response>
   </message>
 
   <message id="PDFX002W" type="WARN">
-    <reason>There are multiple index terms specified with start="%1", but there is only one term to end this range, or the ranges for this term overlap.</reason>
-    <response>Ensure that each term with this start value has a matching end value, and that the specified ranges for this value do not overlap</response>
+    <reason>There are multiple index terms specified with a @start attribute value of '%1', but there is only one term to end this range, or the ranges for this term overlap.</reason>
+    <response>Make sure that each term with this start value has a matching end value, and that the specified ranges for this value do not overlap.</response>
   </message>
 
   <message id="PDFX003W" type="WARN">
-    <reason>There are multiple index entries found to close the index range for "%1".</reason>
-    <response>Ensure that any index term with start="%1" has only one matching end term with end="%1".</response>
+    <reason>Multiple index entries close the index range '%1'.</reason>
+    <response>Make sure that each index term with with a @start attribute value of '%1' has only one matching term with an @end attribute value of '%1'.</response>
   </message>
 
   <message id="PDFX004F" type="ERROR">

--- a/src/main/plugins/org.dita.pdf2/resource/messages.xml
+++ b/src/main/plugins/org.dita.pdf2/resource/messages.xml
@@ -15,6 +15,18 @@ See the accompanying LICENSE file for applicable license.
     <response></response>
   </message>
 
+  <!-- DOTA067W and DOTA068W actually come from Java code inside the PDF plug-in.
+       DOTA prefix is innacurate. No reason to change at this point. -->
+  <message id="DOTA067W" type="WARN">
+    <reason>Ignoring index-see '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
+    <response></response>
+  </message>
+
+  <message id="DOTA068W" type="WARN">
+    <reason>Ignoring index-see-also '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
+    <response></response>
+  </message>
+
   <!-- Start of Java Messages -->
 
   <message id="PDFJ001E" type="ERROR">
@@ -30,18 +42,6 @@ See the accompanying LICENSE file for applicable license.
   <message id="PDFJ003I" type="INFO">
     <reason>Index entry '%1' will be sorted under the "Special characters" heading.</reason>
     <response/>
-  </message>
-
-  <!-- DOTA067W and DOTA068W actually come from Java code inside the PDF plug-in.
-       DOTA prefix is innacurate. No reason to change at this point. -->
-  <message id="DOTA067W" type="WARN">
-    <reason>Ignoring index-see '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
-    <response></response>
-  </message>
-
-  <message id="DOTA068W" type="WARN">
-    <reason>Ignoring index-see-also '%1' inside parent index entry '%2' because the parent indexterm contains indexterm children.</reason>
-    <response></response>
   </message>
 
   <!-- Start of XSL Messages -->

--- a/src/main/plugins/org.dita.xhtml/resource/messages.xml
+++ b/src/main/plugins/org.dita.xhtml/resource/messages.xml
@@ -12,22 +12,22 @@ See the accompanying LICENSE file for applicable license.
 
   <message id="DOTA006W" type="WARN">
     <reason>Absolute paths on the local file system are not supported for the CSSPATH parameter.</reason>
-    <response>Please use a relative path or full URI instead.</response>
+    <response>Use a relative path or full URI instead.</response>
   </message>
 
   <message id="DOTA007E" type="ERROR">
     <reason>Cannot find the running-footer file '%1'.</reason>
-    <response>Please double check the value to ensure it is specified correctly.</response>
+    <response>Check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA008E" type="ERROR">
     <reason>Cannot find the running-header file '%1'.</reason>
-    <response>Please double check the value to ensure it is specified correctly.</response>
+    <response>Check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA009E" type="ERROR">
     <reason>Cannot find the specified heading file '%1'.</reason>
-    <response>Please double check the value to ensure it is specified correctly.</response>
+    <response>Check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA069W" type="WARN">

--- a/src/main/plugins/org.dita.xhtml/resource/messages.xml
+++ b/src/main/plugins/org.dita.xhtml/resource/messages.xml
@@ -16,22 +16,22 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTA007E" type="ERROR">
-    <reason>Cannot find the running-footer file "%1".</reason>
+    <reason>Cannot find the running-footer file '%1'.</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA008E" type="ERROR">
-    <reason>Cannot find the running-header file "%1".</reason>
+    <reason>Cannot find the running-header file '%1'.</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA009E" type="ERROR">
-    <reason>Cannot find the specified heading file "%1".</reason>
+    <reason>Cannot find the specified heading file '%1'.</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
 
   <message id="DOTA069W" type="WARN">
-    <reason>Target "%1" is deprecated.</reason>
+    <reason>Target '%1' is deprecated.</reason>
     <response>Remove references to this target from your custom XSLT or plug-ins.</response>
   </message>
 

--- a/src/main/plugins/org.dita.xhtml/resource/messages.xml
+++ b/src/main/plugins/org.dita.xhtml/resource/messages.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 This file is part of the DITA Open Toolkit project.
 

--- a/src/main/plugins/org.dita.xhtml/resource/messages.xml
+++ b/src/main/plugins/org.dita.xhtml/resource/messages.xml
@@ -7,24 +7,32 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <messages>
+
+  <!-- Start of Ant Messages -->
+
   <message id="DOTA006W" type="WARN">
     <reason>Absolute paths on the local file system are not supported for the CSSPATH parameter.</reason>
     <response>Please use a relative path or full URI instead.</response>
   </message>
+
   <message id="DOTA007E" type="ERROR">
     <reason>Cannot find the running-footer file "%1".</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
+
   <message id="DOTA008E" type="ERROR">
     <reason>Cannot find the running-header file "%1".</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
+
   <message id="DOTA009E" type="ERROR">
     <reason>Cannot find the specified heading file "%1".</reason>
     <response>Please double check the value to ensure it is specified correctly.</response>
   </message>
+
   <message id="DOTA069W" type="WARN">
     <reason>Target "%1" is deprecated.</reason>
     <response>Remove references to this target from your custom XSLT or plug-ins.</response>
   </message>
+
 </messages>


### PR DESCRIPTION
## Description

Error message refactoring for #3973 

- [x] Add blank lines between messages for readability (8dfb8ca)
- [x] Normalize whitespace (d6369fc)
- [x] End all reason elements with periods (cf6c169)
- [x] Sort messages by ID within files (067e5b7)
- [x] Use single quotes for `%` placeholders (a17c7c8)
- [x] Mark unused message duplicates as deprecated (f097570)
- [x] Use XML-domain–style markup for attribute & element references 
      (`@rev` attribute, `&lt;topicref&gt;` element, etc.)
      (9d64912, 4253c33 , 13e57f6, and 62c8d0b)
- [x] Align references to DITA and DITAVAL files (479930e)
- [x] Replace "tag" references with "element" (e060b7a)
- [x] Update “file” references to “resource” (0c7753f)
- [x] Align “couldn’t” & “could not” → “cannot” (adb9a2d)
- [x] Deprecate any obsolete messages that are no longer used in the code

