### PR TITLE
Refactor to remove Ant from install and uninstall process

### DIFF
--- a/src/main/bin/dita
+++ b/src/main/bin/dita
@@ -175,5 +175,5 @@ ant_sys_opts=
 if [ -n "$CYGHOME" ]; then
   ant_sys_opts="-Dcygwin.user.home=\"$CYGHOME\""
 fi
-ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
+ant_exec_command="exec \"$JAVACMD\" $ANT_OPTS -Djava.awt.headless=true -Dcli.log-format=fancy -Dcli.color=true -classpath \"$LOCALCLASSPATH\" -Dant.home=\"$DITA_HOME\" -Ddita.dir=\"$DITA_HOME\" -Dant.library.dir=\"$ANT_LIB\" $ant_sys_opts org.apache.tools.ant.launch.Launcher $ANT_ARGS -cp \"$CLASSPATH\""
 eval $ant_exec_command "$ant_exec_args"

--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -58,7 +58,7 @@ if "%_JAVACMD%" == "" set _JAVACMD=java.exe
 
 :runAnt
 rem sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
-"%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -Dsun.io.useCanonCaches=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
+"%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -Dcli.log-format=fancy -Dcli.color=true -Dsun.io.useCanonCaches=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%

--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -9,6 +9,7 @@ temp-file-name-scheme = org.dita.dost.module.reader.DefaultTempFileScheme
 #filter-attributes =
 #flag-attributes =
 cli.color = true
+cli.log-format = fancy
 default.coderef-charset=UTF-8
 
 # Integration

--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -8,8 +8,8 @@ default.cascade = merge
 temp-file-name-scheme = org.dita.dost.module.reader.DefaultTempFileScheme
 #filter-attributes =
 #flag-attributes =
-cli.color = true
-cli.log-format = fancy
+cli.color = false
+cli.log-format = legacy
 default.coderef-charset=UTF-8
 
 # Integration

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <project name="dita.integrator" default="integrate">
 
-  <echo level="warn">WARN: Ant integrator has been deprecated. Use dita command instead.</echo>
+  <echo level="warn">WARN: The Ant integration process is deprecated. Use the 'dita install' command instead.</echo>
   
   <dirname property="ant.file.dita.integrator.dir" file="${ant.file.dita.integrator}"/>
   

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -7,6 +7,8 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <project name="dita.integrator" default="integrate">
+
+  <echo level="warn">WARN: Ant integrator has been deprecated. Use dita command instead.</echo>
   
   <dirname property="ant.file.dita.integrator.dir" file="${ant.file.dita.integrator}"/>
   

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -20,60 +20,17 @@ See the accompanying LICENSE file for applicable license.
       </not>
     </and>
   </condition>
-  
-  <!-- Try to initialize ${dita.dir} again if it was not set. -->
-  <!-- Deprecated since 1.8 -->
-  <condition property="dita.dir" value="${basedir}">
-    <not>
-      <isset property="dita.dir"/>
-    </not>
-  </condition>
-  
-  <!-- Deprecated since 3.1 -->
-  <path id="dost.class.path">
-    <pathelement location="${dita.dir}/lib/dost.jar"/>
-    <pathelement location="${dita.dir}/lib/dost-configuration.jar"/>
-    <pathelement location="${dita.dir}/lib/commons-io-2.4.jar"/>
-  </path>
-  
-  <taskdef name="integrate" classname="org.dita.dost.ant.IntegratorTask">
-    <classpath refid="dost.class.path"/>
-  </taskdef>
+
+  <taskdef name="integrate" classname="org.dita.dost.ant.IntegratorTask"/>
   <taskdef name="install" classname="org.dita.dost.ant.PluginInstallTask"/>
 
   <target name="integrate">
     <integrate ditadir="${dita.dir}" />
-    <antcall target="configuration-jar"/>
-  </target>
-
-  <!-- Deprecated since 3.2 -->
-  <target name="configuration-jar">
-    <!-- place property files into a JAR so Ant will find them -->
-    <jar destfile="${basedir}/lib/dost-configuration.jar">
-      <fileset dir="${basedir}/config">
-        <include name="messages.xml"/>
-        <include name="messages_*.properties"/>
-        <include name="plugins.xml"/>
-        <include name="configuration.properties"/>
-        <include name="CatalogManager.properties"/>
-        <include name="org.dita.dost.platform/plugin.properties"/>
-      </fileset>
-    </jar>
-  </target>
-  
-  <target name="lax" description="Run integration in lax mode">
-    <echo>WARN: The lax integration mode has been removed, using strict mode</echo>
-    <antcall target="integrate"/>
-  </target>
-
-  <target name="strict" description="Run integration in strict mode">
-    <antcall target="integrate"/>
   </target>
 
   <target name="install" description="Install plug-in" >
     <property name="force" value="false"/>
     <install pluginFile="${plugin.file}" force="${force}"/>
-    <antcall target="configuration-jar"/>
   </target>
   
   <target name="uninstall" description="Uninstall plug-in">

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -21,27 +21,21 @@ See the accompanying LICENSE file for applicable license.
     </and>
   </condition>
 
-  <taskdef name="integrate" classname="org.dita.dost.ant.IntegratorTask"/>
-  <taskdef name="install" classname="org.dita.dost.ant.PluginInstallTask"/>
 
   <target name="integrate">
+    <taskdef name="integrate" classname="org.dita.dost.ant.IntegratorTask"/>
     <integrate ditadir="${dita.dir}" />
   </target>
 
   <target name="install" description="Install plug-in" >
     <property name="force" value="false"/>
+    <taskdef name="install" classname="org.dita.dost.ant.PluginInstallTask"/>
     <install pluginFile="${plugin.file}" force="${force}"/>
   </target>
-  
+
   <target name="uninstall" description="Uninstall plug-in">
-    <fail unless="plugin.id"/>
-    <available property="plugin.exists" file="${dita.dir}/plugins/${plugin.id}"/>
-    <fail unless="plugin.exists">Plug-in ${dita.dir}/plugins/${plugin.id} doesn't exist.</fail>
-    <antcall target="uninstall.delete"/>
+    <taskdef name="uninstall" classname="org.dita.dost.ant.PluginUninstallTask"/>
+    <uninstall id="${plugin.id}"/>
   </target>
-  <target name="uninstall.delete" if="plugin.exists">
-    <delete dir="${dita.dir}/plugins/${plugin.id}"/>
-    <antcall target="integrate"/>
-  </target>
-  
+
 </project>

--- a/src/main/integrator.xml
+++ b/src/main/integrator.xml
@@ -21,7 +21,6 @@ See the accompanying LICENSE file for applicable license.
     </and>
   </condition>
 
-
   <target name="integrate">
     <taskdef name="integrate" classname="org.dita.dost.ant.IntegratorTask"/>
     <integrate ditadir="${dita.dir}" />

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -212,7 +212,7 @@ public final class ExtensibleAntInvoker extends Task {
         logger.debug("{0} processing took {1} ms", mod.getClass().getSimpleName(), end - start);
       }
     } catch (final DITAOTException e) {
-      throw new BuildException("Failed to run pipeline: " + e.getMessage(), e);
+      throw new BuildException(e.getMessage(), e);
     }
   }
 

--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -7,88 +7,25 @@
  */
 package org.dita.dost.ant;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
-import java.io.*;
-import java.net.MalformedURLException;
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.*;
-import java.util.stream.Collectors;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
-import org.apache.tools.ant.taskdefs.Expand;
-import org.apache.tools.ant.taskdefs.Get;
 import org.dita.dost.log.DITAOTAntLogger;
