### PR TITLE
Remove @filter-copy-to in map clean

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
@@ -30,7 +30,9 @@ See the accompanying LICENSE file for applicable license.
   <xsl:template match="*[contains(@class, ' ditaot-d/mapref-topicmeta-container ')]"/>
   
   <xsl:template match="*[contains(@class, ' ditaot-d/keydef ')]"/>
-  
+
+  <xsl:template match="@filter-copy-to"/>
+
   <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle ')]">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX072I'"/>


### PR DESCRIPTION
## Description
Remove @filter-copy-to in map clean

## Motivation and Context
Preprocessing-time attribute that should be removed at map clean step.

## How Has This Been Tested?
Current tests pass.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_
