### PR TITLE
Fix bug in task label header level calculation

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/task.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/task.xsl
@@ -697,7 +697,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:param name="use-label"/>
     <xsl:if test="$GENERATE-TASK-LABELS='YES'">
       <div class="tasklabel">
-        <xsl:element name="h{dita2html:get-heading-level(.)}">
+        <xsl:element name="h{min((6, dita2html:get-heading-level(.) + 1))}">
           <xsl:attribute name="class">sectiontitle tasklabel</xsl:attribute>
           <xsl:value-of select="$use-label"/>
         </xsl:element>

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/taskdisplay.xsl
@@ -710,7 +710,7 @@ See the accompanying LICENSE file for applicable license.
   <xsl:param name="use-label"/>
   <xsl:if test="$GENERATE-TASK-LABELS='YES'">
     <div class="tasklabel">
-      <xsl:element name="h{dita2html:get-heading-level(.)}">
+      <xsl:element name="h{min((6, dita2html:get-heading-level(.) + 1))}">
         <xsl:attribute name="class">sectiontitle tasklabel</xsl:attribute>
         <xsl:value-of select="$use-label"/>
       </xsl:element>

--- a/src/test/java/org/dita/dost/IntegrationTestHtml5.java
+++ b/src/test/java/org/dita/dost/IntegrationTestHtml5.java
@@ -28,6 +28,11 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
   }
 
   @Test
+  public void html5() throws Throwable {
+    builder().name("html5").transtype(HTML5).input(Paths.get("map.ditamap")).put("args.gen.task.lbl", "YES").test();
+  }
+
+  @Test
   public void html5_cssNoCopy() throws Throwable {
     final File srcDir = new File(resourceDir, "html5_css" + File.separator + "src");
     final File actDir = builder()

--- a/src/test/resources/html5/exp/html5/concept.html
+++ b/src/test/resources/html5/exp/html5/concept.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <title>Concept</title>
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+</head>
+<body id="concept">
+<main role="main">
+  <article role="article" aria-labelledby="ariaid-title1">
+    <h1 class="title topictitle1" id="ariaid-title1">Concept</h1>
+    <div class="body conbody">
+      <p class="p">Body.</p>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5/exp/html5/index.html
+++ b/src/test/resources/html5/exp/html5/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <title>Map</title>
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+</head>
+<body>
+<h1 class="title topictitle1">Map</h1>
+<nav>
+  <ul class="map">
+    <li class="topicref"><a href="topic.html">Topic</a></li>
+    <li class="topicref"><a href="concept.html">Concept</a></li>
+    <li class="topicref"><a href="task.html">Task</a></li>
+    <li class="topicref"><a href="reference.html">Reference</a></li>
+  </ul>
+</nav>
+</body>
+</html>

--- a/src/test/resources/html5/exp/html5/reference.html
+++ b/src/test/resources/html5/exp/html5/reference.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <title>Reference</title>
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+</head>
+<body id="reference">
+<main role="main">
+  <article role="article" aria-labelledby="ariaid-title1">
+    <h1 class="title topictitle1" id="ariaid-title1">Reference</h1>
+    <div class="body refbody">
+      <section class="section"><h2 class="title sectiontitle">Section title</h2>
+        <p class="p">Body.</p>
+      </section>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5/exp/html5/task.html
+++ b/src/test/resources/html5/exp/html5/task.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <title>Task</title>
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+</head>
+<body id="task">
+<main role="main">
+  <article role="article" aria-labelledby="ariaid-title1">
+    <h1 class="title topictitle1" id="ariaid-title1">Task</h1>
+    <div class="body taskbody">
+      <section class="section context">
+        <div class="tasklabel">
+          <h1 class="sectiontitle tasklabel">About this task</h1>
+        </div>
+        <p class="p">Context.</p>
+      </section>
+      <section>
+        <div class="tasklabel">
+          <h1 class="sectiontitle tasklabel">Procedure</h1>
+        </div>
+        <div class="ol steps">
+          <div class="li step p">
+            <span class="ph cmd">Command.</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5/exp/html5/task.html
+++ b/src/test/resources/html5/exp/html5/task.html
@@ -15,13 +15,13 @@
     <div class="body taskbody">
       <section class="section context">
         <div class="tasklabel">
-          <h1 class="sectiontitle tasklabel">About this task</h1>
+          <h2 class="sectiontitle tasklabel">About this task</h2>
         </div>
         <p class="p">Context.</p>
       </section>
       <section>
         <div class="tasklabel">
-          <h1 class="sectiontitle tasklabel">Procedure</h1>
+          <h2 class="sectiontitle tasklabel">Procedure</h2>
         </div>
         <div class="ol steps">
           <div class="li step p">

--- a/src/test/resources/html5/exp/html5/topic.html
+++ b/src/test/resources/html5/exp/html5/topic.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <title>Topic</title>
+  <link rel="stylesheet" type="text/css" href="commonltr.css">
+</head>
+<body id="topic">
+<main role="main">
+  <article role="article" aria-labelledby="ariaid-title1">
+    <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
+    <div class="body">
+      <p class="p">Body.</p>
+    </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5/src/concept.dita
+++ b/src/test/resources/html5/src/concept.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="concept">
+  <title>Concept</title>
+  <conbody>
+    <p>Body.</p>
+  </conbody>
+</concept>

--- a/src/test/resources/html5/src/map.ditamap
+++ b/src/test/resources/html5/src/map.ditamap
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <title>Map</title>
+  <topicref href="topic.dita"/>
+  <topicref href="concept.dita"/>
+  <topicref href="task.dita"/>
+  <topicref href="reference.dita"/>
+</map>

--- a/src/test/resources/html5/src/reference.dita
+++ b/src/test/resources/html5/src/reference.dita
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
+<reference id="reference">
+  <title>Reference</title>
+  <refbody>
+    <section>
+      <title>Section title</title>
+      <p>Body.</p>
+    </section>
+  </refbody>
+</reference>

--- a/src/test/resources/html5/src/task.dita
+++ b/src/test/resources/html5/src/task.dita
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
+<task id="task">
+  <title>Task</title>
+  <taskbody>
+    <context>
+      <p>Context.</p>
+    </context>
+    <steps>
+      <step>
+        <cmd>Command.</cmd>
+      </step>
+    </steps>
+  </taskbody>
+</task>

--- a/src/test/resources/html5/src/topic.dita
+++ b/src/test/resources/html5/src/topic.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic">
+  <title>Topic</title>
+  <body>
+    <p>Body.</p>
+  </body>
+</topic>


### PR DESCRIPTION
## Description
Fix bug in task label header level calculation. Task label header level should be one level below topic title.

## Motivation and Context
Fixes bug introduced in #4330.

## How Has This Been Tested?
New test added.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_
