### PR TITLE
Support the @ sign in the path of a plugin being installed

### DIFF
--- a/src/main/java/org/dita/dost/ant/PluginInstallTask.java
+++ b/src/main/java/org/dita/dost/ant/PluginInstallTask.java
@@ -337,12 +337,14 @@ public final class PluginInstallTask extends Task {
     } catch (MalformedURLException | URISyntaxException e) {
       // Ignore
     }
-    if (pluginFile.contains("@")) {
-      final String[] tokens = pluginFile.split("@");
+
+    final String pluginFileName = this.pluginFile.getFileName().toString();
+    if (pluginFileName.contains("@")) {
+      final String[] tokens = pluginFileName.split("@");
       pluginName = tokens[0];
       pluginVersion = new SemVerMatch(tokens[1]);
     } else {
-      pluginName = pluginFile;
+      pluginName = pluginFileName;
       pluginVersion = null;
     }
   }


### PR DESCRIPTION
*This merge request is a proposal. I don't know if the '@' sign is forbidden on purpose*
## Description

This merge enables DITA-OT binary to install a plugin with a path that includes a '@' sign.  
For that the path to the plugin file is no longer observed but only the file name itself is split up into name and version.

## Motivation and Context

When building and installing a plugin with a Jenkins pipeline, Jenkins starts to label its working directories with '@' if there are two or more pipelines in parallel. Hence the current DITA-OT implementation aborts the build when the plugin is installed.

## How Has This Been Tested?

Installing custom plugin zip files with and without a version in its name in directories with and without '@'.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
There should be no effect on the old functionality. It just expands the use cases.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->

## Additional notes  
Since the exception in the try-catch assigning `this.pluginFile` is ignored, there might arise problems. I'm open for ideas here.