### PR TITLE
Prevent redundant duplicates from branch filter in preprocess2

### DIFF
--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -195,9 +195,10 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
               attr.getOwnerElement().setAttribute(BRANCH_COPY_TO, gen);
             }
 
-            final URI dstUri = map.resolve(gen);
+            final URI dstUri = stripFragment(map.resolve(gen));
             if (dstUri != null) {
-              final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(attr.getValue()));
+              final URI absTarget = stripFragment(currentFile.resolve(attr.getValue()));
+              final FileInfo hrefFileInfo = job.getFileInfo(absTarget);
               if (hrefFileInfo != null) {
                 final URI newResult = addSuffix(hrefFileInfo.result, suffix);
                 final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).uri(dstUri).result(newResult);

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -154,9 +154,10 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
               attr.getOwnerElement().setAttribute(BRANCH_COPY_TO, gen);
             }
 
-            final URI dstUri = map.resolve(gen);
+            final URI dstUri = stripFragment(map.resolve(gen));
             if (dstUri != null) {
-              final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(attr.getValue()));
+              final URI absTarget = stripFragment(currentFile.resolve(attr.getValue()));
+              final FileInfo hrefFileInfo = job.getFileInfo(absTarget);
               if (hrefFileInfo != null) {
                 final URI newResult = addSuffix(hrefFileInfo.result, suffix);
                 final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).uri(dstUri).result(newResult);

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -10,6 +10,7 @@ package org.dita.dost.module.filter;
 import static java.util.Collections.singletonList;
 import static org.dita.dost.module.filter.MapBranchFilterModule.BRANCH_COPY_TO;
 import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.URLUtils.stripFragment;
 import static org.dita.dost.util.XMLUtils.getChildElements;
 
 import java.io.File;
@@ -151,11 +152,11 @@ public class TopicBranchFilterModule extends AbstractBranchFilterModule {
         } catch (final DITAOTException e) {
           logger.error("Failed to filter " + srcAbsUri + " to " + dstAbsUri + ": " + e.getMessage(), e);
         }
-        topicref.setAttribute(ATTRIBUTE_NAME_HREF, copyTo);
-        topicref.removeAttribute(BRANCH_COPY_TO);
-        // disable filtering again
-        topicref.setAttribute(SKIP_FILTER, Boolean.TRUE.toString());
       }
