### PR TITLE
Move map specific reader code to map module

### DIFF
--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -9,7 +9,7 @@ package org.dita.dost.module;
 
 import static org.dita.dost.util.Configuration.printTranstype;
 import static org.dita.dost.util.Constants.*;
-import static org.dita.dost.util.FilterUtils.*;
+import static org.dita.dost.util.FilterUtils.SUBJECT_SCHEME_EXTENSION;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -906,7 +906,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     job.add(new FileInfo.Builder(root).isInput(true).build());
 
     try {
-      logger.info("Serializing job specification");
+      logger.debug("Serializing job specification");
       job.write();
     } catch (final IOException e) {
       throw new DITAOTException("Failed to serialize job configuration files: " + e.getMessage(), e);

--- a/src/main/java/org/dita/dost/module/ProfileModule.java
+++ b/src/main/java/org/dita/dost/module/ProfileModule.java
@@ -47,17 +47,17 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
 
     for (final FileInfo f : job.getFileInfo(fileInfoFilter)) {
       final URI file = job.tempDirURI.resolve(f.uri);
-      logger.info("Processing " + file);
+      logger.info("Processing {0}", file);
 
       try {
         job.getStore().transform(file, getProcessingPipe(file));
         if (!writer.hasElementOutput()) {
-          logger.info("All content in " + file + " was filtered out");
+          logger.info("All content in {0} was filtered out", file);
           job.remove(f);
           job.getStore().delete(file);
         }
       } catch (final Exception e) {
-        logger.error("Failed to profile " + file + ": " + e.getMessage());
+        logger.error("Failed to profile " + file + ": " + e.getMessage(), e);
       }
     }
 
@@ -119,7 +119,6 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
   }
 
   private void initSubjectScheme() throws DITAOTException {
-    //    if (filterUtils != null) {
     final Document doc = getMapDocument();
     if (doc != null) {
       final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
@@ -159,7 +158,6 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
         subjectSchemeFilter.setDefaultValueMap(subjectSchemeReader.getDefaultValueMap());
       }
     }
-    //    }
   }
 
   private Document getMapDocument() throws DITAOTException {
@@ -172,7 +170,7 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
     final FileInfo fi = fis.iterator().next();
     final URI currentFile = job.tempDirURI.resolve(fi.uri);
     try {
-      logger.debug("Reading " + currentFile);
+      logger.debug("Reading {0}", currentFile);
       return job.getStore().getDocument(currentFile);
     } catch (final IOException e) {
       throw new DITAOTException(new SAXException("Failed to parse " + currentFile, e));

--- a/src/main/java/org/dita/dost/module/ProfileModule.java
+++ b/src/main/java/org/dita/dost/module/ProfileModule.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2013 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.module;
+
+import static java.util.stream.Collectors.mapping;
+import static org.dita.dost.util.Configuration.printTranstype;
+import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.XMLUtils.ancestors;
+import static org.dita.dost.util.XMLUtils.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.tools.ant.util.FileUtils;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.pipeline.AbstractPipelineInput;
+import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.reader.DitaValReader;
+import org.dita.dost.reader.SubjectSchemeReader;
+import org.dita.dost.util.FilterUtils;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.writer.ProfilingFilter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+/**
+ * Filter module class.
+ */
+final class ProfileModule extends AbstractPipelineModuleImpl {
+
+  private FilterUtils filterUtils;
+  private ProfilingFilter writer;
+
+  @Override
+  public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
+    init(input);
+
+    for (final FileInfo f : job.getFileInfo(fileInfoFilter)) {
+      final File file = new File(job.tempDir, f.file.getPath());
+      logger.info("Processing " + file.getAbsolutePath());
+
+      writer.setCurrentFile(file.toURI());
+      try {
+        writer.write(file.getAbsoluteFile());
+        if (!writer.hasElementOutput()) {
+          logger.info("All content in " + file.getAbsolutePath() + " was filtered out");
+          job.remove(f);
+          FileUtils.delete(file);
+        }
+      } catch (final Exception e) {
+        logger.error("Failed to profile " + file.getAbsolutePath() + ": " + e.getMessage());
+      }
+    }
+
+    try {
+      job.write();
+    } catch (final IOException e) {
+      throw new DITAOTException(e);
+    }
+
+    return null;
+  }
+
+  private void init(final AbstractPipelineInput input) throws DITAOTException {
+    if (logger == null) {
+      throw new IllegalStateException("Logger not set");
+    }
+    final String transtype = input.getAttribute(ANT_INVOKER_EXT_PARAM_TRANSTYPE);
+    final File ditavalFile = Optional
+      .of(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL))
+      .filter(File::exists)
+      .orElse(null);
+
+    final DitaValReader ditaValReader = new DitaValReader();
+    ditaValReader.setLogger(logger);
+    ditaValReader.setJob(job);
+    if (ditavalFile != null) {
+      ditaValReader.read(ditavalFile.toURI());
+      filterUtils =
+        new FilterUtils(
+          printTranstype.contains(transtype),
+          ditaValReader.getFilterMap(),
+          ditaValReader.getForegroundConflictColor(),
+          ditaValReader.getBackgroundConflictColor()
+        );
+    } else {
+      filterUtils = new FilterUtils(printTranstype.contains(transtype));
+    }
+    filterUtils.setLogger(logger);
+
+    initSubjectScheme();
+
+    writer = new ProfilingFilter();
+    writer.setLogger(logger);
+    writer.setJob(job);
+    writer.setFilterUtils(filterUtils);
+  }
+
+  private void initSubjectScheme() throws DITAOTException {
+    if (filterUtils != null) {
+      final Document doc = getMapDocument();
+      if (doc != null) {
+        final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
+        subjectSchemeReader.setLogger(logger);
+        subjectSchemeReader.setJob(job);
+        logger.info("Loading subject schemes");
+        final List<Element> subjectSchemes = toList(doc.getDocumentElement().getElementsByTagName("*"));
+        subjectSchemes
+          .stream()
+          .filter(SUBJECTSCHEME_ENUMERATIONDEF::matches)
+          .map(enumerationDef1 ->
+            Map.entry(
+              ancestors(enumerationDef1).filter(SUBMAP::matches).findFirst().orElse(doc.getDocumentElement()),
+              enumerationDef1
+            )
+          )
+          .collect(Collectors.groupingBy(Map.Entry::getKey, mapping(Map.Entry::getValue, Collectors.toList())))
+          .forEach((schemeRoot, enumerationDefs) -> {
+            var subjectDefinitions = subjectSchemeReader.getSubjectDefinition(schemeRoot);
+            for (Element enumerationDef : enumerationDefs) {
+              subjectSchemeReader.processEnumerationDef(subjectDefinitions, enumerationDef);
+            }
+          });
+        var subjectSchemeMap = subjectSchemeReader.getSubjectSchemeMap();
+        if (subjectSchemeMap.subjectSchemeMap().isEmpty()) {
+          return;
+        }
+        filterUtils = filterUtils.refine(subjectSchemeMap);
+      }
+    }
+  }
+
+  private Document getMapDocument() throws DITAOTException {
+    final Collection<FileInfo> fis = job.getFileInfo(f ->
+      f.isInput && Objects.equals(f.format, ATTR_FORMAT_VALUE_DITAMAP)
+    );
+    if (fis.isEmpty()) {
+      return null;
+    }
+    final FileInfo fi = fis.iterator().next();
+    final URI currentFile = job.tempDirURI.resolve(fi.uri);
+    try {
+      logger.debug("Reading " + currentFile);
+      return job.getStore().getDocument(currentFile);
+    } catch (final IOException e) {
+      throw new DITAOTException(new SAXException("Failed to parse " + currentFile, e));
+    }
+  }
+}

