### PR TITLE
Remove fileinfos for topics that have their topicref filtered out

### DIFF
--- a/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/filter/MapBranchFilterModuleTest.java
@@ -389,6 +389,6 @@ public class MapBranchFilterModuleTest extends MapBranchFilterModule {
       new InputSource(new File(expDir, "orphan.ditamap").toURI().toString()),
       new InputSource(new File(tempDir, "orphan.ditamap").toURI().toString())
     );
-    assertTrue(job.getFileInfo(URI.create("configure.dita")) != null);
+    assertNull(job.getFileInfo(URI.create("configure.dita")));
   }
 }

--- a/src/test/resources/MapBranchFilterModuleTest/exp/orphan.ditamap
+++ b/src/test/resources/MapBranchFilterModuleTest/exp/orphan.ditamap
@@ -1,0 +1,6 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " href="install.dita"/>
+  </topicgroup>
+</map>

--- a/src/test/resources/MapBranchFilterModuleTest/src/orphan.ditamap
+++ b/src/test/resources/MapBranchFilterModuleTest/src/orphan.ditamap
@@ -1,0 +1,7 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " domains="(map mapgroup-d)                            (topic abbrev-d)                            (topic delay-d)                            a(props deliveryTarget)                            (map ditavalref-d)                            (map glossref-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   " ditaarch:DITAArchVersion="1.3">
+  <topicgroup class="+ map/topicref mapgroup-d/topicgroup ">
+    <ditavalref class="+ map/topicref ditavalref-d/ditavalref " format="ditaval" href="test.ditaval" processing-role="resource-only"></ditavalref>
+    <topicref class="- map/topicref " href="install.dita"/>
+    <topicref class="- map/topicref " href="configure.dita" audience="novice" />
+  </topicgroup>
+</map>


### PR DESCRIPTION
## Description
Remove fileinfos from job configuration for topics that have had their topicref filtered out in branch filtering.

## Motivation and Context
Fixes #4383

## How Has This Been Tested?
TBD
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

