### PR TITLE
Refactor subject scheme reader

### DIFF
--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -180,20 +180,15 @@ public class SubjectSchemeReader {
   }
 
   public void loadSubjectScheme(final Element schemeRoot) {
-    final List<Element> rootChildren = XMLUtils.getChildElements(schemeRoot);
-    for (Element child : rootChildren) {
-      final String attrValue = child.getAttribute(ATTRIBUTE_NAME_CLASS);
-      if (SUBJECTSCHEME_ENUMERATIONDEF.matches(attrValue)) {
-        processEnumerationDef(schemeRoot, child);
-      }
+    for (Element child : XMLUtils.getChildElements(schemeRoot, SUBJECTSCHEME_ENUMERATIONDEF)) {
+      processEnumerationDef(schemeRoot, child);
     }
   }
 
   public void processEnumerationDef(final Element schemeRoot, final Element enumerationDef) {
-    final List<Element> enumChildren = XMLUtils.getChildElements(enumerationDef);
     String elementName = "*";
     QName attributeName = null;
-    for (Element child : enumChildren) {
+    for (Element child : XMLUtils.getChildElements(enumerationDef)) {
       final String attrValue = child.getAttribute(ATTRIBUTE_NAME_CLASS);
       if (SUBJECTSCHEME_ELEMENTDEF.matches(attrValue)) {
         elementName = child.getAttribute(ATTRIBUTE_NAME_NAME);
@@ -303,11 +298,8 @@ public class SubjectSchemeReader {
 
     while (!queue.isEmpty()) {
       final Element node = queue.poll();
-      final NodeList children = node.getChildNodes();
-      for (int i = 0; i < children.getLength(); i++) {
-        if (children.item(i).getNodeType() == Node.ELEMENT_NODE) {
-          queue.offer((Element) children.item(i));
-        }
+      for (Element childElement : XMLUtils.getChildElements(node)) {
+        queue.offer(childElement);
       }
       if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
         final String key = node.getAttribute(ATTRIBUTE_NAME_KEYS);

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -200,10 +200,7 @@ public class SubjectSchemeReader {
         // Put default values.
         final String keyValue = child.getAttribute(ATTRIBUTE_NAME_KEYREF);
         if (keyValue != null) {
-          Map<String, String> S = defaultValueMap.get(attributeName);
-          if (S == null) {
-            S = new HashMap<>();
-          }
+          final Map<String, String> S = defaultValueMap.getOrDefault(attributeName, new HashMap<>());
           S.put(elementName, keyValue);
           defaultValueMap.put(attributeName, S);
         }
@@ -215,14 +212,8 @@ public class SubjectSchemeReader {
         }
         final Element subTree = searchForKey(schemeRoot, keyValue);
         if (subTree != null) {
-          Map<String, Set<Element>> S = bindingMap.get(attributeName);
-          if (S == null) {
-            S = new HashMap<>();
-          }
-          Set<Element> A = S.get(elementName);
-          if (A == null) {
-            A = new HashSet<>();
-          }
+          final Map<String, Set<Element>> S = bindingMap.getOrDefault(attributeName, new HashMap<>());
+          final Set<Element> A = S.getOrDefault(elementName, new HashSet<>());
           if (!A.contains(subTree)) {
             // Add sub-tree to valid values map
             putValuePairsIntoMap(subTree, elementName, attributeName, keyValue);
@@ -283,15 +274,8 @@ public class SubjectSchemeReader {
       return;
     }
 
-    Map<String, Set<String>> valueMap = validValuesMap.get(attName);
-    if (valueMap == null) {
-      valueMap = new HashMap<>();
-    }
-
-    Set<String> valueSet = valueMap.get(elementName);
-    if (valueSet == null) {
-      valueSet = new HashSet<>();
-    }
+    final Map<String, Set<String>> valueMap = validValuesMap.getOrDefault(attName, new HashMap<>());
+    final Set<String> valueSet = valueMap.getOrDefault(elementName, new HashSet<>());
 
     final LinkedList<Element> queue = new LinkedList<>();
     queue.offer(subtree);
@@ -303,7 +287,7 @@ public class SubjectSchemeReader {
       }
       if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
         final String key = node.getAttribute(ATTRIBUTE_NAME_KEYS);
-        if (!(key == null || key.trim().isEmpty() || key.equals(category))) {
+        if (!(key.trim().isEmpty() || key.equals(category))) {
           valueSet.add(key);
         }
       }

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -52,7 +52,7 @@ public final class FilterUtils {
 
   private DITAOTLogger logger;
   /** Actions for filter keys. */
-  private final Map<FilterKey, Action> filterMap;
+  final Map<FilterKey, Action> filterMap;
   /** Set of filter keys for which an error has already been thrown. */
   private final Set<FilterKey> notMappingRules = new HashSet<>();
   private boolean logMissingAction;

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -601,13 +601,20 @@ public final class FilterUtils {
         }
       }
       if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
-        final String key = node.getAttribute(ATTRIBUTE_NAME_KEYS);
-        if (keyValue.equals(key)) {
+        if (getKeyValues(node).contains(keyValue)) {
           return node;
         }
       }
     }
     return null;
+  }
+
+  private static List<String> getKeyValues(Element child) {
+    var value = child.getAttribute(ATTRIBUTE_NAME_KEYS).trim();
+    if (value.isEmpty()) {
+      return List.of();
+    }
+    return Arrays.asList(value.split("\\s+"));
   }
 
   /**
@@ -646,8 +653,7 @@ public final class FilterUtils {
         }
       }
       if (SUBJECTSCHEME_SUBJECTDEF.matches(node)) {
-        final String key = node.getAttribute(ATTRIBUTE_NAME_KEYS);
-        if (key != null && !key.trim().isEmpty()) {
+        for (String key : getKeyValues(node)) {
           final FilterKey k = new FilterKey(attName, key);
           if (!destFilterMap.containsKey(k)) {
             destFilterMap.put(k, action);

--- a/src/test/java/org/dita/dost/reader/SubjectSchemeReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/SubjectSchemeReaderTest.java
@@ -148,6 +148,34 @@ class SubjectSchemeReaderTest {
   }
 
   @Test
+  void loadSubjectScheme_multipleKeyValues() {
+    final Path src = init("multiple-key-values.ditamap");
+
+    reader.loadSubjectScheme(src.toFile());
+
+    var act = reader.getSubjectSchemeMap();
+    assertFalse(act.isEmpty());
+    assertSubjectSchemeEquals(
+      act,
+      new SubjectScheme(
+        Map.of(
+          QName.valueOf("platform"),
+          Map.of(
+            "*",
+            Set.of(createElement(createSubjectDef("os").withChild(createSubjectDef("linux redhat suse windows zos"))))
+          )
+        )
+      )
+    );
+    // FIXME
+    assertEquals(
+      Map.of(QName.valueOf("platform"), Map.of("*", Set.of("linux redhat suse windows zos"))),
+      reader.getValidValuesMap()
+    );
+    assertEquals(Map.of(), reader.getDefaultValueMap());
+  }
+
+  @Test
   void loadSubjectScheme_element() {
     final Path src = init("attribute-element.ditamap");
 
@@ -212,6 +240,7 @@ class SubjectSchemeReaderTest {
         )
       )
     );
+    // FIXME
     assertEquals(Map.of(QName.valueOf("platform"), Map.of("*", Set.of("windows", "zos"))), reader.getValidValuesMap());
     assertEquals(Map.of(), reader.getDefaultValueMap());
   }

--- a/src/test/java/org/dita/dost/reader/SubjectSchemeReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/SubjectSchemeReaderTest.java
@@ -167,9 +167,8 @@ class SubjectSchemeReaderTest {
         )
       )
     );
-    // FIXME
     assertEquals(
-      Map.of(QName.valueOf("platform"), Map.of("*", Set.of("linux redhat suse windows zos"))),
+      Map.of(QName.valueOf("platform"), Map.of("*", Set.of("linux", "redhat", "suse", "windows", "zos"))),
       reader.getValidValuesMap()
     );
     assertEquals(Map.of(), reader.getDefaultValueMap());

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.*;
+import java.util.stream.Stream;
 import javax.xml.namespace.QName;
 import net.sf.saxon.dom.NodeOverNodeInfo;
 import net.sf.saxon.s9api.SaxonApiException;
@@ -31,6 +32,8 @@ import org.dita.dost.util.FilterUtils.FilterKey;
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
@@ -496,8 +499,9 @@ public class FilterUtilsTest {
     assertThrows(NullPointerException.class, () -> new FilterKey(null, null));
   }
 
-  @Test
-  public void refine() {
+  @ParameterizedTest
+  @ValueSource(strings = { "arch redhat", "arch,redhat" })
+  public void refine(String values) {
     final FilterUtils f = new FilterUtils(
       Map.of(new FilterKey(QName.valueOf("platform"), "linux"), Action.INCLUDE),
       null,
@@ -512,7 +516,12 @@ public class FilterUtilsTest {
             Set.of(
               createElement(
                 createSubjectDef("os")
-                  .withChild(createSubjectDef("linux").withChild(createSubjectDef("arch"), createSubjectDef("redhat")))
+                  .withChild(
+                    createSubjectDef("linux")
+                      .withChild(
+                        Stream.of(values.split(",")).map(this::createSubjectDef).toArray(SaplingElement[]::new)
+                      )
+                  )
               )
             )
           )

--- a/src/test/java/org/dita/dost/util/FilterUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FilterUtilsTest.java
@@ -20,12 +20,19 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.*;
 import javax.xml.namespace.QName;
+import net.sf.saxon.dom.NodeOverNodeInfo;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.sapling.SaplingElement;
+import net.sf.saxon.sapling.Saplings;
 import org.dita.dost.TestUtils;
+import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.util.FilterUtils.Action;
 import org.dita.dost.util.FilterUtils.FilterKey;
 import org.dita.dost.util.FilterUtils.Flag;
 import org.dita.dost.util.XMLUtils.AttributesBuilder;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -48,6 +55,8 @@ public class FilterUtilsTest {
     .put(new FilterKey(AUDIENCE, "expert"), Action.INCLUDE)
     .put(new FilterKey(AUDIENCE, "novice"), Action.EXCLUDE)
     .build();
+
+  private XMLUtils xmlUtils = new XMLUtils();
 
   @Test
   public void testNeedExcludeNoAttribute() {
@@ -485,5 +494,57 @@ public class FilterUtilsTest {
   @Test
   public void filterKey_arguments() {
     assertThrows(NullPointerException.class, () -> new FilterKey(null, null));
+  }
+
+  @Test
+  public void refine() {
+    final FilterUtils f = new FilterUtils(
+      Map.of(new FilterKey(QName.valueOf("platform"), "linux"), Action.INCLUDE),
+      null,
+      null
+    );
+    var act = f.refine(
+      new SubjectScheme(
+        Map.of(
+          QName.valueOf("platform"),
+          Map.of(
+            "*",
+            Set.of(
+              createElement(
+                createSubjectDef("os")
+                  .withChild(createSubjectDef("linux").withChild(createSubjectDef("arch"), createSubjectDef("redhat")))
+              )
+            )
+          )
+        )
+      )
+    );
+    assertEquals(
+      Map.of(
+        new FilterKey(QName.valueOf("platform"), "arch"),
+        Action.INCLUDE,
+        new FilterKey(QName.valueOf("platform"), "linux"),
+        Action.INCLUDE,
+        new FilterKey(QName.valueOf("platform"), "redhat"),
+        Action.INCLUDE
+      ),
+      act.filterMap
+    );
+  }
+
+  private SaplingElement createSubjectDef(String keys) {
+    return Saplings
+      .elem("subjectdef")
+      .withAttr("class", "- map/topicref subjectScheme/subjectdef ")
+      .withAttr("keys", keys);
+  }
+
+  private Element createElement(SaplingElement exp) {
+    try {
+      var underlyingValue = Saplings.doc().withChild(exp).toXdmNode(xmlUtils.getProcessor()).getUnderlyingValue();
+      return ((Document) NodeOverNodeInfo.wrap(underlyingValue)).getDocumentElement();
+    } catch (SaxonApiException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/resources/org/dita/dost/reader.SubjectSchemeReaderTest.src/multiple-key-values.ditamap
+++ b/src/test/resources/org/dita/dost/reader.SubjectSchemeReaderTest.src/multiple-key-values.ditamap
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<subjectScheme xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+               class="- map/map subjectScheme/subjectScheme "
+               domains="(map mapgroup-d)                            (map subjectScheme)                            a(props deliveryTarget)                            (topic hazard-d)                            (topic hi-d)                            (topic ut-d)   "
+               processing-role="resource-only" toc="no" ditaarch:DITAArchVersion="1.3">
+  <subjectdef class="- map/topicref subjectScheme/subjectdef " keys="os">
+    <subjectdef class="- map/topicref subjectScheme/subjectdef " keys="linux redhat suse windows zos"/>
+  </subjectdef>
+  <enumerationdef class="- map/topicref subjectScheme/enumerationdef ">
+    <attributedef class="- topic/data subjectScheme/attributedef " name="platform" translate="no"/>
+    <subjectdef class="- map/topicref subjectScheme/subjectdef " keys="os"/>
+  </enumerationdef>
+</subjectScheme>


### PR DESCRIPTION
## Description
Refactor `SubjectSchemeReader` for code readability and more modern Java.

Support multiple keys in a single `@keys` attribute. For example

```xml
<subjectdef keys="linux windows"/>
```

## Motivation and Context
Refactor the code to make it easier to fix bugs and maintain the code in the future.

## How Has This Been Tested?
Existing test and new tests.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Document that we now support multiple keys in a single `@keys` attribute on `<subjectdef>` element. There are no examples of this use case in the DITA spec nor is it explicitly stated that this is supported. But because subject definitions use `@keys` attribute, multiple values per single attribute are supported.
