### PR TITLE
Fix project input URI with escaped characters

### DIFF
--- a/src/main/java/org/dita/dost/ant/UriBasenameTask.java
+++ b/src/main/java/org/dita/dost/ant/UriBasenameTask.java
@@ -7,7 +7,7 @@
  */
 package org.dita.dost.ant;
 
-import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Constants.URI_SEPARATOR;
 
 import java.net.URI;
 import org.apache.tools.ant.BuildException;
@@ -75,7 +75,7 @@ public class UriBasenameTask extends Task {
     if (file == null) {
       throw new BuildException("file attribute required", getLocation());
     }
-    String value = getName(file.toString());
+    String value = getName(file.getPath());
     if (suffix != null && value.endsWith(suffix)) {
       // if the suffix does not starts with a '.' and the
       // char preceding the suffix is a '.', we assume the user

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -81,15 +81,27 @@ See the accompanying LICENSE file for applicable license.
     </dita-ot-fail>
 
     <property name="clean-preprocess.use-result-filename" value="true"/>
-    
-    <basename property="dita.input.filename" file="${args.input}" />
-    <pathconvert property="dita.map.filename.root">
-      <path path="${dita.input.filename}"/>
-      <chainedmapper>
-        <mapper type="flatten"/>
-        <mapper type="regexp" from="^(.+)(\..+?)$$" to="\1"/>
-      </chainedmapper>
-    </pathconvert>
+
+    <local name="input.isFile"/>
+    <condition property="input.isFile" value="true">
+      <available file="${args.input}" type="file"/>
+    </condition>
+    <sequential if:true="${input.isFile}">
+      <basename property="dita.input.filename" file="${args.input}" />
+      <pathconvert property="dita.map.filename.root">
+        <path path="${dita.input.filename}"/>
+        <chainedmapper>
+          <mapper type="flatten"/>
+          <mapper type="regexp" from="^(.+)(\..+?)$$" to="\1"/>
+        </chainedmapper>
+      </pathconvert>
+    </sequential>
+    <sequential unless:true="${input.isFile}">
+      <taskdef name="uriBasenameTask" classname="org.dita.dost.ant.UriBasenameTask"/>
+      <uriBasenameTask property="dita.input.filename" file="${args.input}" />
+      <uriBasenameTask property="dita.map.filename.root" file="${args.input}" suffix=".*"/>
+    </sequential>
+
     <property name="dita.topic.filename.root" value="${dita.map.filename.root}"/>    
     
     <echo level="info" if:true="${legacy-format}">*****************************************************************</echo>

--- a/src/test/java/org/dita/dost/ant/UriBasenameTaskTest.java
+++ b/src/test/java/org/dita/dost/ant/UriBasenameTaskTest.java
@@ -1,18 +1,17 @@
 /*
  * This file is part of the DITA Open Toolkit project.
  *
- * Copyright 2013 Jarno Elovirta
+ * Copyright 2024 Jarno Elovirta
  *
  * See the accompanying LICENSE file for applicable license.
  */
-package org.dita.dost.util;
+package org.dita.dost.ant;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.apache.tools.ant.Project;
-import org.dita.dost.ant.UriBasenameTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +71,14 @@ public class UriBasenameTaskTest {
     basename.setSuffix(".*");
     basename.execute();
     assertEquals("bar", basename.getProject().getProperty("test"));
+  }
+
+  @Test
+  public void testWildcardSuffixWithEscapedCharacters() throws URISyntaxException {
+    basename.setFile(new URI("file:/foo/foo%20bar.baz"));
+    basename.setSuffix(".*");
+    basename.execute();
+    assertEquals("foo bar", basename.getProject().getProperty("test"));
   }
 
   @Test


### PR DESCRIPTION
## Description
Fix defining input file base name without file name extension when input is a URI that contains escaped characters like a space character.

## Motivation and Context
Fixes #4412

## How Has This Been Tested?
Unit test and manual testing.
## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

