### PR TITLE
Handle NPE when filter is not run by returning empty Set

### DIFF
--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -211,6 +211,9 @@ public final class KeyrefPaser extends AbstractXMLFilter {
    * Get set of link targets which have normal processing role. Paths are relative to current file.
    */
   public Set<URI> getNormalProcessingRoleTargets() {
+    if (normalProcessingRoleTargets == null) {
+      return Set.of();
+    }
     return Collections.unmodifiableSet(normalProcessingRoleTargets);
   }
 


### PR DESCRIPTION
## Description
Handle NPE when filter is not run by returning empty Set.

## Motivation and Context
When filter is not ran against any file, the internal set is still null.
## How Has This Been Tested?
Existing tests.
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No user facing change.
