### PR TITLE
Fix -dita-use-conref-target in preprocess2

### DIFF
--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -148,7 +148,9 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
       final QName attQName = new QName(atts.getURI(i), atts.getLocalName(i));
       final String origValue = atts.getValue(i);
       String attValue = origValue;
-      if (ATTRIBUTE_NAME_CONREF.equals(attQName.getLocalPart())) {
+      if (attValue.equals(ATTR_VALUE_DITA_USE_CONREF_TARGET)) {
+        // retain original value
+      } else if (ATTRIBUTE_NAME_CONREF.equals(attQName.getLocalPart())) {
         attValue = replaceHREF(QName.valueOf(ATTRIBUTE_NAME_CONREF), atts).toString();
       } else if (
         ATTRIBUTE_NAME_HREF.equals(attQName.getLocalPart()) || ATTRIBUTE_NAME_COPY_TO.equals(attQName.getLocalPart())


### PR DESCRIPTION
## Description
Fix how `-dita-use-conref-target` is handled during preprocess2.

## Motivation and Context
When `@href` has value `-dita-use-conref-target` preprocess2 treats it as a resource during initial parse and rewrites the attribute. If any attribute has value `-dita-use-conref-target`, it needs to passed through as is.

## How Has This Been Tested?
Existing test.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


