### PR TITLE
Rewrite messages.xml in integration to support overriding and deduplication

### DIFF
--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -15,7 +15,7 @@ default.coderef-charset=UTF-8
 # Integration
 plugindirs = plugins;demo
 plugin.ignores =
-plugin.order = org.dita.base org.oasis-open.dita.v1_3 org.oasis-open.dita.v1_2
+plugin.order = org.dita.base org.dita.xhtml org.dita.htmlhelp org.dita.pdf2 org.oasis-open.dita.v1_3 org.oasis-open.dita.v1_2
 registry = https://plugins.dita-ot.org/
 
 # PDF2 defaults

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -362,17 +362,17 @@ public final class Integrator {
   private void processMessages() throws IOException {
     final Path messagesXmlFile = ditaDir.toPath().resolve(CONFIG_DIR).resolve("messages.xml");
     if (Files.exists(messagesXmlFile)) {
-      final Map<String, Message> messages = readMessages(messagesXmlFile);
+      final List<Message> messages = readMessages(messagesXmlFile);
       writeMessages(messages, messagesXmlFile);
     }
   }
 
-  private void writeMessages(Map<String, Message> messages, Path messagesXmlFile) throws IOException {
+  private void writeMessages(List<Message> messages, Path messagesXmlFile) throws IOException {
     try (final OutputStream messagesOut = Files.newOutputStream(messagesXmlFile)) {
       final XMLStreamWriter out = XMLOutputFactory.newInstance().createXMLStreamWriter(messagesOut);
       out.writeStartDocument();
       out.writeStartElement("messages");
-      for (Message message : messages.values()) {
+      for (Message message : messages) {
         out.writeStartElement("message");
         out.writeAttribute("id", message.id());
         out.writeAttribute("type", message.severity());
@@ -397,7 +397,7 @@ public final class Integrator {
   }
 
   /** Read and merge messages. */
-  private Map<String, Message> readMessages(Path messagesXmlFile) throws IOException {
+  private List<Message> readMessages(Path messagesXmlFile) throws IOException {
     final Map<String, Message> messages = new HashMap<>();
     try (final InputStream in = Files.newInputStream(messagesXmlFile)) {
       final XMLStreamReader src = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(in));
@@ -453,7 +453,7 @@ public final class Integrator {
     } catch (XMLStreamException e) {
       throw new IOException(e);
     }
-    return messages;
+    return messages.values().stream().sorted(Comparator.comparing(Message::id)).toList();
   }
 
   private void writeMessageBundle() throws IOException, XMLStreamException {

--- a/src/test/java/org/dita/dost/platform/IntegratorTest.java
+++ b/src/test/java/org/dita/dost/platform/IntegratorTest.java
@@ -143,6 +143,10 @@ public class IntegratorTest {
           .toString()
       )
     );
+    assertXMLEqual(
+      new InputSource(Paths.get(expDir.getAbsolutePath(), "config", "messages.xml").toUri().toString()),
+      new InputSource(Paths.get(tempDir.getAbsolutePath(), "config", "messages.xml").toUri().toString())
+    );
   }
 
   @Test

--- a/src/test/resources/IntegratorTest/exp/config/messages.xml
+++ b/src/test/resources/IntegratorTest/exp/config/messages.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<messages>
+  <message id="DOTJ0001" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+
+  <message id="DOTJ0002" type="WARN">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+
+  <message id="DOTJ0003" type="INFO">
+    <reason>Reason</reason>
+    <response>Response override</response>
+  </message>
+
+  <message id="DOTJ0004" type="INFO">
+    <reason>Reason override</reason>
+    <response>Response</response>
+  </message>
+
+  <message id="DOTJ0005" type="WARN">
+    <reason>Reason override</reason>
+    <response>Response override</response>
+  </message>
+</messages>

--- a/src/test/resources/IntegratorTest/src/config/messages.xml
+++ b/src/test/resources/IntegratorTest/src/config/messages.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<messages>
+  <message id="DOTJ0001" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+
+  <message id="DOTJ0002" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+  <message id="DOTJ0002" type="WARN">
+  </message>
+
+  <message id="DOTJ0003" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+  <message id="DOTJ0003">
+    <response>Response override</response>
+  </message>
+
+  <message id="DOTJ0004" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+  <message id="DOTJ0004">
+    <reason>Reason override</reason>
+  </message>
+
+  <message id="DOTJ0005" type="INFO">
+    <reason>Reason</reason>
+    <response>Response</response>
+  </message>
+  <message id="DOTJ0005" type="WARN">
+    <reason>Reason override</reason>
+    <response>Response override</response>
+  </message>
+</messages>


### PR DESCRIPTION
## Description
Add integration process to rewrite `messages.xml` to

* allow overriding messages in part or completely
* remove duplicates.

## Motivation and Context
Allows plug-ins to override messages completely or only override part of the message configuration.

Relates to #4086, #4068

## How Has This Been Tested?
Manual testing

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
For example we have a built-in message

```xml
<message id="DOTX029I" type="INFO">
    <reason>The @type attribute on a &lt;%1&gt; element was set to '%3', but the reference is to a more specific '%4' '%2'.</reason>
    <response>This may cause links to sort incorrectly in the output.</response>
</message> 
```

A custom plug-in can use the old extension point to add a new messages file that would change the severity level

```xml
<message id="DOTX029I" type="WARN">
</message> 
```

or replace the response text

```xml
<message id="DOTX029I" >
    <response>Complain to person X who handles all reltables.</response>
</message> response
```

The only required info is the `@id` attribute. You can omit `@type`, `<reason>`, or `<response>` in which case the previous declaration of the message will provide that value.