-import org.dita.dost.platform.*;
-import org.dita.dost.platform.Registry.Dependency;
-import org.dita.dost.util.Configuration;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
+import org.dita.dost.platform.PluginInstall;
+import org.dita.dost.platform.SemVerMatch;
 
 public final class PluginInstallTask extends Task {
 
-  private List<String> registries;
-
-  private File tempDir;
-  private final ObjectMapper mapper = new ObjectMapper();
-  private List<String> installedPlugins;
   private Path pluginFile;
-  private URL pluginUrl;
+  private URI pluginUrl;
   private String pluginName;
   private SemVerMatch pluginVersion;
   private boolean force;
-  private Integrator integrator;
-
-  @Override
-  public void init() {
-    registries =
-      Arrays
-        .stream(Configuration.configuration.get("registry").trim().split("\\s+"))
-        .map(registry -> registry.endsWith("/") ? registry : (registry + "/"))
-        .collect(Collectors.toList());
-    try {
-      tempDir = Files.createTempDirectory(null).toFile();
-    } catch (IOException e) {
-      throw new BuildException("Failed to create temporary directory: " + e.getMessage(), e);
-    }
-    installedPlugins = Plugins.getInstalledPlugins().stream().map(Map.Entry::getKey).toList();
-
-    final DITAOTAntLogger logger;
-    logger = new DITAOTAntLogger(getProject());
-    logger.setTarget(getOwningTarget());
-    logger.setTask(this);
-
-    integrator = new Integrator(getProject().getBaseDir());
-    integrator.setLogger(logger);
-  }
-
-  private void cleanUp() {
-    if (tempDir != null) {
-      try {
-        FileUtils.deleteDirectory(tempDir);
-      } catch (IOException e) {
-        throw new BuildException(e);
-      }
-    }
-  }
 
   @Override
   public void execute() throws BuildException {
@@ -96,232 +33,28 @@ public final class PluginInstallTask extends Task {
       throw new BuildException(new IllegalStateException("pluginName argument not set"));
     }
 
+    final PluginInstall pluginInstall = new PluginInstall();
+    final DITAOTAntLogger logger = new DITAOTAntLogger(getProject());
+    logger.setTarget(getOwningTarget());
+    logger.setTask(this);
+    pluginInstall.setLogger(logger);
+    pluginInstall.setForce(force);
+    pluginInstall.setDitaDir(getDitaDir());
+    pluginInstall.setPluginFile(pluginFile);
+    pluginInstall.setPluginUri(pluginUrl);
+    pluginInstall.setPluginName(pluginName);
+    pluginInstall.setPluginVersion(pluginVersion);
+
     try {
-      final Map<String, File> installs = new HashMap<>();
-      if (pluginFile != null && Files.exists(pluginFile)) {
-        final File tempPluginDir = unzip(pluginFile.toFile());
-        final String name = getPluginName(tempPluginDir);
-        installs.put(name, tempPluginDir);
-      } else if (pluginUrl != null) {
-        final File tempFile = get(pluginUrl, null);
-        final File tempPluginDir = unzip(tempFile);
-        final String name = getPluginName(tempPluginDir);
-        installs.put(name, tempPluginDir);
-      } else {
-        final Set<Registry> plugins = readRegistry(this.pluginName, pluginVersion);
-        for (final Registry plugin : plugins) {
-          final File tempFile = get(plugin.url, plugin.cksum);
-          final File tempPluginDir = unzip(tempFile);
-          final String name = plugin.name;
-          installs.put(name, tempPluginDir);
-        }
-      }
-      for (final Map.Entry<String, File> install : installs.entrySet()) {
-        final String name = install.getKey();
-        final File tempPluginDir = install.getValue();
-        final File pluginDir = getPluginDir(name);
-        if (pluginDir.exists()) {
-          if (force) {
-            log("Force install to " + pluginDir, Project.MSG_INFO);
-            integrator.addRemoved(name);
-            FileUtils.deleteDirectory(pluginDir);
-          } else {
-            throw new BuildException(
-              new IllegalStateException(String.format("Plug-in %s already installed: %s", name, pluginDir))
-            );
-          }
-        }
-        FileUtils.copyDirectory(tempPluginDir, pluginDir);
-      }
-    } catch (IOException e) {
-      throw new BuildException(e.getMessage(), e);
-    } finally {
-      cleanUp();
-    }
-    try {
-      integrator.execute();
-    } catch (final Exception e) {
-      throw new BuildException("Integration failed: " + e.getMessage(), e);
+      pluginInstall.execute();
+    } catch (Exception e) {
+      throw new BuildException("Failed to install %s %s: %s".formatted(pluginName, pluginVersion, e.getMessage()), e);
     }
   }
 
-  private String getFileHash(final File file) {
-    try (
-      DigestInputStream digestInputStream = new DigestInputStream(
-        new BufferedInputStream(new FileInputStream(file)),
-        MessageDigest.getInstance("SHA-256")
-      )
-    ) {
-      IOUtils.copy(digestInputStream, new NullOutputStream());
-      final MessageDigest digest = digestInputStream.getMessageDigest();
-      final byte[] sha256 = digest.digest();
-      return printHexBinary(sha256);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalArgumentException(e);
-    } catch (IOException e) {
-      throw new BuildException("Failed to calculate file checksum: " + e.getMessage(), e);
-    }
+  private File getDitaDir() {
+    return Paths.get(getProject().getProperty("dita.dir")).toFile();
   }
-
-  private String printHexBinary(final byte[] md5) {
-    final StringBuilder sb = new StringBuilder();
-    for (byte b : md5) {
-      sb.append(String.format("%02X", b));
-    }
-    return sb.toString().toLowerCase();
-  }
-
-  private String getPluginName(final File pluginDir) {
-    final File config = new File(pluginDir, "plugin.xml");
-    try {
-      final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(config);
-      return doc.getDocumentElement().getAttribute("id");
-    } catch (SAXException | IOException | ParserConfigurationException e) {
-      throw new BuildException("Failed to read plugin name: " + e.getMessage(), e);
-    }
-  }
-
-  private File getPluginDir(final String id) {
-    return Paths.get(getProject().getProperty("dita.dir"), "plugins", id).toFile();
-  }
-
-  private Set<Registry> readRegistry(final String name, final SemVerMatch version) {
-    log(String.format("Reading registries for %s@%s", name, version), Project.MSG_INFO);
-    Registry res = null;
-    for (final String registry : registries) {
-      final URI registryUrl = URI.create(registry + name + ".json");
-      log(String.format("Read registry %s", registry), Project.MSG_INFO);
-      try (BufferedInputStream in = new BufferedInputStream(registryUrl.toURL().openStream())) {
-        log("Parse registry", Project.MSG_INFO);
-        final JsonFactory factory = mapper.getFactory();
-        final JsonParser parser = factory.createParser(in);
-        final JsonNode obj = mapper.readTree(parser);
-        final Collection<Registry> regs;
-        if (obj.isArray()) {
-          regs = Arrays.asList(mapper.treeToValue(obj, Registry[].class));
-        } else {
-          regs = resolveAlias(mapper.treeToValue(obj, Alias.class));
-        }
-        final Optional<Registry> reg = findPlugin(regs, version);
-        if (reg.isPresent()) {
-          final Registry plugin = reg.get();
-          log(String.format("Plugin found at %s@%s", registryUrl, plugin.vers), Project.MSG_INFO);
-          res = plugin;
-          break;
-        }
-      } catch (MalformedURLException e) {
-        log(String.format("Invalid registry URL %s: %s", registryUrl, e.getMessage()), e, Project.MSG_ERR);
-      } catch (FileNotFoundException e) {
-        log(String.format("Registry configuration %s not found", registryUrl), e, Project.MSG_INFO);
-      } catch (IOException e) {
-        log(
-          String.format("Failed to read registry configuration %s: %s", registryUrl, e.getMessage()),
-          e,
-          Project.MSG_ERR
-        );
-      }
-    }
-    if (res == null) {
-      throw new BuildException("Unable to find plugin " + pluginFile + " in any configured registry.");
-    }
-
-    Set<Registry> results = new HashSet<>();
-    results.add(res);
-    res.deps
-      .stream()
-      .filter(dep -> !installedPlugins.contains(dep.name))
-      .flatMap(dep -> readRegistry(dep.name, dep.req).stream())
-      .forEach(results::add);
-
-    return results;
-  }
-
-  private Collection<Registry> resolveAlias(Alias registry) {
-    return readRegistry(registry.alias(), null);
-  }
-
-  private File get(final URL url, final String expectedChecksum) {
-    final File tempPluginFile = new File(tempDir, "plugin.zip");
-
-    final Get get = new Get();
-    get.setProject(getProject());
-    get.setTaskName("get");
-    get.setSrc(url);
-    get.setDest(tempPluginFile);
-    get.setIgnoreErrors(false);
-    get.setVerbose(false);
-    get.execute();
-
-    if (expectedChecksum != null) {
-      final String checksum = getFileHash(tempPluginFile);
-      if (!checksum.equalsIgnoreCase(expectedChecksum)) {
-        throw new BuildException(
-          new IllegalArgumentException(
-            String.format(
-              "Downloaded plugin file checksum %s does not match expected value %s",
-              checksum,
-              expectedChecksum
-            )
-          )
-        );
-      }
-    }
-
-    return tempPluginFile;
-  }
-
-  private File unzip(final File input) {
-    final File tempPluginDir = new File(tempDir, "plugin");
-
-    final Expand unzip = new Expand();
-    unzip.setProject(getProject());
-    unzip.setTaskName("unzip");
-    unzip.setSrc(input);
-    unzip.setDest(tempPluginDir);
-    unzip.execute();
-
-    return findBaseDir(tempPluginDir);
-  }
-
-  private File findBaseDir(final File tempPluginDir) {
-    final File config = new File(tempPluginDir, "plugin.xml");
-    if (config.exists()) {
-      return tempPluginDir;
-    } else {
-      for (final File dir : tempPluginDir.listFiles(File::isDirectory)) {
-        final File res = findBaseDir(dir);
-        if (res != null) {
-          return res;
-        }
-      }
-      return null;
-    }
-  }
-
-  private Optional<Registry> findPlugin(final Collection<Registry> regs, final SemVerMatch version) {
-    if (version == null) {
-      return regs.stream().filter(this::matchingPlatformVersion).max(Comparator.comparing(o -> o.vers));
-    } else {
-      return regs.stream().filter(this::matchingPlatformVersion).filter(reg -> version.contains(reg.vers)).findFirst();
-    }
-  }
-
-  @VisibleForTesting
-  boolean matchingPlatformVersion(final Registry reg) {
-    final Optional<Dependency> platformDependency = reg.deps
-      .stream()
-      .filter(dep -> dep.name.equals("org.dita.base"))
-      .findFirst();
-    if (platformDependency.isPresent()) {
-      final SemVer platform = new SemVer(Configuration.configuration.get("otversion"));
-      final Dependency dep = platformDependency.get();
-      return dep.req.contains(platform);
-    } else {
-      return true;
-    }
-  }
-
-  // Setters
 
   public void setPluginFile(final String pluginFile) {
     try {
@@ -332,9 +65,9 @@ public final class PluginInstallTask extends Task {
     try {
       final URI uri = new URI(pluginFile);
       if (uri.isAbsolute()) {
-        this.pluginUrl = uri.toURL();
+        this.pluginUrl = uri;
       }
-    } catch (MalformedURLException | URISyntaxException e) {
+    } catch (URISyntaxException e) {
       // Ignore
     }
     if (pluginFile.contains("@")) {

--- a/src/main/java/org/dita/dost/ant/PluginUninstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginUninstallTask.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.ant;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.dita.dost.log.DITAOTAntLogger;
+import org.dita.dost.platform.Integrator;
+
+public final class PluginUninstallTask extends Task {
+
+  private String id;
+
+  @Override
+  public void execute() throws BuildException {
+    if (id == null) {
+      throw new BuildException(new IllegalStateException("id argument not set"));
+    }
+
+    final File pluginDir = getPluginDir(id);
+    if (!pluginDir.exists()) {
+      throw new BuildException("Plug-in directory %s doesn't exist".formatted(pluginDir));
+    }
+
+    log("Delete plug-in directory %s".formatted(pluginDir), Project.MSG_DEBUG);
+    try {
+      FileUtils.deleteDirectory(pluginDir);
+    } catch (IOException e) {
+      throw new BuildException("Failed to delete plug-in directory %s".formatted(pluginDir), e);
+    }
+
+    final DITAOTAntLogger logger = new DITAOTAntLogger(getProject());
+    logger.setTarget(getOwningTarget());
+    logger.setTask(this);
+    final Integrator integrator = new Integrator(getDitaDir());
+    integrator.setLogger(logger);
+    try {
+      integrator.execute();
+    } catch (final Exception e) {
+      throw new BuildException("Integration failed: " + e.getMessage(), e);
+    }
+  }
+
+  private File getDitaDir() {
+    return Paths.get(getProject().getProperty("dita.dir")).toFile();
+  }
+
+  private File getPluginDir(final String id) {
+    return Paths.get(getDitaDir().getAbsolutePath(), "plugins", id).toFile();
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -33,7 +33,7 @@ abstract class Arguments {
   /**
    * Our current message output status. Follows Project.MSG_XXX.
    */
-  int msgOutputLevel = Project.MSG_WARN;
+  int msgOutputLevel = Project.MSG_INFO;
   /**
    * File that we are using for configuration.
    */
@@ -107,9 +107,9 @@ abstract class Arguments {
     if (isLongForm(arg, "-help") || arg.equals("-h")) {
       justPrintUsage = true;
     } else if (isLongForm(arg, "-verbose") || arg.equals("-v")) {
-      msgOutputLevel = Project.MSG_INFO;
-    } else if (isLongForm(arg, "-debug") || arg.equals("-d")) {
       msgOutputLevel = Project.MSG_VERBOSE;
+    } else if (isLongForm(arg, "-debug") || arg.equals("-d")) {
+      msgOutputLevel = Project.MSG_DEBUG;
     } else if (isLongForm(arg, "-emacs") || arg.equals("-e")) {
       emacsMode = true;
     } else if (isLongForm(arg, "-logfile") || arg.equals("-l")) {

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -63,7 +63,7 @@ abstract class Arguments {
   /**
    * Whether or not output to the log is to be unadorned.
    */
-  boolean emacsMode = Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("fancy");
+  boolean emacsMode = Configuration.configuration.getOrDefault("cli.log-format", "legacy").equals("fancy");
   /**
    * optional thread priority
    */

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -63,7 +63,7 @@ abstract class Arguments {
   /**
    * Whether or not output to the log is to be unadorned.
    */
-  boolean emacsMode;
+  boolean emacsMode = Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("fancy");
   /**
    * optional thread priority
    */

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -395,7 +395,7 @@ public class ConversionArguments extends Arguments {
   @Override
   String getUsage(final boolean compact) {
     final UsageBuilder buf = UsageBuilder
-      .builder(compact)
+      .builder(compact, useColor)
       .usage(locale.getString("conversion.usage.input"))
       .usage(locale.getString("conversion.usage.project"))
       //                .usage("dita --propertyfile=<file> [options]")

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -10,6 +10,7 @@ package org.dita.dost.invoker;
 
 import static org.dita.dost.invoker.ArgumentParser.getPluginArguments;
 import static org.dita.dost.invoker.Main.locale;
+import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
 import static org.dita.dost.util.XMLUtils.toList;
 
@@ -184,6 +185,8 @@ public class ConversionArguments extends Arguments {
       definedProps.put("args.resources", String.join(File.pathSeparator, resources));
     }
     definedProps.putAll(loadPropertyFiles());
+
+    definedProps.put("cli.log-format", configuration.get("cli.log-format"));
 
     return this;
   }

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -105,6 +105,7 @@ public class ConversionArguments extends Arguments {
 
   @Override
   ConversionArguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_WARN;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -195,12 +195,12 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
 
     final String msg = message.toString();
     if (error == null && !msg.trim().isEmpty()) {
-      printMessage(msg, out, Project.MSG_VERBOSE);
+      out.println(msg);
     } else if (!msg.isEmpty()) {
       if (legacyFormat) {
-        printMessage(msg, err, Project.MSG_ERR);
+        err.println(msg);
       } else {
-        printMessage(removeLevelPrefix(message).toString(), err, Project.MSG_ERR);
+        err.println(removeLevelPrefix(message));
       }
     }
     log(msg);
@@ -256,7 +256,7 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
         msg = StringUtils.LINE_SEP + event.getTarget().getName() + ":";
       }
       if (msg != null) {
-        printMessage(msg, out, event.getPriority());
+        out.println(msg);
         log(msg);
       }
     }
@@ -347,9 +347,9 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
       final String msg = message.toString();
       final PrintStream dst = priority == Project.MSG_ERR ? err : out;
       if (legacyFormat) {
-        printMessage(msg, dst, priority);
+        dst.println(msg);
       } else {
-        printMessage(removeLevelPrefix(new StringBuilder(msg)).toString(), dst, priority);
+        dst.println(removeLevelPrefix(new StringBuilder(msg)));
       }
       log(msg);
     }
@@ -366,37 +366,6 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
    */
   protected static String formatTime(final long millis) {
     return DateUtils.formatElapsedTime(millis);
-  }
-
-  /**
-   * Prints a message to a PrintStream.
-   *
-   * @param message The message to print. Should not be <code>null</code>.
-   * @param stream A PrintStream to print the message to. Must not be
-   *            <code>null</code>.
-   * @param priority The priority of the message. (Ignored in this
-   *            implementation.)
-   */
-  private void printMessage(final String message, final PrintStream stream, final int priority) {
-    if (useColor && priority == Project.MSG_ERR) {
-      //      stream.print(ANSI_RED);
-      stream.print(message);
-      //      stream.println(ANSI_RESET);
-    } else {
-      stream.println(message);
-    }
-    //    if (useColor && priority == Project.MSG_ERR) {
-    //      stream.print(ANSI_RED);
-    //      stream.print("Error");
-    //      stream.print(ANSI_RESET);
-    //      stream.print(": ");
-    //    } else if (useColor && priority == Project.MSG_WARN) {
-    //      stream.print(ANSI_YELLOW);
-    //      stream.print("Warning");
-    //      stream.print(ANSI_RESET);
-    //      stream.print(": ");
-    //    }
-    //    stream.println(message);
   }
 
   /**

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -25,10 +25,7 @@
 
 package org.dita.dost.invoker;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.StringReader;
+import java.io.*;
 import java.text.DateFormat;
 import java.util.Date;
 import org.apache.tools.ant.BuildEvent;
@@ -186,19 +183,23 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
         message.append(" in ").append(formatTime(System.currentTimeMillis() - startTime));
       }
     } else {
-      // message.append(StringUtils.LINE_SEP);
-      // message.append(getBuildFailedMessage());
-      //            message.append(StringUtils.LINE_SEP);
       if (useColor) {
         message.append(ANSI_RED);
       }
-      message.append("Error: ");
+      message.append(Main.locale.getString("error_msg").formatted(""));
       if (useColor) {
         message.append(ANSI_RESET);
       }
-      throwableMessage(message, error, Project.MSG_VERBOSE <= msgOutputLevel);
+      try (var buf = new StringWriter(); var printWriter = new PrintWriter(buf)) {
+        error.printStackTrace(printWriter);
+        printWriter.flush();
+        message.append(Main.locale.getString("exception_msg").formatted(buf));
+      } catch (IOException e) {
+        // Failed to print stack trace
+      }
+
       if (msgOutputLevel >= Project.MSG_INFO) {
-        message.append(StringUtils.LINE_SEP).append(StringUtils.LINE_SEP);
+        message.append(StringUtils.LINE_SEP);
         if (useColor) {
           message.append(ANSI_BOLD).append(ANSI_RED);
         }

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -37,24 +37,14 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.util.DateUtils;
 import org.apache.tools.ant.util.FileUtils;
 import org.apache.tools.ant.util.StringUtils;
+import org.dita.dost.log.AbstractLogger;
 
 /**
  * Writes build events to a PrintStream. Currently, it only writes which targets
  * are being executed, and any messages that get logged.
  *
  */
-class DefaultLogger implements BuildLogger {
-
-  public static final String ANSI_RESET = "\u001B[0m";
-  public static final String ANSI_BLACK = "\u001B[30m";
-  public static final String ANSI_RED = "\u001B[31m";
-  public static final String ANSI_GREEN = "\u001B[32m";
-  public static final String ANSI_YELLOW = "\u001B[33m";
-  public static final String ANSI_BLUE = "\u001B[34m";
-  public static final String ANSI_PURPLE = "\u001B[35m";
-  public static final String ANSI_CYAN = "\u001B[36m";
-  public static final String ANSI_WHITE = "\u001B[37m";
-  public static final String ANSI_BOLD = "\u001b[1m";
+class DefaultLogger extends AbstractLogger implements BuildLogger {
 
   /**
    * Size of left-hand column for right-justified task name.
@@ -71,26 +61,29 @@ class DefaultLogger implements BuildLogger {
   private PrintStream err;
 
   /** Lowest level of message to write out */
-  private int msgOutputLevel = Project.MSG_ERR;
+  //  private int msgOutputLevel = Project.MSG_ERR;
 
   /** Time of the start of the build */
   private long startTime = System.currentTimeMillis();
 
   // CheckStyle:ConstantNameCheck OFF - bc
   /** Line separator */
-  protected static final String lSep = StringUtils.LINE_SEP;
+  //  protected static final String lSep = StringUtils.LINE_SEP;
   // CheckStyle:ConstantNameCheck ON
 
   /** Whether or not to use emacs-style output */
   private boolean emacsMode = false;
-  private boolean useColor = false;
+
+  //  private boolean useColor = false;
 
   // CheckStyle:VisibilityModifier ON
 
   /**
    * Sole constructor.
    */
-  public DefaultLogger() {}
+  public DefaultLogger() {
+    msgOutputLevel = Project.MSG_ERR;
+  }
 
   /**
    * Sets the highest level of message this logger should respond to.
@@ -187,7 +180,13 @@ class DefaultLogger implements BuildLogger {
       // message.append(StringUtils.LINE_SEP);
       // message.append(getBuildFailedMessage());
       //            message.append(StringUtils.LINE_SEP);
+      if (useColor) {
+        message.append(ANSI_RED);
+      }
       message.append("Error: ");
+      if (useColor) {
+        message.append(ANSI_RESET);
+      }
       throwableMessage(message, error, Project.MSG_VERBOSE <= msgOutputLevel);
     }
     // message.append(StringUtils.LINE_SEP);
@@ -198,7 +197,11 @@ class DefaultLogger implements BuildLogger {
     if (error == null && !msg.trim().isEmpty()) {
       printMessage(msg, out, Project.MSG_VERBOSE);
     } else if (!msg.isEmpty()) {
-      printMessage(msg, err, Project.MSG_ERR);
+      if (useColor) {
+        printMessage(removeLevelPrefix(message).toString(), err, Project.MSG_ERR);
+      } else {
+        printMessage(msg, err, Project.MSG_ERR);
+      }
     }
     log(msg);
   }
@@ -325,7 +328,7 @@ class DefaultLogger implements BuildLogger {
       if (priority != Project.MSG_ERR) {
         printMessage(msg, out, priority);
       } else {
-        printMessage(msg, err, priority);
+        printMessage(removeLevelPrefix(new StringBuilder(msg)).toString(), err, priority);
       }
       log(msg);
     }
@@ -355,21 +358,21 @@ class DefaultLogger implements BuildLogger {
    */
   private void printMessage(final String message, final PrintStream stream, final int priority) {
     if (useColor && priority == Project.MSG_ERR) {
-      stream.print(ANSI_RED);
+      //      stream.print(ANSI_RED);
       stream.print(message);
-      stream.println(ANSI_RESET);
+      //      stream.println(ANSI_RESET);
     } else {
       stream.println(message);
     }
     //    if (useColor && priority == Project.MSG_ERR) {
     //      stream.print(ANSI_RED);
     //      stream.print("Error");
-    //      stream.println(ANSI_RESET);
+    //      stream.print(ANSI_RESET);
     //      stream.print(": ");
     //    } else if (useColor && priority == Project.MSG_WARN) {
     //      stream.print(ANSI_YELLOW);
     //      stream.print("Warning");
-    //      stream.println(ANSI_RESET);
+    //      stream.print(ANSI_RESET);
     //      stream.print(": ");
     //    }
     //    stream.println(message);
@@ -405,5 +408,10 @@ class DefaultLogger implements BuildLogger {
   protected String extractProjectName(final BuildEvent event) {
     final Project project = event.getProject();
     return (project != null) ? project.getName() : null;
+  }
+
+  @Override
+  public void log(String msg, Throwable t, int level) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -236,9 +236,29 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
   @Override
   public void targetStarted(final BuildEvent event) {
     if (Project.MSG_INFO <= msgOutputLevel && !event.getTarget().getName().equals("")) {
-      final String msg = StringUtils.LINE_SEP + event.getTarget().getName() + ":";
-      printMessage(msg, out, event.getPriority());
-      log(msg);
+      final String msg;
+      if (useColor) {
+        if (event.getTarget().getDescription() == null) {
+          msg = null;
+        } else {
+          msg =
+            new StringBuilder()
+              .append(StringUtils.LINE_SEP)
+              .append(ANSI_BLUE)
+              .append("==> ")
+              .append(ANSI_RESET)
+              .append(ANSI_BOLD)
+              .append(event.getTarget().getDescription())
+              .append(ANSI_RESET)
+              .toString();
+        }
+      } else {
+        msg = StringUtils.LINE_SEP + event.getTarget().getName() + ":";
+      }
+      if (msg != null) {
+        printMessage(msg, out, event.getPriority());
+        log(msg);
+      }
     }
   }
 

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -174,8 +174,17 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
     final Throwable error = event.getException();
     final StringBuilder message = new StringBuilder();
     if (error == null) {
-      // message.append(StringUtils.LINE_SEP);
-      // message.append(getBuildSuccessfulMessage());
+      if (msgOutputLevel >= Project.MSG_INFO) {
+        message.append(StringUtils.LINE_SEP);
+        if (useColor) {
+          message.append(ANSI_BOLD).append(ANSI_GREEN);
+        }
+        message.append(getBuildSuccessfulMessage());
+        if (useColor) {
+          message.append(ANSI_RESET);
+        }
+        message.append(" in ").append(formatTime(System.currentTimeMillis() - startTime));
+      }
     } else {
       // message.append(StringUtils.LINE_SEP);
       // message.append(getBuildFailedMessage());
@@ -188,6 +197,17 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
         message.append(ANSI_RESET);
       }
       throwableMessage(message, error, Project.MSG_VERBOSE <= msgOutputLevel);
+      if (msgOutputLevel >= Project.MSG_INFO) {
+        message.append(StringUtils.LINE_SEP).append(StringUtils.LINE_SEP);
+        if (useColor) {
+          message.append(ANSI_BOLD).append(ANSI_RED);
+        }
+        message.append(getBuildFailedMessage());
+        if (useColor) {
+          message.append(ANSI_RESET);
+        }
+        message.append(" in ").append(formatTime(System.currentTimeMillis() - startTime));
+      }
     }
     // message.append(StringUtils.LINE_SEP);
     // message.append("Total time: ");

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -273,23 +273,22 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
     }
     if (Project.MSG_INFO <= msgOutputLevel && !event.getTarget().getName().equals("")) {
       final String msg;
-      if (useColor) {
-        if (event.getTarget().getDescription() == null) {
-          msg = null;
-        } else {
-          msg =
-            new StringBuilder()
-              .append(StringUtils.LINE_SEP)
-              .append(ANSI_BLUE)
-              .append("==> ")
-              .append(ANSI_RESET)
-              .append(ANSI_BOLD)
-              .append(event.getTarget().getDescription())
-              .append(ANSI_RESET)
-              .toString();
-        }
+      if (event.getTarget().getDescription() == null) {
+        msg = null;
       } else {
-        msg = StringUtils.LINE_SEP + event.getTarget().getName() + ":";
+        var buf = new StringBuilder().append(StringUtils.LINE_SEP);
+        if (useColor) {
+          buf.append(ANSI_BLUE);
+        }
+        buf.append("==> ");
+        if (useColor) {
+          buf.append(ANSI_RESET).append(ANSI_BOLD);
+        }
+        buf.append(event.getTarget().getDescription());
+        if (useColor) {
+          buf.append(ANSI_RESET);
+        }
+        msg = buf.toString();
       }
       if (msg != null) {
         out.println(msg);

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -197,10 +197,10 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
     if (error == null && !msg.trim().isEmpty()) {
       printMessage(msg, out, Project.MSG_VERBOSE);
     } else if (!msg.isEmpty()) {
-      if (useColor) {
-        printMessage(removeLevelPrefix(message).toString(), err, Project.MSG_ERR);
-      } else {
+      if (legacyFormat) {
         printMessage(msg, err, Project.MSG_ERR);
+      } else {
+        printMessage(removeLevelPrefix(message).toString(), err, Project.MSG_ERR);
       }
     }
     log(msg);
@@ -345,10 +345,11 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
       }
 
       final String msg = message.toString();
-      if (priority != Project.MSG_ERR) {
-        printMessage(msg, out, priority);
+      final PrintStream dst = priority == Project.MSG_ERR ? err : out;
+      if (legacyFormat) {
+        printMessage(msg, dst, priority);
       } else {
-        printMessage(removeLevelPrefix(new StringBuilder(msg)).toString(), err, priority);
+        printMessage(removeLevelPrefix(new StringBuilder(msg)).toString(), dst, priority);
       }
       log(msg);
     }

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -361,6 +361,18 @@ class DefaultLogger implements BuildLogger {
     } else {
       stream.println(message);
     }
+    //    if (useColor && priority == Project.MSG_ERR) {
+    //      stream.print(ANSI_RED);
+    //      stream.print("Error");
+    //      stream.println(ANSI_RESET);
+    //      stream.print(": ");
+    //    } else if (useColor && priority == Project.MSG_WARN) {
+    //      stream.print(ANSI_YELLOW);
+    //      stream.print("Warning");
+    //      stream.println(ANSI_RESET);
+    //      stream.print(": ");
+    //    }
+    //    stream.println(message);
   }
 
   /**

--- a/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
 
 public class DeliverablesArguments extends Arguments {
 
@@ -23,7 +24,7 @@ public class DeliverablesArguments extends Arguments {
 
   @Override
   DeliverablesArguments parse(final String[] arguments) {
-    useColor = getUseColor();
+    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();
@@ -67,7 +68,7 @@ public class DeliverablesArguments extends Arguments {
   @Override
   String getUsage(final boolean compact) {
     return UsageBuilder
-      .builder(compact)
+      .builder(compact, useColor)
       .usage(locale.getString("deliverables.usage"))
       .arguments(null, null, "file", locale.getString("deliverables.argument.file"))
       .build();

--- a/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/DeliverablesArguments.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
 import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
 
 public class DeliverablesArguments extends Arguments {
 
@@ -24,7 +23,6 @@ public class DeliverablesArguments extends Arguments {
 
   @Override
   DeliverablesArguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/InstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/InstallArguments.java
@@ -77,7 +77,7 @@ public class InstallArguments extends Arguments {
   @Override
   String getUsage(final boolean compact) {
     return UsageBuilder
-      .builder(compact)
+      .builder(compact, useColor)
       .usage(locale.getString("install.usage"))
       .arguments(null, null, "id", locale.getString("install.argument.id"))
       .arguments(null, null, "url", locale.getString("install.argument.url"))

--- a/src/main/java/org/dita/dost/invoker/InstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/InstallArguments.java
@@ -21,6 +21,7 @@ public class InstallArguments extends Arguments {
 
   @Override
   Arguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/InstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/InstallArguments.java
@@ -21,7 +21,6 @@ public class InstallArguments extends Arguments {
 
   @Override
   Arguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -149,14 +149,6 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
   }
 
   private void printErrorMessage(final String msg) {
-    //    if (args != null && args.useColor) {
-    //      System.err.print(DefaultLogger.ANSI_RED);
-    //      System.err.print(locale.getString("error_msg").formatted(msg));
-    //      System.err.println(DefaultLogger.ANSI_RESET);
-    //    } else {
-    //      System.err.println(locale.getString("error_msg").formatted(msg));
-    //    }
-    //    System.err.println();
     logger.error(msg);
   }
 

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -723,9 +723,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
    * not
    */
   private File findBuildFile(final String start, final String suffix) {
-    if (args.msgOutputLevel >= Project.MSG_INFO) {
-      System.out.println("Searching for " + suffix + " ...");
-    }
+    logger.debug("Searching for " + suffix);
 
     File parent = new File(new File(start).getAbsolutePath());
     File file = new File(parent, suffix);

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -249,7 +249,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       }
       if (this.args.repeat > 1) {
         for (int i = 0; i < durations.length; i++) {
-          System.out.println(locale.getString("conversion.repeatDuration").formatted(i + 1, durations[i]));
+          logger.info(locale.getString("conversion.repeatDuration").formatted(i + 1, durations[i]));
         }
       }
     } catch (final BuildException be) {
@@ -409,10 +409,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
 
     // Normalize buildFile for re-import detection
     buildFile = FileUtils.getFileUtils().normalize(buildFile.getAbsolutePath());
-
-    if (args.msgOutputLevel >= Project.MSG_VERBOSE) {
-      System.out.println("Buildfile " + buildFile);
-    }
+    logger.debug("Buildfile " + buildFile);
 
     if (args.logFile != null) {
       PrintStream logTo;
@@ -507,9 +504,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
   }
 
   private Map<String, Object> readProperties(File localPropertiesFile) {
-    if (args.msgOutputLevel >= Project.MSG_VERBOSE) {
-      System.out.println("Reading " + localPropertiesFile);
-    }
+    logger.debug("Reading " + localPropertiesFile);
     try (InputStream in = Files.newInputStream(localPropertiesFile.toPath())) {
       final Properties localProperties = new Properties();
       localProperties.load(in);
@@ -518,7 +513,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         .stream()
         .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
     } catch (IOException e) {
-      System.err.println("Failed to read " + localPropertiesFile);
+      logger.error("Failed to read " + localPropertiesFile, e);
       return Collections.emptyMap();
     }
   }
@@ -702,8 +697,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
   private File getParentFile(final File file) {
     final File parent = file.getParentFile();
 
-    if (parent != null && args.msgOutputLevel >= Project.MSG_VERBOSE) {
-      System.out.println("Searching in " + parent.getAbsolutePath());
+    if (parent != null) {
+      logger.trace("Searching in " + parent.getAbsolutePath());
     }
 
     return parent;
@@ -936,7 +931,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
   }
 
   /**
-   * Prints the Ant version information to <code>System.out</code>.
+   * Prints the Ant version information logger.
    *
    * @throws BuildException if the version information is unavailable
    */

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -166,6 +166,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
    *                                 <code>null</code> in which case the system classloader is
    *                                 used.
    */
+  @Deprecated
   public static void start(
     final String[] args,
     final Properties additionalUserProperties,
@@ -295,6 +296,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
    *
    * @param args Command line arguments. Must not be <code>null</code>.
    */
+  @Deprecated
   public static void main(final String[] args) {
     start(args, null, null);
   }

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -145,12 +145,12 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
   private void printMessage(final Throwable t) {
     final String message = t.getMessage();
     if (message != null && !message.trim().isEmpty()) {
-      printErrorMessage(message);
+      printErrorMessage(message, t);
     }
   }
 
-  private void printErrorMessage(final String msg) {
-    logger.error(msg);
+  private void printErrorMessage(final String msg, final Throwable t) {
+    logger.error(msg, t);
   }
 
   /**
@@ -637,7 +637,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       for (Publication.Param param : deliverable.publication().params()) {
         if (RESERVED_PARAMS.containsKey(param.name())) {
           printErrorMessage(
-            MessageUtils.getMessage("DOTJ085E", param.name(), RESERVED_PARAMS.get(param.name())).toString()
+            MessageUtils.getMessage("DOTJ085E", param.name(), RESERVED_PARAMS.get(param.name())).toString(),
+            null
           );
         }
       }
@@ -845,10 +846,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       } catch (final Throwable t) {
         // yes, I know it is bad style to catch Throwable,
         // but if we don't, we lose valuable information
-        printErrorMessage("Caught an exception while logging the end of the build. Exception was:");
+        printErrorMessage("Caught an exception while logging the end of the build. Exception was:", null);
         t.printStackTrace();
         if (error != null) {
-          printErrorMessage("There has been an error prior to that:");
+          printErrorMessage("There has been an error prior to that:", null);
           error.printStackTrace();
         }
         throw new BuildException(t);
@@ -916,7 +917,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         logger = ClasspathUtils.newInstance(args.loggerClassname, Main.class.getClassLoader(), BuildLogger.class);
       } catch (final BuildException e) {
         printErrorMessage(
-          "The specified logger class " + args.loggerClassname + " could not be used because " + e.getMessage()
+          "The specified logger class " + args.loggerClassname + " could not be used because " + e.getMessage(),
+          e
         );
         throw new RuntimeException();
       }

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -27,6 +27,7 @@
 package org.dita.dost.invoker;
 
 import static org.dita.dost.invoker.Arguments.*;
+import static org.dita.dost.log.DITAOTAntLogger.USE_COLOR;
 import static org.dita.dost.util.Configuration.transtypes;
 import static org.dita.dost.util.Constants.ANT_TEMP_DIR;
 import static org.dita.dost.util.LangUtils.pair;
@@ -354,6 +355,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       final File basePluginDir = new File(ditaDir, Configuration.pluginResourceDirs.get("org.dita.base").getPath());
       buildFile = findBuildFile(basePluginDir.getAbsolutePath(), "build.xml");
       definedProps.putAll(getLocalProperties(ditaDir));
+      definedProps.put(USE_COLOR, Boolean.toString(conversionArgs.useColor));
       if (conversionArgs.projectFile == null) {
         projectProps = Collections.singletonList(definedProps);
       } else {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -922,6 +922,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         );
         throw new RuntimeException();
       }
+    } else if (Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("legacy")) {
+      logger = new org.apache.tools.ant.DefaultLogger();
     } else {
       logger = new DefaultLogger();
       ((DefaultLogger) logger).useColor(args.useColor);

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -917,7 +917,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
         );
         throw new RuntimeException();
       }
-    } else if (Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("legacy")) {
+    } else if (Configuration.configuration.getOrDefault("cli.log-format", "legacy").equals("legacy")) {
       logger = new org.apache.tools.ant.DefaultLogger();
     } else {
       logger = new DefaultLogger();

--- a/src/main/java/org/dita/dost/invoker/PluginsArguments.java
+++ b/src/main/java/org/dita/dost/invoker/PluginsArguments.java
@@ -13,11 +13,13 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import org.apache.tools.ant.Project;
 
 public class PluginsArguments extends Arguments {
 
   @Override
   PluginsArguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_WARN;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();
@@ -32,6 +34,6 @@ public class PluginsArguments extends Arguments {
 
   @Override
   String getUsage(final boolean compact) {
-    return UsageBuilder.builder(compact).usage(locale.getString("plugins.usage")).build();
+    return UsageBuilder.builder(compact, useColor).usage(locale.getString("plugins.usage")).build();
   }
 }

--- a/src/main/java/org/dita/dost/invoker/PluginsArguments.java
+++ b/src/main/java/org/dita/dost/invoker/PluginsArguments.java
@@ -13,13 +13,11 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import org.apache.tools.ant.Project;
 
 public class PluginsArguments extends Arguments {
 
   @Override
   PluginsArguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_WARN;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
@@ -13,13 +13,11 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import org.apache.tools.ant.Project;
 
 public class TranstypesArguments extends Arguments {
 
   @Override
   TranstypesArguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
+++ b/src/main/java/org/dita/dost/invoker/TranstypesArguments.java
@@ -13,11 +13,13 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import org.apache.tools.ant.Project;
 
 public class TranstypesArguments extends Arguments {
 
   @Override
   TranstypesArguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();
@@ -32,6 +34,6 @@ public class TranstypesArguments extends Arguments {
 
   @Override
   String getUsage(final boolean compact) {
-    return UsageBuilder.builder(compact).usage(locale.getString("transtypes.usage")).build();
+    return UsageBuilder.builder(compact, useColor).usage(locale.getString("transtypes.usage")).build();
   }
 }

--- a/src/main/java/org/dita/dost/invoker/UninstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/UninstallArguments.java
@@ -22,7 +22,6 @@ public class UninstallArguments extends Arguments {
 
   @Override
   UninstallArguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/UninstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/UninstallArguments.java
@@ -75,7 +75,7 @@ public class UninstallArguments extends Arguments {
   @Override
   String getUsage(final boolean compact) {
     return UsageBuilder
-      .builder(compact)
+      .builder(compact, useColor)
       .usage(locale.getString("uninstall.usage"))
       .arguments(null, null, "id", locale.getString("uninstall.argument.id"))
       .build();

--- a/src/main/java/org/dita/dost/invoker/UninstallArguments.java
+++ b/src/main/java/org/dita/dost/invoker/UninstallArguments.java
@@ -22,6 +22,7 @@ public class UninstallArguments extends Arguments {
 
   @Override
   UninstallArguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -154,17 +154,9 @@ public class UsageBuilder {
     return " ".repeat(Math.max(0, max + 2));
   }
 
-  private static class Key implements Comparable<Key> {
-
-    final String shortKey;
-    final String longKey;
-    final String value;
-    final String string;
-
-    private Key(String shortKey, String longKey, String value) {
-      this.shortKey = shortKey;
-      this.longKey = longKey;
-      this.value = value;
+  private record Key(String shortKey, String longKey, String value) implements Comparable<Key> {
+    @Override
+    public String toString() {
       final StringBuilder buf = new StringBuilder();
       if (shortKey != null) {
         buf.append("-").append(shortKey);
@@ -184,29 +176,7 @@ public class UsageBuilder {
       if (shortKey == null && longKey == null & value != null) {
         buf.append("<").append(value).append(">");
       }
-      string = buf.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      Key key = (Key) o;
-      return (
-        Objects.equals(shortKey, key.shortKey) &&
-        Objects.equals(longKey, key.longKey) &&
-        Objects.equals(value, key.value)
-      );
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(shortKey, longKey, value);
-    }
-
-    @Override
-    public String toString() {
-      return string;
+      return buf.toString();
     }
 
     @Override

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -22,8 +22,10 @@ public class UsageBuilder {
   private final Map<Key, String> options = new HashMap<>();
   private final Map<Key, String> arguments = new LinkedHashMap<>();
   private final List<String> footers = new ArrayList<>();
+  private final boolean useColor;
 
-  private UsageBuilder(final boolean compact) {
+  private UsageBuilder(final boolean compact, final boolean useColor) {
+    this.useColor = useColor;
     options("h", "help", null, locale.getString("help.option.help"));
     if (!compact) {
       options("d", "debug", null, locale.getString("help.option.debug"));
@@ -32,8 +34,8 @@ public class UsageBuilder {
     }
   }
 
-  public static UsageBuilder builder(final boolean compact) {
-    return new UsageBuilder(compact);
+  public static UsageBuilder builder(final boolean compact, final boolean useColor) {
+    return new UsageBuilder(compact, useColor);
   }
 
   public UsageBuilder usage(final String usage) {
@@ -64,12 +66,15 @@ public class UsageBuilder {
   public String build() {
     final String padding = getPadding();
 
-    buf.append(ANSI_BOLD).append("Usage").append(ANSI_RESET).append(":\n");
+    bold("Usage");
+    buf.append(":\n");
     for (String usage : usages) {
       buf.append("  ").append(usage).append("\n");
     }
     if (!subcommands.isEmpty()) {
-      buf.append("\n").append(ANSI_BOLD).append("Subcommands").append(ANSI_RESET).append(":\n");
+      buf.append("\n");
+      bold("Subcommands");
+      buf.append(":\n");
       for (Map.Entry<String, String> subcommand : sortSubCommands(subcommands)) {
         buf
           .append("  ")
@@ -81,7 +86,9 @@ public class UsageBuilder {
       buf.append("\n  See 'dita <subcommand> --help' for details about a specific subcommand.\n");
     }
     if (!arguments.isEmpty()) {
-      buf.append("\n").append(ANSI_BOLD).append("Arguments").append(ANSI_RESET).append(":\n");
+      buf.append("\n");
+      bold("Arguments");
+      buf.append(":\n");
       for (Map.Entry<Key, String> argument : arguments.entrySet()) {
         buf
           .append("  ")
@@ -92,7 +99,9 @@ public class UsageBuilder {
       }
     }
     if (!options.isEmpty()) {
-      buf.append("\n").append(ANSI_BOLD).append("Options").append(ANSI_RESET).append(":\n");
+      buf.append("\n");
+      bold("Options");
+      buf.append(":\n");
       for (Map.Entry<Key, String> option : sort(options)) {
         buf
           .append("  ")
@@ -115,6 +124,14 @@ public class UsageBuilder {
     final List<Map.Entry<Key, String>> entries = new ArrayList<>(arguments.entrySet());
     entries.sort(Map.Entry.comparingByKey());
     return entries;
+  }
+
+  private void bold(final String text) {
+    if (useColor) {
+      buf.append(ANSI_BOLD).append(text).append(ANSI_RESET);
+    } else {
+      buf.append(text);
+    }
   }
 
   private List<Map.Entry<String, String>> sortSubCommands(Map<String, String> arguments) {

--- a/src/main/java/org/dita/dost/invoker/VersionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/VersionArguments.java
@@ -13,11 +13,13 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import org.apache.tools.ant.Project;
 
 class VersionArguments extends Arguments {
 
   @Override
   VersionArguments parse(final String[] arguments) {
+    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();
@@ -32,6 +34,6 @@ class VersionArguments extends Arguments {
 
   @Override
   String getUsage(final boolean compact) {
-    return UsageBuilder.builder(compact).usage(locale.getString("version.usage")).build();
+    return UsageBuilder.builder(compact, useColor).usage(locale.getString("version.usage")).build();
   }
 }

--- a/src/main/java/org/dita/dost/invoker/VersionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/VersionArguments.java
@@ -13,13 +13,11 @@ import static org.dita.dost.invoker.Main.locale;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import org.apache.tools.ant.Project;
 
 class VersionArguments extends Arguments {
 
   @Override
   VersionArguments parse(final String[] arguments) {
-    msgOutputLevel = Project.MSG_INFO;
     final Deque<String> args = new ArrayDeque<>(Arrays.asList(arguments));
     while (!args.isEmpty()) {
       final String arg = args.pop();

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -224,7 +224,7 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
   public abstract void log(final String msg, final Throwable t, final int level);
 
   protected void log(final String msg, final Object[] args, final Throwable t, final int level) {
-    if (level <= msgOutputLevel) {
+    if (level > msgOutputLevel) {
       return;
     }
     StringBuilder buf = null;
@@ -264,12 +264,12 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     log(res, t, level);
   }
 
-  private static String removeLevelPrefix(String msg) {
+  protected static String removeLevelPrefix(String msg) {
     var start = msg.indexOf("][");
     if (start == -1) {
       return msg;
     }
-    var end = msg.indexOf("] ", start);
+    var end = msg.indexOf("]", start + 1);
     if (end == -1) {
       return msg;
     }
@@ -281,7 +281,7 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     if (start == -1) {
       return msg;
     }
-    var end = msg.indexOf("] ", start);
+    var end = msg.indexOf("]", start + 1);
     if (end == -1) {
       return msg;
     }

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -1,0 +1,275 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.log;
+
+import java.text.MessageFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.tools.ant.Project;
+import org.dita.dost.invoker.Main;
+import org.slf4j.helpers.MarkerIgnoringBase;
+
+/**
+ * Abstract logger implementation based on SLF4J.
+ */
+public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAOTLogger {
+
+  public static final String ANSI_RESET = "\u001B[0m";
+  public static final String ANSI_BLACK = "\u001B[30m";
+  public static final String ANSI_RED = "\u001B[31m";
+  public static final String ANSI_GREEN = "\u001B[32m";
+  public static final String ANSI_YELLOW = "\u001B[33m";
+  public static final String ANSI_BLUE = "\u001B[34m";
+  public static final String ANSI_PURPLE = "\u001B[35m";
+  public static final String ANSI_CYAN = "\u001B[36m";
+  public static final String ANSI_WHITE = "\u001B[37m";
+  public static final String ANSI_BOLD = "\u001b[1m";
+
+  protected int msgOutputLevel;
+  protected boolean useColor;
+
+  public void setOutputLevel(final int msgOutputLevel) {
+    this.msgOutputLevel = msgOutputLevel;
+  }
+
+  public void setUseColor(final boolean useColor) {
+    this.useColor = useColor;
+  }
+
+  @Override
+  public void info(final String msg) {
+    log(msg, new Object[] {}, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    log(format, new Object[] { arg }, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    log(format, arguments, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String msg, Throwable t) {
+    log(msg, new Object[] {}, t, Project.MSG_INFO);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return msgOutputLevel >= Project.MSG_WARN;
+  }
+
+  @Override
+  public void warn(final String msg) {
+    log(msg, new Object[] {}, null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    log(format, new Object[] { arg }, null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    log(format, arguments, null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String msg, Throwable t) {
+    log(msg, new Object[] {}, t, Project.MSG_WARN);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return msgOutputLevel >= Project.MSG_ERR;
+  }
+
+  @Override
+  public void error(final String msg) {
+    log(msg, new Object[] {}, null, Project.MSG_ERR);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    if (arg instanceof Throwable) {
+      log(format, new Object[] {}, (Throwable) arg, Project.MSG_ERR);
+    } else {
+      log(format, new Object[] { arg }, null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    if (arg2 instanceof Throwable) {
+      log(format, new Object[] { arg1 }, (Throwable) arg2, Project.MSG_ERR);
+    } else {
+      log(format, new Object[] { arg1, arg2 }, null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    final Object last = arguments[arguments.length - 1];
+    if (last instanceof Throwable) {
+      final Object[] args = new Object[arguments.length - 1];
+      System.arraycopy(arguments, 0, args, 0, args.length);
+      log(format, args, (Throwable) last, Project.MSG_ERR);
+    } else {
+      log(format, arguments, null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(final String msg, final Throwable t) {
+    log(msg, new Object[] {}, t, Project.MSG_ERR);
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return msgOutputLevel >= Project.MSG_DEBUG;
+  }
+
+  @Override
+  public void trace(String msg) {
+    log(msg, new Object[] {}, null, Project.MSG_DEBUG);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    if (arg instanceof Throwable) {
+      log(format, new Object[] {}, (Throwable) arg, Project.MSG_DEBUG);
+    } else {
+      log(format, new Object[] { arg }, null, Project.MSG_DEBUG);
+    }
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    if (arg2 instanceof Throwable) {
+      log(format, new Object[] { arg1 }, (Throwable) arg2, Project.MSG_DEBUG);
+    } else {
+      log(format, new Object[] { arg1, arg2 }, null, Project.MSG_DEBUG);
+    }
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    final Object last = arguments[arguments.length - 1];
+    if (last instanceof Throwable) {
+      final Object[] args = new Object[arguments.length - 1];
+      System.arraycopy(arguments, 0, args, 0, args.length);
+      log(format, args, (Throwable) last, Project.MSG_DEBUG);
+    } else {
+      log(format, arguments, null, Project.MSG_DEBUG);
+    }
+  }
+
+  @Override
+  public void trace(String msg, Throwable t) {
+    log(msg, new Object[] {}, t, Project.MSG_DEBUG);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return msgOutputLevel >= Project.MSG_VERBOSE;
+  }
+
+  @Override
+  public void debug(final String msg) {
+    log(msg, new Object[] {}, null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    log(format, new Object[] { arg }, null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    log(format, arguments, null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String msg, Throwable t) {
+    log(msg, new Object[] {}, t, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return msgOutputLevel >= Project.MSG_INFO;
+  }
+
+  abstract void log(final String msg, final Throwable t, final int level);
+
+  protected void log(final String msg, final Object[] args, final Throwable t, final int level) {
+    if (level <= msgOutputLevel) {
+      return;
+    }
+    StringBuilder buf = null;
+    if (useColor && level == Project.MSG_ERR) {
+      buf =
+        new StringBuilder()
+          .append(ANSI_RED)
+          .append(Main.locale.getString("error_msg").formatted(""))
+          .append(ANSI_RESET);
+    } else if (useColor && level == Project.MSG_WARN) {
+      buf =
+        new StringBuilder()
+          .append(ANSI_YELLOW)
+          .append(Main.locale.getString("warn_msg").formatted(""))
+          .append(ANSI_RESET);
+    }
+    if (args.length > 0) {
+      if (buf == null) {
+        buf = new StringBuilder();
+      }
+      if (msg.contains("{}") || msg.contains("%s")) {
+        buf.append(MessageFormat.format(addIndex(msg), args));
+      } else {
+        buf.append(MessageFormat.format(msg, args));
+      }
+    }
+    log(buf != null ? buf.toString() : msg, t, level);
+  }
+
+  private static final Pattern ARGUMENT = Pattern.compile("\\{}|%s");
+
+  private String addIndex(String msg) {
+    final Matcher matcher = ARGUMENT.matcher(msg);
+    final StringBuilder buf = new StringBuilder();
+    int start = 0;
+    for (int i = 0; matcher.find(start); i++) {
+      buf.append(msg, start, matcher.start());
+      buf.append("{");
+      buf.append(i);
+      buf.append("}");
+      start = matcher.end();
+    }
+    if (start < msg.length()) {
+      buf.append(msg, start, msg.length());
+    }
+    return buf.toString();
+  }
+}

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.tools.ant.Project;
 import org.dita.dost.invoker.Main;
+import org.dita.dost.util.Configuration;
 import org.slf4j.helpers.MarkerIgnoringBase;
 
 /**
@@ -30,8 +31,9 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
   public static final String ANSI_WHITE = "\u001B[37m";
   public static final String ANSI_BOLD = "\u001b[1m";
 
-  protected int msgOutputLevel;
+  protected int msgOutputLevel = Project.MSG_DEBUG;
   protected boolean useColor;
+  protected boolean legacyFormat = Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("legacy");
 
   public void setOutputLevel(final int msgOutputLevel) {
     this.msgOutputLevel = msgOutputLevel;
@@ -228,18 +230,20 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
       return;
     }
     StringBuilder buf = null;
-    if (useColor && level == Project.MSG_ERR) {
-      buf =
-        new StringBuilder()
-          .append(ANSI_RED)
-          .append(Main.locale.getString("error_msg").formatted(""))
-          .append(ANSI_RESET);
-    } else if (useColor && level == Project.MSG_WARN) {
-      buf =
-        new StringBuilder()
-          .append(ANSI_YELLOW)
-          .append(Main.locale.getString("warn_msg").formatted(""))
-          .append(ANSI_RESET);
+    if (!legacyFormat) {
+      if (useColor && level == Project.MSG_ERR) {
+        buf =
+          new StringBuilder()
+            .append(ANSI_RED)
+            .append(Main.locale.getString("error_msg").formatted(""))
+            .append(ANSI_RESET);
+      } else if (useColor && level == Project.MSG_WARN) {
+        buf =
+          new StringBuilder()
+            .append(ANSI_YELLOW)
+            .append(Main.locale.getString("warn_msg").formatted(""))
+            .append(ANSI_RESET);
+      }
     }
     if (args.length > 0) {
       if (buf == null) {
@@ -254,7 +258,7 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
       buf.append(msg);
     }
     final String res;
-    if (!useColor) {
+    if (legacyFormat) {
       res = buf != null ? buf.toString() : msg;
     } else if (buf != null) {
       res = removeLevelPrefix(buf).toString();

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -221,7 +221,7 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     return msgOutputLevel >= Project.MSG_INFO;
   }
 
-  abstract void log(final String msg, final Throwable t, final int level);
+  public abstract void log(final String msg, final Throwable t, final int level);
 
   protected void log(final String msg, final Object[] args, final Throwable t, final int level) {
     if (level <= msgOutputLevel) {
@@ -276,7 +276,7 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     return msg.substring(0, start) + msg.substring(end);
   }
 
-  private static StringBuilder removeLevelPrefix(StringBuilder msg) {
+  protected static StringBuilder removeLevelPrefix(StringBuilder msg) {
     var start = msg.indexOf("][");
     if (start == -1) {
       return msg;

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -250,8 +250,43 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
       } else {
         buf.append(MessageFormat.format(msg, args));
       }
+    } else if (buf != null) {
+      buf.append(msg);
     }
-    log(buf != null ? buf.toString() : msg, t, level);
+    final String res;
+    if (!useColor) {
+      res = buf != null ? buf.toString() : msg;
+    } else if (buf != null) {
+      res = removeLevelPrefix(buf).toString();
+    } else {
+      res = removeLevelPrefix(msg);
+    }
+    log(res, t, level);
+  }
+
+  private static String removeLevelPrefix(String msg) {
+    var start = msg.indexOf("][");
+    if (start == -1) {
+      return msg;
+    }
+    var end = msg.indexOf("] ", start);
+    if (end == -1) {
+      return msg;
+    }
+    return msg.substring(0, start) + msg.substring(end);
+  }
+
+  private static StringBuilder removeLevelPrefix(StringBuilder msg) {
+    var start = msg.indexOf("][");
+    if (start == -1) {
+      return msg;
+    }
+    var end = msg.indexOf("] ", start);
+    if (end == -1) {
+      return msg;
+    }
+    msg.replace(start, end, "");
+    return msg;
   }
 
   private static final Pattern ARGUMENT = Pattern.compile("\\{}|%s");

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -33,7 +33,9 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
 
   protected int msgOutputLevel = Project.MSG_DEBUG;
   protected boolean useColor;
-  protected boolean legacyFormat = Configuration.configuration.getOrDefault("cli.log-format", "fancy").equals("legacy");
+  protected boolean legacyFormat = Configuration.configuration
+    .getOrDefault("cli.log-format", "legacy")
+    .equals("legacy");
 
   public void setOutputLevel(final int msgOutputLevel) {
     this.msgOutputLevel = msgOutputLevel;

--- a/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
@@ -18,6 +18,8 @@ import org.apache.tools.ant.Task;
  */
 public final class DITAOTAntLogger extends AbstractLogger {
 
+  public static final String USE_COLOR = "dita.use-color";
+
   private final Project project;
   private Task task;
   private Target target;
@@ -33,6 +35,7 @@ public final class DITAOTAntLogger extends AbstractLogger {
       throw new NullPointerException();
     }
     this.project = project;
+    this.useColor = Boolean.parseBoolean(project.getProperty(USE_COLOR));
   }
 
   /**

--- a/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
@@ -55,7 +55,7 @@ public final class DITAOTAntLogger extends AbstractLogger {
   }
 
   @Override
-  void log(final String msg, final Throwable t, final int level) {
+  public void log(final String msg, final Throwable t, final int level) {
     if (task != null) {
       project.log(task, msg, level);
     } else if (target != null) {

--- a/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
+++ b/src/main/java/org/dita/dost/log/DITAOTAntLogger.java
@@ -7,18 +7,16 @@
  */
 package org.dita.dost.log;
 
-import java.text.MessageFormat;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
-import org.slf4j.helpers.MarkerIgnoringBase;
 
 /**
  * Logger proxy to Ant logger.
  *
  * @author Jarno Elovirta
  */
-public final class DITAOTAntLogger extends MarkerIgnoringBase implements DITAOTLogger {
+public final class DITAOTAntLogger extends AbstractLogger {
 
   private final Project project;
   private Task task;
@@ -30,6 +28,7 @@ public final class DITAOTAntLogger extends MarkerIgnoringBase implements DITAOTL
    * @throws NullPointerException if project is {@code null}
    */
   public DITAOTAntLogger(final Project project) {
+    super();
     if (project == null) {
       throw new NullPointerException();
     }
@@ -53,171 +52,7 @@ public final class DITAOTAntLogger extends MarkerIgnoringBase implements DITAOTL
   }
 
   @Override
-  public void info(final String msg) {
-    log(msg, null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object arg) {
-    log(MessageFormat.format(format, arg), null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object arg1, Object arg2) {
-    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object... arguments) {
-    log(MessageFormat.format(format, arguments), null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String msg, Throwable t) {
-    log(msg, t, Project.MSG_INFO);
-  }
-
-  @Override
-  public boolean isWarnEnabled() {
-    return false;
-  }
-
-  @Override
-  public void warn(final String msg) {
-    log(msg, null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object arg) {
-    log(MessageFormat.format(format, arg), null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object... arguments) {
-    log(MessageFormat.format(format, arguments), null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object arg1, Object arg2) {
-    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String msg, Throwable t) {
-    log(msg, t, Project.MSG_WARN);
-  }
-
-  @Override
-  public boolean isErrorEnabled() {
-    return true;
-  }
-
-  @Override
-  public void error(final String msg) {
-    log(msg, null, Project.MSG_ERR);
-  }
-
-  @Override
-  public void error(String format, Object arg) {
-    if (arg instanceof Throwable) {
-      log(format, (Throwable) arg, Project.MSG_ERR);
-    } else {
-      log(MessageFormat.format(format, arg), null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(String format, Object arg1, Object arg2) {
-    if (arg2 instanceof Throwable) {
-      log(MessageFormat.format(format, arg1), (Throwable) arg2, Project.MSG_ERR);
-    } else {
-      log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(String format, Object... arguments) {
-    final Object last = arguments[arguments.length - 1];
-    if (last instanceof Throwable) {
-      final Object[] init = new Object[arguments.length - 1];
-      System.arraycopy(arguments, 0, init, 0, init.length);
-      log(MessageFormat.format(format, init), (Throwable) last, Project.MSG_ERR);
-    } else {
-      log(MessageFormat.format(format, arguments), null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(final String msg, final Throwable t) {
-    log(msg, t, Project.MSG_ERR);
-  }
-
-  @Override
-  public boolean isTraceEnabled() {
-    return false;
-  }
-
-  @Override
-  public void trace(String msg) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object arg) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object arg1, Object arg2) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object... arguments) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String msg, Throwable t) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean isDebugEnabled() {
-    return true;
-  }
-
-  @Override
-  public void debug(final String msg) {
-    log(msg, null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object arg) {
-    log(MessageFormat.format(format, arg), null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object arg1, Object arg2) {
-    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object... arguments) {
-    log(MessageFormat.format(format, arguments), null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String msg, Throwable t) {
-    log(msg, t, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public boolean isInfoEnabled() {
-    return true;
-  }
-
-  private void log(final String msg, final Throwable t, final int level) {
+  void log(final String msg, final Throwable t, final int level) {
     if (task != null) {
       project.log(task, msg, level);
     } else if (target != null) {

--- a/src/main/java/org/dita/dost/log/StandardLogger.java
+++ b/src/main/java/org/dita/dost/log/StandardLogger.java
@@ -8,33 +8,15 @@
 package org.dita.dost.log;
 
 import java.io.PrintStream;
-import java.text.MessageFormat;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.tools.ant.Project;
-import org.dita.dost.invoker.Main;
-import org.slf4j.helpers.MarkerIgnoringBase;
 
 /**
  * Logger to standard out and error.
  */
-public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLogger {
-
-  public static final String ANSI_RESET = "\u001B[0m";
-  public static final String ANSI_BLACK = "\u001B[30m";
-  public static final String ANSI_RED = "\u001B[31m";
-  public static final String ANSI_GREEN = "\u001B[32m";
-  public static final String ANSI_YELLOW = "\u001B[33m";
-  public static final String ANSI_BLUE = "\u001B[34m";
-  public static final String ANSI_PURPLE = "\u001B[35m";
-  public static final String ANSI_CYAN = "\u001B[36m";
-  public static final String ANSI_WHITE = "\u001B[37m";
-  public static final String ANSI_BOLD = "\u001b[1m";
+public final class StandardLogger extends AbstractLogger {
 
   private final PrintStream err;
   private final PrintStream out;
-  private int msgOutputLevel;
-  private boolean useColor;
 
   public StandardLogger(
     final PrintStream out,
@@ -42,229 +24,19 @@ public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLo
     final int msgOutputLevel,
     final boolean useColor
   ) {
+    super();
     this.out = out;
     this.err = err;
     this.msgOutputLevel = msgOutputLevel;
     this.useColor = useColor;
   }
 
-  public void setOutputLevel(final int msgOutputLevel) {
-    this.msgOutputLevel = msgOutputLevel;
-  }
-
-  public void setUseColor(final boolean useColor) {
-    this.useColor = useColor;
-  }
-
   @Override
-  public void info(final String msg) {
-    log(msg, null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object arg) {
-    log(format, new Object[] { arg }, null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object arg1, Object arg2) {
-    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String format, Object... arguments) {
-    log(format, arguments, null, Project.MSG_INFO);
-  }
-
-  @Override
-  public void info(String msg, Throwable t) {
-    log(msg, t, Project.MSG_INFO);
-  }
-
-  @Override
-  public boolean isWarnEnabled() {
-    return false;
-  }
-
-  @Override
-  public void warn(final String msg) {
-    log(msg, null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object arg) {
-    log(format, new Object[] { arg }, null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object... arguments) {
-    log(format, arguments, null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String format, Object arg1, Object arg2) {
-    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_WARN);
-  }
-
-  @Override
-  public void warn(String msg, Throwable t) {
-    log(msg, t, Project.MSG_WARN);
-  }
-
-  @Override
-  public boolean isErrorEnabled() {
-    return true;
-  }
-
-  @Override
-  public void error(final String msg) {
-    log(msg, null, Project.MSG_ERR);
-  }
-
-  @Override
-  public void error(String format, Object arg) {
-    if (arg instanceof Throwable) {
-      log(format, (Throwable) arg, Project.MSG_ERR);
-    } else {
-      log(format, new Object[] { arg }, null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(String format, Object arg1, Object arg2) {
-    if (arg2 instanceof Throwable) {
-      log(format, new Object[] { arg1 }, (Throwable) arg2, Project.MSG_ERR);
-    } else {
-      log(format, new Object[] { arg1, arg2 }, null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(String format, Object... arguments) {
-    final Object last = arguments[arguments.length - 1];
-    if (last instanceof Throwable) {
-      final Object[] args = new Object[arguments.length - 1];
-      System.arraycopy(arguments, 0, args, 0, args.length);
-      log(format, args, (Throwable) last, Project.MSG_ERR);
-    } else {
-      log(format, arguments, null, Project.MSG_ERR);
-    }
-  }
-
-  @Override
-  public void error(final String msg, final Throwable t) {
-    log(msg, t, Project.MSG_ERR);
-  }
-
-  @Override
-  public boolean isTraceEnabled() {
-    return false;
-  }
-
-  @Override
-  public void trace(String msg) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object arg) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object arg1, Object arg2) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String format, Object... arguments) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void trace(String msg, Throwable t) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean isDebugEnabled() {
-    return true;
-  }
-
-  @Override
-  public void debug(final String msg) {
-    log(msg, null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object arg) {
-    log(format, new Object[] { arg }, null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object arg1, Object arg2) {
-    log(format, new Object[] { arg1, arg2 }, null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String format, Object... arguments) {
-    log(format, arguments, null, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public void debug(String msg, Throwable t) {
-    log(msg, t, Project.MSG_VERBOSE);
-  }
-
-  @Override
-  public boolean isInfoEnabled() {
-    return true;
-  }
-
-  private void log(final String msg, final Throwable t, final int level) {
-    log(msg, new Object[] {}, t, level);
-  }
-
-  private void log(final String msg, final Object[] args, final Throwable t, final int level) {
-    if (level > msgOutputLevel) {
-      return;
-    }
-    if (useColor && level == Project.MSG_ERR) {
-      err.print(ANSI_RED);
-      err.printf(Main.locale.getString("error_msg"), "");
-      err.print(ANSI_RESET);
-    } else if (useColor && level == Project.MSG_WARN) {
-      err.print(ANSI_YELLOW);
-      err.printf(Main.locale.getString("warn_msg"), "");
-      err.print(ANSI_RESET);
-    }
-    if (args.length > 0) {
-      if (msg.contains("{}") || msg.contains("%s")) {
-        out.println(MessageFormat.format(addIndex(msg), args));
-      } else {
-        out.println(MessageFormat.format(msg, args));
-      }
+  public void log(final String msg, final Throwable t, final int level) {
+    if (level == Project.MSG_ERR || level == Project.MSG_WARN) {
+      err.println(msg);
     } else {
       out.println(msg);
     }
-  }
-
-  private static final Pattern ARGUMENT = Pattern.compile("\\{}|%s");
-
-  private String addIndex(String msg) {
-    final Matcher matcher = ARGUMENT.matcher(msg);
-    final StringBuilder buf = new StringBuilder();
-    int start = 0;
-    for (int i = 0; matcher.find(start); i++) {
-      buf.append(msg, start, matcher.start());
-      buf.append("{");
-      buf.append(i);
-      buf.append("}");
-      start = matcher.end();
-    }
-    if (start < msg.length()) {
-      buf.append(msg, start, msg.length());
-    }
-    return buf.toString();
   }
 }

--- a/src/main/java/org/dita/dost/log/StandardLogger.java
+++ b/src/main/java/org/dita/dost/log/StandardLogger.java
@@ -10,6 +10,7 @@ package org.dita.dost.log;
 import java.io.PrintStream;
 import java.text.MessageFormat;
 import org.apache.tools.ant.Project;
+import org.dita.dost.invoker.Main;
 import org.slf4j.helpers.MarkerIgnoringBase;
 
 /**
@@ -17,14 +18,40 @@ import org.slf4j.helpers.MarkerIgnoringBase;
  */
 public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLogger {
 
+  public static final String ANSI_RESET = "\u001B[0m";
+  public static final String ANSI_BLACK = "\u001B[30m";
+  public static final String ANSI_RED = "\u001B[31m";
+  public static final String ANSI_GREEN = "\u001B[32m";
+  public static final String ANSI_YELLOW = "\u001B[33m";
+  public static final String ANSI_BLUE = "\u001B[34m";
+  public static final String ANSI_PURPLE = "\u001B[35m";
+  public static final String ANSI_CYAN = "\u001B[36m";
+  public static final String ANSI_WHITE = "\u001B[37m";
+  public static final String ANSI_BOLD = "\u001b[1m";
+
   private final PrintStream err;
   private final PrintStream out;
-  private final int msgOutputLevel;
+  private int msgOutputLevel;
+  private boolean useColor;
 
-  public StandardLogger(final PrintStream out, final PrintStream err, final int msgOutputLevel) {
+  public StandardLogger(
+    final PrintStream out,
+    final PrintStream err,
+    final int msgOutputLevel,
+    final boolean useColor
+  ) {
     this.out = out;
     this.err = err;
     this.msgOutputLevel = msgOutputLevel;
+    this.useColor = useColor;
+  }
+
+  public void setOutputLevel(final int msgOutputLevel) {
+    this.msgOutputLevel = msgOutputLevel;
+  }
+
+  public void setUseColor(final boolean useColor) {
+    this.useColor = useColor;
   }
 
   @Override
@@ -196,8 +223,16 @@ public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLo
     if (level > msgOutputLevel) {
       return;
     }
-    if (level == Project.MSG_ERR || level == Project.MSG_WARN) {
+    if (useColor && level == Project.MSG_ERR) {
+      err.print(ANSI_RED);
+      err.print(Main.locale.getString("error_msg").formatted(""));
       err.println(msg);
+      err.print(ANSI_RESET);
+    } else if (useColor && level == Project.MSG_WARN) {
+      err.print(ANSI_YELLOW);
+      err.print(Main.locale.getString("warn_msg").formatted(""));
+      err.println(msg);
+      err.print(ANSI_RESET);
     } else {
       out.println(msg);
     }

--- a/src/main/java/org/dita/dost/log/StandardLogger.java
+++ b/src/main/java/org/dita/dost/log/StandardLogger.java
@@ -226,13 +226,13 @@ public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLo
     if (useColor && level == Project.MSG_ERR) {
       err.print(ANSI_RED);
       err.print(Main.locale.getString("error_msg").formatted(""));
-      err.println(msg);
       err.print(ANSI_RESET);
+      err.println(msg);
     } else if (useColor && level == Project.MSG_WARN) {
       err.print(ANSI_YELLOW);
       err.print(Main.locale.getString("warn_msg").formatted(""));
-      err.println(msg);
       err.print(ANSI_RESET);
+      err.println(msg);
     } else {
       out.println(msg);
     }

--- a/src/main/java/org/dita/dost/log/StandardLogger.java
+++ b/src/main/java/org/dita/dost/log/StandardLogger.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.log;
+
+import java.io.PrintStream;
+import java.text.MessageFormat;
+import org.apache.tools.ant.Project;
+import org.slf4j.helpers.MarkerIgnoringBase;
+
+/**
+ * Logger to standard out and error.
+ */
+public final class StandardLogger extends MarkerIgnoringBase implements DITAOTLogger {
+
+  private final PrintStream err;
+  private final PrintStream out;
+  private final int msgOutputLevel;
+
+  public StandardLogger(final PrintStream out, final PrintStream err, final int msgOutputLevel) {
+    this.out = out;
+    this.err = err;
+    this.msgOutputLevel = msgOutputLevel;
+  }
+
+  @Override
+  public void info(final String msg) {
+    log(msg, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    log(MessageFormat.format(format, arg), null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    log(MessageFormat.format(format, arguments), null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void info(String msg, Throwable t) {
+    log(msg, t, Project.MSG_INFO);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return false;
+  }
+
+  @Override
+  public void warn(final String msg) {
+    log(msg, null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    log(MessageFormat.format(format, arg), null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    log(MessageFormat.format(format, arguments), null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_WARN);
+  }
+
+  @Override
+  public void warn(String msg, Throwable t) {
+    log(msg, t, Project.MSG_WARN);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return true;
+  }
+
+  @Override
+  public void error(final String msg) {
+    log(msg, null, Project.MSG_ERR);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    if (arg instanceof Throwable) {
+      log(format, (Throwable) arg, Project.MSG_ERR);
+    } else {
+      log(MessageFormat.format(format, arg), null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    if (arg2 instanceof Throwable) {
+      log(MessageFormat.format(format, arg1), (Throwable) arg2, Project.MSG_ERR);
+    } else {
+      log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    final Object last = arguments[arguments.length - 1];
+    if (last instanceof Throwable) {
+      final Object[] init = new Object[arguments.length - 1];
+      System.arraycopy(arguments, 0, init, 0, init.length);
+      log(MessageFormat.format(format, init), (Throwable) last, Project.MSG_ERR);
+    } else {
+      log(MessageFormat.format(format, arguments), null, Project.MSG_ERR);
+    }
+  }
+
+  @Override
+  public void error(final String msg, final Throwable t) {
+    log(msg, t, Project.MSG_ERR);
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return false;
+  }
+
+  @Override
+  public void trace(String msg) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void trace(String msg, Throwable t) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return true;
+  }
+
+  @Override
+  public void debug(final String msg) {
+    log(msg, null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    log(MessageFormat.format(format, arg), null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    log(MessageFormat.format(format, arg1, arg2), null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    log(MessageFormat.format(format, arguments), null, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public void debug(String msg, Throwable t) {
+    log(msg, t, Project.MSG_VERBOSE);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return true;
+  }
+
+  private void log(final String msg, final Throwable t, final int level) {
+    if (level > msgOutputLevel) {
+      return;
+    }
+    if (level == Project.MSG_ERR || level == Project.MSG_WARN) {
+      err.println(msg);
+    } else {
+      out.println(msg);
+    }
+  }
+}

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -90,9 +90,9 @@ public abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
       final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
       try {
         reader.setProperty(FEATURE_GRAMMAR_POOL, grammarPool);
-        logger.info("Using Xerces grammar pool for DTD and schema caching.");
+        logger.debug("Using Xerces grammar pool for DTD and schema caching.");
       } catch (final NoClassDefFoundError e) {
-        logger.debug("Xerces not available, not using grammar caching");
+        logger.warn("Xerces not available, not using grammar caching");
       } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
         logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
       }

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -94,7 +94,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
     }
 
     if (destDir != null) {
-      logger.info("Transforming into " + destDir.getAbsolutePath());
+      logger.debug("Transforming into " + destDir.getAbsolutePath());
     }
     processor = xmlUtils.getProcessor();
     final XsltCompiler xsltCompiler = processor.newXsltCompiler();

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -228,9 +228,9 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();
         try {
           reader.setProperty("http://apache.org/xml/properties/internal/grammar-pool", grammarPool);
-          logger.info("Using Xerces grammar pool for DTD and schema caching.");
+          logger.debug("Using Xerces grammar pool for DTD and schema caching.");
         } catch (final NoClassDefFoundError e) {
-          logger.debug("Xerces not available, not using grammar caching");
+          logger.warn("Xerces not available, not using grammar caching");
         } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
           logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
         }

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -246,13 +246,13 @@ public final class Integrator {
     removed.removeAll(mod);
     removed.sort(Comparator.naturalOrder());
     for (final String p : removed) {
-      logger.info("Removed " + p);
+      logger.info("Removed {}", p);
     }
     final List<String> added = new ArrayList<>(mod);
     added.removeAll(orig);
     added.sort(Comparator.naturalOrder());
     for (final String p : added) {
-      logger.info("Added " + p);
+      logger.info("Added {}", p);
     }
   }
 
@@ -272,7 +272,7 @@ public final class Integrator {
     // generate the files from template
     for (final Entry<String, Value> template : templateSet.entrySet()) {
       final File templateFile = new File(ditaDir, template.getKey());
-      logger.debug("Process template " + templateFile.getPath());
+      logger.trace("Process template " + templateFile.getPath());
       //            fileGen.setPluginId(template.getValue().id);
       fileGen.generate(templateFile);
     }
@@ -355,7 +355,7 @@ public final class Integrator {
       if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
         throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
       }
-      logger.debug("Generate configuration properties " + outFile.getPath());
+      logger.trace("Generate configuration properties {}", outFile.getPath());
       out = new BufferedOutputStream(new FileOutputStream(outFile));
       configuration.store(out, "DITA-OT runtime configuration, do not edit manually");
     } catch (final Exception e) {
@@ -459,7 +459,7 @@ public final class Integrator {
       try {
         customIntegrator.process();
       } catch (final Exception e) {
-        logger.error("Custom integrator " + customIntegrator.getClass().getName() + " failed: " + e.getMessage(), e);
+        logger.error("Custom integrator {} failed: {}", customIntegrator.getClass().getName(), e.getMessage(), e);
       }
     }
   }
@@ -526,7 +526,7 @@ public final class Integrator {
       if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
         throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
       }
-      logger.debug("Generate environment shell " + outFile.getPath());
+      logger.trace("Generate environment shell " + outFile.getPath());
       out = new BufferedWriter(new FileWriter(outFile));
 
       out.write("#!/bin/sh\n");
@@ -557,7 +557,7 @@ public final class Integrator {
       if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
         throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
       }
-      logger.debug("Generate environment batch " + outFile.getPath());
+      logger.trace("Generate environment batch " + outFile.getPath());
       out = new BufferedWriter(new FileWriter(outFile));
 
       for (final File relativeLib : jars) {
@@ -583,7 +583,7 @@ public final class Integrator {
       if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
         throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
       }
-      logger.debug("Generate start command shell " + outFile.getPath());
+      logger.trace("Generate start command shell {}", outFile.getPath());
       out = new BufferedWriter(new FileWriter(outFile));
 
       out.write(
@@ -656,7 +656,7 @@ public final class Integrator {
       if (!(outFile.getParentFile().exists()) && !outFile.getParentFile().mkdirs()) {
         throw new RuntimeException("Failed to make directory " + outFile.getParentFile().getAbsolutePath());
       }
-      logger.debug("Generate start command batch " + outFile.getPath());
+      logger.trace("Generate start command batch {}", outFile.getPath());
       out = new BufferedWriter(new FileWriter(outFile));
 
       out.write(
@@ -732,8 +732,7 @@ public final class Integrator {
           .map(val -> new Value(plugin, val))
           .collect(Collectors.toList());
         if (!extensionPoints.contains(key)) {
-          final String msg = "Plug-in " + plugin + " uses an undefined extension point " + key;
-          throw new RuntimeException(msg);
+          throw new RuntimeException("Plug-in %s uses an undefined extension point %s".formatted(plugin, key));
         }
         if (featureTable.containsKey(key)) {
           final List<Value> value = featureTable.get(key);
@@ -827,7 +826,7 @@ public final class Integrator {
     if (!descSet.isEmpty()) {
       final URI b = new File(ditaDir, CONFIG_DIR + File.separator + "plugins.xml").toURI();
       for (final File descFile : descSet) {
-        logger.debug("Read plug-in configuration " + descFile.getPath());
+        logger.trace("Read plug-in configuration {}", descFile.getPath());
         final Element plugin = parseDesc(descFile);
         if (plugin != null) {
           final URI base = getRelativePath(b, descFile.toURI());
@@ -840,7 +839,7 @@ public final class Integrator {
 
   private void writePlugins() throws TransformerException {
     final File plugins = new File(ditaDir, CONFIG_DIR + File.separator + "plugins.xml");
-    logger.debug("Writing " + plugins);
+    logger.trace("Writing {}", plugins);
     try {
       new XMLUtils().writeDocument(pluginsDoc, plugins);
     } catch (final IOException e) {
@@ -904,13 +903,11 @@ public final class Integrator {
   private void validatePlugin(final Features f) {
     final String id = f.getPluginId();
     if (!ID_PATTERN.matcher(id).matches()) {
-      final String msg = "Plug-in ID '" + id + "' doesn't follow syntax rules.";
-      throw new IllegalArgumentException(msg);
+      throw new IllegalArgumentException("Plug-in ID '%s' doesn't follow syntax rules.".formatted(id));
     }
     final List<String> version = f.getFeature("package.version");
     if (version != null && !version.isEmpty() && !VERSION_PATTERN.matcher(version.get(0)).matches()) {
-      final String msg = "Plug-in version '" + version.get(0) + "' doesn't follow syntax rules.";
-      throw new IllegalArgumentException(msg);
+      throw new IllegalArgumentException("Plug-in version '%s' doesn't follow syntax rules.".formatted(version.get(0)));
     }
   }
 

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -246,13 +246,13 @@ public final class Integrator {
     removed.removeAll(mod);
     removed.sort(Comparator.naturalOrder());
     for (final String p : removed) {
-      logger.warn("Removed " + p);
+      logger.info("Removed " + p);
     }
     final List<String> added = new ArrayList<>(mod);
     added.removeAll(orig);
     added.sort(Comparator.naturalOrder());
     for (final String p : added) {
-      logger.warn("Added " + p);
+      logger.info("Added " + p);
     }
   }
 

--- a/src/main/java/org/dita/dost/platform/PluginInstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginInstall.java
@@ -181,13 +181,13 @@ public final class PluginInstall {
   }
 
   private Set<Registry> readRegistry(final String name, final SemVerMatch version) {
-    logger.info(String.format("Reading registries for %s@%s", name, version));
+    logger.info("Reading registries for {0} {1}", name, Objects.requireNonNullElse(version, ""));
     Registry res = null;
     for (final String registry : registries) {
       final URI registryUrl = URI.create(registry + name + ".json");
-      logger.info(String.format("Read registry %s", registry));
+      logger.debug("Read registry {0}", registry);
       try (BufferedInputStream in = new BufferedInputStream(registryUrl.toURL().openStream())) {
-        logger.info("Parse registry");
+        logger.debug("Parse registry");
         final JsonFactory factory = mapper.getFactory();
         final JsonParser parser = factory.createParser(in);
         final JsonNode obj = mapper.readTree(parser);
@@ -200,14 +200,14 @@ public final class PluginInstall {
         final Optional<Registry> reg = findPlugin(regs, version);
         if (reg.isPresent()) {
           final Registry plugin = reg.get();
-          logger.info("Plugin found at {0}@{1}", registryUrl, plugin.vers);
+          logger.debug("Plugin found at {0}@{1}", registryUrl, plugin.vers);
           res = plugin;
           break;
         }
       } catch (MalformedURLException e) {
-        logger.error("Invalid registry URL %s: %s", registryUrl, e.getMessage(), e);
+        logger.error("Invalid registry URL {0}: {1}", registryUrl, e.getMessage(), e);
       } catch (FileNotFoundException e) {
-        logger.info("Registry configuration %s not found", registryUrl, e);
+        // Ignore
       } catch (IOException e) {
         logger.error("Failed to read registry configuration {0}: {1}", registryUrl, e.getMessage(), e);
       }
@@ -237,7 +237,7 @@ public final class PluginInstall {
     final HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
     final HttpRequest request = HttpRequest.newBuilder().GET().uri(uri).build();
     try {
-      logger.info("Download %s".formatted(request.uri()));
+      logger.info("Download {0}", request.uri());
       client.send(request, HttpResponse.BodyHandlers.ofFile(tempPluginFile.toPath()));
     } catch (IOException | InterruptedException e) {
       throw new Exception(Main.locale.getString("install.error.download_failure").formatted(uri), e);
@@ -261,7 +261,7 @@ public final class PluginInstall {
   private Path unzip(final File input) throws Exception {
     final Path tempPluginDir = new File(tempDir, "plugin").toPath();
 
-    logger.debug("Expanding %s to %s".formatted(input, tempPluginDir));
+    logger.debug("Expanding {0} to {1}", input, tempPluginDir);
     try (ZipInputStream zipIn = new ZipInputStream(Files.newInputStream(input.toPath()))) {
       for (ZipEntry ze; (ze = zipIn.getNextEntry()) != null;) {
         Path resolvedPath = tempPluginDir.resolve(ze.getName()).normalize();
@@ -272,7 +272,7 @@ public final class PluginInstall {
           Files.createDirectories(resolvedPath);
         } else {
           Files.createDirectories(resolvedPath.getParent());
-          logger.debug("Write %s".formatted(resolvedPath));
+          logger.debug("Write {0}", resolvedPath);
           Files.copy(zipIn, resolvedPath);
         }
       }

--- a/src/main/java/org/dita/dost/platform/PluginInstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginInstall.java
@@ -1,0 +1,345 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2018 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.platform;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.tools.ant.BuildException;
+import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.platform.Registry.Dependency;
+import org.dita.dost.util.Configuration;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public final class PluginInstall {
+
+  private List<String> registries;
+  private File tempDir;
+  private final ObjectMapper mapper = new ObjectMapper();
+  private List<String> installedPlugins;
+  private Integrator integrator;
+
+  private DITAOTLogger logger;
+  private File ditaDir;
+
+  private Path pluginFile;
+  private URI pluginUri;
+  private String pluginName;
+  private SemVerMatch pluginVersion;
+  private boolean force;
+
+  private void init() {
+    registries =
+      Arrays
+        .stream(Configuration.configuration.get("registry").trim().split("\\s+"))
+        .map(registry -> registry.endsWith("/") ? registry : (registry + "/"))
+        .collect(Collectors.toList());
+    try {
+      tempDir = Files.createTempDirectory(null).toFile();
+    } catch (IOException e) {
+      throw new BuildException("Failed to create temporary directory: " + e.getMessage(), e);
+    }
+    installedPlugins = Plugins.getInstalledPlugins().stream().map(Map.Entry::getKey).toList();
+
+    integrator = new Integrator(ditaDir);
+    integrator.setLogger(logger);
+  }
+
+  public void execute() throws Exception {
+    init();
+    if (pluginFile == null && pluginUri == null && pluginName == null) {
+      throw new BuildException(new IllegalStateException("pluginName argument not set"));
+    }
+
+    try {
+      final Map<String, Path> installs = new HashMap<>();
+      if (pluginFile != null && Files.exists(pluginFile)) {
+        final Path tempPluginDir = unzip(pluginFile.toFile());
+        final String name = getPluginName(tempPluginDir);
+        installs.put(name, tempPluginDir);
+      } else if (pluginUri != null) {
+        final File tempFile = get(pluginUri, null);
+        final Path tempPluginDir = unzip(tempFile);
+        final String name = getPluginName(tempPluginDir);
+        installs.put(name, tempPluginDir);
+      } else {
+        final Set<Registry> plugins = readRegistry(this.pluginName, pluginVersion);
+        for (final Registry plugin : plugins) {
+          final File tempFile = get(plugin.url.toURI(), plugin.cksum);
+          final Path tempPluginDir = unzip(tempFile);
+          final String name = plugin.name;
+          installs.put(name, tempPluginDir);
+        }
+      }
+      for (final Map.Entry<String, Path> install : installs.entrySet()) {
+        final String name = install.getKey();
+        final Path tempPluginDir = install.getValue();
+        final File pluginDir = getPluginDir(name);
+        if (pluginDir.exists()) {
+          if (force) {
+            logger.info("Force install to {0}", pluginDir);
+            integrator.addRemoved(name);
+            FileUtils.deleteDirectory(pluginDir);
+          } else {
+            throw new BuildException(
+              new IllegalStateException(String.format("Plug-in %s already installed: %s", name, pluginDir))
+            );
+          }
+        }
+        FileUtils.copyDirectory(tempPluginDir.toFile(), pluginDir);
+      }
+    } catch (IOException e) {
+      throw new BuildException(e.getMessage(), e);
+    } finally {
+      cleanUp();
+    }
+    try {
+      integrator.execute();
+    } catch (final Exception e) {
+      throw new BuildException("Integration failed: " + e.getMessage(), e);
+    }
+  }
+
+  private void cleanUp() {
+    if (tempDir != null) {
+      try {
+        FileUtils.deleteDirectory(tempDir);
+      } catch (IOException e) {
+        throw new BuildException(e);
+      }
+    }
+  }
+
+  private String getFileHash(final File file) {
+    try (
+      DigestInputStream digestInputStream = new DigestInputStream(
+        new BufferedInputStream(new FileInputStream(file)),
+        MessageDigest.getInstance("SHA-256")
+      )
+    ) {
+      IOUtils.copy(digestInputStream, new NullOutputStream());
+      final MessageDigest digest = digestInputStream.getMessageDigest();
+      final byte[] sha256 = digest.digest();
+      return printHexBinary(sha256);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalArgumentException(e);
+    } catch (IOException e) {
+      throw new BuildException("Failed to calculate file checksum: " + e.getMessage(), e);
+    }
+  }
+
+  private String printHexBinary(final byte[] md5) {
+    final StringBuilder sb = new StringBuilder();
+    for (byte b : md5) {
+      sb.append(String.format("%02X", b));
+    }
+    return sb.toString().toLowerCase();
+  }
+
+  private String getPluginName(final Path pluginDir) {
+    final Path config = pluginDir.resolve("plugin.xml");
+    try {
+      final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(config.toFile());
+      return doc.getDocumentElement().getAttribute("id");
+    } catch (SAXException | IOException | ParserConfigurationException e) {
+      throw new BuildException("Failed to read plugin name: " + e.getMessage(), e);
+    }
+  }
+
+  private File getPluginDir(final String id) {
+    return Paths.get(ditaDir.getAbsolutePath(), "plugins", id).toFile();
+  }
+
+  private Set<Registry> readRegistry(final String name, final SemVerMatch version) {
+    logger.info(String.format("Reading registries for %s@%s", name, version));
+    Registry res = null;
+    for (final String registry : registries) {
+      final URI registryUrl = URI.create(registry + name + ".json");
+      logger.info(String.format("Read registry %s", registry));
+      try (BufferedInputStream in = new BufferedInputStream(registryUrl.toURL().openStream())) {
+        logger.info("Parse registry");
+        final JsonFactory factory = mapper.getFactory();
+        final JsonParser parser = factory.createParser(in);
+        final JsonNode obj = mapper.readTree(parser);
+        final Collection<Registry> regs;
+        if (obj.isArray()) {
+          regs = Arrays.asList(mapper.treeToValue(obj, Registry[].class));
+        } else {
+          regs = resolveAlias(mapper.treeToValue(obj, Alias.class));
+        }
+        final Optional<Registry> reg = findPlugin(regs, version);
+        if (reg.isPresent()) {
+          final Registry plugin = reg.get();
+          logger.info("Plugin found at {0}@{1}", registryUrl, plugin.vers);
+          res = plugin;
+          break;
+        }
+      } catch (MalformedURLException e) {
+        logger.error("Invalid registry URL %s: %s", registryUrl, e.getMessage(), e);
+      } catch (FileNotFoundException e) {
+        logger.info("Registry configuration %s not found", registryUrl, e);
+      } catch (IOException e) {
+        logger.error("Failed to read registry configuration {0}: {1}", registryUrl, e.getMessage(), e);
+      }
+    }
+    if (res == null) {
+      throw new BuildException("Unable to find plugin " + pluginFile + " in any configured registry.");
+    }
+
+    Set<Registry> results = new HashSet<>();
+    results.add(res);
+    res.deps
+      .stream()
+      .filter(dep -> !installedPlugins.contains(dep.name))
+      .flatMap(dep -> readRegistry(dep.name, dep.req).stream())
+      .forEach(results::add);
+
+    return results;
+  }
+
+  private Collection<Registry> resolveAlias(Alias registry) {
+    return readRegistry(registry.alias(), null);
+  }
+
+  private File get(final URI uri, final String expectedChecksum) throws Exception {
+    final File tempPluginFile = new File(tempDir, "plugin.zip");
+
+    final HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+    final HttpRequest request = HttpRequest.newBuilder().GET().uri(uri).build();
+    try {
+      logger.info("Download %s".formatted(request.uri()));
+      client.send(request, HttpResponse.BodyHandlers.ofFile(tempPluginFile.toPath()));
+    } catch (IOException | InterruptedException e) {
+      throw new Exception("Failed to download %s".formatted(uri), e);
+    }
+
+    if (expectedChecksum != null) {
+      final String checksum = getFileHash(tempPluginFile);
+      if (!checksum.equalsIgnoreCase(expectedChecksum)) {
+        throw new BuildException(
+          new IllegalArgumentException(
+            "Downloaded plugin file checksum %s does not match expected value %s".formatted(checksum, expectedChecksum)
+          )
+        );
+      }
+    }
+
+    return tempPluginFile;
+  }
+
+  /**
+   * @see <a href="https://snyk.io/research/zip-slip-vulnerability">Zip Slip Vulnerability</a>
+   */
+  private Path unzip(final File input) throws Exception {
+    final Path tempPluginDir = new File(tempDir, "plugin").toPath();
+
+    logger.debug("Expanding %s to %s".formatted(input, tempPluginDir));
+    try (ZipInputStream zipIn = new ZipInputStream(Files.newInputStream(input.toPath()))) {
+      for (ZipEntry ze; (ze = zipIn.getNextEntry()) != null;) {
+        Path resolvedPath = tempPluginDir.resolve(ze.getName()).normalize();
+        if (!resolvedPath.startsWith(tempPluginDir)) {
+          throw new Exception("Entry with an illegal path: %s".formatted(ze.getName()));
+        }
+        if (ze.isDirectory()) {
+          Files.createDirectories(resolvedPath);
+        } else {
+          Files.createDirectories(resolvedPath.getParent());
+          logger.debug("Write %s".formatted(resolvedPath));
+          Files.copy(zipIn, resolvedPath);
+        }
+      }
+    } catch (IOException e) {
+      throw new Exception("Failed to expand %s to %s".formatted(input, tempPluginDir), e);
+    }
+
+    return findBaseDir(tempPluginDir);
+  }
+
+  private Path findBaseDir(final Path tempPluginDir) throws IOException {
+    return Files
+      .find(tempPluginDir, 256, (path, attributes) -> path.getFileName().toString().equals("plugin.xml"))
+      .findFirst()
+      .orElseThrow(() -> new IOException("plugin.xml not found"))
+      .getParent();
+  }
+
+  private Optional<Registry> findPlugin(final Collection<Registry> regs, final SemVerMatch version) {
+    if (version == null) {
+      return regs.stream().filter(this::matchingPlatformVersion).max(Comparator.comparing(o -> o.vers));
+    } else {
+      return regs.stream().filter(this::matchingPlatformVersion).filter(reg -> version.contains(reg.vers)).findFirst();
+    }
+  }
+
+  @VisibleForTesting
+  boolean matchingPlatformVersion(final Registry reg) {
+    final Optional<Dependency> platformDependency = reg.deps
+      .stream()
+      .filter(dep -> dep.name.equals("org.dita.base"))
+      .findFirst();
+    if (platformDependency.isPresent()) {
+      final SemVer platform = new SemVer(Configuration.configuration.get("otversion"));
+      final Dependency dep = platformDependency.get();
+      return dep.req.contains(platform);
+    } else {
+      return true;
+    }
+  }
+
+  public void setForce(final boolean force) {
+    this.force = force;
+  }
+
+  public void setLogger(DITAOTLogger logger) {
+    this.logger = logger;
+  }
+
+  public void setDitaDir(File ditaDir) {
+    this.ditaDir = ditaDir;
+  }
+
+  public void setPluginFile(Path pluginFile) {
+    this.pluginFile = pluginFile;
+  }
+
+  public void setPluginUri(URI pluginUri) {
+    this.pluginUri = pluginUri;
+  }
+
+  public void setPluginName(String pluginName) {
+    this.pluginName = pluginName;
+  }
+
+  public void setPluginVersion(SemVerMatch pluginVersion) {
+    this.pluginVersion = pluginVersion;
+  }
+}

--- a/src/main/java/org/dita/dost/platform/PluginUninstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginUninstall.java
@@ -40,7 +40,7 @@ public final class PluginUninstall {
       throw new CliException(Main.locale.getString("uninstall.error.plugin_not_found").formatted(id));
     }
 
-    logger.debug("Delete plug-in directory {0}", pluginDir);
+    logger.info("Delete plug-in directory {0}", pluginDir);
     try {
       FileUtils.deleteDirectory(pluginDir);
     } catch (IOException e) {

--- a/src/main/java/org/dita/dost/platform/PluginUninstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginUninstall.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.BuildException;
+import org.dita.dost.invoker.CliException;
+import org.dita.dost.invoker.Main;
 import org.dita.dost.log.DITAOTLogger;
 
 public final class PluginUninstall {
@@ -35,7 +37,7 @@ public final class PluginUninstall {
 
     final File pluginDir = Paths.get(ditaDir.getAbsolutePath(), "plugins", id).toFile();
     if (!pluginDir.exists()) {
-      throw new Exception("Plug-in directory %s doesn't exist".formatted(pluginDir));
+      throw new CliException(Main.locale.getString("uninstall.error.plugin_not_found").formatted(id));
     }
 
     logger.debug("Delete plug-in directory {0}", pluginDir);

--- a/src/main/java/org/dita/dost/platform/PluginUninstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginUninstall.java
@@ -40,7 +40,7 @@ public final class PluginUninstall {
       throw new CliException(Main.locale.getString("uninstall.error.plugin_not_found").formatted(id));
     }
 
-    logger.info("Delete plug-in directory {0}", pluginDir);
+    logger.debug("Delete plug-in directory {0}", pluginDir);
     try {
       FileUtils.deleteDirectory(pluginDir);
     } catch (IOException e) {

--- a/src/main/java/org/dita/dost/platform/PluginUninstall.java
+++ b/src/main/java/org/dita/dost/platform/PluginUninstall.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.platform;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.BuildException;
+import org.dita.dost.log.DITAOTLogger;
+
+public final class PluginUninstall {
+
+  private String id;
+  private DITAOTLogger logger;
+  private File ditaDir;
+
+  private Integrator integrator;
+
+  private void init() {
+    integrator = new Integrator(ditaDir);
+    integrator.setLogger(logger);
+  }
+
+  public void execute() throws Exception {
+    init();
+    if (id == null) {
+      throw new BuildException(new IllegalStateException("id argument not set"));
+    }
+
+    final File pluginDir = Paths.get(ditaDir.getAbsolutePath(), "plugins", id).toFile();
+    if (!pluginDir.exists()) {
+      throw new Exception("Plug-in directory %s doesn't exist".formatted(pluginDir));
+    }
+
+    logger.debug("Delete plug-in directory {0}", pluginDir);
+    try {
+      FileUtils.deleteDirectory(pluginDir);
+    } catch (IOException e) {
+      throw new BuildException("Failed to delete plug-in directory %s".formatted(pluginDir), e);
+    }
+
+    integrator.setLogger(logger);
+    try {
+      integrator.execute();
+    } catch (final Exception e) {
+      throw new BuildException("Integration failed: " + e.getMessage(), e);
+    }
+  }
+
+  public void setLogger(DITAOTLogger logger) {
+    this.logger = logger;
+  }
+
+  public void setDitaDir(File ditaDir) {
+    this.ditaDir = ditaDir;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -113,7 +113,10 @@ public final class Configuration {
     }
     // Override with system properties
     for (var systemProperty : new String[] { "cli.log-format", "cli.color" }) {
-      c.put(systemProperty, System.getProperty(systemProperty, c.get(systemProperty)));
+      var value = System.getProperty(systemProperty);
+      if (value != null) {
+        c.put(systemProperty, value);
+      }
     }
 
     configuration = Collections.unmodifiableMap(c);

--- a/src/main/java/org/dita/dost/util/Configuration.java
+++ b/src/main/java/org/dita/dost/util/Configuration.java
@@ -10,11 +10,7 @@ package org.dita.dost.util;
 import static org.dita.dost.platform.Integrator.CONF_PARSER_FORMAT;
 import static org.dita.dost.util.Constants.*;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.*;
 import org.dita.dost.platform.Integrator;
 
@@ -114,6 +110,10 @@ public final class Configuration {
     }
     for (final Map.Entry<Object, Object> e : properties.entrySet()) {
       c.put(e.getKey().toString(), e.getValue().toString());
+    }
+    // Override with system properties
+    for (var systemProperty : new String[] { "cli.log-format", "cli.color" }) {
+      c.put(systemProperty, System.getProperty(systemProperty, c.get(systemProperty)));
     }
 
     configuration = Collections.unmodifiableMap(c);

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -200,55 +200,62 @@ See the accompanying LICENSE file for applicable license.
   </target>
   
   <target name="log-arg">
-    <condition property="xml.parser" value="XMLReader ${org.xml.sax.driver}">
+    <condition property="legacy-format" value="true" else="false">
+      <equals arg1="${cli.log-format}" arg2="legacy"/>
+    </condition>
+    <condition property="log-prefix" value="* " else="">
+      <equals arg1="${cli.log-format}" arg2="legacy"/>
+    </condition>
+
+    <condition property="xml.parser" value="XMLReader ${org.xml.sax.driver}" if:true="${legacy-format}">
       <and>
         <isset property="org.xml.sax.driver"/>
         <not><isset property="xml.parser"/></not>
       </and>
     </condition>
-    <condition property="xml.parser" value="Xerces">
+    <condition property="xml.parser" value="Xerces" if:true="${legacy-format}">
       <and>
         <available classname="org.apache.xerces.parsers.SAXParser"/>
         <not><isset property="xml.parser"/></not>
       </and>
     </condition>
-    <condition property="xml.parser" value="Xerces in Sun JDK 1.5">
+    <condition property="xml.parser" value="Xerces in Sun JDK 1.5" if:true="${legacy-format}">
       <and>
         <available classname="com.sun.org.apache.xerces.internal.parsers.SAXParser"/>
         <not><isset property="xml.parser"/></not>
       </and>
     </condition>
-    <condition property="xml.parser" value="Crimson">
+    <condition property="xml.parser" value="Crimson" if:true="${legacy-format}">
       <and>
         <available classname="org.apache.crimson.parser.XMLReaderImpl"/>
         <not><isset property="xml.parser"/></not>
       </and>
     </condition>
-    <condition property="xslt.parser" value="Saxon" else="Xalan">
+    <condition property="xslt.parser" value="Saxon" else="Xalan" if:true="${legacy-format}">
       <or>
         <available classname="net.sf.saxon.StyleSheet"/>
         <available classname="net.sf.saxon.Transform"/>
       </or>
     </condition>
-    <condition property="collator" value="ICU" else="JDL">
+    <condition property="collator" value="ICU" else="JDL" if:true="${legacy-format}">
       <available classname="com.ibm.icu.text.Collator"/>
     </condition>
     <!-- output parameters info -->
-    <echo level="info">*****************************************************************</echo>
-    <echo level="info">* basedir = ${basedir}</echo>
-    <echo level="info">* dita.dir = ${dita.dir}</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
+    <echo level="info" if:true="${legacy-format}">* basedir = ${basedir}</echo>
+    <echo level="info" if:true="${legacy-format}">* dita.dir = ${dita.dir}</echo>
     <!--echo level="info">* input = ${args.input}</echo-->
-    <echo level="info">* transtype = ${transtype}</echo>
-    <echo level="info">* tempdir = ${dita.temp.dir}</echo>
-    <echo level="info">* outputdir = ${output.dir}</echo>
-    <echo level="info">* clean.temp = ${clean.temp}</echo>
-    <echo level="info">* DITA-OT version = ${otversion}</echo>
-    <echo level="info">* XML parser = ${xml.parser}</echo>
-    <echo level="info">* XSLT processor = ${xslt.parser}</echo>
-    <echo level="info">* collator = ${collator}</echo>
-    <echo level="info">*****************************************************************</echo>
-    <echoproperties regex="^(arg|preprocess|dita)" taskname="echo" failonerror="false"/>
-    <echo level="info">*****************************************************************</echo>
+    <echo level="info">${log-prefix}transtype = ${transtype}</echo>
+    <echo level="info">${log-prefix}tempdir = ${dita.temp.dir}</echo>
+    <echo level="info">${log-prefix}outputdir = ${output.dir}</echo>
+    <echo level="info" if:true="${legacy-format}">* clean.temp = ${clean.temp}</echo>
+    <echo level="info">${log-prefix}DITA-OT version = ${otversion}</echo>
+    <echo level="info" if:true="${legacy-format}">* XML parser = ${xml.parser}</echo>
+    <echo level="info" if:true="${legacy-format}">* XSLT processor = ${xslt.parser}</echo>
+    <echo level="info" if:true="${legacy-format}">* collator = ${collator}</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
+    <echoproperties regex="^(arg|preprocess|dita)" taskname="echo" failonerror="false" if:true="${legacy-format}"/>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
   </target>
 
 </project>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -94,10 +94,10 @@ See the accompanying LICENSE file for applicable license.
     </pathconvert>
     <property name="dita.topic.filename.root" value="${dita.map.filename.root}"/>    
     
-    <echo level="info">*****************************************************************</echo>
-    <echo level="info">* input = ${args.input}</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
+    <echo level="info">${log-prefix}input = ${args.input}</echo>
     <echo level="info" if:set="args.resources">* resources = ${args.resources}</echo>
-    <echo level="info">*****************************************************************</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
     
     <echoxml file="${dita.temp.dir}/.job.xml">
       <job>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -13,7 +13,6 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="preprocess2"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
-    description="Map-first preprocessing"
     dita:depends="{depend.preprocess.pre},
                   preprocess2.init,
                   ditaval-merge,
@@ -28,7 +27,6 @@ See the accompanying LICENSE file for applicable license.
                   {depend.preprocess.post}"/>
 
   <target name="preprocess2.maps"
-          description="Map-first preprocessing map steps"
           depends="map-reader,
                   map-mapref,
                   map-reader-profile,

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -42,8 +42,7 @@ See the accompanying LICENSE file for applicable license.
                   clean-preprocess,
                   copy-files,
                   {depend.preprocess.post}"
-    dita:extension="depends org.dita.dost.platform.InsertDependsAction"
-    description="Preprocessing ended" />
+    dita:extension="depends org.dita.dost.platform.InsertDependsAction" />
   
   <target name="preprocess.init">
     <dita-ot-fail id="DOTA002F">
@@ -90,10 +89,10 @@ See the accompanying LICENSE file for applicable license.
     </pathconvert>
     <property name="dita.topic.filename.root" value="${dita.map.filename.root}"/>
     
-    <echo level="info">*****************************************************************</echo>
-    <echo level="info">* input = ${args.input}</echo>
-    <echo level="info">* resources = ${args.resources}</echo>
-    <echo level="info">*****************************************************************</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
+    <echo level="info">${log-prefix}input = ${args.input}</echo>
+    <echo level="info" if:set="args.resources">* resources = ${args.resources}</echo>
+    <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
   </target>
   
   <!-- clean-temp

--- a/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
+++ b/src/main/plugins/org.dita.html5/build_dita2html5_template.xml
@@ -130,14 +130,16 @@ See the accompanying LICENSE file for applicable license.
     </pipeline>
   </target>
 
-  <target name="html5.topics.common" unless="noTopic" if="old.transform">
+  <target name="html5.topics.common" unless="noTopic" if="old.transform"
+          description="Build HTML">
     <html5.topics>
       <dita:extension id="dita.conductor.html5.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper classname="org.dita.dost.ant.types.JobMapper" to="${out.ext}"/>
     </html5.topics>
   </target>
 
-  <target name="html5.topics.common.inner" unless="noTopic" if="inner.transform">
+  <target name="html5.topics.common.inner" unless="noTopic" if="inner.transform"
+          description="Build HTML">
     <html5.topics>
       <dita:extension id="dita.conductor.html5.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper classname="org.dita.dost.ant.types.JobMapper" to="${out.ext}"/>

--- a/src/main/plugins/org.dita.pdf2/build_template.xml
+++ b/src/main/plugins/org.dita.pdf2/build_template.xml
@@ -67,7 +67,8 @@ with those set forth herein.
   <target name="dita2pdf" depends="dita2pdf2"/>
   <target name="dita2pdf2" depends="dita2pdf2.init, build-init, preprocess2, map2pdf2, topic2pdf2"/>
 
-  <target name="transform.topic2pdf.init">
+  <target name="transform.topic2pdf.init"
+          description="Build FO">
     <property name="pdf2.temp.dir" value="${dita.temp.dir}"/>
     
     <property name="customization.dir" value="${dita.plugin.org.dita.pdf2.dir}/Customization"/>
@@ -129,7 +130,8 @@ with those set forth herein.
     </path>
   </target>
 
-  <target name="topic2pdf2" if="noMap">
+  <target name="topic2pdf2" if="noMap"
+          description="Initialize PDF build">
     <antcall target="preview.topic.pdf" inheritRefs="true"/>
   </target>
 
@@ -146,7 +148,8 @@ with those set forth herein.
     <property name="artworkPrefix" value="${artwork.dir}"/>
   </target>
 
-  <target name="map2pdf2" unless="noMap">
+  <target name="map2pdf2" unless="noMap"
+          description="Merge topics">
     <dirname property="dita.temp.dir.fullpath" file="${dita.temp.dir}${file.separator}dummy.file"/>
     <pipeline message="topicmerge" taskname="topic-merge"
               inputmap="${dita.temp.dir.fullpath}${file.separator}${user.input.file}">
@@ -387,7 +390,11 @@ with those set forth herein.
 
   <target name="transform.fo2pdf"
           dita:extension="depends org.dita.dost.platform.InsertDependsAction"
-          dita:depends="{depend.org.dita.pdf2.format}"/>
+          dita:depends="transform.fo2pdf.init,
+                        {depend.org.dita.pdf2.format}"/>
+
+  <target name="transform.fo2pdf.init"
+          description="Format PDF"/>
 
   <target name="copyCoreArtwork">
     <copy todir="${artwork.dir}/Configuration/OpenTopic" failonerror="false">

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -7,7 +7,7 @@
 #
 error_msg=Error: %s
 warn_msg=Warning: %s
-exception_msg=Build failed with and exception: %s
+exception_msg=Build failed with an exception: %s
 help.option.help=Print help information
 help.option.debug=Enable debug logging
 help.option.verbose=Enable verbose logging

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -7,6 +7,7 @@
 #
 error_msg=Error: %s
 warn_msg=Warning: %s
+exception_msg=Build failed with and exception: %s
 help.option.help=Print help information
 help.option.debug=Enable debug logging
 help.option.verbose=Enable verbose logging

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -26,6 +26,11 @@ install.argument.id=Install specified plug-in ID from registry
 install.argument.url=Install plug-in from a URL
 install.argument.file=Install plug-in from a local ZIP file
 install.option.force=Force-install plug-in (overwrite existing version)
+install.error.exists=Plug-in %s already installed
+install.error.not_found_from_registry=Unable to find plugin %s in any configured registry
+install.error.plugin_xml_not_found=Unable to find plugin.xml
+install.error.download_failure=Failed to download %s
+install.error.checksum_mismatch=Downloaded plugin file checksum %s does not match expected value %s
 # Uninstall subcommand
 uninstall.usage=dita uninstall <id>
 uninstall.argument.id=Uninstall plug-in with the specified ID

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -29,6 +29,7 @@ install.option.force=Force-install plug-in (overwrite existing version)
 uninstall.usage=dita uninstall <id>
 uninstall.argument.id=Uninstall plug-in with the specified ID
 uninstall.error.identifier_not_defined=You must specify plug-in identifier when using the uninstall subcommand
+uninstall.error.plugin_not_found=Plug-in %s not found
 # Transtypes subcommand
 transtypes.usage=dita transtypes [options]
 # Conversion command

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -6,6 +6,7 @@
 # See the accompanying LICENSE file for applicable license.
 #
 error_msg=Error: %s
+warn_msg=Warning: %s
 help.option.help=Print help information
 help.option.debug=Enable debug logging
 help.option.verbose=Enable verbose logging

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -611,11 +611,11 @@ public abstract class AbstractIntegrationTest {
 
   static class TestListener implements BuildListener {
 
-    private final Pattern fatalPattern = Pattern.compile("\\[\\w+F\\]|\\[FATAL\\]");
-    private final Pattern errorPattern = Pattern.compile("\\[\\w+E\\]|\\[ERROR\\]");
-    private final Pattern warnPattern = Pattern.compile("\\[\\w+W\\]|\\[WARN\\]");
-    private final Pattern infoPattern = Pattern.compile("\\[\\w+I\\]|\\[INFO\\]");
-    private final Pattern debugPattern = Pattern.compile("\\[\\w+D\\]|\\[DEBUG\\]");
+    private final Pattern fatalPattern = Pattern.compile("\\[\\w+F\\]");
+    private final Pattern errorPattern = Pattern.compile("\\[\\w+E\\]");
+    private final Pattern warnPattern = Pattern.compile("\\[\\w+W\\]");
+    private final Pattern infoPattern = Pattern.compile("\\[\\w+I\\]");
+    private final Pattern debugPattern = Pattern.compile("\\[\\w+D\\]");
 
     public final List<TestListener.Message> messages = new ArrayList<>();
     final PrintStream out;

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -611,11 +611,11 @@ public abstract class AbstractIntegrationTest {
 
   static class TestListener implements BuildListener {
 
-    private final Pattern fatalPattern = Pattern.compile("\\[\\w+F\\]\\[FATAL\\]");
-    private final Pattern errorPattern = Pattern.compile("\\[\\w+E\\]\\[ERROR\\]");
-    private final Pattern warnPattern = Pattern.compile("\\[\\w+W\\]\\[WARN\\]");
-    private final Pattern infoPattern = Pattern.compile("\\[\\w+I\\]\\[INFO\\]");
-    private final Pattern debugPattern = Pattern.compile("\\[\\w+D\\]\\[DEBUG\\]");
+    private final Pattern fatalPattern = Pattern.compile("\\[\\w+F\\]|\\[FATAL\\]");
+    private final Pattern errorPattern = Pattern.compile("\\[\\w+E\\]|\\[ERROR\\]");
+    private final Pattern warnPattern = Pattern.compile("\\[\\w+W\\]|\\[WARN\\]");
+    private final Pattern infoPattern = Pattern.compile("\\[\\w+I\\]|\\[INFO\\]");
+    private final Pattern debugPattern = Pattern.compile("\\[\\w+D\\]|\\[DEBUG\\]");
 
     public final List<TestListener.Message> messages = new ArrayList<>();
     final PrintStream out;
@@ -626,37 +626,37 @@ public abstract class AbstractIntegrationTest {
       this.err = err;
     }
 
-    //@Override
+    @Override
     public void buildStarted(BuildEvent event) {
       messages.add(new TestListener.Message(-1, "build started: " + event.getMessage()));
     }
 
-    //@Override
+    @Override
     public void buildFinished(BuildEvent event) {
       messages.add(new TestListener.Message(-1, "build finished: " + event.getMessage()));
     }
 
-    //@Override
+    @Override
     public void targetStarted(BuildEvent event) {
       messages.add(new TestListener.Message(-1, event.getTarget().getName() + ":"));
     }
 
-    //@Override
+    @Override
     public void targetFinished(BuildEvent event) {
       messages.add(new TestListener.Message(-1, "target finished: " + event.getTarget().getName()));
     }
 
-    //@Override
+    @Override
     public void taskStarted(BuildEvent event) {
       messages.add(new TestListener.Message(Project.MSG_DEBUG, "task started: " + event.getTask().getTaskName()));
     }
 
-    //@Override
+    @Override
     public void taskFinished(BuildEvent event) {
       messages.add(new TestListener.Message(Project.MSG_DEBUG, "task finished: " + event.getTask().getTaskName()));
     }
 
-    //@Override
+    @Override
     public void messageLogged(BuildEvent event) {
       final String message = event.getMessage();
       int level;

--- a/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
+++ b/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
@@ -47,6 +47,8 @@ class AbstractLoggerTest extends AbstractLogger {
 
   @BeforeEach
   void setUp() {
+    useColor = true;
+    msgOutputLevel = Project.MSG_DEBUG;
     expMessage = null;
     expThrowable = null;
     expLevel = null;
@@ -55,7 +57,17 @@ class AbstractLoggerTest extends AbstractLogger {
   @Test
   void logArguments_filter() {
     msgOutputLevel = Project.MSG_WARN;
+
     log("Message", null, null, Project.MSG_INFO);
+  }
+
+  @Test
+  void logArguments_filter_default() {
+    expMessage = "Message";
+    expThrowable = null;
+    expLevel = Project.MSG_DEBUG;
+
+    log("Message", new Object[] {}, null, Project.MSG_DEBUG);
   }
 
   @ParameterizedTest

--- a/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
+++ b/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.log;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.apache.tools.ant.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AbstractLoggerTest extends AbstractLogger {
+
+  static List<Arguments> removeLevelPrefix() {
+    return List.of(
+      Arguments.of("[DOTJ037W][INFO] Message", "[DOTJ037W] Message"),
+      Arguments.of("[DOTJ037W][INFO]: Message", "[DOTJ037W]: Message"),
+      Arguments.of("[DOTJ037W] Message", "[DOTJ037W] Message")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("removeLevelPrefix")
+  void removeLevelPrefix_StringBuilder(String src, String exp) {
+    assertEquals(exp, AbstractLogger.removeLevelPrefix(new StringBuilder(src)).toString());
+  }
+
+  @ParameterizedTest
+  @MethodSource("removeLevelPrefix")
+  void removeLevelPrefix_String(String src, String exp) {
+    assertEquals(exp, AbstractLogger.removeLevelPrefix(src));
+  }
+
+  private String expMessage;
+  private Throwable expThrowable;
+  private Integer expLevel;
+
+  @BeforeEach
+  void setUp() {
+    expMessage = null;
+    expThrowable = null;
+    expLevel = null;
+  }
+
+  @Test
+  void logArguments_filter() {
+    msgOutputLevel = Project.MSG_WARN;
+    log("Message", null, null, Project.MSG_INFO);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "Message {} {}", "Message {0} {1}", "Message %s %s" })
+  void logArguments(String msg) {
+    useColor = true;
+    msgOutputLevel = Project.MSG_INFO;
+    expMessage = "Message first second";
+    expThrowable = null;
+    expLevel = Project.MSG_INFO;
+
+    log(msg, new Object[] { "first", "second" }, null, Project.MSG_INFO);
+  }
+
+  @Override
+  public void log(String msg, Throwable t, int level) {
+    assertEquals(expMessage, msg);
+    assertEquals(expThrowable, t);
+    assertEquals(expLevel, level);
+  }
+}

--- a/src/test/java/org/dita/dost/log/StandardLoggerTest.java
+++ b/src/test/java/org/dita/dost/log/StandardLoggerTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2023 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.log;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.tools.ant.Project;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class StandardLoggerTest {
+
+  private static final String MSG = "message ä";
+
+  private StandardLogger logger;
+  private ByteArrayOutputStream out;
+  private ByteArrayOutputStream err;
+
+  @BeforeEach
+  void setUp() {
+    out = new ByteArrayOutputStream();
+    err = new ByteArrayOutputStream();
+    logger =
+      new StandardLogger(
+        new PrintStream(out, true, StandardCharsets.UTF_8),
+        new PrintStream(err, true, StandardCharsets.UTF_8),
+        Project.MSG_DEBUG,
+        false
+      );
+  }
+
+  @Test
+  void debug() {
+    logger.debug(MSG);
+
+    assertOut(MSG);
+    assertErr();
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value = {
+      "Message {0} {1} {2}, Message first second third",
+      "Message {} {} {}, Message first second third",
+      "Message {} {} {} suffix, Message first second third suffix",
+      "{} {} {}, first second third",
+      "Message {} {} {}., Message first second third.",
+      "Message %s %s %s, Message first second third",
+    }
+  )
+  void debug(final String msg, final String exp) {
+    logger.debug(msg, "first", "second", "third");
+
+    assertOut(exp);
+    assertErr();
+  }
+
+  @Test
+  void info() {
+    logger.info(MSG);
+
+    assertOut(MSG);
+    assertErr();
+  }
+
+  @Test
+  void warn() {
+    logger.warn(MSG);
+
+    assertOut(MSG);
+    assertErr();
+  }
+
+  @Test
+  void error() {
+    logger.error(MSG);
+
+    assertOut(MSG);
+    assertErr();
+  }
+
+  private void assertOut() {
+    assertEquals(0, out.size());
+  }
+
+  private void assertOut(final String exp) {
+    assertEquals(exp + "\n", new String(out.toByteArray(), StandardCharsets.UTF_8));
+  }
+
+  private void assertErr() {
+    assertEquals(0, err.size());
+  }
+
+  private void assertErr(final String exp) {
+    assertEquals(exp + "\n", new String(err.toByteArray(), StandardCharsets.UTF_8));
+  }
+}

--- a/src/test/java/org/dita/dost/log/StandardLoggerTest.java
+++ b/src/test/java/org/dita/dost/log/StandardLoggerTest.java
@@ -78,16 +78,16 @@ class StandardLoggerTest {
   void warn() {
     logger.warn(MSG);
 
-    assertOut(MSG);
-    assertErr();
+    assertOut();
+    assertErr(MSG);
   }
 
   @Test
   void error() {
     logger.error(MSG);
 
-    assertOut(MSG);
-    assertErr();
+    assertOut();
+    assertErr(MSG);
   }
 
   private void assertOut() {

--- a/src/test/java/org/dita/dost/platform/PluginInstallTest.java
+++ b/src/test/java/org/dita/dost/platform/PluginInstallTest.java
@@ -1,23 +1,22 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2018 Jarno Elovirta
+ * Copyright 2023 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
 
-package org.dita.dost.ant;
+package org.dita.dost.platform;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.dita.dost.platform.Registry;
 import org.dita.dost.platform.Registry.Dependency;
 import org.junit.jupiter.api.Test;
 
-public class PluginInstallTaskTest {
+public class PluginInstallTest {
 
-  final PluginInstallTask registryTask = new PluginInstallTask();
+  final PluginInstall registryTask = new PluginInstall();
 
   @Test
   public void matchingPlatformVersion() {

--- a/src/test/resources/bookmap1/src/chapter2.ditamap
+++ b/src/test/resources/bookmap1/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap1/src/chapter3.ditamap
+++ b/src/test/resources/bookmap1/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap1/src/chapter4.ditamap
+++ b/src/test/resources/bookmap1/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap1/src/chapter5.ditamap
+++ b/src/test/resources/bookmap1/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap2/src/chapter2.ditamap
+++ b/src/test/resources/bookmap2/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap2/src/chapter3.ditamap
+++ b/src/test/resources/bookmap2/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap2/src/chapter4.ditamap
+++ b/src/test/resources/bookmap2/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap2/src/chapter5.ditamap
+++ b/src/test/resources/bookmap2/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap3/src/chapter2.ditamap
+++ b/src/test/resources/bookmap3/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap3/src/chapter3.ditamap
+++ b/src/test/resources/bookmap3/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap3/src/chapter4.ditamap
+++ b/src/test/resources/bookmap3/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap3/src/chapter5.ditamap
+++ b/src/test/resources/bookmap3/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap4/src/chapter2.ditamap
+++ b/src/test/resources/bookmap4/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap4/src/chapter3.ditamap
+++ b/src/test/resources/bookmap4/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap4/src/chapter4.ditamap
+++ b/src/test/resources/bookmap4/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap4/src/chapter5.ditamap
+++ b/src/test/resources/bookmap4/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap5/src/chapter2.ditamap
+++ b/src/test/resources/bookmap5/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap5/src/chapter3.ditamap
+++ b/src/test/resources/bookmap5/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap5/src/chapter4.ditamap
+++ b/src/test/resources/bookmap5/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap5/src/chapter5.ditamap
+++ b/src/test/resources/bookmap5/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap6/src/chapter2.ditamap
+++ b/src/test/resources/bookmap6/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap6/src/chapter3.ditamap
+++ b/src/test/resources/bookmap6/src/chapter3.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap6/src/chapter4.ditamap
+++ b/src/test/resources/bookmap6/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap6/src/chapter5.ditamap
+++ b/src/test/resources/bookmap6/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/bookmap7/src/chapter2.ditamap
+++ b/src/test/resources/bookmap7/src/chapter2.ditamap
@@ -3,7 +3,7 @@
   Sourceforge.net. See the accompanying LICENSE file for
   applicable licenses.-->
 <!-- Copyright by Comtech Services, Inc -->
-<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "..\..\dtd\map.dtd">
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA 1.3 Map//EN" "map.dtd">
 <map id="chapter2" title="chapter2" toc="yes">
 <topicref id="DITAOT-installguide" href="title.xml" linking="none" 
   navtitle="DITA Open Toolkit Installation Guide" type="concept">

--- a/src/test/resources/bookmap7/src/chapter4.ditamap
+++ b/src/test/resources/bookmap7/src/chapter4.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="chaper3">
 <booktitle>
 <mainbooktitle>My little book</mainbooktitle>

--- a/src/test/resources/bookmap7/src/chapter5.ditamap
+++ b/src/test/resources/bookmap7/src/chapter5.ditamap
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Arbortext, Inc., 1988-2006, v.4002-->
 <!DOCTYPE bookmap PUBLIC "-//OASIS//DTD DITA 1.3 BookMap//EN"
- "..\..\dtd\bookmap.dtd">
+ "bookmap.dtd">
 <bookmap id="testbook3">
 <booktitle>
 <booklibrary>Batty Things</booklibrary>

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -4,6 +4,8 @@ otversion = 1.2.3
 chunk.id-generation-scheme = counter
 default.cascade = nomerge
 temp-file-name-scheme = org.dita.dost.module.reader.DefaultTempFileScheme
+cli.color = false
+cli.log-format = legacy
 
 # Integration
 plugindirs = plugins;demo


### PR DESCRIPTION
## Description
Refactor to remove Ant `integrator.xml` from install and uninstall process and only use Java code.

## Motivation and Context
Simplify install and uninstall code by removing redundant Ant layer from between. This will make future work on install and uninstall easier.

The existing code path is for install and uninstall is:
```mermaid
flowchart
  A[Bash] --> B[Java] --> C[Ant] --> D[Java]
```

and this simplifies it to

```mermaid
flowchart
  A[Bash] --> B[Java]
```

## How Has This Been Tested?
Existing tests and manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No user facing change.

