### PR TITLE
Validate reserved properties also with double hyphen prefix

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -156,7 +156,14 @@ public class ConversionArguments extends Arguments {
       } else if (ARGUMENTS.containsKey(getArgumentName(arg))) {
         definedProps.putAll(handleParameterArg(arg, args, ARGUMENTS.get(getArgumentName(arg))));
       } else if (getPluginArguments().containsKey(getArgumentName(arg))) {
-        definedProps.putAll(handleParameterArg(arg, args, getPluginArguments().get(getArgumentName(arg))));
+        final String argument = getArgumentName(arg);
+        final String name = argument.substring(2);
+        if (RESERVED_PROPERTIES.containsKey(name)) {
+          throw new BuildException(
+            "Property %s cannot be set with --, use %s instead".formatted(name, RESERVED_PROPERTIES.get(name))
+          );
+        }
+        definedProps.putAll(handleParameterArg(arg, args, getPluginArguments().get(argument)));
       } else if (LAUNCH_COMMANDS.contains(arg)) {
         // catch script/ant mismatch with a meaningful message
         // we could ignore it, but there are likely to be other

--- a/src/test/java/org/dita/dost/invoker/ConversionArgumentsTest.java
+++ b/src/test/java/org/dita/dost/invoker/ConversionArgumentsTest.java
@@ -10,10 +10,16 @@ package org.dita.dost.invoker;
 
 import static java.io.File.pathSeparator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
+import java.util.stream.Stream;
+import org.apache.tools.ant.BuildException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConversionArgumentsTest {
 
@@ -36,6 +42,18 @@ public class ConversionArgumentsTest {
     arguments.parse(new String[] { "--input=foo.dita" });
 
     assertEquals("foo.dita", arguments.definedProps.get("args.input"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void input_reserved(String argument) {
+    assertThrows(BuildException.class, () -> arguments.parse(new String[] { argument }));
+  }
+
+  public static Stream<Arguments> input_reserved() {
+    return Stream
+      .of("args.input", "output.dir", "args.filter", "dita.temp.dir")
+      .flatMap(name -> Stream.of("-D", "--").map(prefix -> Arguments.of("%s%s=value".formatted(prefix, name))));
   }
 
   @Test


### PR DESCRIPTION
## Description
Validate reserved properties also with double hyphen prefix (`--`).

## Motivation and Context
Make validation the same for `--` and `-D` prefixes.

## How Has This Been Tested?
New tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