--- a/src/main/java/org/dita/dost/module/ProfileModule.java
+++ b/src/main/java/org/dita/dost/module/ProfileModule.java
@@ -34,7 +34,7 @@ import org.xml.sax.SAXException;
 /**
  * Filter module class.
  */
-final class ProfileModule extends AbstractPipelineModuleImpl {
+public final class ProfileModule extends AbstractPipelineModuleImpl {
 
   private FilterUtils filterUtils;
   private ProfilingFilter writer;

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -37,6 +37,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.AbstractPipelineModuleImpl;
+import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.reader.*;
 import org.dita.dost.util.*;
@@ -104,14 +105,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   KeydefFilter keydefFilter;
   boolean validate = true;
   ContentHandler nullHandler;
-  private TempFileNameScheme tempFileNameScheme;
+  TempFileNameScheme tempFileNameScheme;
   /** Absolute path to input file. */
   URI rootFile;
   List<URI> resources;
   /** Subject scheme absolute file paths. */
   private final Set<URI> schemeSet = ConcurrentHashMap.newKeySet();
   /** Subject scheme usage. Key is absolute file path, value is set of applicable subject schemes. */
-  private final Map<URI, Set<URI>> schemeDictionary = new HashMap<>();
+  final Map<URI, Set<URI>> schemeDictionary = new HashMap<>();
   private final Map<URI, URI> copyTo = new ConcurrentHashMap<>();
   Mode processingMode;
   /** Generate {@code xtrf} and {@code xtrc} attributes */
@@ -119,12 +120,13 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   /** use grammar pool cache */
   private boolean gramcache = true;
   /** Profiling is enabled. */
-  private boolean profilingEnabled;
+  boolean profilingEnabled;
   String transtype;
   private File ditavalFile;
   FilterUtils filterUtils;
   /** Absolute path to current destination file. */
   File outputFile;
+  SubjectScheme subjectSchemeMap;
   Map<QName, Map<String, Set<String>>> validateMap;
   Map<QName, Map<String, String>> defaultValueMap;
   /** XMLReader instance for parsing dita file */
@@ -135,6 +137,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   TopicFragmentFilter topicFragmentFilter;
   /** Files found during additional resource crawl. **/
   final Set<URI> additionalResourcesSet = ConcurrentHashMap.newKeySet();
+
+  SubjectSchemeReader subjectSchemeReader;
 
   public abstract void readStartFile() throws DITAOTException;
 
@@ -209,32 +213,36 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
    * @param validate whether validate input file
    * @throws SAXException parsing exception
    */
-  void initXMLReader(final boolean validate) throws SAXException {
-    reader = XMLUtils.getXMLReader();
-    reader.setFeature(FEATURE_NAMESPACE, true);
-    reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
-    if (validate) {
-      reader.setFeature(FEATURE_VALIDATION, true);
-      try {
-        reader.setFeature(FEATURE_VALIDATION_SCHEMA, true);
-      } catch (final SAXNotRecognizedException e) {
-        // Not Xerces, ignore exception
+  void initXMLReader(final boolean validate) throws DITAOTException {
+    try {
+      reader = XMLUtils.getXMLReader();
+      reader.setFeature(FEATURE_NAMESPACE, true);
+      reader.setFeature(FEATURE_NAMESPACE_PREFIX, true);
+      if (validate) {
+        reader.setFeature(FEATURE_VALIDATION, true);
+        try {
+          reader.setFeature(FEATURE_VALIDATION_SCHEMA, true);
+        } catch (final SAXNotRecognizedException e) {
+          // Not Xerces, ignore exception
+        }
+      } else {
+        logger.warn(MessageUtils.getMessage("DOTJ037W").toString());
       }
-    } else {
-      logger.warn(MessageUtils.getMessage("DOTJ037W").toString());
-    }
-    if (gramcache) {
-      final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
-      try {
-        reader.setProperty("http://apache.org/xml/properties/internal/grammar-pool", grammarPool);
-        logger.info("Using Xerces grammar pool for DTD and schema caching.");
-      } catch (final NoClassDefFoundError e) {
-        logger.debug("Xerces not available, not using grammar caching");
-      } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
-        logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
+      if (gramcache) {
+        final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
+        try {
+          reader.setProperty("http://apache.org/xml/properties/internal/grammar-pool", grammarPool);
+          logger.info("Using Xerces grammar pool for DTD and schema caching.");
+        } catch (final NoClassDefFoundError e) {
+          logger.debug("Xerces not available, not using grammar caching");
+        } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
+          logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
+        }
       }
+      reader.setEntityResolver(CatalogUtils.getCatalogResolver());
+    } catch (SAXException e) {
+      throw new DITAOTException(e);
     }
-    reader.setEntityResolver(CatalogUtils.getCatalogResolver());
   }
 
   void parseInputParameters(final AbstractPipelineInput input) {
@@ -360,8 +368,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         return;
       }
     }
-    validateMap = Collections.emptyMap();
-    defaultValueMap = Collections.emptyMap();
     logger.info("Processing " + currentFile + " to " + outputFile.toURI());
     final String[] params = { currentFile.toString() };
 
@@ -830,22 +836,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     } catch (final IOException e) {
       throw new DITAOTException("Failed to serialize job configuration files: " + e.getMessage(), e);
     }
-
-    try {
-      final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
-      subjectSchemeReader.setLogger(logger);
-      subjectSchemeReader.setJob(job);
-      subjectSchemeReader.writeMapToXML(
-        addMapFilePrefix(listFilter.getRelationshipGrap()),
-        new File(job.tempDir, FILE_NAME_SUBJECT_RELATION)
-      );
-      subjectSchemeReader.writeMapToXML(
-        addMapFilePrefix(schemeDictionary),
-        new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY)
-      );
-    } catch (final IOException e) {
-      throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
-    }
   }
 
   /** Filter copy-to where target is used directly. */
