### PR TITLE
Add extension points to preprocess2

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -16,10 +16,14 @@ See the accompanying LICENSE file for applicable license.
     dita:depends="{depend.preprocess.pre},
                   preprocess2.init,
                   ditaval-merge,
-                  
+
+                  {depend.preprocess2.maps.pre},
                   preprocess2.maps,
+                  {depend.preprocess2.maps.post},
+                  {depend.preprocess2.topics.pre},
                   preprocess2.topics,
-                  
+                  {depend.preprocess2.topics.post},
+
                   map-clean-map,
                   clean-preprocess,
                   copy-files2,

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -51,6 +51,10 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 2.1 -->
   <extension-point id="depend.preprocess.copy-subsidiary.pre" name="Copy subsidiary pre-target"/>
   <extension-point id="depend.preprocess.post" name="Preprocessing post-target"/>
+  <extension-point id="depend.preprocess2.maps.pre" name="Map-first pre-processing maps pre-target"/>
+  <extension-point id="depend.preprocess2.maps.post" name="Map-first pre-processing maps post-target"/>
+  <extension-point id="depend.preprocess2.topics.pre" name="Map-first pre-processing topics pre-target"/>
+  <extension-point id="depend.preprocess2.topics.post" name="Map-first pre-processing topics post-target"/>
   <extension-point id="dita.preprocess.debug-filter.param" name="Debug filter module parameters"/>
   <extension-point id="dita.preprocess.map-reader.param" name="Debug filter module parameters"/>
   <extension-point id="dita.preprocess.topic-reader.param" name="Debug filter module parameters"/>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -51,10 +51,10 @@ See the accompanying LICENSE file for applicable license.
   <!-- Deprecated since 2.1 -->
   <extension-point id="depend.preprocess.copy-subsidiary.pre" name="Copy subsidiary pre-target"/>
   <extension-point id="depend.preprocess.post" name="Preprocessing post-target"/>
-  <extension-point id="depend.preprocess2.maps.pre" name="Map-first pre-processing maps pre-target"/>
-  <extension-point id="depend.preprocess2.maps.post" name="Map-first pre-processing maps post-target"/>
-  <extension-point id="depend.preprocess2.topics.pre" name="Map-first pre-processing topics pre-target"/>
-  <extension-point id="depend.preprocess2.topics.post" name="Map-first pre-processing topics post-target"/>
+  <extension-point id="depend.preprocess2.maps.pre" name="Runs an Ant target before pre-processing maps"/>
+  <extension-point id="depend.preprocess2.maps.post" name="Runs an Ant target after pre-processing maps"/>
+  <extension-point id="depend.preprocess2.topics.pre" name="Runs an Ant target before pre-processing topics"/>
+  <extension-point id="depend.preprocess2.topics.post" name="Runs an Ant target after pre-processing topics"/>
   <extension-point id="dita.preprocess.debug-filter.param" name="Debug filter module parameters"/>
   <extension-point id="dita.preprocess.map-reader.param" name="Debug filter module parameters"/>
   <extension-point id="dita.preprocess.topic-reader.param" name="Debug filter module parameters"/>


### PR DESCRIPTION
## Description
Add extension points to preprocess2 to allow running targets between map and topic processing.

## Motivation and Context
Fixes #4394 

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
To be listed in extension point list for preprocess2.

