### PR TITLE
Add message for generic parsing exceptions

### DIFF
--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -451,7 +451,7 @@ See the accompanying LICENSE file for applicable license.
   </message>
 
   <message id="DOTJ088E" type="ERROR">
-    <reason>%1</reason>
+    <reason>XML parsing error: %1</reason>
     <response></response>
   </message>
 

--- a/src/main/config/messages_template.xml
+++ b/src/main/config/messages_template.xml
@@ -450,6 +450,11 @@ See the accompanying LICENSE file for applicable license.
     <response>Ignoring chunk operation.</response>
   </message>
 
+  <message id="DOTJ088E" type="ERROR">
+    <reason>%1</reason>
+    <response></response>
+  </message>
+
   <!-- End of Java Messages -->
 
   <!-- Start of XSL Messages -->

--- a/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
+++ b/src/main/java/org/dita/dost/exception/DITAOTXMLErrorHandler.java
@@ -9,6 +9,7 @@
 package org.dita.dost.exception;
 
 import org.dita.dost.log.DITAOTLogger;
+import org.dita.dost.log.MessageUtils;
 import org.dita.dost.util.Configuration;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -49,7 +50,10 @@ public final class DITAOTXMLErrorHandler implements ErrorHandler {
     if (mode == Configuration.Mode.STRICT) {
       throw ex;
     } else {
-      logger.error(ex.getMessage(), ex);
+      logger.error(
+        MessageUtils.getMessage("DOTJ088E", saxException.getMessage()).setLocation(saxException).toString(),
+        saxException
+      );
     }
   }
 

--- a/src/main/java/org/dita/dost/log/MessageBean.java
+++ b/src/main/java/org/dita/dost/log/MessageBean.java
@@ -19,6 +19,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
+import org.xml.sax.SAXParseException;
 
 /**
  * Class description goes here.
@@ -230,6 +231,14 @@ public final class MessageBean {
     ret.srcFile = toURI(location.getFileName());
     ret.srcLine = location.getLineNumber();
     ret.srcColumn = location.getColumnNumber();
+    return ret;
+  }
+
+  public MessageBean setLocation(SAXParseException exception) {
+    final MessageBean ret = new MessageBean(this);
+    ret.srcFile = toURI(exception.getSystemId());
+    ret.srcLine = exception.getLineNumber();
+    ret.srcColumn = exception.getColumnNumber();
     return ret;
   }
 

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -187,3 +187,4 @@ DOTJ084E=Included file {0} contained invalid byte sequence for charset {1}
 DOTJ021E=File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.
 DOTJ086W=Split chunk attribute found on ''<{0}>'' element that does not reference a topic. Ignoring chunk operation.
 DOTJ087W=Found chunk attribute with value ''{0}'' inside combine chunk. Ignoring chunk operation.
+DOTJ088E={0}

--- a/src/test/resources/messages_en_US.properties
+++ b/src/test/resources/messages_en_US.properties
@@ -187,4 +187,4 @@ DOTJ084E=Included file {0} contained invalid byte sequence for charset {1}
 DOTJ021E=File '%1' will not generate output because because all content has been filtered out by DITAVAL "exclude" conditions, or because the file is not valid DITA.
 DOTJ086W=Split chunk attribute found on ''<{0}>'' element that does not reference a topic. Ignoring chunk operation.
 DOTJ087W=Found chunk attribute with value ''{0}'' inside combine chunk. Ignoring chunk operation.
-DOTJ088E={0}
+DOTJ088E=XML parsing error: {0}


### PR DESCRIPTION
## Description
When the input XML is in some way invalid but it can still be parsed, for example

```xml
<topic id="%50">
```

the XML parser will throw an exception with message

> Attribute value "%50" of type ID must be an NCName when namespaces are enabled.

We currently capture this and log out as an error message.

In order to give as many messages an ID as possible, we add a message ID for generic parsing errors where the `<reason>` of the message is provided by the XML parser and the `<response>` is left empty. The logged message will be

> Error: file:/Volumes/tmp/src/topic.dita:3:17: [DOTJ088E] Attribute value "%50" of type ID must be an NCName when namespaces are enabled.

or for example with incorrect attribute name that goes against the DTD

> Error: file:/Volumes/tmp/src/topic.dita:3:36: [DOTJ088E] Attribute "xml:langx" must be declared for element type "topic".

## Motivation and Context
Add error ID for parsing exceptions to improve debugging.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This is a generic error message, so we don't know in advance what the error message will be. Users may override the message configuration to be e.g.

```
<reason>Error in parsing file: %1</reason>
```

if they want to add more context to the message.