### PR TITLE
Separate install and uninstall subcommand classpath

### DIFF
--- a/src/main/bin/dita
+++ b/src/main/bin/dita
@@ -67,7 +67,14 @@ if [ -z "$DITA_HOME" -o ! -d "$DITA_HOME" ] ; then
 fi
 
 # Set environment variables
-. "$DITA_HOME/config/env.sh"
+case "$1" in
+  install|uninstall)
+    # No plug-in libraries in classpath
+    ;;
+  *)
+    . "$DITA_HOME/config/env.sh"
+    ;;
+esac
 
 # Add build script to arguments
 ant_exec_args="$ant_exec_args \"-buildfile\" \"$DITA_HOME/build.xml\" \"-main\" \"org.dita.dost.invoker.Main\""

--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -29,6 +29,9 @@ if "%DITA_HOME%"=="" goto setDefaultDitaHome
 rem %~dp0 is expanded pathname of the current script under NT
 set DITA_HOME=%~dp0..
 
+rem Save subcommand
+set DITA_CMD_SUBCOMMAND=%1
+
 rem Slurp the command line arguments. This loop allows for an unlimited number
 rem of arguments (up to the command line limit, anyway).
 set DITA_CMD_LINE_ARGS=
@@ -43,10 +46,15 @@ rem and for NT handling to skip to.
 
 :doneStart
 
-:checkJava
+rem No plug-in libraries in classpath
+set CLASSPATH=""
+if "%DITA_CMD_SUBCOMMAND%" == "install" goto checkJava
+if "%DITA_CMD_SUBCOMMAND%" == "uninstall" goto checkJava
+
 rem Set environment variables
 call "%DITA_HOME%\config\env.bat"
 
+:checkJava
 set _JAVACMD=%JAVACMD%
 
 if "%JAVA_HOME%" == "" goto noJavaHome


### PR DESCRIPTION
## Description
Don't add plug-in JARs to `install` or `uninstall` subcommand classpath.

## Motivation and Context
`uninstall` subcommand will try to delete the plug-in and the delete may fail if plug-in JAR files have been opened; `install --force` has the same issue. This will fix the problem by not adding plug-in JAR files to classpath when running install or uninstall commands.

Fix fox bug reported in #4325.

## How Has This Been Tested?
Manual testing.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No user facing changes.

