### PR TITLE
Only remove logging level when content matches supported level names

### DIFF
--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -285,7 +285,10 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     if (end == -1) {
       return msg;
     }
-    return msg.substring(0, start) + msg.substring(end);
+    return switch (msg.substring(start + 2, end)) {
+      case "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" -> msg.substring(0, start) + msg.substring(end);
+      default -> msg;
+    };
   }
 
   protected static StringBuilder removeLevelPrefix(StringBuilder msg) {
@@ -297,8 +300,10 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
     if (end == -1) {
       return msg;
     }
-    msg.replace(start, end, "");
-    return msg;
+    return switch (msg.substring(start + 2, end)) {
+      case "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" -> msg.replace(start, end, "");
+      default -> msg;
+    };
   }
 
   private static final Pattern ARGUMENT = Pattern.compile("\\{}|%s");

--- a/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
+++ b/src/test/java/org/dita/dost/log/AbstractLoggerTest.java
@@ -25,7 +25,10 @@ class AbstractLoggerTest extends AbstractLogger {
     return List.of(
       Arguments.of("[DOTJ037W][INFO] Message", "[DOTJ037W] Message"),
       Arguments.of("[DOTJ037W][INFO]: Message", "[DOTJ037W]: Message"),
-      Arguments.of("[DOTJ037W] Message", "[DOTJ037W] Message")
+      Arguments.of("[DOTJ037W] Message", "[DOTJ037W] Message"),
+      Arguments.of("[DOTJ037W][Warning]: Message", "[DOTJ037W][Warning]: Message"),
+      Arguments.of("[WARN][DOTJ037W]: Message", "[WARN][DOTJ037W]: Message"),
+      Arguments.of("[WARN] Message", "[WARN] Message")
     );
   }
 


### PR DESCRIPTION
## Description
Only remove logging level from log message when content matches supported level names like `INFO` or `WARN`. Previous implementation removed anything that was between `][` and `]`.

## Motivation and Context
Fixes https://github.com/orgs/dita-ot/discussions/4415

## How Has This Been Tested?
Unit tests.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