@@ -942,23 +932,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   }
 
   /**
-   * Convert absolute paths to relative temporary directory paths
-   * @return map with relative keys and values
-   */
-  private Map<URI, Set<URI>> addMapFilePrefix(final Map<URI, Set<URI>> map) {
-    final Map<URI, Set<URI>> res = new HashMap<>();
-    for (final Map.Entry<URI, Set<URI>> e : map.entrySet()) {
-      final URI key = e.getKey();
-      final Set<URI> newSet = new HashSet<>();
-      for (final URI file : e.getValue()) {
-        newSet.add(tempFileNameScheme.generateTempFileName(file));
-      }
-      res.put(key.equals(ROOT_URI) ? key : tempFileNameScheme.generateTempFileName(key), newSet);
-    }
-    return res;
-  }
-
-  /**
    * add FlagImangesSet to Properties, which needn't to change the dir level,
    * just ouput to the ouput dir.
    *
@@ -998,7 +971,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     prop.setProperty(REL_FLAGIMAGE_LIST, StringUtils.join(newSet, COMMA));
   }
 
-  void init() throws SAXException {
+  void init() throws DITAOTException {
     try {
       final String cls = Optional
         .ofNullable(job.getProperty("temp-file-name-scheme"))

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -829,13 +829,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       throw new RuntimeException("Unable to set input file to job configuration");
     }
     job.add(new FileInfo.Builder(root).isInput(true).build());
-
-    try {
-      logger.info("Serializing job specification");
-      job.write();
-    } catch (final IOException e) {
-      throw new DITAOTException("Failed to serialize job configuration files: " + e.getMessage(), e);
-    }
   }
 
   /** Filter copy-to where target is used directly. */

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -37,9 +37,11 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.AbstractPipelineModuleImpl;
-import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
-import org.dita.dost.reader.*;
+import org.dita.dost.reader.DitaValReader;
+import org.dita.dost.reader.GenListModuleReader;
+import org.dita.dost.reader.GrammarPoolManager;
+import org.dita.dost.reader.KeydefFilter;
 import org.dita.dost.util.*;
 import org.dita.dost.writer.DitaWriterFilter;
 import org.dita.dost.writer.TopicFragmentFilter;
@@ -105,14 +107,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   KeydefFilter keydefFilter;
   boolean validate = true;
   ContentHandler nullHandler;
-  TempFileNameScheme tempFileNameScheme;
+  private TempFileNameScheme tempFileNameScheme;
   /** Absolute path to input file. */
   URI rootFile;
   List<URI> resources;
   /** Subject scheme absolute file paths. */
   private final Set<URI> schemeSet = ConcurrentHashMap.newKeySet();
   /** Subject scheme usage. Key is absolute file path, value is set of applicable subject schemes. */
-  final Map<URI, Set<URI>> schemeDictionary = new HashMap<>();
+  private final Map<URI, Set<URI>> schemeDictionary = new HashMap<>();
   private final Map<URI, URI> copyTo = new ConcurrentHashMap<>();
   Mode processingMode;
   /** Generate {@code xtrf} and {@code xtrc} attributes */
@@ -120,13 +122,12 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   /** use grammar pool cache */
   private boolean gramcache = true;
   /** Profiling is enabled. */
-  boolean profilingEnabled;
+  private boolean profilingEnabled;
   String transtype;
   private File ditavalFile;
   FilterUtils filterUtils;
   /** Absolute path to current destination file. */
   File outputFile;
-  SubjectScheme subjectSchemeMap;
   Map<QName, Map<String, Set<String>>> validateMap;
   Map<QName, Map<String, String>> defaultValueMap;
   /** XMLReader instance for parsing dita file */
@@ -137,8 +138,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   TopicFragmentFilter topicFragmentFilter;
   /** Files found during additional resource crawl. **/
   final Set<URI> additionalResourcesSet = ConcurrentHashMap.newKeySet();
-
-  SubjectSchemeReader subjectSchemeReader;
 
   public abstract void readStartFile() throws DITAOTException;
 

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -19,13 +19,13 @@ import java.util.*;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
+import org.dita.dost.module.ProfileModule;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
 import org.dita.dost.reader.SubjectSchemeReader;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.NormalizeFilter;
-import org.dita.dost.writer.ProfilingFilter;
 import org.dita.dost.writer.ValidationFilter;
 import org.xml.sax.XMLFilter;
 
@@ -61,6 +61,18 @@ public final class MapReaderModule extends AbstractReaderModule {
       throw new DITAOTException(e.getMessage(), e);
     }
 
+    if (profilingEnabled) {
+      var profileModule = new ProfileModule();
+      profileModule.setJob(job);
+      profileModule.setLogger(logger);
+      profileModule.setXmlUtils(xmlUtils);
+      profileModule.setParallel(parallel);
+      profileModule.setProcessingMode(processingMode);
+      profileModule.setFileInfoFilter((fileInfo -> Objects.equals(fileInfo.format, ATTR_FORMAT_VALUE_DITAMAP)));
+
+      profileModule.execute(input);
+    }
+
     return null;
   }
 
@@ -87,14 +99,14 @@ public final class MapReaderModule extends AbstractReaderModule {
       pipe.add(debugFilter);
     }
 
