### PR TITLE
Fix preprocess2 initialization with memory store

### DIFF
--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -96,7 +96,9 @@ See the accompanying LICENSE file for applicable license.
     <echo level="info">${log-prefix}input = ${args.input}</echo>
     <echo level="info" if:set="args.resources">* resources = ${args.resources}</echo>
     <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>
-    
+
+    <!-- TODO: change property initialization to not use physical files -->
+    <mkdir dir="${dita.temp.dir}"/>
     <echoxml file="${dita.temp.dir}/.job.xml">
       <job>
         <property name="temp-file-name-scheme">


### PR DESCRIPTION
## Description
Fix preprocess2 initialization with in-memory store.

## Motivation and Context
Temporary directory is not initialized with in-memory store, but preprocess2 assumes the temporary directory is created.

## How Has This Been Tested?
Manual testing
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


