### PR TITLE
Generate root map metadata to HTML5 index file

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -7,7 +7,9 @@ Copyright 2004, 2005 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet version="3.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                exclude-result-prefixes="xs">
 
   <!-- Get each value in each <keywords>. Nested indexterms should have unique entries. Other
        elements (based on keyword) cannot nest. -->
@@ -216,21 +218,28 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' topic/abstract ')]" mode="gen-shortdesc-metadata">
-    <xsl:variable name="shortmeta">
-      <xsl:for-each select="*[contains(@class,' topic/shortdesc ')]">
-        <xsl:text> </xsl:text>
-        <xsl:apply-templates select="*|text()" mode="text-only"/>
-      </xsl:for-each>
+    <xsl:variable name="shortmeta" as="xs:string">
+      <xsl:value-of>
+        <xsl:for-each select="*[contains(@class,' topic/shortdesc ')]">
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="*|text()" mode="text-only"/>
+        </xsl:for-each>
+      </xsl:value-of>
     </xsl:variable>
-    <xsl:if test="normalize-space($shortmeta)!=''">
+    <xsl:if test="normalize-space($shortmeta)">
       <meta name="abstract" content="{normalize-space($shortmeta)}"/>
       <meta name="description" content="{normalize-space($shortmeta)}"/>
     </xsl:if>
   </xsl:template>
 
   <xsl:template match="*[contains(@class,' map/shortdesc ')]" mode="gen-metadata">
-    <xsl:if test="normalize-space(.)!=''">
-      <meta name="description" content="{normalize-space(.)}"/>
+    <xsl:variable name="content" as="xs:string">
+      <xsl:value-of>
+        <xsl:apply-templates mode="text-only"/>
+      </xsl:value-of>
+    </xsl:variable>
+    <xsl:if test="normalize-space($content)">
+      <meta name="description" content="{normalize-space($content)}"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -37,16 +37,22 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- CONTENT: Description - shortdesc -->
     <xsl:apply-templates select="*[contains(@class,' topic/shortdesc ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' map/shortdesc ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/shortdesc ')]" mode="gen-metadata"/>
+
+    <!-- CONTENT: Abstract - abstract -->
     <xsl:apply-templates select="*[contains(@class,' topic/abstract ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/abstract ')]" mode="gen-shortdesc-metadata"/>
 
     <!-- CONTENT: Source - prolog/source/@href -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/source ')]/@href |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/source ')]/@href |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/source ')]/@href" mode="gen-metadata"/>
 
     <!-- CONTENT: Coverage prolog/metadata/category -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/category ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/category ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/category ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/category ')]" mode="gen-metadata"/>
 
     <!-- CONTENT: Subject - prolog/metadata/keywords -->
@@ -60,46 +66,76 @@ See the accompanying LICENSE file for applicable license.
     <!-- Audience -->
     <!-- prolog/metadata/audience/@experiencelevel and other attributes -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@experiencelevel |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/audience ')]/@experiencelevel |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@experiencelevel |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@experiencelevel" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@importance |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/audience ')]/@importance |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@importance |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@importance" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@job |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/audience ')]/@job |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@job |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@job" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@name |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/audience ')]/@name |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@name |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@name" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@type |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/audience ')]/@type |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@type |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/audience ')]/@type" mode="gen-metadata"/>
 
 
     <!-- <prodname> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prodname ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prodname ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prodname ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prodname ')]" mode="gen-metadata"/>
 
     <!-- <vrmlist><vrm modification="3" release="2" version="5"/></vrmlist> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@version |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@version |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@version |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@version" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@release |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@release |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@release |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@release" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@modification |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@modification |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@modification |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/vrmlist ')]/*[contains(@class,' topic/vrm ')]/@modification" mode="gen-metadata"/>
 
     <!-- <brand> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/brand ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/brand ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/brand ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/brand ')]" mode="gen-metadata"/>
     <!-- <component> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/component ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/component ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/component ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/component ')]" mode="gen-metadata"/>
     <!-- <featnum> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/featnum ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/featnum ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/featnum ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/featnum ')]" mode="gen-metadata"/>
     <!-- <prognum> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prognum ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prognum ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prognum ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/prognum ')]" mode="gen-metadata"/>
     <!-- <platform> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/platform ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/platform ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/platform ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/platform ')]" mode="gen-metadata"/>
     <!-- <series> -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/series ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/series ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/series ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/prodinfo ')]/*[contains(@class,' topic/series ')]" mode="gen-metadata"/>
 
     <!-- = = = = = = = = = = = INTELLECTUAL PROPERTY = = = = = = = = = = = -->
