### PR TITLE
Update PDF Theme plug-in to version 0.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ def bundled = [
         "index": "https://github.com/dita-ot/org.dita.index/releases/download/1.0.0/org.dita.index-1.0.0.zip",
         "axf": "https://github.com/dita-ot/org.dita.pdf2.axf/releases/download/3.6.1/org.dita.pdf2.axf-3.6.1.zip",
         "xep": "https://github.com/dita-ot/org.dita.pdf2.xep/releases/download/3.6.3/org.dita.pdf2.xep-3.6.3.zip",
-        "theme": "https://github.com/jelovirt/pdf-generator/releases/download/0.7.0/com.elovirta.pdf-0.7.0.zip",
+        "theme": "https://github.com/jelovirt/pdf-generator/releases/download/0.7.1/com.elovirta.pdf-0.7.1.zip",
 ]
 
 apply from: 'gradle/dist.gradle'


### PR DESCRIPTION
## Description
Update PDF Theme plug-in to version 0.7.1

## Motivation and Context
Version 0.7.1 only changes how target DITA-OT version are compared in code generation. This change makes it possible to compare the version number of future version where there is no explicit support yet added. This way the theme plug-in doesn't have to be released with support for e.g. version 4.2 _before_ DITA-OT 4.2 is released.
