### PR TITLE
centralize heading level computation in HTML outputs

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -696,16 +696,8 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*" mode="generate-task-label">
     <xsl:param name="use-label"/>
     <xsl:if test="$GENERATE-TASK-LABELS='YES'">
-      <xsl:variable name="headLevel">
-        <xsl:variable name="headCount" select="count(ancestor::*[contains(@class,' topic/topic ')]) + 1"
-          as="xs:integer"/>
-        <xsl:choose>
-          <xsl:when test="$headCount > 6">h6</xsl:when>
-          <xsl:otherwise>h<xsl:value-of select="$headCount"/></xsl:otherwise>
-        </xsl:choose>
-      </xsl:variable>
       <div class="tasklabel">
-        <xsl:element name="{$headLevel}">
+        <xsl:element name="h{dita2html:get-heading-level(.)}">
           <xsl:attribute name="class">sectiontitle tasklabel</xsl:attribute>
           <xsl:value-of select="$use-label"/>
         </xsl:element>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -319,12 +319,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- Condensed topic title into single template without priorities; use $headinglevel to set heading.
      If desired, somebody could pass in the value to manually set the heading level -->
 <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]">
-  <xsl:param name="headinglevel" as="xs:integer">
-      <xsl:choose>
-          <xsl:when test="count(ancestor::*[contains(@class, ' topic/topic ')]) > 6">6</xsl:when>
-          <xsl:otherwise><xsl:sequence select="count(ancestor::*[contains(@class, ' topic/topic ')])"/></xsl:otherwise>
-      </xsl:choose>
-  </xsl:param>
+  <xsl:param name="headinglevel" as="xs:integer" select="dita2html:get-heading-level(.)"/>
   <xsl:element name="h{$headinglevel}">
       <xsl:attribute name="class" select="concat('topictitle', $headinglevel)"/>
       <xsl:call-template name="commonattributes">
@@ -350,6 +345,35 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- Hide titlealts - they need to get pulled into the proper places -->
 <xsl:template match="*[contains(@class, ' topic/titlealts ')]"/>
+
+
+<!-- =========== HEADING LEVELS =========== -->
+
+<!-- returns heading level (1 through 6) appropriate at the specified element -->
+<xsl:function name="dita2html:get-heading-level" as="xs:integer">
+  <xsl:param name="element" as="element()"/>
+  <xsl:sequence select="min((6, count($element/ancestor-or-self::*[dita2html:is-heading-level(.)])))"/>
+</xsl:function>
+
+<!-- returns true() for elements that count as a heading level -->
+<!-- (this is an accessor function to the moded templates below) -->
+<xsl:function name="dita2html:is-heading-level" as="xs:boolean">
+  <xsl:param name="element" as="element()"/>
+  <xsl:apply-templates select="$element" mode="dita2html:is-heading-level"/>
+</xsl:function>
+<xsl:template match="*" mode="dita2html:is-heading-level">
+  <xsl:sequence select="false()"/>
+</xsl:template>
+
+<!-- <topic> always increments the heading level (title or not) -->
+<xsl:template match="*[contains(@class, 'topic/topic ')]" mode="dita2html:is-heading-level">
+  <xsl:sequence select="true()"/>
+</xsl:template>
+
+<!-- <section> and <example> with titles increment the heading level -->
+<xsl:template match="*[contains(@class, 'topic/section ') or contains(@class, 'topic/example ')][*[contains(@class, 'topic/title ')] or @spectitle]" mode="dita2html:is-heading-level">
+  <xsl:sequence select="true()"/>
+</xsl:template>
 
 
 <!-- =========== BODY/SECTION (not sensitive to nesting depth) =========== -->
@@ -2180,15 +2204,8 @@ See the accompanying LICENSE file for applicable license.
      </xsl:choose>
   </xsl:variable>
 
-  <xsl:variable name="headCount" select="count(ancestor::*[contains(@class, ' topic/topic ')]) + 1"/>
-  <xsl:variable name="headLevel">
-    <xsl:choose>
-      <xsl:when test="$headCount > 6">h6</xsl:when>
-      <xsl:otherwise>h<xsl:value-of select="$headCount"/></xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
-
   <!-- based on graceful defaults, build an appropriate section-level heading -->
+  <xsl:variable name="headLevel" as="xs:integer" select="dita2html:get-heading-level(.)"/>
   <xsl:choose>
     <xsl:when test="not($heading = '')">
       <xsl:if test="normalize-space($heading) = ''">
@@ -2199,14 +2216,14 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="headLevel" select="$headLevel"/>
       </xsl:apply-templates>
       <xsl:if test="@spectitle and not(*[contains(@class, ' topic/title ')])">