@@ -107,45 +143,57 @@ See the accompanying LICENSE file for applicable license.
     <!-- INTELLECTUAL PROPERTY: Contributor - prolog/author -->
     <!-- INTELLECTUAL PROPERTY: Creator -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/author ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/author ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/author ')]" mode="gen-metadata"/>
 
     <!-- INTELLECTUAL PROPERTY: Publisher - prolog/publisher -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/publisher ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/publisher ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/publisher ')]" mode="gen-metadata"/>
 
     <!-- INTELLECTUAL PROPERTY: Rights - prolog/copyright -->
     <!-- Put primary first, then secondary, then remainder -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][@type='primary'] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/copyright ')][@type='primary'] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][@type='primary']" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][@type='secondary'] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/copyright ')][@type='secondary'] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][@type='seconday']" mode="gen-metadata"/>
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][not(@type)] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/copyright ')][not(@type)] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/copyright ')][not(@type)]" mode="gen-metadata"/>
 
     <!-- Usage Rights - prolog/permissions -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/permissions ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/permissions ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/permissions ')]" mode="gen-metadata"/>
 
     <!-- = = = = = = = = = = = INSTANTIATION = = = = = = = = = = = -->
 
     <!-- INSTANTIATION: Date - prolog/critdates/created -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/created ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/created ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/created ')]" mode="gen-metadata"/>
 
     <!-- prolog/critdates/revised/@modified -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@modified |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@modified |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@modified" mode="gen-metadata"/>
 
     <!-- prolog/critdates/revised/@golive -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@golive |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@golive |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@golive" mode="gen-metadata"/>
 
     <!-- prolog/critdates/revised/@expiry -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@expiry |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@expiry |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/critdates ')]/*[contains(@class,' topic/revised ')]/@expiry" mode="gen-metadata"/>
 
     <!-- prolog/metadata/othermeta -->
     <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/othermeta ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/othermeta ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/othermeta ')] |
                                  self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/othermeta ')]" mode="gen-metadata"/>
 
     <!-- INSTANTIATION: Format -->
@@ -180,11 +228,19 @@ See the accompanying LICENSE file for applicable license.
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match="*[contains(@class,' map/shortdesc ')]" mode="gen-metadata">
+    <xsl:if test="normalize-space(.)!=''">
+      <meta name="description" content="{normalize-space(.)}"/>
+    </xsl:if>
+  </xsl:template>
+
   <!-- CONTENT: Subject - prolog/metadata/keywords -->
   <xsl:template match="*" mode="gen-keywords-metadata">
     <xsl:variable name="keywords-content">
       <!-- for each item inside keywords (including nested index terms) -->
-      <xsl:for-each select="descendant::*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::*">
+      <xsl:for-each select="descendant::*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
+                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
+                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::*">
         <!-- If this is the first term or keyword with this value -->
         <xsl:if test="generate-id(key('meta-keywords',text()[1])[1]) = generate-id(.)">
           <xsl:if test="position() > 2">


### PR DESCRIPTION
## Description
This pull request updates the HTML5 transformation to also extract metadata from the `<topicmeta>` element in the root map.

The additional template patterns for the root-map `<topicmeta>` element are deliberately simple and verbose in this pull request. The metadata templates in the `mode="getMeta"` template could be streamlined, but I think that belongs in a subsequent merge request.

## Motivation and Context
Fixes #4351.

## How Has This Been Tested?
I ran the usual unit tests. I also used the testcase in #4351.

There are no unit tests that test this new functionality. They should probably be added, but I am not sure how to do it.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This change can cause additional HTML5 `<meta>` elements to be published in the `index.html` file that weren't there before. However, the change only affects the `index.html` file itself; metadata propagation behaviors into topics are unchanged.

A release notes writeup could be as follows:

> In earlier versions, the HTML5 transformation published `<meta>` metadata elements in topic-level .html files but not in the index.html TOC file. Now, it also publishes `<meta>` metadata elements from the root map's `<topicmeta>` in the index.html TOC file.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
