### PR TITLE
Fix non-DITA map references

### DIFF
--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -170,7 +170,7 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
           if (res == null) {
             res = new AttributesImpl(atts);
           }
-          attValue = ATTR_FORMAT_VALUE_DITA;
+          attValue = MAPGROUP_D_MAPREF.matches(atts) ? ATTR_FORMAT_VALUE_DITAMAP : ATTR_FORMAT_VALUE_DITA;
           if (!format.equals(ATTR_FORMAT_VALUE_DITA)) {
             XMLUtils.addOrSetAttribute(
               res,


### PR DESCRIPTION
## Description
Fix `<mapref>` when the target is a non-DITA map, such as Markdown Map that is parsed as DITA.

## How Has This Been Tested?
Current tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

