### PR TITLE
Update org.dita.normalize to 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ def distFileName = (project.hasProperty("tag") && tag.empty) ?
 def bundled = [
         "eclipsehelp": "https://github.com/dita-ot/org.dita.eclipsehelp/releases/download/3.4/org.dita.eclipsehelp-3.4.0.zip",
         "markdown": "https://github.com/jelovirt/org.lwdita/releases/download/5.5.0/org.lwdita-5.5.0.zip",
-        "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/1.1.0.zip",
+        "normalize": "https://github.com/dita-ot/org.dita.normalize/archive/refs/tags/2.0.zip",
         "dita11": "https://github.com/dita-ot/org.dita.specialization.dita11/archive/1.1.1.zip",
         "dita12": "https://github.com/dita-ot/org.oasis-open.dita.v1_2/archive/1.2.1.zip",
         "dita20": "https://github.com/dita-ot/dita/releases/download/2.0.0-20240115/org.oasis-open.dita.v2_0.zip",


### PR DESCRIPTION
## Description
Update org.dita.normalize plug-in to version 2.0.

## Motivation and Context
Move to normalize plug-in that is based on preprocess2.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

