### PR TITLE
Skip transformation if source file doesn't exist

### DIFF
--- a/src/main/java/org/dita/dost/store/AbstractStore.java
+++ b/src/main/java/org/dita/dost/store/AbstractStore.java
@@ -15,7 +15,6 @@ import static org.dita.dost.util.URLUtils.toURI;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import net.sf.saxon.s9api.XsltTransformer;
 import org.dita.dost.exception.DITAOTException;
@@ -101,6 +100,9 @@ public abstract class AbstractStore implements Store {
     //            throw new IllegalArgumentException("Only file URI scheme supported: " + input);
     //        }
     final URI srcFile = setFragment(src, null);
+    if (!exists(srcFile)) {
+      return;
+    }
     final URI dst = toURI(srcFile.toString() + FILE_EXTENSION_TEMP).normalize();
     transformURI(srcFile, dst, filters);
     try {

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -318,6 +318,9 @@ public class CacheStore extends AbstractStore implements Store {
   public void transform(final URI src, final ContentHandler dst) throws DITAOTException {
     final URI f = src.normalize();
     if (isTempFile(f)) {
+      if (!exists(f)) {
+        return;
+      }
       if (cache.containsKey(f)) {
         try {
           final Source source = getSource(src);
@@ -338,6 +341,9 @@ public class CacheStore extends AbstractStore implements Store {
   public void transform(final URI input, final List<XMLFilter> filters) throws DITAOTException {
     final URI src = input.normalize();
     if (isTempFile(src)) {
+      if (!exists(src)) {
+        return;
+      }
       try {
         final Source source = getSource(src);
         final ContentHandler serializer = getContentHandler(src);
@@ -356,6 +362,9 @@ public class CacheStore extends AbstractStore implements Store {
   @Override
   void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
     if (isTempFile(input)) {
+      if (!exists(input)) {
+        return;
+      }
       try {
         ContentHandler dst = getContentHandler(output);
         ContentHandler pipe = getPipe(filters, dst);
@@ -381,6 +390,9 @@ public class CacheStore extends AbstractStore implements Store {
 
   @Override
   public void transform(final URI src, final XsltTransformer transformer) throws DITAOTException {
+    if (!exists(src)) {
+      return;
+    }
     final boolean useTmpBuf = !isTempFile(src.normalize());
     final URI dst = useTmpBuf ? toURI(src + FILE_EXTENSION_TEMP).normalize() : src;
     Destination result = null;
@@ -415,6 +427,9 @@ public class CacheStore extends AbstractStore implements Store {
 
   @Override
   void transformUri(final URI src, final URI dst, final XsltTransformer transformer) throws DITAOTException {
+    if (!exists(src)) {
+      return;
+    }
     Destination result = null;
     try {
       final Source source = getSource(src);

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -171,6 +171,9 @@ public class StreamStore extends AbstractStore implements Store {
 
   @Override
   void transformURI(final URI input, final URI output, final List<XMLFilter> filters) throws DITAOTException {
+    if (!exists(input)) {
+      return;
+    }
     Serializer result = null;
     try {
       XMLReader reader = xmlUtils.getXMLReader();
@@ -215,6 +218,9 @@ public class StreamStore extends AbstractStore implements Store {
 
   @Override
   public void transform(final URI src, final XsltTransformer transformer) throws DITAOTException {
+    if (!exists(src)) {
+      return;
+    }
     final URI dst = toURI(src.toString() + FILE_EXTENSION_TEMP).normalize();
     transformUri(src, dst, transformer);
     try {
@@ -226,6 +232,9 @@ public class StreamStore extends AbstractStore implements Store {
 
   @Override
   void transformUri(final URI src, final URI dst, final XsltTransformer transformer) throws DITAOTException {
+    if (!exists(src)) {
+      return;
+    }
     Destination result = null;
     try {
       final Source source = getSource(src);

--- a/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
+++ b/src/test/java/org/dita/dost/IntegrationTestPreprocess2.java
@@ -38,18 +38,6 @@ public class IntegrationTestPreprocess2 extends IntegrationTest {
     builder().name(Paths.get("copyto", "basic")).transtype(PREPROCESS).input(Paths.get("TC2.ditamap")).test();
   }
 
-  @Test
-  public void testconrefmissingfile() throws Throwable {
-    builder()
-      .name(Paths.get("conref", "conrefmissingfile"))
-      .transtype(PREPROCESS)
-      .input(Paths.get("badconref.dita"))
-      .put("validate", "false")
-      .warnCount(1)
-      .errorCount(5)
-      .test();
-  }
-
   @Disabled
   @Test
   public void testcopyto_linktarget() throws Throwable {


### PR DESCRIPTION
## Description
In XSLT and SAX filter transformations early exit if the source file doesn't exist.

## Motivation and Context
Fixes #4383

DITA-OT 4.2 updated Saxon version and Saxon now throws and exception when `EmptySource` is used as source for XSLT transtormation. To prevent this exception, we add a guard clause to check whether source exists before running XSLT transformation. In addition to preventing the exception, this is also an optimization to prevent work that we know will not succeed. 

## How Has This Been Tested?
Existing tests.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


