### PR TITLE
Fix missing log level prefix when not using colours

### DIFF
--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -233,18 +233,24 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     }
     StringBuilder buf = null;
     if (!legacyFormat) {
-      if (useColor && level == Project.MSG_ERR) {
-        buf =
-          new StringBuilder()
-            .append(ANSI_RED)
-            .append(Main.locale.getString("error_msg").formatted(""))
-            .append(ANSI_RESET);
-      } else if (useColor && level == Project.MSG_WARN) {
-        buf =
-          new StringBuilder()
-            .append(ANSI_YELLOW)
-            .append(Main.locale.getString("warn_msg").formatted(""))
-            .append(ANSI_RESET);
+      if (level == Project.MSG_ERR) {
+        buf = new StringBuilder();
+        if (useColor) {
+          buf.append(ANSI_RED);
+        }
+        buf.append(Main.locale.getString("error_msg").formatted(""));
+        if (useColor) {
+          buf.append(ANSI_RESET);
+        }
+      } else if (level == Project.MSG_WARN) {
+        buf = new StringBuilder();
+        if (useColor) {
+          buf.append(ANSI_YELLOW);
+        }
+        buf.append(Main.locale.getString("warn_msg").formatted(""));
+        if (useColor) {
+          buf.append(ANSI_RESET);
+        }
       }
     }
     if (args.length > 0) {


### PR DESCRIPTION
## Description
Fix missing log level prefix `Error: ` or `Warning: ` when not using colours in CLI.

## Motivation and Context
Fixes #4406
## How Has This Been Tested?
Manual testing.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


