### PR TITLE
Fix some issues occuring when using http urls as input files.

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -10,6 +10,8 @@
 package org.dita.dost.invoker;
 
 import static org.dita.dost.invoker.Main.locale;
+import static org.dita.dost.util.Constants.OS_NAME;
+import static org.dita.dost.util.Constants.OS_NAME_WINDOWS;
 import static org.dita.dost.util.LangUtils.pair;
 
 import java.io.File;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.dita.dost.util.Configuration;
+import org.dita.dost.util.URLUtils;
 
 /**
  * Command line arguments.
@@ -297,6 +300,10 @@ abstract class Arguments {
 
     @Override
     String getValue(final String value) {
+      String scheme = URLUtils.toURI(value).getScheme();
+      if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS) && scheme != null && !"file".equals(scheme)) {
+        return value;
+      }
       final Path f = Paths.get(value).toAbsolutePath().normalize();
       if (Files.exists(f)) {
         return f.toString();

--- a/src/main/java/org/dita/dost/module/reader/DefaultTempFileScheme.java
+++ b/src/main/java/org/dita/dost/module/reader/DefaultTempFileScheme.java
@@ -25,7 +25,7 @@ public class DefaultTempFileScheme implements TempFileNameScheme {
   public URI generateTempFileName(final URI src) {
     assert src.isAbsolute();
     //final URI b = baseInputDir.toURI();
-    final URI rel = toURI(b.relativize(src).toString());
+    final URI rel = toURI(b.relativize(src).getPath());
     return rel;
   }
 }


### PR DESCRIPTION
## Description

This pull request fixes some issues occuring when using http urls as input files.

## Motivation and Context
1. Fixes #4419
2. Error `java.lang.IllegalArgumentException: URI has a query component` happens when file urls have parameters. Updated DefaultTempFileScheme to ignore those.
The same error also occurs in CleanPreprocessModule. No fix provided as it is manageable with customized result rewrite rules.

## How Has This Been Tested?
Project built and tested manually with both url and local files on windows.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_