### PR TITLE
In `index.html` metadata, ignore `<keyword>` metadata in `@keys`/`@href` contexts

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -246,10 +246,11 @@ See the accompanying LICENSE file for applicable license.
   <!-- CONTENT: Subject - prolog/metadata/keywords -->
   <xsl:template match="*" mode="gen-keywords-metadata">
     <xsl:variable name="keywords-content">
-      <!-- for each item inside keywords (including nested index terms) -->
+      <!-- consider keywords, including nested index terms
+           (but for map-level metadata, ignore keydef-specific or content-specific keywords) -->
       <xsl:for-each select="descendant::*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
-                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
-                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::*">
+                            descendant::*[contains(@class,' map/topicmeta ')][not(ancestor::*[@href or @keys])]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
+                            descendant::*[contains(@class,' map/topicmeta ')][not(ancestor::*[@href or @keys])]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::*">
         <!-- If this is the first term or keyword with this value -->
         <xsl:if test="generate-id(key('meta-keywords',text()[1])[1]) = generate-id(.)">
           <xsl:if test="position() > 2">


### PR DESCRIPTION
## Description
Updates the HTML5 metadata generation in `index.html` to *not* consider `<keyword>` elements in `@keys` and `@href` contexts:

* Text variable definitions
* Topic-specific (i.e. not map-level) metadata

## Motivation and Context
Fixes #4405.

## How Has This Been Tested?
I ran the testcase from #4405. I also ran the usual tests.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

In `get-meta.xsl`, the metadata template that matches `<keywords>` elements is updated to exclude any elements that have a `@keys` or `@href` attribute in the element ancestry.

## Documentation and Compatibility
No documentation change is needed. A release notes entry could be as follows:

> In the DITA-OT 4.2 release, the HTML5 transformation was updated to include map-level `<keywords>` metadata in the `index.html` file (#4351, #4352). However, this inadvertently also included variable definition keywords. In this release, only `<keywords>` not in a `@keys` (key definition) or `@href` (topic) context are considered. (#4405)

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
