### PR TITLE
Fix escaping log messages from XSLT #4376

### DIFF
--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -201,7 +201,7 @@ public final class XMLUtils {
               .negate()
           )
         )
-        .map(XdmNode::toString)
+        .map(XdmNode::getStringValue)
         .collect(Collectors.joining());
       switch (level) {
         case "FATAL" -> {

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -293,7 +293,7 @@ public class XMLUtilsTest {
 
     final List<Message> act = logger.getMessages();
     assertEquals(1, act.size());
-    assertEquals(new Message(Message.Level.INFO, "message <debug/>", null), act.get(0));
+    assertEquals(new Message(Message.Level.INFO, "message ", null), act.get(0));
   }
 
   @Test
@@ -315,7 +315,7 @@ public class XMLUtilsTest {
 
     final List<Message> act = logger.getMessages();
     assertEquals(1, act.size());
-    assertEquals(new Message(Message.Level.WARN, "message <debug/>", null), act.get(0));
+    assertEquals(new Message(Message.Level.WARN, "message ", null), act.get(0));
   }
 
   @Test
@@ -332,7 +332,7 @@ public class XMLUtilsTest {
 
     final List<Message> act = logger.getMessages();
     assertEquals(1, act.size());
-    assertEquals(new Message(Message.Level.INFO, "message <debug/>", null), act.get(0));
+    assertEquals(new Message(Message.Level.INFO, "message ", null), act.get(0));
   }
 
   @Test
@@ -356,7 +356,7 @@ public class XMLUtilsTest {
     } catch (SaxonApiUncheckedException e) {
       final TerminationException cause = (TerminationException) e.getCause();
       assertEquals("DOTX037W", cause.getErrorCodeQName().getLocalPart());
-      assertEquals("message <debug/>", cause.getMessage());
+      assertEquals("message ", cause.getMessage());
     }
   }
 
@@ -374,7 +374,7 @@ public class XMLUtilsTest {
 
     final List<Message> act = logger.getMessages();
     assertEquals(1, act.size());
-    assertEquals(new Message(Message.Level.ERROR, "message <debug/>", null), act.get(0));
+    assertEquals(new Message(Message.Level.ERROR, "message ", null), act.get(0));
   }
 
   @Test
@@ -391,7 +391,7 @@ public class XMLUtilsTest {
       listener.message(msg, null, false, null);
       fail();
     } catch (UncheckedXPathException e) {
-      assertEquals("message <debug/>", e.getMessage());
+      assertEquals("message ", e.getMessage());
     } catch (Throwable e) {
       fail();
     }
@@ -404,17 +404,17 @@ public class XMLUtilsTest {
 
     final XdmNode msg = Saplings
       .doc()
-      .withChild(Saplings.text("abc "), Saplings.elem("def").withChild(Saplings.elem("hij")))
+      .withChild(
+        Saplings.text("abc "),
+        Saplings.elem("def").withChild(Saplings.elem("hij").withText("text"), Saplings.text(" suffix"))
+      )
       .toXdmNode(new XMLUtils().getProcessor());
 
     listener.message(msg, null, false, null);
 
     final List<Message> act = logger.getMessages();
     assertEquals(1, act.size());
-    assertEquals("""
-                abc <def>
-                   <hij/>
-                </def>""", act.get(0).message);
+    assertEquals("abc text suffix", act.get(0).message);
   }
 
   @Test


### PR DESCRIPTION
## Description
Fix escaping XML delimiter characters in log messages thrown by XSLT.

## Motivation and Context
Fixes regression bug #4376. This change effectively changes the behaviour of logging from XSLT, e.g. from fix to #3969. If you want to output XML from XSLT messages, you have to serialize the nodes into XML strings manually. From now on, log message will not contain XML element, only text.

## How Has This Been Tested?
Unit tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