-    if (filterUtils != null) {
-      final ProfilingFilter profilingFilter = new ProfilingFilter();
-      profilingFilter.setLogger(logger);
-      profilingFilter.setJob(job);
-      profilingFilter.setFilterUtils(filterUtils);
-      profilingFilter.setCurrentFile(fileToParse);
-      pipe.add(profilingFilter);
-    }
+    //    if (filterUtils != null) {
+    //      final ProfilingFilter profilingFilter = new ProfilingFilter();
+    //      profilingFilter.setLogger(logger);
+    //      profilingFilter.setJob(job);
+    //      profilingFilter.setFilterUtils(filterUtils);
+    //      profilingFilter.setCurrentFile(fileToParse);
+    //      pipe.add(profilingFilter);
+    //    }
 
     final ValidationFilter validationFilter = new ValidationFilter();
     validationFilter.setLogger(logger);

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -19,7 +19,6 @@ import java.util.*;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
-import org.dita.dost.module.ProfileModule;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
@@ -61,17 +60,17 @@ public final class MapReaderModule extends AbstractReaderModule {
       throw new DITAOTException(e.getMessage(), e);
     }
 
-    if (profilingEnabled) {
-      var profileModule = new ProfileModule();
-      profileModule.setJob(job);
-      profileModule.setLogger(logger);
-      profileModule.setXmlUtils(xmlUtils);
-      profileModule.setParallel(parallel);
-      profileModule.setProcessingMode(processingMode);
-      profileModule.setFileInfoFilter((fileInfo -> Objects.equals(fileInfo.format, ATTR_FORMAT_VALUE_DITAMAP)));
-
-      profileModule.execute(input);
-    }
+    //    if (profilingEnabled) {
+    //      var profileModule = new ProfileModule();
+    //      profileModule.setJob(job);
+    //      profileModule.setLogger(logger);
+    //      profileModule.setXmlUtils(xmlUtils);
+    //      profileModule.setParallel(parallel);
+    //      profileModule.setProcessingMode(processingMode);
+    //      profileModule.setFileInfoFilter((fileInfo -> Objects.equals(fileInfo.format, ATTR_FORMAT_VALUE_DITAMAP)));
+    //
+    //      profileModule.execute(input);
+    //    }
 
     return null;
   }

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -8,21 +8,19 @@
 
 package org.dita.dost.module.reader;
 
-import static org.dita.dost.reader.GenListModuleReader.ROOT_URI;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.exists;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
-import org.dita.dost.reader.SubjectSchemeReader;
 import org.dita.dost.writer.DebugFilter;
 import org.dita.dost.writer.NormalizeFilter;
 import org.dita.dost.writer.ValidationFilter;
@@ -60,18 +58,6 @@ public final class MapReaderModule extends AbstractReaderModule {
       throw new DITAOTException(e.getMessage(), e);
     }
 
-    //    if (profilingEnabled) {
-    //      var profileModule = new ProfileModule();
-    //      profileModule.setJob(job);
-    //      profileModule.setLogger(logger);
-    //      profileModule.setXmlUtils(xmlUtils);
-    //      profileModule.setParallel(parallel);
-    //      profileModule.setProcessingMode(processingMode);
-    //      profileModule.setFileInfoFilter((fileInfo -> Objects.equals(fileInfo.format, ATTR_FORMAT_VALUE_DITAMAP)));
-    //
-    //      profileModule.execute(input);
-    //    }
-
     return null;
   }
 
@@ -98,18 +84,9 @@ public final class MapReaderModule extends AbstractReaderModule {
       pipe.add(debugFilter);
     }
 
-    //    if (filterUtils != null) {
-    //      final ProfilingFilter profilingFilter = new ProfilingFilter();
-    //      profilingFilter.setLogger(logger);
-    //      profilingFilter.setJob(job);
-    //      profilingFilter.setFilterUtils(filterUtils);
-    //      profilingFilter.setCurrentFile(fileToParse);
-    //      pipe.add(profilingFilter);
-    //    }
-
     final ValidationFilter validationFilter = new ValidationFilter();
     validationFilter.setLogger(logger);
-    validationFilter.setValidateMap(validateMap);
+    //    validationFilter.setValidateMap(validateMap);
     validationFilter.setCurrentFile(fileToParse);
     validationFilter.setJob(job);
     validationFilter.setProcessingMode(processingMode);
@@ -127,7 +104,7 @@ public final class MapReaderModule extends AbstractReaderModule {
     listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
     pipe.add(listFilter);
 
-    ditaWriterFilter.setDefaultValueMap(defaultValueMap);
+    //    ditaWriterFilter.setDefaultValueMap(defaultValueMap);
     ditaWriterFilter.setCurrentFile(currentFile);
     ditaWriterFilter.setOutputFile(outputFile);
     pipe.add(ditaWriterFilter);
@@ -155,42 +132,41 @@ public final class MapReaderModule extends AbstractReaderModule {
     }
     //        }
   }
