### PR TITLE
Bump logback to 1.4.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.8'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.2'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.15.2'


### PR DESCRIPTION
## Description

Updates logback module to resolve security findings

## Motivation and Context

We currently use 1.4.8 which has security findings. 1.4.14 is (for now) clean for both logback-classic and logback-core
https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
https://mvnrepository.com/artifact/ch.qos.logback/logback-core

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

Unit tests and validated dist build with update

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

Updates a dependency version