-        <xsl:element name="{$headLevel}">
+        <xsl:element name="h{$headLevel}">
           <xsl:attribute name="class">sectiontitle</xsl:attribute>
           <xsl:value-of select="@spectitle"/>
         </xsl:element>
       </xsl:if>
     </xsl:when>
     <xsl:when test="$defaulttitle">
-      <xsl:element name="{$headLevel}">
+      <xsl:element name="h{$headLevel}">
         <xsl:attribute name="class">sectiontitle</xsl:attribute>
         <xsl:value-of select="$defaulttitle"/>
       </xsl:element>
@@ -2217,14 +2234,8 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:template match="*[contains(@class, ' topic/section ')]/*[contains(@class, ' topic/title ')] | 
   *[contains(@class, ' topic/example ')]/*[contains(@class, ' topic/title ')]" name="topic.section_title">
-  <xsl:param name="headLevel">
-    <xsl:variable name="headCount" select="count(ancestor::*[contains(@class, ' topic/topic ')])+1"/>
-    <xsl:choose>
-      <xsl:when test="$headCount > 6">h6</xsl:when>
-      <xsl:otherwise>h<xsl:value-of select="$headCount"/></xsl:otherwise>
-    </xsl:choose>
-  </xsl:param>
-  <xsl:element name="{$headLevel}">
+  <xsl:param name="headLevel" as="xs:integer" select="dita2html:get-heading-level(.)"/>
+  <xsl:element name="h{$headLevel}">
     <xsl:attribute name="class">sectiontitle</xsl:attribute>
     <xsl:call-template name="commonattributes">
       <xsl:with-param name="default-output-class" select="'sectiontitle'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -709,16 +709,8 @@ See the accompanying LICENSE file for applicable license.
 <xsl:template match="*" mode="generate-task-label">
   <xsl:param name="use-label"/>
   <xsl:if test="$GENERATE-TASK-LABELS='YES'">
-    <xsl:variable name="headLevel">
-      <xsl:variable name="headCount" select="count(ancestor::*[contains(@class,' topic/topic ')]) + 1"
-        as="xs:integer"/>
-      <xsl:choose>
-        <xsl:when test="$headCount > 6">h6</xsl:when>
-        <xsl:otherwise>h<xsl:value-of select="$headCount"/></xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
     <div class="tasklabel">
-      <xsl:element name="{$headLevel}">
+      <xsl:element name="h{dita2html:get-heading-level(.)}">
         <xsl:attribute name="class">sectiontitle tasklabel</xsl:attribute>
         <xsl:value-of select="$use-label"/>
       </xsl:element>


### PR DESCRIPTION
## Description
This change centralizes the computation of the heading level (`h1` through `h6`) in HTML outputs.

## Motivation and Context
All instances of HTML heading creation now share a common computation of heading level.

In addition, a new template mode (`dita2html:is-heading-level`) allows specialized elements to declare themselves as heading levels. For example, consider a specialization of `<bodydiv>` called `<description-section>`:

```
<description-section>
  <section>
    <title>Description of ABC</title>
  </section>
  <section>
    <title>Description of XYZ</title>
  </section>
</description-section>
```

A plugin can now declare `<description-section>` as a heading level:

```
<xsl:template match="*[contains-token(@class, 'mine/description-section)]" mode="dita2html:is-heading-level">
  <xsl:sequence select="true()"/>
</xsl:template>
```

which enables the following:

* The plugin can call `dita2html:section-heading` with the `defaulttitle` parameter to create its own hardcoded "Description" title.
* `<section>` and `<example>` elements inside `<description-section>` increment their heading levels as needed.

## How Has This Been Tested?
I ran the usual tests. I also used the following testcase to verify there is no change in `xhtml` and `html5` outputs:

[4330.zip](https://github.com/dita-ot/dita-ot/files/13403687/4330.zip)

If this pull request is approved, I will contribute a similar pull request to the LwDITA project.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No documentation is needed. This is a fairly low-level enhancement for specific use cases, and such users will already be looking through the code to see how to extend it.

The parameter interface of the template for `(section|example)/title` elements has changed -- the `headLevel` parameter is now an integer (1 through 6) instead of a string (`h1` through `h6`). This is now consistent with the rest of the code.

A release notes entry could be as follows:

> For HTML outputs, a new `dita2html:is-heading-level` template mode allows plugins to declare their own elements that contribute to heading level (`h1` through `h6`). For example, a specialization of `<bodydiv>` could declare itself as a heading level and create its own HTML heading (by calling `dita2html:section-heading` with the `defaulttitle` parameter), and any `<section>` or `<example>` elements inside will adjust their heading levels accordingly.
>
> As part of this change, the parameter interface of the template for `(section|example)/title` elements has changed -- the `headLevel` parameter is now an integer (1 through 6) instead of a string (`h1` through `h6`). Existing code using this interface must be modified.


## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
