### PR TITLE
Rewrite usr.input.file.list in preprocess2 cleanup

### DIFF
--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -10,12 +10,14 @@ package org.dita.dost.module;
 
 import static java.util.Collections.emptyMap;
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Job.USER_INPUT_FILE_LIST_FILE;
 import static org.dita.dost.util.XMLUtils.toErrorReporter;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -165,6 +167,13 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     final FileInfo start = job.getFileInfo(f -> f.isInput).iterator().next();
     if (start != null) {
       job.setInputMap(start.uri);
+
+      final File inputfile = new File(job.tempDir, USER_INPUT_FILE_LIST_FILE);
+      try {
+        Files.writeString(inputfile.toPath(), start.file.getPath());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     try {


### PR DESCRIPTION
## Description
Fix `usr.input.file.list`update in preprocess2 cleanup.

## Motivation and Context
Preprocess2 fails to update list file when changing temp name scheme.

## How Has This Been Tested?
Existing tests.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Should not have been visible to PDF2 users. The bug only affected e.g. custon HTML5 transtype when used with preprocess2.