+      topicref.setAttribute(ATTRIBUTE_NAME_HREF, copyTo);
+      topicref.removeAttribute(BRANCH_COPY_TO);
+      // disable filtering again
+      topicref.setAttribute(SKIP_FILTER, Boolean.TRUE.toString());
     }
     for (final Element child : getChildElements(topicref, MAP_TOPICREF)) {
       if (DITAVAREF_D_DITAVALREF.matches(child)) {
@@ -175,7 +176,7 @@ public class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
     final String href = topicref.getAttribute(ATTRIBUTE_NAME_HREF);
     final Attr skipFilter = topicref.getAttributeNode(SKIP_FILTER);
-    final URI srcAbsUri = job.tempDirURI.resolve(map.resolve(href));
+    final URI srcAbsUri = stripFragment(job.tempDirURI.resolve(map.resolve(href)));
     if (
       !fs.isEmpty() &&
       skipFilter == null &&

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -43,7 +43,7 @@ import org.xml.sax.XMLFilter;
  *
  * @since 2.5
  */
-public final class TopicBranchFilterModule extends AbstractBranchFilterModule {
+public class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
   private static final String SKIP_FILTER = "skip-filter";
 

--- a/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
@@ -296,6 +296,10 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
 
     m.processMap(job.getFileInfo(URI.create("test.ditamap")));
 
+    assertXMLEqual(
+      new InputSource(new File(expDir, "test.ditamap").toURI().toString()),
+      new InputSource(new File(tempDir, "test.ditamap").toURI().toString())
+    );
     final Set<FileInfo> exp = getDuplicateTopicFileInfos();
     exp.add(
       new Job.FileInfo.Builder()

--- a/src/test/java/org/dita/dost/module/filter/TopicBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/TopicBranchFilterModuleTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2016 Jarno Elovirta
+ *
+ *  See the accompanying LICENSE file for applicable license.
+ */
+package org.dita.dost.module.filter;
+
+import static org.dita.dost.TestUtils.CachingLogger.Message.Level.ERROR;
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.dita.dost.TestUtils;
+import org.dita.dost.TestUtils.CachingLogger;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.Job.FileInfo;
+import org.dita.dost.util.XMLUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.InputSource;
+
+public class TopicBranchFilterModuleTest extends TopicBranchFilterModule {
+
+  private final File resourceDir = TestUtils.getResourceDir(TopicBranchFilterModuleTest.class);
+  private final File expDir = new File(resourceDir, "exp");
+
+  @TempDir
+  private File tempDir;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    TestUtils.copy(new File(resourceDir, "src"), tempDir);
+  }
+
+  @Test
+  public void testDuplicateTopic() throws IOException {
+    final TopicBranchFilterModule m = new TopicBranchFilterModule();
+    final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+    job.setInputDir(tempDir.toURI());
+    job.addAll(getDuplicateTopicFileInfos());
+    m.setJob(job);
+    final CachingLogger logger = new CachingLogger();
+    m.setLogger(logger);
+    m.setXmlUtils(new XMLUtils());
+
+    m.processMap(URI.create("test.ditamap"));
+
+    assertXMLEqual(
+      new InputSource(new File(expDir, "test.ditamap").toURI().toString()),
+      new InputSource(new File(tempDir, "test.ditamap").toURI().toString())
+    );
+    assertXMLEqual(
+      new InputSource(new File(expDir, "t1.xml").toURI().toString()),
+      new InputSource(new File(tempDir, "t1.xml").toURI().toString())
+    );
+    assertXMLEqual(
+      new InputSource(new File(expDir, "t1-1.xml").toURI().toString()),
+      new InputSource(new File(tempDir, "t1-1.xml").toURI().toString())
+    );
+    assertEquals(getDuplicateTopicFileInfos(), new HashSet<>(job.getFileInfo()));
+    assertEquals(0, logger.getMessages().stream().filter(msg -> msg.level == ERROR).count());
+  }
+
+  private Set<FileInfo> getDuplicateTopicFileInfos() {
+    final Set<FileInfo> res = new HashSet<>();
+    res.add(
+      new FileInfo.Builder()
+        .src(new File(tempDir, "test.ditamap").toURI())
+        .result(new File(tempDir, "test.ditamap").toURI())
+        .uri(URI.create("test.ditamap"))
+        .format(ATTR_FORMAT_VALUE_DITAMAP)
+        .build()
+    );
+    for (final String uri : Arrays.asList("test.ditaval", "test2.ditaval")) {
+      res.add(
+        new FileInfo.Builder()
+          .src(new File(tempDir, uri).toURI())
+          .result(new File(tempDir, uri).toURI())
+          .uri(URI.create(uri))
+          .format(ATTR_FORMAT_VALUE_DITAVAL)
+          .build()
+      );
+    }
+    for (final String uri : List.of("t1.xml")) {
+      res.add(
+        new FileInfo.Builder()
+          .src(new File(tempDir, uri).toURI())
+          .result(new File(tempDir, uri).toURI())
+          .uri(URI.create(uri))
+          .format(ATTR_FORMAT_VALUE_DITA)
+          .build()
+      );
+    }
+    res.add(
+      new FileInfo.Builder()
+        .src(new File(tempDir, "t1.xml").toURI())
+        .result(new File(tempDir, "t1-1.xml").toURI())
+        .uri(URI.create("t1-1.xml"))
+        .format(ATTR_FORMAT_VALUE_DITA)
+        .build()
+    );
+    return res;
+  }
+}

--- a/src/test/resources/MapBranchFilterModuleTest/exp/test.ditamap
+++ b/src/test/resources/MapBranchFilterModuleTest/exp/test.ditamap
@@ -1,17 +1,17 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
   <title class="- topic/title ">My map</title>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
-    <topicref class="- map/topicref " href="t1.xml">
-      <topicref class="- map/topicref " href="t1.xml#nested"/>
-      <topicref class="- map/topicref " href="t1.xml#nested2"/>
-    </topicref>
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " filter-copy-to="t1-1.xml" href="t1.xml">
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested" href="t1.xml#nested"/>
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested2" href="t1.xml#nested2"/>
+    </topicref>
   </topicgroup>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test2.ditaval" processing-role="resource-only"></ditavalref>
     <topicref class="- map/topicref " href="t1.xml">
       <topicref class="- map/topicref " href="t1.xml#nested"/>
       <topicref class="- map/topicref " href="t1.xml#nested2"/>
     </topicref>
-    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test2.ditaval" processing-role="resource-only"></ditavalref>
   </topicgroup>
 </map>

--- a/src/test/resources/TopicBranchFilterModuleTest/exp/t1-1.xml
+++ b/src/test/resources/TopicBranchFilterModuleTest/exp/t1-1.xml
@@ -1,0 +1,6 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " id="t1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">T1</title>
+  <body class="- topic/body ">
+    <p class="- topic/p " audience="novice">Novice</p>
+  </body>
+</topic>

--- a/src/test/resources/TopicBranchFilterModuleTest/exp/t1.xml
+++ b/src/test/resources/TopicBranchFilterModuleTest/exp/t1.xml
@@ -1,0 +1,5 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " id="t1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">T1</title>
+  <body class="- topic/body ">
+  </body>
+</topic>

--- a/src/test/resources/TopicBranchFilterModuleTest/exp/t1.xml
+++ b/src/test/resources/TopicBranchFilterModuleTest/exp/t1.xml
@@ -1,5 +1,6 @@
 <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " id="t1" ditaarch:DITAArchVersion="1.3">
   <title class="- topic/title ">T1</title>
   <body class="- topic/body ">
+    <p class="- topic/p " audience="expert">Expert</p>
   </body>
 </topic>

--- a/src/test/resources/TopicBranchFilterModuleTest/exp/test.ditamap
+++ b/src/test/resources/TopicBranchFilterModuleTest/exp/test.ditamap
@@ -3,8 +3,8 @@
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
     <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
     <topicref class="- map/topicref " href="t1-1.xml">
-      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested" href="t1.xml#nested"/>
-      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested2" href="t1.xml#nested2"/>
+      <topicref class="- map/topicref " href="t1-1.xml#nested"/>
+      <topicref class="- map/topicref " href="t1-1.xml#nested2"/>
     </topicref>
   </topicgroup>
   <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">

--- a/src/test/resources/TopicBranchFilterModuleTest/exp/test.ditamap
+++ b/src/test/resources/TopicBranchFilterModuleTest/exp/test.ditamap
@@ -1,0 +1,17 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">My map</title>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " href="t1-1.xml">
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested" href="t1.xml#nested"/>
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested2" href="t1.xml#nested2"/>
+    </topicref>
+  </topicgroup>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test2.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " href="t1.xml">
+      <topicref class="- map/topicref " href="t1.xml#nested"/>
+      <topicref class="- map/topicref " href="t1.xml#nested2"/>
+    </topicref>
+  </topicgroup>
+</map>

--- a/src/test/resources/TopicBranchFilterModuleTest/src/t1-1.xml
+++ b/src/test/resources/TopicBranchFilterModuleTest/src/t1-1.xml
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " id="t1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">T1</title>
+  <body class="- topic/body ">
+    <p class="- topic/p " audience="expert">Expert</p>
+    <p class="- topic/p " audience="novice">Novice</p>
+  </body>
+</topic>

--- a/src/test/resources/TopicBranchFilterModuleTest/src/t1.xml
+++ b/src/test/resources/TopicBranchFilterModuleTest/src/t1.xml
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " id="t1" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">T1</title>
+  <body class="- topic/body ">
+    <p class="- topic/p " audience="expert">Expert</p>
+    <p class="- topic/p " audience="novice">Novice</p>
+  </body>
+</topic>

--- a/src/test/resources/TopicBranchFilterModuleTest/src/test.ditamap
+++ b/src/test/resources/TopicBranchFilterModuleTest/src/test.ditamap
@@ -1,0 +1,17 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">My map</title>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " filter-copy-to="t1-1.xml" href="t1.xml">
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested" href="t1.xml#nested"/>
+      <topicref class="- map/topicref " filter-copy-to="t1-1.xml#nested2" href="t1.xml#nested2"/>
+    </topicref>
+  </topicgroup>
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test2.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " href="t1.xml">
+      <topicref class="- map/topicref " href="t1.xml#nested"/>
+      <topicref class="- map/topicref " href="t1.xml#nested2"/>
+    </topicref>
+  </topicgroup>
+</map>

--- a/src/test/resources/TopicBranchFilterModuleTest/src/test.ditaval
+++ b/src/test/resources/TopicBranchFilterModuleTest/src/test.ditaval
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="exclude" att="audience" val="expert"/>
+  <prop action="include" att="audience"/>
+</val>

--- a/src/test/resources/TopicBranchFilterModuleTest/src/test2.ditaval
+++ b/src/test/resources/TopicBranchFilterModuleTest/src/test2.ditaval
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="exclude" att="audience" val="novice"/>
+  <prop action="include" att="audience"/>
+</val>


### PR DESCRIPTION
## Description
Fix map-first pre-processing where duplicate branches are incorrectly processed when topic references include fragments.

## Motivation and Context
Fixes #4380

Related to #3903 that fixes a similar bug in legacy pre-processing.

## How Has This Been Tested?
TBD

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

