### PR TITLE
Remove deprecated table classes

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_tables.scss
+++ b/src/main/plugins/org.dita.html5/sass/_tables.scss
@@ -15,40 +15,6 @@ table .desc {
   font-style: italic;
 }
 
-// deprecated
-
-.cellrowborder {
-  @warn "The .cellrowborder class is deprecated since v2.3.";
-  border-bottom: solid 1px;
-  border-left: 0;
-  border-right: solid 1px;
-  border-top: 0;
-}
-
-.row-nocellborder {
-  @warn "The .row-nocellborder class is deprecated since v2.3.";
-  border-bottom: solid 1px;
-  border-left: 0;
-  border-top: 0;
-}
-
-.cell-norowborder {
-  @warn "The .cell-norowborder class is deprecated since v2.3.";
-  border-left: 0;
-  border-right: solid 1px;
-  border-top: 0;
-}
-
-.nocellnorowborder {
-  @warn "The .nocellnorowborder class is deprecated since v2.3.";
-  border: 0;
-}
-
-.firstcol {
-  @warn "The .firstcol class is deprecated since v2.3.";
-  font-weight: bold;
-}
-
 // @pgwide
 
 .table--pgwide-1 {


### PR DESCRIPTION
## Description
Remove deprecated table classes from HTML5 stylesheets.

## Motivation and Context
The table styles have been deprecated since 2.3, time to remove

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

Release notes.