-
-  @Override
-  void outputResult() throws DITAOTException {
-    super.outputResult();
-
-    try {
-      final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
-      subjectSchemeReader.setLogger(logger);
-      subjectSchemeReader.setJob(job);
-      subjectSchemeReader.writeMapToXML(
-        addMapFilePrefix(listFilter.getRelationshipGrap()),
-        new File(job.tempDir, FILE_NAME_SUBJECT_RELATION)
-      );
-      subjectSchemeReader.writeMapToXML(
-        addMapFilePrefix(schemeDictionary),
-        new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY)
-      );
-    } catch (final IOException e) {
-      throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Convert absolute paths to relative temporary directory paths
-   * @return map with relative keys and values
-   */
-  private Map<URI, Set<URI>> addMapFilePrefix(final Map<URI, Set<URI>> map) {
-    final Map<URI, Set<URI>> res = new HashMap<>();
-    for (final Map.Entry<URI, Set<URI>> e : map.entrySet()) {
-      final URI key = e.getKey();
-      final Set<URI> newSet = new HashSet<>();
-      for (final URI file : e.getValue()) {
-        newSet.add(tempFileNameScheme.generateTempFileName(file));
-      }
-      res.put(key.equals(ROOT_URI) ? key : tempFileNameScheme.generateTempFileName(key), newSet);
-    }
-    return res;
-  }
+  //  @Override
+  //  void outputResult() throws DITAOTException {
+  //    super.outputResult();
+  //
+  //    try {
+  //      final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
+  //      subjectSchemeReader.setLogger(logger);
+  //      subjectSchemeReader.setJob(job);
+  //      subjectSchemeReader.writeMapToXML(
+  //        addMapFilePrefix(listFilter.getRelationshipGrap()),
+  //        new File(job.tempDir, FILE_NAME_SUBJECT_RELATION)
+  //      );
+  //      subjectSchemeReader.writeMapToXML(
+  //        addMapFilePrefix(schemeDictionary),
+  //        new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY)
+  //      );
+  //    } catch (final IOException e) {
+  //      throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
+  //    }
+  //  }
+  //
+  //  /**
+  //   * Convert absolute paths to relative temporary directory paths
+  //   * @return map with relative keys and values
+  //   */
+  //  private Map<URI, Set<URI>> addMapFilePrefix(final Map<URI, Set<URI>> map) {
+  //    final Map<URI, Set<URI>> res = new HashMap<>();
+  //    for (final Map.Entry<URI, Set<URI>> e : map.entrySet()) {
+  //      final URI key = e.getKey();
+  //      final Set<URI> newSet = new HashSet<>();
+  //      for (final URI file : e.getValue()) {
+  //        newSet.add(tempFileNameScheme.generateTempFileName(file));
+  //      }
+  //      res.put(key.equals(ROOT_URI) ? key : tempFileNameScheme.generateTempFileName(key), newSet);
+  //    }
+  //    return res;
+  //  }
 }

--- a/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/MapReaderModule.java
@@ -86,7 +86,6 @@ public final class MapReaderModule extends AbstractReaderModule {
 
     final ValidationFilter validationFilter = new ValidationFilter();
     validationFilter.setLogger(logger);
-    //    validationFilter.setValidateMap(validateMap);
     validationFilter.setCurrentFile(fileToParse);
     validationFilter.setJob(job);
     validationFilter.setProcessingMode(processingMode);
@@ -104,7 +103,6 @@ public final class MapReaderModule extends AbstractReaderModule {
     listFilter.setErrorHandler(new DITAOTXMLErrorHandler(fileToParse.toString(), logger, processingMode));
     pipe.add(listFilter);
 
-    //    ditaWriterFilter.setDefaultValueMap(defaultValueMap);
     ditaWriterFilter.setCurrentFile(currentFile);
     ditaWriterFilter.setOutputFile(outputFile);
     pipe.add(ditaWriterFilter);
@@ -132,41 +130,4 @@ public final class MapReaderModule extends AbstractReaderModule {
     }
     //        }
   }
-  //  @Override
-  //  void outputResult() throws DITAOTException {
-  //    super.outputResult();
-  //
-  //    try {
-  //      final SubjectSchemeReader subjectSchemeReader = new SubjectSchemeReader();
-  //      subjectSchemeReader.setLogger(logger);
-  //      subjectSchemeReader.setJob(job);
-  //      subjectSchemeReader.writeMapToXML(
-  //        addMapFilePrefix(listFilter.getRelationshipGrap()),
-  //        new File(job.tempDir, FILE_NAME_SUBJECT_RELATION)
-  //      );
-  //      subjectSchemeReader.writeMapToXML(
-  //        addMapFilePrefix(schemeDictionary),
-  //        new File(job.tempDir, FILE_NAME_SUBJECT_DICTIONARY)
-  //      );
-  //    } catch (final IOException e) {
-  //      throw new DITAOTException("Failed to serialize subject scheme files: " + e.getMessage(), e);
-  //    }
-  //  }
-  //
-  //  /**
-  //   * Convert absolute paths to relative temporary directory paths
-  //   * @return map with relative keys and values
-  //   */
-  //  private Map<URI, Set<URI>> addMapFilePrefix(final Map<URI, Set<URI>> map) {
-  //    final Map<URI, Set<URI>> res = new HashMap<>();
-  //    for (final Map.Entry<URI, Set<URI>> e : map.entrySet()) {
-  //      final URI key = e.getKey();
-  //      final Set<URI> newSet = new HashSet<>();
-  //      for (final URI file : e.getValue()) {
-  //        newSet.add(tempFileNameScheme.generateTempFileName(file));
-  //      }
-  //      res.put(key.equals(ROOT_URI) ? key : tempFileNameScheme.generateTempFileName(key), newSet);
-  //    }
-  //    return res;
-  //  }
 }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -30,6 +30,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.DITAOTXMLErrorHandler;
 import org.dita.dost.exception.UncheckedDITAOTException;
 import org.dita.dost.log.MessageUtils;
