### PR TITLE
Use XSLT3 for stylesheets

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/common/dita-textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/dita-textonly.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
      includes index terms, etc. 
 
      To use, process any content with mode="dita-ot:text-only" -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/dita-utilities.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/dita-utilities.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <!-- Common utilities that can be used by DITA transforms -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/functions.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/functions.xsl
@@ -8,7 +8,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/map2textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/map2textonly.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/output-message.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
   message in an installed plugin. Additional parameters to
   the message are optional.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/related-links.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
     exclude-result-prefixes="related-links xs">

--- a/src/main/plugins/org.dita.base/xsl/common/topic2textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/topic2textonly.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/ui-d2textonly.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/ui-d2textonly.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/common/uri-utils.xsl
+++ b/src/main/plugins/org.dita.base/xsl/common/uri-utils.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot">              
 
   <xsl:function name="dita-ot:normalize" as="xs:anyURI">

--- a/src/main/plugins/org.dita.base/xsl/job-helper.xsl
+++ b/src/main/plugins/org.dita.base/xsl/job-helper.xsl
@@ -7,7 +7,7 @@ Copyright 2013 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
   
   <xsl:output method="text"/>
   

--- a/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs">
   
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conrefImpl.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:conref="http://dita-ot.sourceforge.net/ns/200704/conref"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:conref="http://dita-ot.sourceforge.net/ns/200704/conref"
   xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/conref_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/conref_template.xsl
@@ -6,7 +6,7 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/conrefImpl.xsl"/>
   <dita:extension id="dita.xsl.conref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/map-conref_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/map-conref_template.xsl
@@ -6,7 +6,7 @@ Copyright 2017 Jarno Elovirta
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/conrefImpl.xsl"/>
   <dita:extension id="dita.xsl.conref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maplink_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maplink_template.xsl
@@ -7,7 +7,7 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/maplinkImpl.xsl"/>
   <dita:extension id="dita.xsl.maplink" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappullImpl.xsl
@@ -32,7 +32,7 @@ Other modes can be found within the code, and may or may not prove useful for ov
 <!-- 20090903 RDA: added <?ditaot gentext?> and <?ditaot linktext?> PIs for RFE 1367897.
                    Allows downstream processes to identify original text vs. generated link text. -->
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mappull_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mappull_template.xsl
@@ -7,7 +7,7 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/mappullImpl.xsl"/>
   <dita:extension id="dita.xsl.mappull" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
   <xsl:output method="xml" encoding="utf-8" indent="no" />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/maprefImpl.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                version="2.0"
+                version="3.0"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:mappull="http://dita-ot.sourceforge.net/ns/200704/mappull"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/mapref_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/mapref_template.xsl
@@ -6,7 +6,7 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
         <xsl:import href="plugin:org.dita.base:xsl/preprocess/maprefImpl.xsl"/>
         <dita:extension id="dita.xsl.mapref" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>
         <xsl:output method="xml" encoding="utf-8" indent="no" />

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpull-pr-d.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpull-pr-d.xsl
@@ -6,7 +6,7 @@ Copyright 2007 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:topicpull="http://dita-ot.sourceforge.net/ns/200704/topicpull"
   xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpull-task.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpull-task.xsl
@@ -7,7 +7,7 @@ Copyright 2010 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <!-- This file added for SourceForge bug report #2962813 --> 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:topicpull="http://dita-ot.sourceforge.net/ns/200704/topicpull"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpullImpl.xsl
@@ -46,7 +46,7 @@ mode="topicpull:figure-linktext" and mode="topicpull:table-linktext"
 <!-- 20090903 RDA: added <?ditaot gentext?> and <?ditaot linktext?> PIs for RFE 1367897.
                    Allows downstream processes to identify original text vs. generated link text. -->
           
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:topicpull="http://dita-ot.sourceforge.net/ns/200704/topicpull"

--- a/src/main/plugins/org.dita.base/xsl/preprocess/topicpull_template.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/topicpull_template.xsl
@@ -6,7 +6,7 @@ Copyright 2006 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpullImpl.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpull-task.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/preprocess/topicpull-pr-d.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/abbrev-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/abbrev-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
      xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.html5/xsl/choicetable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/choicetable.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
 
   <xsl:template mode="generate-table-header" match="

--- a/src/main/plugins/org.dita.html5/xsl/concept.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/concept.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="related-links xs">
 
   <!-- Concepts have their own group. -->

--- a/src/main/plugins/org.dita.html5/xsl/cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/cover.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot ditamsg">
 
   <!-- optional @class attribute for TOC <body> element

--- a/src/main/plugins/org.dita.html5/xsl/css-class.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/css-class.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot">
 
   <xsl:function name="dita-ot:css-class" as="xs:string">

