### PR TITLE
Use generated copy-to from branch filtering as key value

### DIFF
--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -48,7 +48,7 @@ import org.w3c.dom.*;
  */
 public class MapBranchFilterModule extends AbstractBranchFilterModule {
 
-  private static final String BRANCH_COPY_TO = "filter-copy-to";
+  public static final String BRANCH_COPY_TO = "filter-copy-to";
 
   /** Current map being processed, relative to temporary directory */
   private URI map;

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -8,6 +8,7 @@
 package org.dita.dost.module.filter;
 
 import static java.util.Collections.singletonList;
+import static org.dita.dost.module.filter.MapBranchFilterModule.BRANCH_COPY_TO;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.XMLUtils.getChildElements;
 
@@ -45,7 +46,6 @@ import org.xml.sax.XMLFilter;
 public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
   private static final String SKIP_FILTER = "skip-filter";
-  private static final String BRANCH_COPY_TO = "filter-copy-to";
 
   /** Current map being processed, relative to temporary directory */
   private URI map;

--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -12,6 +12,7 @@ import static net.sf.saxon.s9api.streams.Predicates.isElement;
 import static net.sf.saxon.s9api.streams.Steps.child;
 import static net.sf.saxon.s9api.streams.Steps.precedingSibling;
 import static net.sf.saxon.type.BuiltInAtomicType.STRING;
+import static org.dita.dost.module.filter.MapBranchFilterModule.BRANCH_COPY_TO;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.KeyScope.ROOT_ID;
 import static org.dita.dost.util.URLUtils.toURI;
@@ -239,9 +240,11 @@ public final class KeyrefReader implements AbstractReader {
         if (!keyDefs.containsKey(key)) {
           final XdmNode copy = elem;
           final URI href = toURI(
-            copy.attribute(ATTRIBUTE_NAME_COPY_TO) == null
-              ? copy.attribute(ATTRIBUTE_NAME_HREF)
-              : copy.attribute(ATTRIBUTE_NAME_COPY_TO)
+            copy.attribute(BRANCH_COPY_TO) != null
+              ? copy.attribute(BRANCH_COPY_TO)
+              : copy.attribute(ATTRIBUTE_NAME_COPY_TO) != null
+                ? copy.attribute(ATTRIBUTE_NAME_COPY_TO)
+                : copy.attribute(ATTRIBUTE_NAME_HREF)
           );
           final String scope = copy.attribute(ATTRIBUTE_NAME_SCOPE);
           final String format = copy.attribute(ATTRIBUTE_NAME_FORMAT);

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -615,7 +615,7 @@ public class TestKeyrefReader {
 
     assertEquals("topic-original.dita", root.get("original").href.toString());
     assertEquals("topic-copy.dita", root.get("copy").href.toString());
-    assertEquals("topic-original.dita", root.get("branch-copy").href.toString());
+    assertEquals("topic-branch-copy.dita", root.get("branch-copy").href.toString());
   }
 
   @Test

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -615,6 +615,7 @@ public class TestKeyrefReader {
 
     assertEquals("topic-original.dita", root.get("original").href.toString());
     assertEquals("topic-copy.dita", root.get("copy").href.toString());
+    assertEquals("topic-original.dita", root.get("branch-copy").href.toString());
   }
 
   @Test

--- a/src/test/resources/TestKeyrefReader/src/copyto.ditamap
+++ b/src/test/resources/TestKeyrefReader/src/copyto.ditamap
@@ -3,6 +3,8 @@
   ditaarch:DITAArchVersion="1.3">
   <keydef class="+ map/topicref mapgroup-d/keydef " href="topic-original.dita" keys="original" processing-role="resource-only"/>
   <keydef class="+ map/topicref mapgroup-d/keydef " href="topic-original.dita" keys="copy" copy-to="topic-copy.dita" processing-role="resource-only"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " href="topic-original.dita" keys="branch-copy" filter-copy-to="topic-branch-copy.dita" processing-role="resource-only"/>
   <topicref class="- map/topicref " keyref="original"/>
   <topicref class="- map/topicref " keyref="copy"/>
+  <topicref class="- map/topicref " keyref="branch-copy"/>
 </map>


### PR DESCRIPTION
## Description
Use generated copy-to from branch filtering attribute `@filter-copy-to` as key value instead of `@href`.

## Motivation and Context
Fix bug in map-first processing where key definitions are branch filtered with `<dvrResourcePrefix>`. The key resolution code needs to use `@filter-copy-to` instead of `@href`.

## How Has This Been Tested?
Existing tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


