### PR TITLE
Deprecate compact attributes with Sass @warn rules

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_lists.scss
+++ b/src/main/plugins/org.dita.html5/sass/_lists.scss
@@ -16,7 +16,7 @@ ul.simple {
   font-weight: bold;
 }
 
-/* Use CSS to expand lists with @compact="no" */
+/* Use CSS to expand compact lists */
 .dltermexpand {
   font-weight: bold;
   margin-top: 1em;
@@ -24,14 +24,16 @@ ul.simple {
 
 /* Compact lists use attributes up to DITA-OT 4.1.2 */
 *[compact="yes"] > li {
+  @warn "Compact attributes are deprecated since v4.2.";
   margin-top: 0;
 }
 
 *[compact="no"] > li {
+  @warn "Compact attributes are deprecated since v4.2.";
   margin-top: 0.53em;
 }
 
-/* Compact lists use classes starting in DITA-OT 4.1.3 */
+/* Compact lists use classes starting in DITA-OT 4.2 */
 .compact > li {
   margin-top: 0;
 }


### PR DESCRIPTION
## Description

@chrispy-snps submitted #4303 assuming it would be merged into a pending 4.1.3 hotfix, but since that's no longer planned, this updates the code comments to reflect the version in which the changes will be included per https://github.com/dita-ot/dita-ot/pull/4303#issuecomment-1872150926.

While we're at it, we may as well implement the deprecation notices as [Sass warnings](https://sass-lang.com/documentation/at-rules/warn/) as we did for 2.3, so they're not forgotten and to remind us to remove the deprecated rules in a future version.