--- a/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/dita2html5.xsl
@@ -7,7 +7,7 @@ Copyright 2012 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
   
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5Impl.xsl"/>
   

--- a/src/main/plugins/org.dita.html5/xsl/dita2html5Impl_template.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/dita2html5Impl_template.xsl
@@ -7,7 +7,7 @@ Copyright 2016 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
   <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/functions.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/functions.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table">
 
   <xsl:variable name="HTML_ID_SEPARATOR" select="'__'"/>

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <!-- Get each value in each <keywords>. Nested indexterms should have unique entries. Other

--- a/src/main/plugins/org.dita.html5/xsl/glossdisplay.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/glossdisplay.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="related-links">
 
   <!-- Glossary entries belong in the group with concepts. -->

--- a/src/main/plugins/org.dita.html5/xsl/hazard-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hazard-d.xsl
@@ -3,7 +3,7 @@
 This file is part of the DITA Open Toolkit project. 
 See the accompanying license.txt file for applicable licenses.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
      xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/hi-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:template match="*[contains(@class,' hi-d/b ')]" name="topic.hi-d.b">

--- a/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/htmlflag.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
      must be explicitly requested by the HTML code by processing with the "process-exception" mode.
               -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->

--- a/src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5-cover.xsl
@@ -7,7 +7,7 @@ Copyright 2012 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.html5:xsl/map2html5-coverImpl.xsl"/>
 

--- a/src/main/plugins/org.dita.html5/xsl/map2html5-coverImpl_template.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5-coverImpl_template.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot ditamsg">
 
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5Impl.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/map2html5Impl.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="2.0"
+                xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="3.0"
                 exclude-result-prefixes="dita-ot ditamsg">
 
   <xsl:param name="OUTEXT" select="'.html'"/>

--- a/src/main/plugins/org.dita.html5/xsl/mapwalker.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/mapwalker.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <!-- write technique adapted from Norman Walsh's DocBook XSLT
      first instance technique adapted from Jeni Tennison and Steve Muench -->
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:key name="topicref"

--- a/src/main/plugins/org.dita.html5/xsl/markup-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/markup-d.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="*[contains(@class, ' markup-d/markupname ')]">
     <code>

--- a/src/main/plugins/org.dita.html5/xsl/nav.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/nav.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot ditamsg">
   
   <xsl:import href="plugin:org.dita.html5:xsl/map2html5Impl.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/pr-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:import href="plugin:org.dita.html5:xsl/syntax-braces.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/properties.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/properties.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
 
   <xsl:variable name="empty-property" as="element(property)">

--- a/src/main/plugins/org.dita.html5/xsl/reference.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/reference.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot dita2html related-links">
   
   <xsl:template match="*[contains(@class, ' reference/properties ')]

--- a/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/rel-links.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita2html ditamsg dita-ot table simpletable">
 
   <xsl:template match="*[contains(@class, ' topic/simpletable ')]" mode="generate-table-summary-attribute">

--- a/src/main/plugins/org.dita.html5/xsl/svg-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/svg-d.xsl
@@ -6,7 +6,7 @@ Copyright 2018 Jarno Elovirta
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:svg="http://www.w3.org/2000/svg"

--- a/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <xsl:template match="*[contains(@class,' sw-d/filepath ')]" name="topic.sw-d.filepath">

--- a/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-braces.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   
   <!-- Logical containers -->

--- a/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/syntax-svg.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:svg="http://www.w3.org/2000/svg">
   

--- a/src/main/plugins/org.dita.html5/xsl/tables.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/tables.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot dita2html ditamsg table">
 
   <!-- XML Exchange Table Model Document Type Definition default is all -->

--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot related-links dita2html ditamsg ">
   
   <!-- Determines whether to generate titles for task sections. Values are YES and NO. -->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot dita2html ditamsg">
   
   <xsl:include href="plugin:org.dita.html5:xsl/get-meta.xsl"/>

--- a/src/main/plugins/org.dita.html5/xsl/ui-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ui-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:template match="*[contains(@class,' ui-d/screen ')]" name="topic.ui-d.screen">

--- a/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/ut-d.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.html5/xsl/xml-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/xml-d.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="*[contains(@class, ' xml-d/xmlelement ')]">
     <code>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2hhc_template.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2hhc_template.xsl
@@ -7,7 +7,7 @@ Copyright 2010 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Import the main ditamap to HTML Help Contents conversion -->

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2hhp_template.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2hhp_template.xsl
@@ -7,7 +7,7 @@ Copyright 2010 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhcImpl.xsl
@@ -21,7 +21,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0"
+                version="3.0"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 exclude-result-prefixes="dita-ot"
   >

