### PR TITLE
Validate use of deliverable without project

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -188,7 +188,15 @@ public class ConversionArguments extends Arguments {
 
     definedProps.put("cli.log-format", configuration.get("cli.log-format"));
 
+    validate();
+
     return this;
+  }
+
+  private void validate() {
+    if (definedProps.containsKey("project.deliverable") && projectFile == null) {
+      throw new CliException(locale.getString("conversion.error.project_not_defined"));
+    }
   }
 
   /**

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -61,6 +61,7 @@ conversion.option.propertyfile=Load all properties from file
 conversion.option.repeat=Performs the transformation N times
 conversion.repeatDuration=%d %dms
 conversion.option.temp=Temporary directory
+conversion.error.project_not_defined=No project specified. You must set a project file to define a deliverable
 conversion.error.input_and_transformation_not_defined=Input file and transformation type not defined
 conversion.error.transformation_not_defined=Transformation type not defined
 conversion.error.input_not_defined=Input file not defined


### PR DESCRIPTION
## Description
Validate use of `--deliverable` without `--project` and throw an error.

## Motivation and Context
Better error condition handling.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
So small that it doesn't really need to be mentioned anywhere.
