### PR TITLE
Add CSS class "inline" to inline images.

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1412,13 +1412,14 @@ See the accompanying LICENSE file for applicable license.
     <img>
       <xsl:call-template name="commonattributes">
         <xsl:with-param name="default-output-class">
-          <xsl:if test="@placement = 'break'"><!--Align only works for break-->
-            <xsl:choose>
-              <xsl:when test="@align = 'left'">imageleft</xsl:when>
-              <xsl:when test="@align = 'right'">imageright</xsl:when>
-              <xsl:when test="@align = 'center'">imagecenter</xsl:when>
-            </xsl:choose>
-          </xsl:if>
+          <xsl:choose>
+            <!-- Align only works for break -->
+            <xsl:when test="@placement = 'break' and @align = 'left'">imageleft</xsl:when>
+            <xsl:when test="@placement = 'break' and @align = 'right'">imageright</xsl:when>
+            <xsl:when test="@placement = 'break' and @align = 'center'">imagecenter</xsl:when>
+            <!-- The default is inline -->
+            <xsl:when test="@placement = 'inline' or not(@placement)">inline</xsl:when>
+          </xsl:choose>
         </xsl:with-param>
       </xsl:call-template>
       <xsl:call-template name="setid"/>

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1414,9 +1414,9 @@ See the accompanying LICENSE file for applicable license.
         <xsl:with-param name="default-output-class">
           <xsl:choose>
             <!-- Align only works for break -->
-            <xsl:when test="@placement = 'break' and @align = 'left'">imageleft</xsl:when>
-            <xsl:when test="@placement = 'break' and @align = 'right'">imageright</xsl:when>
-            <xsl:when test="@placement = 'break' and @align = 'center'">imagecenter</xsl:when>
+            <xsl:when test="@placement = 'break' and @align = 'left'">break imageleft</xsl:when>
+            <xsl:when test="@placement = 'break' and @align = 'right'">break imageright</xsl:when>
+            <xsl:when test="@placement = 'break' and @align = 'center'">break imagecenter</xsl:when>
             <!-- The default is inline -->
             <xsl:when test="@placement = 'inline' or not(@placement)">inline</xsl:when>
           </xsl:choose>


### PR DESCRIPTION
## Description
Add CSS class `inline` to inline images in HTML5 output, as suggested in https://github.com/dita-ot/dita-ot/issues/4432.

## Motivation and Context
Simplifies formatting, positioning, and scaling of inline images in HTML5.

## How Has This Been Tested?
[html5-inline-image.zip](https://github.com/dita-ot/dita-ot/files/14573648/html5-inline-image.zip)

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
    _none_
- Will this change affect backwards compatibility or other users' overrides?
    _no_

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