--- a/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhpImpl.xsl
+++ b/src/main/plugins/org.dita.htmlhelp/xsl/map2htmlhelp/map2hhpImpl.xsl
@@ -27,7 +27,7 @@ See the accompanying LICENSE file for applicable license.
 
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
 <!-- Include error message template -->
 <xsl:include href="plugin:org.dita.base:xsl/common/output-message.xsl"/>

--- a/src/main/plugins/org.dita.pdf2.fop/cfg/fo/attrs/commons-attr_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/cfg/fo/attrs/commons-attr_fop.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
 
   <xsl:attribute-set name="__toc__mini__table">
     <xsl:attribute name="table-layout">fixed</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2.fop/cfg/fo/attrs/tables-attr_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/cfg/fo/attrs/tables-attr_fop.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
 
   <xsl:attribute-set name="simpletable">
     <xsl:attribute name="table-layout">fixed</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/index_fop.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
   xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  version="2.0"
+  version="3.0"
   exclude-result-prefixes="opentopic-index opentopic-func xs">
 
   <xsl:variable name="index.continued-enabled" select="false()"/>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/root-processing_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/root-processing_fop.xsl
@@ -15,7 +15,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:xmp="http://ns.adobe.com/xap/1.0/"
                 xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0" exclude-result-prefixes="dita-ot xs">
+                version="3.0" exclude-result-prefixes="dita-ot xs">
     
   <xsl:template match="/" name="rootTemplate">
     <xsl:call-template name="validateTopicRefs"/>

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/tables_fop.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-  version="2.0"
+  version="3.0"
   exclude-result-prefixes="xs dita-ot">
 
     <xsl:template match="*[contains(@class, ' topic/dt ')]">

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic2fo_shell_fop_template.xsl
@@ -7,7 +7,7 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
   
   <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
 

--- a/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic_fop.xsl
+++ b/src/main/plugins/org.dita.pdf2.fop/xsl/fo/topic_fop.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     exclude-result-prefixes="dita-ot xs"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*|@alt" mode="graphicAlternateText">
         <xsl:attribute name="fox:alt-text"><xsl:apply-templates select="." mode="text-only"/></xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/basic-settings.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/basic-settings.xsl
@@ -6,7 +6,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- (c) Copyright Suite Solutions -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs">
 
   <xsl:param name="locale"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/commons-attr.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:rx="http://www.renderx.com/XSL/Extensions"
-    version="2.0">
+    version="3.0">
 
   <!-- common attribute sets -->
 

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/concept-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/concept-attr.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:rx="http://www.renderx.com/XSL/Extensions"
-    version="2.0">
+    version="3.0">
 
     <xsl:attribute-set name="concept">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/custom.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/custom.xsl
@@ -33,6 +33,6 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/front-matter-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/front-matter-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:attribute-set name="__frontmatter">
         <xsl:attribute name="text-align">center</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/glossary-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/glossary-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="3.0">
     <xsl:attribute-set name="__glossary__label">
         <xsl:attribute name="space-before">20pt</xsl:attribute>
         <xsl:attribute name="space-after">20pt</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hazard-d-attr.xsl
@@ -4,7 +4,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying license.txt file for applicable licenses.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <!-- Source: https://www.nema.org/Standards/ComplimentaryDocuments/ANSI%20Z535_1-2017%20CONTENTS%20AND%20SCOPE.pdf -->
   <xsl:variable name="hazard.ansi.red" select="'#C8102E'"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hi-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/hi-domain-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
 
     <xsl:attribute-set name="b">
         <xsl:attribute name="font-weight">bold</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/index-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/index-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:opentopic-index="http://www.idiominc.com/opentopic/index" xmlns:fo="http://www.w3.org/1999/XSL/Format"
-  exclude-result-prefixes="opentopic-index" version="2.0">
+  exclude-result-prefixes="opentopic-index" version="3.0">
 
     <xsl:attribute-set name="__index__label">
         <xsl:attribute name="space-before">20pt</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/layout-masters-attr.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
     
   <xsl:attribute-set name="simple-page-master">
     <xsl:attribute name="page-width" select="$page-width"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/learning-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/learning-elements-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:attribute-set name="time">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/links-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="3.0">
 
     <xsl:attribute-set name="linklist">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lists-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <!--Common-->
     <xsl:attribute-set name="li.itemgroup">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lot-lof-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/lot-lof-attr.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:rx="http://www.renderx.com/XSL/Extensions"
-    version="2.0">
+    version="3.0">
 
   <xsl:attribute-set name ="__lotf__heading" use-attribute-sets="__toc__header">
   </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/map-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/map-elements-attr.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
