### PR TITLE
Disable CLI colour output when CLI is connected to a pipe

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -95,6 +95,8 @@ abstract class Arguments {
       return false;
     } else if (Objects.equals(System.getenv("TERM"), "dumb")) {
       return false;
+    } else if (System.console() == null) {
+      return false;
     }
     return Boolean.parseBoolean(Configuration.configuration.getOrDefault("cli.color", "true"));
   }


### PR DESCRIPTION
## Description
Disable CLI colour output when CLI is connected to a pipe or redirected to a file.

## Motivation and Context
In almost every case you don't colours when you pipe output from a command to grep or redirect to a file. This doesn't offer a way to force colours when using pipe, but we can add `--color` or system variable `COLOR` if that is needed.

## How Has This Been Tested?
Manual testing.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

