### PR TITLE
use `@class="compact"` instead of `@compact="yes"` for HTML outputs

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_lists.scss
+++ b/src/main/plugins/org.dita.html5/sass/_lists.scss
@@ -22,12 +22,18 @@ ul.simple {
   margin-top: 1em;
 }
 
+/* Compact lists use attributes up to DITA-OT 4.1.2 */
 *[compact="yes"] > li {
   margin-top: 0;
 }
 
 *[compact="no"] > li {
   margin-top: 0.53em;
+}
+
+/* Compact lists use classes starting in DITA-OT 4.1.3 */
+.compact > li {
+  margin-top: 0;
 }
 
 .liexpand {

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -637,8 +637,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>
     <ul>
-      <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates select="@compact"/>
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class" select="'compact'[current()/@compact = 'yes']"/>
+      </xsl:call-template>
       <xsl:call-template name="setid"/>
       <xsl:apply-templates/>
     </ul>
@@ -652,9 +653,12 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="setaname"/>
     <ul>
       <xsl:call-template name="commonattributes">
-        <xsl:with-param name="default-output-class" select="'simple'"/>
+        <xsl:with-param name="default-output-class">
+          <xsl:value-of select="'simple',
+                                'compact'[current()/@compact = 'yes']"
+                        separator=" "/>
+        </xsl:with-param>
       </xsl:call-template>
-      <xsl:apply-templates select="@compact"/>
       <xsl:call-template name="setid"/>
       <xsl:apply-templates/>
     </ul>
@@ -668,8 +672,9 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <xsl:call-template name="setaname"/>
     <ol>
-      <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates select="@compact"/>
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class" select="'compact'[current()/@compact = 'yes']"/>
+      </xsl:call-template>
       <xsl:choose>
         <xsl:when test="$olcount mod 3 = 1"/>
         <xsl:when test="$olcount mod 3 = 2"><xsl:attribute name="type">a</xsl:attribute></xsl:when>
@@ -753,12 +758,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:call-template name="setaname"/>
     <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
     <dl>
-      <!-- handle DL compacting - default=yes -->
-      <xsl:if test="@compact = 'no'">
-        <xsl:attribute name="class">dlexpand</xsl:attribute>
-      </xsl:if>
-      <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates select="@compact"/>
+      <xsl:call-template name="commonattributes">
+        <xsl:with-param name="default-output-class">
+          <xsl:value-of select="'compact'[current()/@compact = 'yes']"/>
+        </xsl:with-param>
+      </xsl:call-template>
       <xsl:call-template name="setid"/>
       <xsl:apply-templates/>
     </dl>
@@ -1958,13 +1962,6 @@ See the accompanying LICENSE file for applicable license.
   <!-- If an element has @dir, copy it to the output -->
   <xsl:template match="@dir">
     <xsl:attribute name="dir" select="."/>
-  </xsl:template>
-  
-  <!-- if the element has a compact=yes attribute, assert it in XHTML form -->
-  <xsl:template match="@compact">
-    <xsl:if test=". = 'yes'">
-     <xsl:attribute name="compact">compact</xsl:attribute><!-- assumes that no compaction is default -->
-    </xsl:if>
   </xsl:template>
   
   <xsl:template name="setscale">

--- a/src/main/plugins/org.dita.xhtml/resource/commonltr.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonltr.css
@@ -325,11 +325,16 @@ ul.simple {
   font-weight: bold;
   margin-top: 1em;
 }
+/* Compact lists use attributes up to DITA-OT 4.1.2 */
 *[compact="yes"] > li {
   margin-top: 0;
 }
 *[compact="no"] > li {
   margin-top: .53em;
+}
+/* Compact lists use classes starting in DITA-OT 4.1.3 */
+.compact > li {
+  margin-top: 0;
 }
 .liexpand {
   margin-top: 1em;

--- a/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
+++ b/src/main/plugins/org.dita.xhtml/resource/commonrtl.css
@@ -329,11 +329,16 @@ ul.simple {
   font-weight: bold;
   margin-top: 1em;
 }
+/* Compact lists use attributes up to DITA-OT 4.1.2 */
 *[compact="yes"] > li {
   margin-top: 0;
 }
 *[compact="no"] > li {
   margin-top: .53em;
+}
+/* Compact lists use classes starting in DITA-OT 4.1.3 */
+.compact > li {
+  margin-top: 0;
 }
 .liexpand {
   margin-top: 1em;

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -781,8 +781,9 @@ See the accompanying LICENSE file for applicable license.
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="setaname"/>
   <ul>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:apply-templates select="@compact"/>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class" select="'compact'[current()/@compact = 'yes']"/>
+    </xsl:call-template>
     <xsl:call-template name="setid"/>
     <xsl:apply-templates/>
   </ul>
@@ -797,9 +798,12 @@ See the accompanying LICENSE file for applicable license.
   <xsl:call-template name="setaname"/>
   <ul>
     <xsl:call-template name="commonattributes">
-      <xsl:with-param name="default-output-class" select="'simple'"/>
+      <xsl:with-param name="default-output-class">
+        <xsl:value-of select="'simple',
+                              'compact'[current()/@compact = 'yes']"
+                      separator=" "/>
+      </xsl:with-param>
     </xsl:call-template>
-    <xsl:apply-templates select="@compact"/>
     <xsl:call-template name="setid"/>
     <xsl:apply-templates/>
   </ul>
@@ -814,8 +818,9 @@ See the accompanying LICENSE file for applicable license.
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:call-template name="setaname"/>
   <ol>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:apply-templates select="@compact"/>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class" select="'compact'[current()/@compact = 'yes']"/>
+    </xsl:call-template>
     <xsl:choose>
       <xsl:when test="$olcount mod 3 = 1"/>
       <xsl:when test="$olcount mod 3 = 2"><xsl:attribute name="type">a</xsl:attribute></xsl:when>
@@ -909,8 +914,11 @@ See the accompanying LICENSE file for applicable license.
     <xsl:if test="@compact = 'no'">
       <xsl:attribute name="class">dlexpand</xsl:attribute>
     </xsl:if>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:apply-templates select="@compact"/>
+    <xsl:call-template name="commonattributes">
+      <xsl:with-param name="default-output-class">
+        <xsl:value-of select="'compact'[current()/@compact = 'yes']"/>
+      </xsl:with-param>
+    </xsl:call-template>
     <xsl:call-template name="setid"/>
     <xsl:apply-templates/>
   </dl>
@@ -2054,13 +2062,6 @@ See the accompanying LICENSE file for applicable license.
 <!-- If an element has @dir, copy it to the output -->
 <xsl:template match="@dir">
   <xsl:attribute name="dir" select="."/>
-</xsl:template>
-
-<!-- if the element has a compact=yes attribute, assert it in XHTML form -->
-<xsl:template match="@compact">
-  <xsl:if test=". = 'yes'">
-   <xsl:attribute name="compact">compact</xsl:attribute><!-- assumes that no compaction is default -->
-  </xsl:if>
 </xsl:template>
 
 <xsl:template name="setscale">


### PR DESCRIPTION
## Description
Use `@class="... compact"`  instead of `@compact="yes"` for the XHTML and HTML5 outputs. The relevant CSS rules are updated accordingly.

Although the deprecation applies only to HTML5, the XHTML transformation was also updated for consistency.

## Motivation and Context
Fixes #4298.

## How Has This Been Tested?
I ran the testcase in #4298 for both XHTML and HTML5 and confirmed that the browser results were visually identical. I also ran `./gradlew check`.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No documentation change is needed for this fix.

A release notes entry could be something like:

> The DITA standard defines a `@compact` attribute for list elements. Previously, this attribute was published to XHTML and HTML5 outputs as an HTML `@compact` attribute. However, the `@compact` attribute was deprecated in HTML4 (over 20 years ago). Now, DITA `@compact` attributes are published as `@class="compact"` keywords in both the XHTML and HTML5 outputs. The default CSS rules have been updated accordingly. Custom CSS rules referencing the `@compact` attribute should be updated.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>