-  version="2.0">
+  version="3.0">
 
   <xsl:attribute-set name="reltable">
   </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/markup-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/markup-domain-attr.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
   
   <xsl:attribute-set name="markupname">
     <xsl:attribute name="font-family">monospace</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/pr-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/pr-domain-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
 
     <xsl:attribute-set name="codeph">
         <xsl:attribute name="font-family">monospace</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/reference-elements-attr.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:rx="http://www.renderx.com/XSL/Extensions"
-  version="2.0">
+  version="3.0">
 
   <xsl:attribute-set name="properties" use-attribute-sets="base-font">
     <xsl:attribute name="width">100%</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/static-content-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/static-content-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
   <xsl:attribute-set name="odd__header">
     <xsl:attribute name="text-align">end</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/svg-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/svg-domain-attr.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
   
   <xsl:attribute-set name="svgref">
   </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/sw-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/sw-domain-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
 
     <xsl:attribute-set name="msgph">
         <xsl:attribute name="font-family">monospace</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/tables-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" version="3.0">
 
   <!-- contents of table entries or similer structures -->
   <xsl:attribute-set name="common.table.body.entry">

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/task-elements-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:attribute-set name="task">
     </xsl:attribute-set>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/toc-attr.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:variable name="toc.text-indent" select="'14pt'"/>
     <xsl:variable name="toc.toc-indent" select="'30pt'"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/topic-attr.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:rx="http://www.renderx.com/XSL/Extensions"
-    version="2.0">
+    version="3.0">
 
     <xsl:attribute-set name="tm">
         <xsl:attribute name="border-start-width">0pt</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/ui-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/ui-domain-attr.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
 
     <xsl:attribute-set name="uicontrol">
         <xsl:attribute name="font-weight">bold</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/xml-domain-attr.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/attrs/xml-domain-attr.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
   
   <xsl:attribute-set name="xmlelement">
     <xsl:attribute name="font-family">monospace</xsl:attribute>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/layout-masters.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/layout-masters.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
     
     <xsl:template name="createLayoutMasters">
       <xsl:call-template name="createDefaultLayoutMasters"/>

--- a/src/main/plugins/org.dita.pdf2/cfg/fo/xsl/custom.xsl
+++ b/src/main/plugins/org.dita.pdf2/cfg/fo/xsl/custom.xsl
@@ -33,6 +33,6 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
 </xsl:stylesheet>

--- a/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/attr-set-reflection.xsl
@@ -32,7 +32,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    version='2.0'>
+    version='3.0'>
 
 <!--
 A word of explanation:

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmergeImpl.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <!-- An adaptation of the Toolkit topicmerge.xsl for FO plugin use. -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"

--- a/src/main/plugins/org.dita.pdf2/xsl/common/topicmerge_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/topicmerge_template.xsl
@@ -7,7 +7,7 @@ Copyright 2011 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.pdf2:xsl/common/topicmergeImpl.xsl"/>
   <dita:extension id="org.dita.pdf2.xsl.topicmerge" behavior="org.dita.dost.platform.ImportXSLAction" xmlns:dita="http://dita-ot.sourceforge.net"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/common/vars.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/common/vars.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:opentopic-vars="http://www.idiominc.com/opentopic/vars"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   exclude-result-prefixes="opentopic-vars xs">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/abbrev-domain.xsl
@@ -12,7 +12,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:opentopic="http://www.idiominc.com/opentopic"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs opentopic dita-ot ditamsg">
   
   <xsl:param name="first-use-scope" select="'document'"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/bookmarks.xsl
@@ -39,7 +39,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
                 xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
                 exclude-result-prefixes="xs opentopic-index opentopic opentopic-func ot-placeholder"
-                version="2.0">
+                version="3.0">
 
     <!-- Determines whether letter headings in an index generate bookmarks.
          0 = no bookmarks.

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/commons.xsl
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="dita-ot ot-placeholder opentopic opentopic-index opentopic-func dita2xslfo xs"
-    version="2.0">
+    version="3.0">
 
     <!-- FIXME these imports should be moved to shell -->
     <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic.xsl"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/concept.xsl
@@ -40,7 +40,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="dita-ot ot-placeholder opentopic opentopic-index opentopic-func dita2xslfo xs"
-    version="2.0">
+    version="3.0">
 
   <xsl:template match="*[contains(@class, ' concept/concept ')]" mode="processTopic"
                 name="processConcept">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flag-rules.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flag-rules.xsl
@@ -7,7 +7,7 @@ Copyright 2007 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  exclude-result-prefixes="xs" version="2.0">
+  exclude-result-prefixes="xs" version="3.0">
 
  <!-- ========== Flagging with flags & revisions ========== -->
  

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging-from-preprocess.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    version="2.0"
+    version="3.0"
     exclude-result-prefixes="xs dita-ot">
 
   <!-- For reference, flagging info as it appears in the topics: -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/flagging.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/flagging.xsl
