### PR TITLE
Open Saxon receiver explicitly in in-memory store

### DIFF
--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -301,6 +301,11 @@ public class CacheStore extends AbstractStore implements Store {
 
     final Destination dst = getDestination(outputFile);
     final Receiver receiver = dst.getReceiver(pipelineConfiguration, new SerializationProperties());
+    try {
+      receiver.open();
+    } catch (XPathException e) {
+      throw new SaxonApiException("Failed to open receiver for %s".formatted(outputFile), e);
+    }
 
     final ReceivingContentHandler receivingContentHandler = new ReceivingContentHandler();
     receivingContentHandler.setPipelineConfiguration(pipelineConfiguration);


### PR DESCRIPTION
## Description
Open Saxon Receiver explicitly to fix NullPointerException when trying to write to receiver.

## Motivation and Context
Fix bug that occurs when using in-memory store and running preprocess2. The processing fails with

> java.lang.NullPointerException: Cannot invoke "net.sf.saxon.tree.tiny.TinyTree.addNode(short, int, int, int, int)" because "tt" is null

## How Has This Been Tested?
No new tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

