### PR TITLE
Collect keywords only from top level topicmeta in map

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -258,7 +258,7 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="gen-keywords-metadata">
     <xsl:variable name="topicmeta" as="element()*"
-                  select="descendant::*[contains(@class,' map/topicmeta ')]"/>
+                  select="*[contains(@class,' map/topicmeta ')]"/>
     <xsl:variable name="keywords" as="element()*"
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
                             *[contains(@class,' topic/keywords ')]/

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -13,6 +13,7 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- Get each value in each <keywords>. Nested indexterms should have unique entries. Other
        elements (based on keyword) cannot nest. -->
+  <!-- Deprecated since 4.2.1 -->
   <xsl:key name="meta-keywords" match="*[ancestor::*[contains(@class,' topic/keywords ')]]" use="text()[1]"/>
 
   <!-- Deprecated since 3.6 -->
@@ -244,24 +245,26 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
 
   <!-- CONTENT: Subject - prolog/metadata/keywords -->
-  <xsl:template match="*" mode="gen-keywords-metadata">
-    <xsl:variable name="keywords-content">
-      <!-- for each item inside keywords (including nested index terms) -->
-      <xsl:for-each select="descendant::*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
-                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::* |
-                            descendant::*[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/keywords ')]/descendant-or-self::*">
-        <!-- If this is the first term or keyword with this value -->
-        <xsl:if test="generate-id(key('meta-keywords',text()[1])[1]) = generate-id(.)">
-          <xsl:if test="position() > 2">
-            <xsl:text>, </xsl:text>
-          </xsl:if>
-          <xsl:value-of select="normalize-space(text()[1])"/>
-        </xsl:if>
-      </xsl:for-each>
-    </xsl:variable>
+  <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="gen-keywords-metadata">
+    <xsl:variable name="keywords" as="element()*"
+                  select="descendant::*[contains(@class,' topic/prolog ')]/
+                            *[contains(@class,' topic/metadata ')]/
+                              *[contains(@class,' topic/keywords ')]/
+                                *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+    <xsl:if test="exists($keywords)">
+      <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
+    </xsl:if>
+  </xsl:template>
 
-    <xsl:if test="string-length($keywords-content) > 0">
-      <meta name="keywords" content="{$keywords-content}"/>
+  <xsl:template match="*[contains(@class, ' map/map ')]" mode="gen-keywords-metadata">
+    <xsl:variable name="topicmeta" as="element()*"
+                  select="descendant::*[contains(@class,' map/topicmeta ')]"/>
+    <xsl:variable name="keywords" as="element()*"
+                  select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
+                            *[contains(@class,' topic/keywords ')]/
+                              *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+    <xsl:if test="exists($keywords)">
+      <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/test/resources/html5/exp/html5/concept.html
+++ b/src/test/resources/html5/exp/html5/concept.html
@@ -5,16 +5,28 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
   <meta name="generator" content="DITA-OT">
+  <meta content="topicref concept, concept, nested concept" name="keywords" />
   <title>Concept</title>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <link href="commonltr.css" rel="stylesheet" type="text/css" />
 </head>
 <body id="concept">
 <main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
+  <article aria-labelledby="ariaid-title1" role="article">
     <h1 class="title topictitle1" id="ariaid-title1">Concept</h1>
     <div class="body conbody">
       <p class="p">Body.</p>
     </div>
+    <nav class="related-links" role="navigation">
+      <div class="familylinks">
+        <div class="parentlink"><strong>Parent topic:</strong> <a class="link" href="topic.html">Topic</a></div>
+      </div>
+    </nav>
+    <article aria-labelledby="ariaid-title2" class="topic concept nested1" id="nested-concept">
+      <h2 class="title topictitle2" id="ariaid-title2">Nested Concept</h2>
+      <div class="body conbody">
+        <p class="p">Body.</p>
+      </div>
+    </article>
   </article>
 </main>
 </body>

--- a/src/test/resources/html5/exp/html5/index.html
+++ b/src/test/resources/html5/exp/html5/index.html
@@ -5,17 +5,20 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
   <meta name="generator" content="DITA-OT">
+  <meta content="metadata, topicmeta, topicref topic, topicref concept, topicref task, topicref reference" name="keywords" />
   <title>Map</title>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <link href="commonltr.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
 <h1 class="title topictitle1">Map</h1>
 <nav>
   <ul class="map">
-    <li class="topicref"><a href="topic.html">Topic</a></li>
-    <li class="topicref"><a href="concept.html">Concept</a></li>
-    <li class="topicref"><a href="task.html">Task</a></li>
-    <li class="topicref"><a href="reference.html">Reference</a></li>
+    <li class="topicref"><a href="topic.html">Topic</a><ul>
+      <li class="topicref"><a href="concept.html">Concept</a></li>
+      <li class="topicref"><a href="task.html">Task</a></li>
+      <li class="topicref"><a href="reference.html">Reference</a></li>
+    </ul>
+    </li>
   </ul>
 </nav>
 </body>

--- a/src/test/resources/html5/exp/html5/index.html
+++ b/src/test/resources/html5/exp/html5/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
   <meta name="generator" content="DITA-OT">
-  <meta content="metadata, topicmeta, topicref topic, topicref concept, topicref task, topicref reference" name="keywords" />
+  <meta content="metadata, topicmeta" name="keywords" />
   <title>Map</title>
   <link href="commonltr.css" rel="stylesheet" type="text/css" />
 </head>

--- a/src/test/resources/html5/exp/html5/reference.html
+++ b/src/test/resources/html5/exp/html5/reference.html
@@ -5,18 +5,34 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
   <meta name="generator" content="DITA-OT">
+  <meta content="topicref reference, reference, nested reference" name="keywords" />
   <title>Reference</title>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <link href="commonltr.css" rel="stylesheet" type="text/css" />
 </head>
 <body id="reference">
 <main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
+  <article aria-labelledby="ariaid-title1" role="article">
     <h1 class="title topictitle1" id="ariaid-title1">Reference</h1>
     <div class="body refbody">
-      <section class="section"><h2 class="title sectiontitle">Section title</h2>
+      <section class="section">
+        <h2 class="title sectiontitle">Section title</h2>
         <p class="p">Body.</p>
       </section>
     </div>
+    <nav class="related-links" role="navigation">
+      <div class="familylinks">
+        <div class="parentlink"><strong>Parent topic:</strong> <a class="link" href="topic.html">Topic</a></div>
+      </div>
+    </nav>
+    <article aria-labelledby="ariaid-title2" class="topic reference nested1" id="nested-reference">
+      <h2 class="title topictitle2" id="ariaid-title2">Nested Reference</h2>
+      <div class="body refbody">
+        <section class="section">
+          <h3 class="title sectiontitle">Section title</h3>
+          <p class="p">Body.</p>
+        </section>
+      </div>
+    </article>
   </article>
 </main>
 </body>

--- a/src/test/resources/html5/exp/html5/task.html
+++ b/src/test/resources/html5/exp/html5/task.html
@@ -4,9 +4,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
-  <meta name="generator" content="DITA-OT">
+  <meta content="DITA-OT" name="generator">
+  <meta content="topicref task, task, nested task" name="keywords">
   <title>Task</title>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <link href="commonltr.css" rel="stylesheet" type="text/css">
 </head>
 <body id="task">
 <main role="main">
@@ -30,6 +31,33 @@
         </div>
       </section>
     </div>
+
+    <nav class="related-links" role="navigation">
+      <div class="familylinks">
+        <div class="parentlink"><strong>Parent topic:</strong> <a class="link" href="topic.html">Topic</a></div>
+      </div>
+    </nav>
+    <article aria-labelledby="ariaid-title2" class="topic task nested1" id="nested-task">
+      <h2 class="title topictitle2" id="ariaid-title2">Nested Task</h2>
+      <div class="body taskbody">
+        <section class="section context">
+          <div class="tasklabel">
+            <h3 class="sectiontitle tasklabel">About this task</h3>
+          </div>
+          <p class="p">Context.</p>
+        </section>
+        <section>
+          <div class="tasklabel">
+            <h3 class="sectiontitle tasklabel">Procedure</h3>
+          </div>
+          <div class="ol steps">
+            <div class="li step p">
+              <span class="ph cmd">Command.</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </article>
   </article>
 </main>
 </body>

--- a/src/test/resources/html5/exp/html5/topic.html
+++ b/src/test/resources/html5/exp/html5/topic.html
@@ -5,16 +5,30 @@
   <meta charset="UTF-8">
   <meta name="copyright" content="(C) Copyright 2024">
   <meta name="generator" content="DITA-OT">
+  <meta content="topicref topic, topic, nested topic" name="keywords" />
   <title>Topic</title>
-  <link rel="stylesheet" type="text/css" href="commonltr.css">
+  <link href="commonltr.css" rel="stylesheet" type="text/css" />
 </head>
 <body id="topic">
 <main role="main">
-  <article role="article" aria-labelledby="ariaid-title1">
+  <article aria-labelledby="ariaid-title1" role="article">
     <h1 class="title topictitle1" id="ariaid-title1">Topic</h1>
     <div class="body">
       <p class="p">Body.</p>
     </div>
+    <nav class="related-links" role="navigation">
+      <ul class="ullinks">
+        <li class="link ulchildlink"><strong><a href="concept.html">Concept</a></strong><br /></li>
+        <li class="link ulchildlink"><strong><a href="task.html">Task</a></strong><br /></li>
+        <li class="link ulchildlink"><strong><a href="reference.html">Reference</a></strong><br /></li>
+      </ul>
+    </nav>
+    <article aria-labelledby="ariaid-title2" class="topic nested1" id="nested-topic">
+      <h2 class="title topictitle2" id="ariaid-title2">Nested Topic</h2>
+      <div class="body">
+        <p class="p">Body.</p>
+      </div>
+    </article>
   </article>
 </main>
 </body>

--- a/src/test/resources/html5/src/concept.dita
+++ b/src/test/resources/html5/src/concept.dita
@@ -2,7 +2,27 @@
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="concept">
   <title>Concept</title>
+  <prolog>
+    <metadata>
+      <keywords>
+        <keyword>concept</keyword>
+      </keywords>
+    </metadata>
+  </prolog>
   <conbody>
     <p>Body.</p>
   </conbody>
+  <concept id="nested-concept">
+    <title>Nested Concept</title>
+    <prolog>
+      <metadata>
+        <keywords>
+          <keyword>nested concept</keyword>
+        </keywords>
+      </metadata>
+    </prolog>
+    <conbody>
+      <p>Body.</p>
+    </conbody>
+  </concept>
 </concept>

--- a/src/test/resources/html5/src/map.ditamap
+++ b/src/test/resources/html5/src/map.ditamap
@@ -2,8 +2,42 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map>
   <title>Map</title>
-  <topicref href="topic.dita"/>
-  <topicref href="concept.dita"/>
-  <topicref href="task.dita"/>
-  <topicref href="reference.dita"/>
+  <topicmeta>
+    <metadata>
+      <keywords>
+        <keyword>metadata</keyword>
+      </keywords>
+    </metadata>
+    <keywords>
+      <keyword>topicmeta</keyword>
+    </keywords>
+  </topicmeta>
+  <topicref href="topic.dita">
+    <topicmeta>
+      <keywords>
+        <keyword>topicref topic</keyword>
+      </keywords>
+    </topicmeta>
+    <topicref href="concept.dita">
+    <topicmeta>
+      <keywords>
+        <keyword>topicref concept</keyword>
+      </keywords>
+    </topicmeta>
+    </topicref>
+    <topicref href="task.dita">
+      <topicmeta>
+        <keywords>
+          <keyword>topicref task</keyword>
+        </keywords>
+      </topicmeta>
+    </topicref>
+    <topicref href="reference.dita">
+      <topicmeta>
+        <keywords>
+          <keyword>topicref reference</keyword>
+        </keywords>
+      </topicmeta>
+    </topicref>
+  </topicref>
 </map>

--- a/src/test/resources/html5/src/reference.dita
+++ b/src/test/resources/html5/src/reference.dita
@@ -2,10 +2,33 @@
 <!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
 <reference id="reference">
   <title>Reference</title>
+  <prolog>
+    <metadata>
+      <keywords>
+        <keyword>reference</keyword>
+      </keywords>
+    </metadata>
+  </prolog>
   <refbody>
     <section>
       <title>Section title</title>
       <p>Body.</p>
     </section>
   </refbody>
+  <reference id="nested-reference">
+    <title>Nested Reference</title>
+    <prolog>
+      <metadata>
+        <keywords>
+          <keyword>nested reference</keyword>
+        </keywords>
+      </metadata>
+    </prolog>
+    <refbody>
+      <section>
+        <title>Section title</title>
+        <p>Body.</p>
+      </section>
+    </refbody>
+  </reference>
 </reference>

--- a/src/test/resources/html5/src/task.dita
+++ b/src/test/resources/html5/src/task.dita
@@ -2,6 +2,13 @@
 <!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
 <task id="task">
   <title>Task</title>
+  <prolog>
+    <metadata>
+      <keywords>
+        <keyword>task</keyword>
+      </keywords>
+    </metadata>
+  </prolog>
   <taskbody>
     <context>
       <p>Context.</p>
@@ -12,4 +19,24 @@
       </step>
     </steps>
   </taskbody>
+  <task id="nested-task">
+    <title>Nested Task</title>
+    <prolog>
+      <metadata>
+        <keywords>
+          <keyword>nested task</keyword>
+        </keywords>
+      </metadata>
+    </prolog>
+    <taskbody>
+      <context>
+        <p>Context.</p>
+      </context>
+      <steps>
+        <step>
+          <cmd>Command.</cmd>
+        </step>
+      </steps>
+    </taskbody>
+  </task>
 </task>

--- a/src/test/resources/html5/src/topic.dita
+++ b/src/test/resources/html5/src/topic.dita
@@ -2,7 +2,27 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic">
   <title>Topic</title>
+  <prolog>
+    <metadata>
+      <keywords>
+        <keyword>topic</keyword>
+      </keywords>
+    </metadata>
+  </prolog>
   <body>
     <p>Body.</p>
   </body>
+  <topic id="nested-topic">
+    <title>Nested Topic</title>
+    <prolog>
+      <metadata>
+        <keywords>
+          <keyword>nested topic</keyword>
+        </keywords>
+      </metadata>
+    </prolog>
+    <body>
+      <p>Body.</p>
+    </body>
+  </topic>
 </topic>


### PR DESCRIPTION
## Description
Collect `<keyword>` element only from the top level `<topicmeta>` for `index.html`

## Motivation and Context
Fixes #4405. Collecting keywords from all levels is unintuitive behaviour.

## How Has This Been Tested?
Improved HTML5 unit test to cover keyword metadata generation.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