@@ -29,7 +29,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/front-matter.xsl
@@ -35,7 +35,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:opentopic="http://www.idiominc.com/opentopic"
     exclude-result-prefixes="opentopic"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class, ' map/topicmeta ')]">
         <fo:block-container xsl:use-attribute-sets="__frontmatter__owner__container">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/glossary.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
                 exclude-result-prefixes="ot-placeholder"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="ot-placeholder:glossarylist" name="createGlossary">
     <fo:page-sequence master-reference="glossary-sequence" xsl:use-attribute-sets="page-sequence.glossary">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hazard-d.xsl
@@ -7,7 +7,7 @@ See the accompanying license.txt file for applicable licenses.
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot">
 
   <xsl:template match="*[contains(@class, ' hazard-d/hazardstatement ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/hi-domain.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class,' hi-d/b ')]">
         <fo:inline xsl:use-attribute-sets="b">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocessImpl.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocessImpl.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- UPDATES: 20100524: SF Bug 2385466, disallow font-family="inherit" due to 
                         lack of support in renderers. -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:opentopic-i18n="http://www.idiominc.com/opentopic/i18n"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/i18n-postprocess_template.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:opentopic-i18n="http://www.idiominc.com/opentopic/i18n"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/index.xsl
@@ -31,7 +31,7 @@ This file is part of the DITA Open Toolkit project.
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/learning-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/learning-elements.xsl
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:opentopic="http://www.idiominc.com/opentopic"
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     exclude-result-prefixes="opentopic opentopic-index dita2xslfo"
-    version="2.0">
+    version="3.0">
 
 
     <xsl:template match="*[contains(@class, ' learningBase/lcTime ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/links.xsl
@@ -39,7 +39,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="dita-ot opentopic-mapmerge opentopic-func related-links xs"
-    version="2.0">
+    version="3.0">
   
   <xsl:import href="plugin:org.dita.base:xsl/common/output-message.xsl"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lists.xsl
@@ -36,7 +36,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <!--Lists-->
     <xsl:template match="*[contains(@class, ' topic/ul ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/lot-lof.xsl
@@ -17,7 +17,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="dita-ot opentopic opentopic-index dita2xslfo ot-placeholder"
-    version="2.0">
+    version="3.0">
   
   <xsl:variable name="tableset">
     <xsl:for-each select="//*[contains (@class, ' topic/table ')][*[contains(@class, ' topic/title ' )]]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/map-elements.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="dita-ot"
-  version="2.0">
+  version="3.0">
 
   <xsl:template match="*[contains(@class,' map/topicmeta ')]/*[@class][dita-ot:matches-searchtitle-class(@class)]" priority="10"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/markup-domain.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
   
   <xsl:template match="*[contains(@class, ' markup-d/markupname ')]">
     <fo:inline xsl:use-attribute-sets="markupname">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/pr-domain.xsl
@@ -34,7 +34,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    version="2.0"
+    version="3.0"
     exclude-result-prefixes="xs">
 
     <xsl:template match="*[contains(@class,' pr-d/codeph ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/preface.xsl
@@ -36,7 +36,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:opentopic="http://www.idiominc.com/opentopic"
     exclude-result-prefixes="opentopic xs"
-    version="2.0">
+    version="3.0">
 
      <xsl:template name="processTopicPreface">
          <xsl:variable name="expectedPrefaceContext" as="xs:boolean" 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/reference-elements.xsl
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:fo="http://www.w3.org/1999/XSL/Format"
   xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
   exclude-result-prefixes="xs dita2xslfo"
-  version="2.0">
+  version="3.0">
 
   <xsl:template match="*[contains(@class, ' reference/reference ')]" mode="processTopic"
                 name="processReference">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/root-processing.xsl
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     exclude-result-prefixes="opentopic-index opentopic opentopic-i18n opentopic-func dita-ot xs ot-placeholder"
-    version="2.0">
+    version="3.0">
     
     <xsl:param name="bookmap-order" select="'discard'" as="xs:string"/>
   

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/static-content.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/static-content.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:template name="insertBodyStaticContents">
         <xsl:call-template name="insertBodyFootnoteSeparator"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/svg-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/svg-domain.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
                 xmlns:svg="http://www.w3.org/2000/svg"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs opentopic dita-ot ditamsg">
 
   <xsl:template match="*[contains(@class,' svg-d/svgref ')]">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/sw-domain.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class,' sw-d/msgph ')]">
       <fo:inline xsl:use-attribute-sets="msgph">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
   xmlns:dita2xslfo="http://dita-ot.sourceforge.net/ns/200910/dita2xslfo"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="opentopic-func xs dita2xslfo dita-ot"
-  version="2.0">
+  version="3.0">
 
     <xsl:variable name="tableAttrs" select="'../../cfg/fo/attrs/tables-attr.xsl'"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/task-elements.xsl
