### PR TITLE
Use S9API instead of DOM in subject scheme processing

### DIFF
--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -11,11 +11,13 @@ package org.dita.dost.module.filter;
 import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toURI;
-import static org.dita.dost.util.XMLUtils.*;
+import static org.dita.dost.util.XMLUtils.getChildElement;
 
 import java.io.*;
 import java.net.URI;
 import java.util.*;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.streams.Steps;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.module.AbstractPipelineModuleImpl;
 import org.dita.dost.module.reader.TempFileNameScheme;
@@ -71,19 +73,22 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
   /**
    * Read subject scheme definitions.
    */
-  SubjectScheme getSubjectScheme(final Element root) {
+  SubjectScheme getSubjectScheme(final XdmNode root) {
     subjectSchemeReader.reset();
     logger.debug("Loading subject schemes");
-    final List<Element> subjectSchemes = toList(root.getElementsByTagName("*"));
-    subjectSchemes
-      .stream()
-      .filter(SUBJECTSCHEME_ENUMERATIONDEF::matches)
-      .forEach(enumerationDef -> {
-        final Element schemeRoot = ancestors(enumerationDef).filter(SUBMAP::matches).findFirst().orElse(root);
-        var subjectDefinitions = subjectSchemeReader.getSubjectDefinition(schemeRoot);
-        subjectSchemeReader.processEnumerationDef(subjectDefinitions, enumerationDef);
-      });
-    return subjectSchemeReader.getSubjectSchemeMap();
+    var enumerationDefs = root.select(Steps.descendant(SUBJECTSCHEME_ENUMERATIONDEF::matches)).toList();
+    if (!enumerationDefs.isEmpty()) {
+      enumerationDefs
+        .stream()
+        .forEach(enumerationDef -> {
+          final XdmNode schemeRoot = enumerationDef.select(Steps.ancestor(SUBMAP::matches)).findFirst().orElse(root);
+          var subjectDefinitions = subjectSchemeReader.getSubjectDefinition(schemeRoot);
+          subjectSchemeReader.processEnumerationDef(subjectDefinitions, enumerationDef);
+        });
+      return subjectSchemeReader.getSubjectSchemeMap();
+    } else {
+      return new SubjectScheme(Map.of());
+    }
   }
 
   /**

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
+import net.sf.saxon.s9api.XdmNode;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.BranchFilterModule.Branch;
@@ -82,9 +83,12 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
 
     logger.info("Processing " + currentFile);
     final Document doc;
+    final SubjectScheme subjectSchemeMap;
     try {
       logger.debug("Reading " + currentFile);
-      doc = job.getStore().getDocument(currentFile);
+      final XdmNode node = job.getStore().getImmutableNode(currentFile);
+      subjectSchemeMap = getSubjectScheme(node.getOutermostElement());
+      doc = xmlUtils.cloneDocument(node);
     } catch (final IOException e) {
       logger.error("Failed to parse " + currentFile, e);
       return;
@@ -93,7 +97,7 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
     logger.debug("Split branches and generate copy-to");
     splitBranches(doc.getDocumentElement(), Branch.EMPTY);
     logger.debug("Filter map");
-    filterBranches(doc.getDocumentElement());
+    filterBranches(doc.getDocumentElement(), subjectSchemeMap);
     logger.debug("Rewrite duplicate topic references");
     rewriteDuplicates(doc.getDocumentElement());
 
@@ -225,11 +229,10 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
   }
 
   /** Filter map and remove excluded content. */
-  private void filterBranches(final Element root) {
+  private void filterBranches(final Element root, final SubjectScheme subjectSchemeMap) {
     final String domains = root.getAttribute(ATTRIBUTE_NAME_DOMAINS);
     final String specializations = root.getAttribute(ATTRIBUTE_NAME_SPECIALIZATIONS);
     final QName[][] props = !domains.isEmpty() ? getExtProps(domains) : getExtPropsFromSpecializations(specializations);
-    final SubjectScheme subjectSchemeMap = getSubjectScheme(root);
     final List<FilterUtils> baseFilter = getBaseFilter(subjectSchemeMap);
     filterBranches(root, baseFilter, props, subjectSchemeMap);
   }

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -76,6 +76,15 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
     currentFile = job.tempDirURI.resolve(map);
 
     logger.info("Processing " + currentFile);
+    final SubjectScheme subjectSchemeMap;
+    try {
+      logger.debug("Reading " + currentFile);
+      subjectSchemeMap = getSubjectScheme(job.getStore().getImmutableNode(currentFile).getOutermostElement());
+    } catch (final IOException e) {
+      logger.error("Failed to parse " + currentFile, e);
+      return;
+    }
+
     final Document doc;
     try {
       logger.debug("Reading " + currentFile);
@@ -84,8 +93,6 @@ public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
       logger.error("Failed to parse " + currentFile, e);
       return;
     }
-
-    final SubjectScheme subjectSchemeMap = getSubjectScheme(doc.getDocumentElement());
     logger.debug("Filter topics and generate copies");
     generateCopies(doc.getDocumentElement(), Collections.emptyList(), subjectSchemeMap);
     logger.debug("Filter existing topics");

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -219,7 +219,7 @@ public class CacheStore extends AbstractStore implements Store {
         if (entry.doc != null) {
           return (Document) entry.doc.cloneNode(true);
         } else if (entry.node != null) {
-          return cloneDocument(entry.node);
+          return xmlUtils.cloneDocument(entry.node);
         } else if (entry.bytes != null) {
           try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
             final InputSource inputSource = new InputSource(in);
@@ -611,22 +611,6 @@ public class CacheStore extends AbstractStore implements Store {
       return source;
     } else {
       throw new IllegalArgumentException();
-    }
-  }
-
-  private Document cloneDocument(final XdmNode node) throws IOException {
-    try {
-      final Document doc = XMLUtils.getDocumentBuilder().newDocument();
-      final DOMDestination destination = new DOMDestination(doc);
-      final Receiver receiver = destination.getReceiver(
-        xmlUtils.getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),
-        new SerializationProperties()
-      );
-      Sender.send(node.asSource(), receiver, new ParseOptions());
-      // Don't save mutable doc into cache
-      return doc;
-    } catch (XPathException e) {
-      throw new IOException(e);
     }
   }
 

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -67,6 +67,15 @@ public class TopicReaderModuleTest {
     );
     job.add(new Job.FileInfo.Builder().src(root.resolve("mysite.dita")).uri(URI.create("mysite.dita")).build());
     job.add(new Job.FileInfo.Builder().src(root.resolve("myproduct.dita")).uri(URI.create("myproduct.dita")).build());
+    job
+      .getFileInfo(fi -> fi.isInput)
+      .forEach(fi -> {
+        try {
+          Files.copy(Paths.get(fi.src), Paths.get(job.tempDirURI.resolve(fi.uri)));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
     reader.setJob(job);
     final PipelineHashIO input = new PipelineHashIO();
     input.setAttribute(ANT_INVOKER_EXT_PARAM_DITADIR, tempDir.getAbsolutePath());
@@ -119,15 +128,6 @@ public class TopicReaderModuleTest {
 
   @Test
   public void readStartFile() throws DITAOTException {
-    job
-      .getFileInfo(fi -> fi.isInput)
-      .forEach(fi -> {
-        try {
-          Files.copy(Paths.get(fi.src), Paths.get(job.tempDirURI.resolve(fi.uri)));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      });
     reader.readStartFile();
 
     assertEquals(1, reader.nonConrefCopytoTargetSet.size());


### PR DESCRIPTION
## Description
Use S9API instead of DOM in subject scheme processing.

## Motivation and Context
S9API is a more modern API to navigate an XML document and is the preferred choice in the current code base.

## How Has This Been Tested?
Existing tests pass.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No user facing changes.