+import org.dita.dost.module.filter.SubjectScheme;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.GenListModuleReader.Reference;
@@ -59,6 +60,9 @@ public final class TopicReaderModule extends AbstractReaderModule {
   static final QName QNAME_FORMAT = new QName(ATTRIBUTE_NAME_FORMAT);
   static final QName QNAME_CLASS = new QName(ATTRIBUTE_NAME_CLASS);
   static final QName QNAME_ORIG_FORMAT = new QName(DITA_OT_NS, ATTRIBUTE_NAME_ORIG_FORMAT);
+
+  private SubjectScheme subjectSchemeMap;
+  private SubjectSchemeReader subjectSchemeReader;
 
   public TopicReaderModule() {
     super();

--- a/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
+++ b/src/main/java/org/dita/dost/reader/SubjectSchemeReader.java
@@ -32,6 +32,8 @@ import org.w3c.dom.Element;
  */
 public class SubjectSchemeReader {
 
+  public static final String ANY_ELEMENT = "*";
+
   private DITAOTLogger logger;
   private Job job;
   private final Map<QName, Map<String, Set<SubjectDefinition>>> bindingMap;
@@ -233,7 +235,7 @@ public class SubjectSchemeReader {
       .getChildElement(enumerationDef, SUBJECTSCHEME_ELEMENTDEF)
       .map(child -> child.getAttribute(ATTRIBUTE_NAME_NAME))
       .filter(Predicate.not(String::isEmpty))
-      .orElse("*");
+      .orElse(ANY_ELEMENT);
 
     final Optional<Element> attributeDefElement = XMLUtils.getChildElement(enumerationDef, SUBJECTSCHEME_ATTRIBUTEDEF);
     final QName attributeName = attributeDefElement

--- a/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
+++ b/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
@@ -69,7 +69,7 @@ public class SubjectSchemeFilter extends AbstractXMLFilter {
         }
       }
     }
-    return Objects.requireNonNullElse(atts, modified);
+    return Objects.requireNonNullElse(modified, atts);
   }
 
   /**

--- a/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
+++ b/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
@@ -44,8 +44,6 @@ public class SubjectSchemeFilter extends AbstractXMLFilter {
     defaultValueMap = defaultMap;
   }
 
-  // SAX methods
-
   @Override
   public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
     throws SAXException {
@@ -71,37 +69,8 @@ public class SubjectSchemeFilter extends AbstractXMLFilter {
         }
       }
     }
-    //    final Map<String, String> defaultValues = defaultValueMap.get(qName);
-    //    if (defaultValues != null) {}
-    //
-    //    for (int i = 0; i < atts.getLength(); i++) {
-    //      final QName attrName = new QName(atts.getURI(i), atts.getLocalName(i));
-    //      final String attrValue = atts.getValue(i);
-    //
-    //      final String defaultValue = getAttributeValue(qName, attrName, attrValue);
-    //      if (defaultValue != null) {
-    //        if (modified == null) {
-    //          modified = new AttributesImpl(atts);
-    //        }
-    //        modified.setValue(modified.getIndex(atts.getURI(i), atts.getLocalName(i)), defaultValue);
-    //      }
-    //    }
-    //    for (QName attrName : defaultValueMap.keySet()) {}
     return Objects.requireNonNullElse(atts, modified);
   }
-
-  //  private String getAttributeValue(final String elemQName, final QName attQName, final String value) {
-  //    if (StringUtils.isEmptyString(value) && !defaultValueMap.isEmpty()) {
-  //      final Map<String, String> defaultMap = defaultValueMap.get(attQName);
-  //      if (defaultMap != null) {
-  //        final String defaultValue = defaultMap.get(elemQName);
-  //        if (defaultValue != null) {
-  //          return defaultValue;
-  //        }
-  //      }
-  //    }
-  //    return value;
-  //  }
 
   /**
    * Validate attribute values

--- a/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
+++ b/src/main/java/org/dita/dost/writer/SubjectSchemeFilter.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.writer;
+
+import static org.dita.dost.util.Constants.COMMA;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.dita.dost.log.MessageUtils;
+import org.dita.dost.util.StringUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+public class SubjectSchemeFilter extends AbstractXMLFilter {
+
+  private Map<QName, Map<String, String>> defaultValueMap = null;
+  private Map<QName, Map<String, Set<String>>> validateMap = null;
+
+  /**
+   * Set valid attribute values.
+   *
+   * <p>The contents of the map is in pseudo-code
+   * {@code Map<AttName, Map<ElemName, <Set<Value>>>}.
+   * For default element mapping, the value is {@code *}.
+   */
+  public void setValidateMap(final Map<QName, Map<String, Set<String>>> validateMap) {
+    this.validateMap = validateMap;
+  }
+
+  /**
+   * Set default value map.
+   * @param defaultMap default value map
+   */
+  public void setDefaultValueMap(final Map<QName, Map<String, String>> defaultMap) {
+    defaultValueMap = defaultMap;
+  }
+
+  // SAX methods
+
+  @Override
+  public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+    throws SAXException {
+    Attributes res = atts;
+    validateAttributeValues(qName, res);
+    res = addDefaultAttributeValues(qName, res);
+
+    super.startElement(uri, localName, qName, res);
+  }
+
+  private Attributes addDefaultAttributeValues(final String qName, final Attributes atts) {
+    AttributesImpl modified = null;
+    for (Map.Entry<QName, Map<String, String>> elementDefaultValues : defaultValueMap.entrySet()) {
+      final QName attrName = elementDefaultValues.getKey();
+      final int index = atts.getIndex(attrName.getNamespaceURI(), attrName.getLocalPart());
+      if (index == -1) {
+        final String defaultValue = elementDefaultValues.getValue().get(qName);
+        if (defaultValue != null) {
+          if (modified == null) {
+            modified = new AttributesImpl(atts);
+          }
+          modified.addAttribute(attrName.getNamespaceURI(), attrName.getLocalPart(), null, "CDATA", defaultValue);
+        }
+      }
+    }
+    //    final Map<String, String> defaultValues = defaultValueMap.get(qName);
+    //    if (defaultValues != null) {}
+    //
+    //    for (int i = 0; i < atts.getLength(); i++) {
+    //      final QName attrName = new QName(atts.getURI(i), atts.getLocalName(i));
+    //      final String attrValue = atts.getValue(i);
+    //
+    //      final String defaultValue = getAttributeValue(qName, attrName, attrValue);
+    //      if (defaultValue != null) {
+    //        if (modified == null) {
+    //          modified = new AttributesImpl(atts);
+    //        }
+    //        modified.setValue(modified.getIndex(atts.getURI(i), atts.getLocalName(i)), defaultValue);
+    //      }
+    //    }
+    //    for (QName attrName : defaultValueMap.keySet()) {}
+    return Objects.requireNonNullElse(atts, modified);
+  }
+
+  //  private String getAttributeValue(final String elemQName, final QName attQName, final String value) {
+  //    if (StringUtils.isEmptyString(value) && !defaultValueMap.isEmpty()) {
+  //      final Map<String, String> defaultMap = defaultValueMap.get(attQName);
+  //      if (defaultMap != null) {
+  //        final String defaultValue = defaultMap.get(elemQName);
+  //        if (defaultValue != null) {
+  //          return defaultValue;
+  //        }
+  //      }
+  //    }
+  //    return value;
+  //  }
+
+  /**
+   * Validate attribute values
+   *
+   * @param qName element name
+   * @param atts attributes
+   */
+  private void validateAttributeValues(final String qName, final Attributes atts) {
+    for (int i = 0; i < atts.getLength(); i++) {
+      final QName attrName = new QName(atts.getURI(i), atts.getLocalName(i));
+      final Map<String, Set<String>> valueMap = validateMap.get(attrName);
+      if (valueMap != null) {
+        Set<String> valueSet = valueMap.get(qName);
+        if (valueSet == null) {
+          valueSet = valueMap.get("*");
+        }
+        if (valueSet != null) {
+          final String attrValue = atts.getValue(i);
+          final String[] keylist = attrValue.trim().split("\\s+");
+          for (final String s : keylist) {
+            if (!StringUtils.isEmptyString(s) && !valueSet.contains(s)) {
+              logger.warn(
+                MessageUtils
+                  .getMessage("DOTJ049W", attrName.toString(), qName, attrValue, StringUtils.join(valueSet, COMMA))
+                  .setLocation(atts)
+                  .toString()
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -309,7 +309,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
    * @param atts attributes
    */
   private void validateAttributeValues(final String qName, final Attributes atts) {
-    if (validateMap.isEmpty()) {
+    if (validateMap == null || validateMap.isEmpty()) {
       return;
     }
     for (int i = 0; i < atts.getLength(); i++) {

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -158,10 +158,16 @@ See the accompanying LICENSE file for applicable license.
         <param name="transtype" value="${transtype}"/>
         <param name="gramcache" value="${args.grammar.cache}"/>
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
-        <param name="profiling.enable" value="${map.filter-on-parse}" unless:set="map.filter-on-parse"/>
+        <!--param name="profiling.enable" value="${map.filter-on-parse}"/-->
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
+      </module>
+      <module class="org.dita.dost.module.ProfileModule" if:true="${map.filter-on-parse}">
+        <ditafileset format="ditamap" input="true"/>
+        <ditafileset format="ditamap" inputResource="true"/>
+        <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
+        <param name="transtype" value="${transtype}"/>
       </module>
     </pipeline>
     <local name="inputMapPath"/>
@@ -251,7 +257,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="map-profile"
     unless="preprocess.map-profile.skip"
     description="Profile input map files">
-    <pipeline message="Profile filtering." taskname="profile">
+    <pipeline message="Profile filtering." taskname="profile" unless:true="${map.filter-on-parse}">
       <module class="org.dita.dost.module.ProfileModule">
         <ditafileset format="ditamap" input="true"/>
         <ditafileset format="ditamap" inputResource="true"/>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -34,6 +34,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="preprocess2.maps"
           depends="map-reader,
                   map-mapref,
+                  map-reader-profile,
                   map-branch-filter,
                   map-keyref,
                   map-conrefpush,
@@ -117,12 +118,14 @@ See the accompanying LICENSE file for applicable license.
     <condition property="topic.filter-on-parse" value="true" else="false">
       <equals arg1="${filter-stage}" arg2="early"/>
     </condition>
+    <!--
     <condition property="build-step.map-profile" value="false" else="true">
       <istrue value="${map.filter-on-parse}"/>
     </condition>
     <condition property="build-step.topic-profile" value="false" else="true">
       <istrue value="${topic.filter-on-parse}"/>
     </condition>
+    -->
 
     <preprocess-skip-init name="preprocess.map-profile" step="map-profile"/>
     <preprocess-skip-init name="preprocess.topic-profile" step="topic-profile"/>
@@ -163,12 +166,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
-      <module class="org.dita.dost.module.ProfileModule" if:true="${map.filter-on-parse}">
-        <ditafileset format="ditamap" input="true"/>
-        <ditafileset format="ditamap" inputResource="true"/>
-        <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
-        <param name="transtype" value="${transtype}"/>
-      </module>
     </pipeline>
     <local name="inputMapPath"/>
     <pathconvert property="inputMapPath">
@@ -192,6 +189,14 @@ See the accompanying LICENSE file for applicable license.
         <dita:extension id="dita.preprocess.mapref.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
+<!--    <pipeline message="Profile filtering." taskname="profile" if:true="${map.filter-on-parse}">-->
+<!--      <module class="org.dita.dost.module.ProfileModule">-->
+<!--        <ditafileset format="ditamap" input="true"/>-->
+<!--        <ditafileset format="ditamap" inputResource="true"/>-->
+<!--        <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>-->
+<!--        <param name="transtype" value="${transtype}"/>-->
+<!--      </module>-->
+<!--    </pipeline>-->
   </target>
 
   <target name="map-branch-filter"
@@ -253,7 +258,20 @@ See the accompanying LICENSE file for applicable license.
       </xslt>
     </pipeline>
   </target>
-  
+
+  <target name="map-reader-profile"
+          unless="preprocess.map-profile.skip"
+          description="Profile input map files">
+    <pipeline message="Profile filtering." taskname="profile" if:true="${map.filter-on-parse}">
+      <module class="org.dita.dost.module.ProfileModule">
+        <ditafileset format="ditamap" input="true"/>
+        <ditafileset format="ditamap" inputResource="true"/>
+        <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>
+        <param name="transtype" value="${transtype}"/>
+      </module>
+    </pipeline>
+  </target>
+
   <target name="map-profile"
     unless="preprocess.map-profile.skip"
     description="Profile input map files">
@@ -372,7 +390,7 @@ See the accompanying LICENSE file for applicable license.
   <target name="topic-profile"
           unless="preprocess.topic-profile.skip"
           description="Profile input files">
-    <pipeline message="Profile filtering." taskname="profile">
+    <pipeline message="Profile filtering." taskname="profile" unless:true="${map.filter-on-parse}">
       <module class="org.dita.dost.module.FilterModule">
         <ditafileset format="dita"/>
         <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -250,7 +250,7 @@ See the accompanying LICENSE file for applicable license.
     unless="preprocess.map-profile.skip"
     description="Profile input map files">
     <pipeline message="Profile filtering." taskname="profile">
-      <module class="org.dita.dost.module.FilterModule">
+      <module class="org.dita.dost.module.ProfileModule">
         <ditafileset format="ditamap" input="true"/>
         <ditafileset format="ditamap" inputResource="true"/>
         <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -118,14 +118,6 @@ See the accompanying LICENSE file for applicable license.
     <condition property="topic.filter-on-parse" value="true" else="false">
       <equals arg1="${filter-stage}" arg2="early"/>
     </condition>
-    <!--
-    <condition property="build-step.map-profile" value="false" else="true">
-      <istrue value="${map.filter-on-parse}"/>
-    </condition>
-    <condition property="build-step.topic-profile" value="false" else="true">
-      <istrue value="${topic.filter-on-parse}"/>
-    </condition>
-    -->
 
     <preprocess-skip-init name="preprocess.map-profile" step="map-profile"/>
     <preprocess-skip-init name="preprocess.topic-profile" step="topic-profile"/>
@@ -161,7 +153,6 @@ See the accompanying LICENSE file for applicable license.
         <param name="transtype" value="${transtype}"/>
         <param name="gramcache" value="${args.grammar.cache}"/>
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
-        <!--param name="profiling.enable" value="${map.filter-on-parse}"/-->
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
         <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -189,14 +180,6 @@ See the accompanying LICENSE file for applicable license.
         <dita:extension id="dita.preprocess.mapref.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
-<!--    <pipeline message="Profile filtering." taskname="profile" if:true="${map.filter-on-parse}">-->
-<!--      <module class="org.dita.dost.module.ProfileModule">-->
-<!--        <ditafileset format="ditamap" input="true"/>-->
-<!--        <ditafileset format="ditamap" inputResource="true"/>-->
-<!--        <param name="ditaval" location="${dita.input.valfile}" if:set="dita.input.valfile"/>-->
-<!--        <param name="transtype" value="${transtype}"/>-->
-<!--      </module>-->
-<!--    </pipeline>-->
   </target>
 
   <target name="map-branch-filter"

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -111,7 +111,9 @@ See the accompanying LICENSE file for applicable license.
         </property>
       </job>
     </echoxml>
-    <property name="map.filter-on-parse" value="false"/>
+    <condition property="map.filter-on-parse" value="true" else="false">
+      <equals arg1="${filter-stage}" arg2="early"/>
+    </condition>
     <condition property="topic.filter-on-parse" value="true" else="false">
       <equals arg1="${filter-stage}" arg2="early"/>
     </condition>

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -50,7 +50,7 @@ public class TopicReaderModuleTest {
   }
 
   @BeforeEach
-  public void setUp() throws SAXException, IOException {
+  public void setUp() throws SAXException, IOException, DITAOTException {
     reader = new TopicReaderModule();
     reader.setLogger(new TestUtils.TestLogger());
     job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));

--- a/src/test/java/org/dita/dost/writer/SubjectSchemeFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/SubjectSchemeFilterTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.writer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import org.dita.dost.TestUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+class SubjectSchemeFilterTest {
+
+  @ParameterizedTest
+  @MethodSource({ "validateMap", "defaultValueMap" })
+  void startElement(
+    Map<String, String> src,
+    Map<String, String> exp,
+    Map<QName, Map<String, Set<String>>> validateMap,
+    Map<QName, Map<String, String>> defaultValueMap,
+    int expMsgCount
+  ) throws SAXException {
+    var filter = new SubjectSchemeFilter();
+    var logger = new TestUtils.CachingLogger();
+    filter.setLogger(logger);
+    filter.setValidateMap(validateMap);
+    filter.setDefaultValueMap(defaultValueMap);
+    filter.setContentHandler(
+      new XMLFilterImpl() {
+        public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+          assertAttributesEquals(attributes(exp), atts);
+        }
+      }
+    );
+    filter.startElement(XMLConstants.NULL_NS_URI, "p", "p", attributes(src));
+    assertEquals(expMsgCount, logger.getMessages().size());
+  }
+
+  private static Arguments[] validateMap() {
+    return new Arguments[] {
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice"),
+        Map.of(new QName("audience"), Map.of("p", Set.of("expert"))),
+        Map.of(),
+        1
+      ),
+      Arguments.of(
+        Map.of("audience", "novice intermediate"),
+        Map.of("audience", "novice intermediate"),
+        Map.of(new QName("audience"), Map.of("p", Set.of("expert"))),
+        Map.of(),
+        2
+      ),
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice"),
+        Map.of(new QName("audience"), Map.of("div", Set.of("expert"))),
+        Map.of(),
+        0
+      ),
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice"),
+        Map.of(new QName("audience"), Map.of("p", Set.of("novice"))),
+        Map.of(),
+        0
+      ),
+      Arguments.of(
+        Map.of("audience", "novice intermediate"),
+        Map.of("audience", "novice intermediate"),
+        Map.of(new QName("audience"), Map.of("p", Set.of("novice", "intermediate"))),
+        Map.of(),
+        0
+      ),
+    };
+  }
+
+  private static Arguments[] defaultValueMap() {
+    return new Arguments[] {
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice", "platform", "linux"),
+        Map.of(),
+        Map.of(new QName("platform"), Map.of("p", "linux")),
+        0
+      ),
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice"),
+        Map.of(),
+        Map.of(new QName("platform"), Map.of("div", "linux")),
+        0
+      ),
+      Arguments.of(
+        Map.of("audience", "novice"),
+        Map.of("audience", "novice"),
+        Map.of(),
+        Map.of(new QName("audience"), Map.of("p", "expert")),
+        0
+      ),
+    };
+  }
+
+  private static Attributes attributes(Map<String, String> atts) {
+    var res = new AttributesImpl();
+    atts.forEach((name, value) -> {
+      res.addAttribute(XMLConstants.NULL_NS_URI, name, name, "CDATA", value);
+    });
+    return res;
+  }
+
+  private void assertAttributesEquals(Attributes exp, Attributes act) {
+    assertEquals(exp.getLength(), act.getLength());
+    for (int i = 0; i < exp.getLength(); i++) {
+      assertEquals(exp.getValue(i), act.getValue(exp.getURI(i), exp.getLocalName(i)));
+    }
+  }
+}


### PR DESCRIPTION
## Description
Refactor subject scheme code for preprocess2 to support all features of subject scheme that preprocess supports. This changes how preprocess2 does filtering. Before preprocess2 map filtering was lazy, meaning it happened at the end of preprocess2 map step. This changes the map filtering to be early, after initial map parsing and mapref merge. It's not as early as in preprocess2 topic processing, because filtering requires reading subject schemes and those are part of the map.

## Motivation and Context
Support all subject scheme features in preprocess2 that are supported by preprocess.

## How Has This Been Tested?
Existing and new tests.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
https://www.dita-ot.org/dev/reference/map-first-preprocessing could mention that since DITA-OT 4.2 preprocess2 supports more subject scheme features.