@@ -37,7 +37,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:opentopic="http://www.idiominc.com/opentopic"
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     exclude-result-prefixes="opentopic opentopic-index dita2xslfo"
-    version="2.0">
+    version="3.0">
 
     <!-- Determines whether to generate titles for task sections. Values are YES and NO. -->
     <xsl:param name="GENERATE-TASK-LABELS">

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/toc.xsl
@@ -41,7 +41,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:opentopic-index="http://www.idiominc.com/opentopic/index"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="xs dita-ot opentopic opentopic-func ot-placeholder opentopic-index"
-    version="2.0">
+    version="3.0">
   
     <xsl:variable name="map" select="//opentopic:map"/>
 

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -40,7 +40,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
     xmlns:ot-placeholder="http://suite-sol.com/namespaces/ot-placeholder"
     exclude-result-prefixes="dita-ot ot-placeholder opentopic opentopic-index opentopic-func dita2xslfo xs"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class, ' topic/topic ')]">
       <xsl:apply-templates select="." mode="processTopic"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo.xsl
@@ -39,7 +39,7 @@ See the accompanying LICENSE file for applicable license.
     xmlns:opentopic-func="http://www.idiominc.com/opentopic/exsl/function"
     xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
     exclude-result-prefixes="opentopic-index opentopic opentopic-i18n opentopic-func"
-    version="2.0">
+    version="3.0">
 
     <xsl:import href="plugin:org.dita.base:xsl/common/dita-utilities.xsl"/>
     <xsl:import href="plugin:org.dita.base:xsl/common/dita-textonly.xsl"/>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo_shell_template.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/topic2fo_shell_template.xsl
@@ -32,7 +32,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
     <xsl:import href="plugin:org.dita.pdf2:xsl/fo/topic2fo.xsl"/>
     

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ui-domain.xsl
@@ -33,7 +33,7 @@ See the accompanying LICENSE file for applicable license.
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class,' ui-d/uicontrol ')]">
         <!-- insert an arrow before all but the first uicontrol in a menucascade -->

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/ut-domain.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    version="2.0">
+    version="3.0">
 
     <xsl:template match="*[contains(@class,' ut-d/imagemap ')]">
         <xsl:variable name="attributes" as="attribute()*"><xsl:call-template name="commonattributes"/></xsl:variable>

--- a/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
+++ b/src/main/plugins/org.dita.pdf2/xsl/fo/xml-domain.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                version="2.0">
+                version="3.0">
   
   <xsl:template match="*[contains(@class, ' xml-d/xmlelement ')]">
     <fo:inline xsl:use-attribute-sets="xmlelement">

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2html-base_template.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2html-base_template.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"                
                 >
 

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2html.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2html.xsl
@@ -13,7 +13,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
 <!-- stylesheet imports -->
 <!-- the main dita to xhtml converter -->

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml-util.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml-util.xsl
@@ -11,7 +11,7 @@ Copyright 2013 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="/">
     <xsl:variable name="content" as="node()*">

--- a/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/dita2xhtml.xsl
@@ -7,7 +7,7 @@ Copyright 2011 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.xhtml:xsl/dita2html-base.xsl"/>
   

--- a/src/main/plugins/org.dita.xhtml/xsl/map2html-cover.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2html-cover.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.xhtml:xsl/dita2html.xsl"/>
   <xsl:import href="plugin:org.dita.xhtml:xsl/map2html-coverImpl.xsl"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2html-coverImpl_template.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2html-coverImpl_template.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot">
 
   <xsl:import href="plugin:org.dita.xhtml:xsl/map2htmtoc/map2htmlImpl.xsl"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmltoc_template.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmltoc_template.xsl
@@ -7,7 +7,7 @@ Copyright 2010 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Import the main ditamap to HTML TOC conversion -->

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlImpl.xsl
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="2.0"
+                xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg" version="3.0"
                 exclude-result-prefixes="dita-ot ditamsg">
 
   <xsl:param name="OUTEXT" select="'.html'"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmlcoverImpl.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot">
 
   <!-- optional @class attribute for TOC <body> element

--- a/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2htmtoc/map2htmtocImpl.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.xhtml/xsl/map2xhtml-cover.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2xhtml-cover.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:import href="plugin:org.dita.xhtml:xsl/dita2xhtml.xsl"/>
   <xsl:import href="plugin:org.dita.xhtml:xsl/map2html-coverImpl.xsl"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/map2xhtmltoc.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 -->
 
 <!-- Map to XHTML -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
 
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/abbrev-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/abbrev-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
      xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/conceptdisplay.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
     xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     exclude-result-prefixes="related-links xs">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/get-meta.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Get each value in each <keywords>. Nested indexterms should have unique entries. Other

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/glossdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/glossdisplay.xsl
@@ -6,7 +6,7 @@ Copyright 2010 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
     xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
     exclude-result-prefixes="related-links">
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/hazard-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/hazard-d.xsl
@@ -3,7 +3,7 @@
 This file is part of the DITA Open Toolkit project. 
 See the accompanying license.txt file for applicable licenses.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
      xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/hi-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/hi-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- hi-d.ent Phrase domain: b | i | u | tt | sup | sub -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/htmlflag.xsl
