### PR TITLE
Move warning about not using validation to Ant

### DIFF
--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -221,8 +221,6 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         } catch (final SAXNotRecognizedException e) {
           // Not Xerces, ignore exception
         }
-      } else {
-        logger.warn(MessageUtils.getMessage("DOTJ037W").toString());
       }
       if (gramcache) {
         final XMLGrammarPool grammarPool = GrammarPoolManager.getGrammarPool();

--- a/src/main/plugins/org.dita.base/build_init.xml
+++ b/src/main/plugins/org.dita.base/build_init.xml
@@ -7,7 +7,8 @@ Copyright 2006 IBM Corporation
 See the accompanying LICENSE file for applicable license.
 -->
 <project name="ditaot-init"
-         xmlns:if="ant:if">
+         xmlns:if="ant:if"
+         xmlns:unless="ant:unless">
     
   <!-- Read configuration properties -->
   <loadproperties>
@@ -150,6 +151,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Validate the xml file or not,default is validation(true)-->
     <property name="validate" value="true"/>
+    <dita-ot-echo id="DOTJ037W" unless:true="${validate}"/>
 
     <!-- Related links to output: none, all, nofamily -->
     <condition property="include.rellinks" value="">


### PR DESCRIPTION
## Description
Move warning about not using validation from Java to Ant.

## Motivation and Context
Fixes #4377. Throwing informative warnings like these should be on the Ant layer.

## Type of Changes

- Refactoring _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Internal change, no need to document for end-users.