@@ -14,7 +14,7 @@ See the accompanying LICENSE file for applicable license.
      must be explicitly requested by the HTML code by processing with the "process-exception" mode.
               -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-  version="2.0">
+  version="3.0">
 
   <xsl:template match="*[contains(@class,' ditaot-d/ditaval-startprop ')]/@style" mode="add-ditaval-style">
     <!-- Add the pre-calculated CSS style for this element -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/map2TOC.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/map2TOC.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:html="http://www.w3.org/1999/xhtml"
         exclude-result-prefixes="html">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/mapwalker.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/mapwalker.xsl
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- write technique adapted from Norman Walsh's DocBook XSLT
      first instance technique adapted from Jeni Tennison and Steve Muench -->
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- stylesheet imports -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/markup-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/markup-d.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="*[contains(@class, ' markup-d/markupname ')]">
     <code>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/pr-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:import href="plugin:org.dita.xhtml:xsl/xslhtml/syntax-braces.xsl"/>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/refdisplay.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
      xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/svg-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/svg-d.xsl
@@ -6,7 +6,7 @@ Copyright 2018 Jarno Elovirta
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:svg="http://www.w3.org/2000/svg"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- software-domain.ent domain: filepath | msgph | userinput | systemoutput | cmdname | msgnum | varname -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-braces.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- syntax diagram -->
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/syntax-svg.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                               xmlns:svg="http://www.w3.org/2000/svg">
 
 <!-- syntax diagram -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tablefunctions.xsl
@@ -13,7 +13,7 @@ Copied from HTML5 plugin to make table and simpletable functions available to XH
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table">
 
   <xsl:function name="table:is-tbody-entry" as="xs:boolean">

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/tables.xsl
@@ -6,7 +6,7 @@ Copyright 2004, 2005 IBM Corporation
 
 See the accompanying LICENSE file for applicable license.
 -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- 20090904 RDA: Add support for stepsection; combine duplicated logic
                    for main steps and steps-unordered templates. -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
      xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ui-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ui-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <!-- Screen -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/ut-d.xsl
@@ -7,7 +7,7 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
      xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
      xmlns:ditamsg="http://dita-ot.sourceforge.net/ns/200704/ditamsg"
      xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/xml-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/xml-d.xsl
@@ -7,7 +7,7 @@ Copyright 2014 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
 
   <xsl:template match="*[contains(@class, ' xml-d/xmlelement ')]">
     <code>

--- a/src/test/resources/BranchFilterModuleTest/src/input.xsl
+++ b/src/test/resources/BranchFilterModuleTest/src/input.xsl
@@ -3,7 +3,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:x="x"
   exclude-result-prefixes="xs x"
-  version="2.0">
+  version="3.0">
   
   <xsl:output indent="yes"/>
   

--- a/src/test/resources/IntegratorTest/exp/plugins/dummy/xsl/shell.xsl
+++ b/src/test/resources/IntegratorTest/exp/plugins/dummy/xsl/shell.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
   
   <xsl:import href="../../../xsl/foo.xsl"/>
   

--- a/src/test/resources/IntegratorTest/exp/xsl/shell.xsl
+++ b/src/test/resources/IntegratorTest/exp/xsl/shell.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                version="2.0">
+                version="3.0">
   
   <xsl:import href="plugin:dummy:foo.xsl"/>
   

--- a/src/test/resources/IntegratorTest/src/plugins/dummy/xsl/shell_template.xsl
+++ b/src/test/resources/IntegratorTest/src/plugins/dummy/xsl/shell_template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita="http://dita-ot.sourceforge.net"  
-                version="2.0">
+                version="3.0">
   
   <dita:extension id="ImportXSLAction.plugin"
                   behavior="org.dita.dost.platform.ImportXSLAction"/>  

--- a/src/test/resources/IntegratorTest/src/xsl/shell_template.xsl
+++ b/src/test/resources/IntegratorTest/src/xsl/shell_template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dita="http://dita-ot.sourceforge.net"  
-                version="2.0">
+                version="3.0">
   
   <dita:extension id="ImportXSLAction"
                   behavior="org.dita.dost.platform.ImportXSLAction"/>  

--- a/src/test/resources/XSpec/generate-common-tests.xsl
+++ b/src/test/resources/XSpec/generate-common-tests.xsl
@@ -14,7 +14,7 @@
                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
                 xmlns:pkg="http://expath.org/ns/pkg"
                 exclude-result-prefixes="xs test x pkg"
-                version="2.0">
+                version="3.0">
 
    <pkg:import-uri>http://www.jenitennison.com/xslt/xspec/generate-common-tests.xsl</pkg:import-uri>
 

--- a/src/test/resources/XSpec/generate-tests-helper.xsl
+++ b/src/test/resources/XSpec/generate-tests-helper.xsl
@@ -8,7 +8,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xhtml="http://www.w3.org/1999/xhtml"

--- a/src/test/resources/XSpec/generate-tests-utils.xsl
+++ b/src/test/resources/XSpec/generate-tests-utils.xsl
@@ -8,7 +8,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:msxsl="urn:schemas-microsoft-com:xslt"

--- a/src/test/resources/XSpec/generate-xspec-tests.xsl
+++ b/src/test/resources/XSpec/generate-xspec-tests.xsl
@@ -8,7 +8,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
 
-<xsl:stylesheet version="2.0" 
+<xsl:stylesheet version="3.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/1999/XSL/TransformAlias"
@@ -46,7 +46,7 @@
   
 <xsl:template match="x:description" mode="x:generate-tests">
   <!-- The compiled stylesheet element. -->
-  <stylesheet version="2.0">
+  <stylesheet version="3.0">
     <xsl:apply-templates select="." mode="x:copy-namespaces" />
   	<import href="{$stylesheet-uri}" />
     <!-- DITA-OT change starts: Saxon 9.8 handles this differently than 9.1 -->

--- a/src/test/xsl/common/dita-utilities.xsl
+++ b/src/test/xsl/common/dita-utilities.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="xs"
-                version="2.0">
+                version="3.0">
   
   <xsl:import href="../../../main/plugins/org.dita.base/xsl/common/dita-utilities.xsl"/>
   <xsl:import href="../../../main/plugins/org.dita.base/xsl/common/output-message.xsl"/>

--- a/src/test/xsl/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
+++ b/src/test/xsl/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl
@@ -4,7 +4,7 @@
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
   
   <xsl:import href="../../../../../../main/plugins/org.dita.base/xsl/preprocess/maplinkImpl.xsl"/>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/simpletable.xsl
@@ -4,7 +4,7 @@
                 xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
   
   <xsl:import href="../../../../../main/plugins/org.dita.html5/xsl/functions.xsl"/>

--- a/src/test/xsl/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/test/xsl/plugins/org.dita.html5/xsl/topic.xsl
@@ -5,7 +5,7 @@
                 xmlns:table="http://dita-ot.sourceforge.net/ns/201007/dita-ot/table"
                 xmlns:simpletable="http://dita-ot.sourceforge.net/ns/201007/dita-ot/simpletable"
                 xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
-                version="2.0"
+                version="3.0"
                 exclude-result-prefixes="xs dita-ot table simpletable">
   
   <xsl:import href="../../../../../main/plugins/org.dita.base/xsl/common/output-message.xsl"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/mocks.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/mocks.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" exclude-result-prefixes="xs dita-ot" version="2.0">
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" exclude-result-prefixes="xs dita-ot" version="3.0">
 
   <xsl:variable name="writing-mode" select="'lr'"/>
   <xsl:variable name="locale" select="'en'"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/simpletable.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  version="2.0">
+  version="3.0">
   
   <xsl:import href="mocks.xsl"/>  
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/xsl/fo/tables.xsl"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/tables.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/tables.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  version="2.0">
+  version="3.0">
   
   <xsl:import href="mocks.xsl"/>
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/xsl/fo/tables.xsl"/>

--- a/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xsl
+++ b/src/test/xsl/plugins/org.dita.pdf2/xsl/fo/topic.xsl
@@ -3,7 +3,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
   exclude-result-prefixes="xs dita-ot"
-  version="2.0">
+  version="3.0">
   
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/cfg/fo/attrs/basic-settings.xsl"/>
   <xsl:import href="../../../../../../main/plugins/org.dita.pdf2/xsl/fo/topic.xsl"/>


### PR DESCRIPTION
## Description
Changes XSLT style templates from version 1.0 and 2.0 to version 3.0.

There are no changes to the actual code; only the stylesheet headers.

## Motivation and Context
This is a pipecleaner change to flush out any external or third-party incompatibilities that might result from switching to XSLT3. Because there are no code changes, the version change is easily reversed to troubleshoot or work around issues.

## How Has This Been Tested?
Automated tests pass. Manual testing with old plug-ins.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This doesn't require end-users or plug-in developers to change anything. However, the release notes could link to https://www.w3.org/TR/xslt-30/#incompatibilities.
