### PR TITLE
Get Resolver via XMLUtils

### DIFF
--- a/src/main/java/org/dita/dost/chunk/ChunkModule.java
+++ b/src/main/java/org/dita/dost/chunk/ChunkModule.java
@@ -298,7 +298,7 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
 
         final String id = nestedTopic.getAttribute(ATTRIBUTE_NAME_ID);
         final Element removedNestedTopic = (Element) topic.removeChild(nestedTopic);
-        final Document doc = xmlUtils.getDocumentBuilder().newDocument();
+        final Document doc = xmlUtils.newDocument();
         final Element adoptedNestedTopic = (Element) doc.adoptNode(removedNestedTopic);
         doc.appendChild(adoptedNestedTopic);
         cascadeNamespaces(adoptedNestedTopic, topic);
@@ -666,7 +666,7 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
     } else {
       final Element navtitle = getNavtitle(rootChunk.topicref());
       if (navtitle != null) {
-        doc = getDocumentBuilder().newDocument();
+        doc = xmlUtils.newDocument();
         final Element ditaWrapper = createDita(doc);
         doc.appendChild(ditaWrapper);
         final Element topic = createTopic(doc, rootChunk.id());
@@ -674,7 +674,7 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
         ditaWrapper.appendChild(topic);
         mergeTopic(rootChunk, rootChunk, topic);
       } else {
-        doc = getDocumentBuilder().newDocument();
+        doc = xmlUtils.newDocument();
         final Element ditaWrapper = createDita(doc);
         doc.appendChild(ditaWrapper);
         mergeTopic(rootChunk, rootChunk, ditaWrapper);

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -61,6 +61,7 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     final ChunkMapReader mapReader = new ChunkMapReader();
     mapReader.setLogger(logger);
     mapReader.setJob(job);
+    mapReader.setXmlUtils(xmlUtils);
     mapReader.supportToNavigation(INDEX_TYPE_ECLIPSEHELP.equals(transtype));
     if (input.getAttribute(ROOT_CHUNK_OVERRIDE) != null) {
       mapReader.setRootChunkOverride(input.getAttribute(ROOT_CHUNK_OVERRIDE));

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -32,7 +32,6 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.commons.io.FileUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
@@ -65,7 +64,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
   private void init(final Map<String, String> input) {
     useResultFilename =
       Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME)).map(Boolean::parseBoolean).orElse(false);
-    final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
+    final Resolver catalogResolver = xmlUtils.getCatalogResolver();
     rewriteTransformer =
       Optional
         .ofNullable(input.get("result.rewrite-rule.xsl"))

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -206,7 +206,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
   private Document serialize(final Collection<FileInfo> fis) throws IOException {
     try {
-      final Document doc = XMLUtils.getDocumentBuilder().newDocument();
+      final Document doc = xmlUtils.newDocument();
       final DOMResult result = new DOMResult(doc);
       XMLStreamWriter out = XMLOutputFactory.newInstance().createXMLStreamWriter(result);
       job.serialize(out, emptyMap(), fis);

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -33,6 +33,7 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
       final ConrefPushReader reader = new ConrefPushReader();
       reader.setLogger(logger);
       reader.setJob(job);
+      reader.setXmlUtils(xmlUtils);
       for (final FileInfo f : fis) {
         final File file = new File(job.tempDirURI.resolve(f.uri));
         logger.info("Reading " + file.toURI());

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -409,7 +409,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
       XMLReader xmlSource = XMLUtils.getXmlReader(ref.format, processingMode).orElse(reader);
       for (final XMLFilter f : getProcessingPipe(currentFile)) {
         f.setParent(xmlSource);
-        f.setEntityResolver(CatalogUtils.getCatalogResolver());
+        f.setEntityResolver(xmlUtils.getCatalogResolver());
         xmlSource = f;
       }
       xmlSource.setContentHandler(nullHandler);

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -105,7 +105,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
     logger.info("Processing " + inputFile.toURI());
     Document doc;
     try {
-      doc = XMLUtils.getDocumentBuilder().newDocument();
+      doc = xmlUtils.newDocument();
       final XsltTransformer transformer = templates.load();
       transformer.setErrorReporter(toErrorReporter(logger));
       transformer.setURIResolver(new ChainedURIResolver(job.getStore(), xmlUtils.getCatalogResolver()));

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -24,7 +24,6 @@ import net.sf.saxon.trans.XPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -109,7 +108,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
       doc = XMLUtils.getDocumentBuilder().newDocument();
       final XsltTransformer transformer = templates.load();
       transformer.setErrorReporter(toErrorReporter(logger));
-      transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
+      transformer.setURIResolver(new ChainedURIResolver(job.getStore(), xmlUtils.getCatalogResolver()));
       transformer.setMessageListener(toMessageListener(logger, processingMode));
 
       transformer.setParameter(new QName("file-being-processed"), XdmItem.makeValue(inputFile.getName()));

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -24,13 +24,9 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.*;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.*;
+import org.dita.dost.util.XMLUtils;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
 
 /**
  * This class reads a list of DITAVAL files, and merges
@@ -98,7 +94,7 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
 
   private void writeMergedDitaval() throws DITAOTException {
     final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
-    ditavalbuilder.setEntityResolver(CatalogUtils.getCatalogResolver());
+    ditavalbuilder.setEntityResolver(xmlUtils.getCatalogResolver());
     XMLStreamWriter export = null;
     try (
       OutputStream exportStream = job

--- a/src/main/java/org/dita/dost/module/MergeDitavalModule.java
+++ b/src/main/java/org/dita/dost/module/MergeDitavalModule.java
@@ -16,7 +16,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -24,9 +23,7 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
-import org.xml.sax.SAXException;
 
 /**
  * This class reads a list of DITAVAL files, and merges
@@ -93,8 +90,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
   }
 
   private void writeMergedDitaval() throws DITAOTException {
-    final DocumentBuilder ditavalbuilder = XMLUtils.getDocumentBuilder();
-    ditavalbuilder.setEntityResolver(xmlUtils.getCatalogResolver());
     XMLStreamWriter export = null;
     try (
       OutputStream exportStream = job
@@ -106,10 +101,10 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
       export.writeStartElement("val");
       export.writeNamespace(DITA_OT_NS_PREFIX, DITA_OT_NAMESPACE);
       for (File curDitaVal : ditavalFiles) {
-        final Document doc = ditavalbuilder.parse(curDitaVal);
+        final Document doc = job.getStore().getDocument(curDitaVal.toURI());
         final Element ditavalRoot = doc.getDocumentElement();
         final NodeList rootChildren = ditavalRoot.getChildNodes();
-        logger.debug("Writing conditions from ditaval: " + curDitaVal);
+        logger.debug("Writing conditions from ditaval: {}", curDitaVal);
         writeConditions(export, rootChildren, curDitaVal.toURI().resolve("."));
       }
       export.writeEndElement();
@@ -118,8 +113,6 @@ public final class MergeDitavalModule extends AbstractPipelineModuleImpl {
       throw new DITAOTException("Failed to merge ditaval files: " + e.getMessage(), e);
     } catch (final XMLStreamException e) {
       throw new DITAOTException("Failed to serialize merged ditaval file: " + e.getMessage(), e);
-    } catch (final SAXException e) {
-      throw new DITAOTException("Failed to parse ditaval file: " + e.getMessage(), e);
     } finally {
       if (export != null) {
         try {

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -73,7 +73,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
       transformer.setParameter(new QName("INPUTMAP"), XdmItem.makeValue(job.getInputMap()));
 
       final Source source = job.getStore().getSource(inputFile.toURI());
-      doc = XMLUtils.getDocumentBuilder().newDocument();
+      doc = xmlUtils.newDocument();
       final DOMDestination result = new DOMDestination(doc);
 
       transformer.setSource(source);

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -24,7 +24,6 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.XMLUtils;
@@ -62,7 +61,7 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
 
       final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(styleFile)).load();
       transformer.setErrorReporter(toErrorReporter(logger));
-      transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
+      transformer.setURIResolver(new ChainedURIResolver(job.getStore(), xmlUtils.getCatalogResolver()));
       transformer.setMessageListener(toMessageListener(logger, processingMode));
 
       if (input.getAttribute("include.rellinks") != null) {

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -192,6 +192,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
     final MapMetaReader metaReader = new MapMetaReader();
     metaReader.setLogger(logger);
     metaReader.setJob(job);
+    metaReader.setXmlUtils(xmlUtils);
     for (final FileInfo f : fis) {
       final File mapFile = job.tempDir.toPath().resolve(f.file.toPath()).toFile();
       //FIXME: this reader gets the parent path of input file

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -28,7 +28,6 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MapMetaReader;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.writer.DitaMapMetaWriter;
@@ -91,7 +90,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
       try {
         final XsltTransformer transformer = xsltExecutable.load();
         transformer.setErrorReporter(toErrorReporter(logger));
-        transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
+        transformer.setURIResolver(new ChainedURIResolver(job.getStore(), xmlUtils.getCatalogResolver()));
         transformer.setMessageListener(toMessageListener(logger, processingMode));
 
         for (Entry<String, String> e : input.getAttributes().entrySet()) {

--- a/src/main/java/org/dita/dost/module/SourceReaderModule.java
+++ b/src/main/java/org/dita/dost/module/SourceReaderModule.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import net.sf.saxon.s9api.Processor;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.dita.dost.reader.GrammarPoolManager;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.xml.sax.*;
@@ -98,7 +97,7 @@ public abstract class SourceReaderModule extends AbstractPipelineModuleImpl {
       }
     }
 
-    final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
+    final Resolver catalogResolver = xmlUtils.getCatalogResolver();
     reader.setEntityResolver(catalogResolver);
 
     processor = xmlUtils.getProcessor();

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -25,7 +25,6 @@ import org.dita.dost.log.MessageUtils;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.reader.MergeMapParser;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job.FileInfo;
 
@@ -113,7 +112,7 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
         final XsltCompiler xsltCompiler = processor.newXsltCompiler();
         final XsltTransformer transformer = xsltCompiler.compile(new StreamSource(style)).load();
         transformer.setErrorReporter(toErrorReporter(logger));
-        transformer.setURIResolver(new ChainedURIResolver(job.getStore(), CatalogUtils.getCatalogResolver()));
+        transformer.setURIResolver(new ChainedURIResolver(job.getStore(), xmlUtils.getCatalogResolver()));
         transformer.setMessageListener(toMessageListener(logger, processingMode));
 
         final StreamSource source = new StreamSource(new ByteArrayInputStream(midBuffer.toByteArray()));

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import javax.xml.transform.Source;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
@@ -31,7 +30,6 @@ import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.exception.UncheckedDITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineInput;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job;
 import org.xmlresolver.Resolver;
@@ -71,7 +69,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
 
   private void init() {
     if (catalog == null) {
-      final Resolver catalogResolver = CatalogUtils.getCatalogResolver();
+      final Resolver catalogResolver = xmlUtils.getCatalogResolver();
       catalog = catalogResolver;
     }
     uriResolver = new ChainedURIResolver(job.getStore(), catalog);

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -233,7 +233,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
           logger.warn("Failed to set Xerces grammar pool for parser: " + e.getMessage());
         }
       }
-      reader.setEntityResolver(CatalogUtils.getCatalogResolver());
+      reader.setEntityResolver(xmlUtils.getCatalogResolver());
     } catch (SAXException e) {
       throw new DITAOTException(e);
     }
@@ -386,7 +386,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       XMLReader xmlSource = parser;
       for (final XMLFilter f : getProcessingPipe(currentFile)) {
         f.setParent(xmlSource);
-        f.setEntityResolver(CatalogUtils.getCatalogResolver());
+        f.setEntityResolver(xmlUtils.getCatalogResolver());
         f.setErrorHandler(errorHandler);
         xmlSource = f;
       }

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -926,8 +926,10 @@ public final class Integrator {
       return null;
     }
     try {
-      return XMLUtils.getDocumentBuilder().parse(plugins);
-    } catch (SAXException | IOException e) {
+      final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      return factory.newDocumentBuilder().parse(plugins);
+    } catch (ParserConfigurationException | SAXException | IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.*;
 import javax.xml.stream.events.XMLEvent;
@@ -163,7 +165,13 @@ public final class Integrator {
       }
     );
     parser = new PluginParser(ditaDir);
-    pluginsDoc = XMLUtils.getDocumentBuilder().newDocument();
+    try {
+      final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      pluginsDoc = factory.newDocumentBuilder().newDocument();
+    } catch (ParserConfigurationException e) {
+      throw new RuntimeException("Failed to initialize XML parser: " + e.getMessage(), e);
+    }
 
     pluginList = getPluginIds(readPlugins());
   }

--- a/src/main/java/org/dita/dost/platform/PluginParser.java
+++ b/src/main/java/org/dita/dost/platform/PluginParser.java
@@ -15,8 +15,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.dita.dost.log.DITAOTLogger;
-import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -69,7 +70,13 @@ public class PluginParser {
     super();
     assert ditaDir.isAbsolute();
     this.ditaDir = ditaDir;
-    builder = XMLUtils.getDocumentBuilder();
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newDefaultInstance();
+    factory.setNamespaceAware(true);
+    try {
+      builder = factory.newDocumentBuilder();
+    } catch (ParserConfigurationException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public void setLogger(final DITAOTLogger logger) {

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -32,11 +32,8 @@ import org.dita.dost.log.MessageUtils;
 import org.dita.dost.module.ChunkModule.ChunkFilenameGenerator;
 import org.dita.dost.module.ChunkModule.ChunkFilenameGeneratorFactory;
 import org.dita.dost.module.reader.TempFileNameScheme;
-import org.dita.dost.util.DitaClass;
-import org.dita.dost.util.Job;
+import org.dita.dost.util.*;
 import org.dita.dost.util.Job.FileInfo;
-import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLSerializer;
 import org.dita.dost.writer.AbstractDomFilter;
 import org.dita.dost.writer.ChunkTopicParser;
 import org.dita.dost.writer.SeparateChunkTopicParser;
@@ -61,6 +58,8 @@ public final class ChunkMapReader extends AbstractDomFilter {
   public static final String CHUNK_TO_CONTENT = "to-content";
   public static final String CHUNK_TO_NAVIGATION = "to-navigation";
   public static final String CHUNK_PREFIX = "Chunk";
+
+  private XMLUtils xmlUtils;
 
   private TempFileNameScheme tempFileNameScheme;
   private Collection<String> rootChunkOverride;
@@ -90,6 +89,10 @@ public final class ChunkMapReader extends AbstractDomFilter {
       throw new RuntimeException(e);
     }
     tempFileNameScheme.setBaseDir(job.getInputDir());
+  }
+
+  public void setXmlUtils(final XMLUtils xmlUtils) {
+    this.xmlUtils = xmlUtils;
   }
 
   public void setRootChunkOverride(final String chunkValue) {
@@ -290,7 +293,7 @@ public final class ChunkMapReader extends AbstractDomFilter {
   }
 
   private Document buildOutputDocument(final Element root) {
-    final Document doc = getDocumentBuilder().newDocument();
+    final Document doc = xmlUtils.newDocument();
     if (workdir != null) {
       doc.appendChild(doc.importNode(workdir, true));
     }

--- a/src/main/java/org/dita/dost/reader/ConrefPushReader.java
+++ b/src/main/java/org/dita/dost/reader/ConrefPushReader.java
@@ -36,7 +36,7 @@ public final class ConrefPushReader extends AbstractXMLReader {
   /** push table.*/
   private final Hashtable<File, Hashtable<MoveKey, DocumentFragment>> pushtable;
   /** Document used to construct push table DocumentFragments. */
-  private final Document pushDocument;
+  private Document pushDocument;
 
   /**keep the file path of current file under parse
     filePath is useful to get the absolute path of the target file.*/
@@ -109,8 +109,10 @@ public final class ConrefPushReader extends AbstractXMLReader {
    */
   public ConrefPushReader() {
     pushtable = new Hashtable<>();
+  }
 
-    pushDocument = XMLUtils.getDocumentBuilder().newDocument();
+  public void setXmlUtils(XMLUtils xmlUtils) {
+    pushDocument = xmlUtils.newDocument();
   }
 
   @Override

--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -72,7 +72,7 @@ public final class KeyrefReader implements AbstractReader {
 
   private DITAOTLogger logger;
   private Job job;
-  private final DocumentBuilder builder;
+  private DocumentBuilder builder;
   private KeyScope rootScope;
   private URI currentFile;
   private XMLUtils xmlUtils;
@@ -80,9 +80,7 @@ public final class KeyrefReader implements AbstractReader {
   /**
    * Constructor.
    */
-  public KeyrefReader() {
-    builder = XMLUtils.getDocumentBuilder();
-  }
+  public KeyrefReader() {}
 
   @Override
   public void read(final File filename) {
@@ -101,6 +99,7 @@ public final class KeyrefReader implements AbstractReader {
 
   public void setXmlUtils(XMLUtils xmlUtils) {
     this.xmlUtils = xmlUtils;
+    builder = xmlUtils.getDocumentBuilder();
   }
 
   /**

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -104,7 +104,7 @@ public final class MapMetaReader extends AbstractDomFilter {
   /** Current document. */
   private Document doc = null;
   /** Result metadata document. */
-  private final Document resultDoc;
+  private Document resultDoc;
   /** Current file. */
   private URI filePath;
 
@@ -114,7 +114,10 @@ public final class MapMetaReader extends AbstractDomFilter {
   public MapMetaReader() {
     super();
     globalMeta = new HashMap<>(16);
-    resultDoc = XMLUtils.getDocumentBuilder().newDocument();
+  }
+
+  public void setXmlUtils(XMLUtils xmlUtils) {
+    resultDoc = xmlUtils.newDocument();
   }
 
   /**

--- a/src/main/java/org/dita/dost/store/CacheStore.java
+++ b/src/main/java/org/dita/dost/store/CacheStore.java
@@ -163,7 +163,7 @@ public class CacheStore extends AbstractStore implements Store {
           return doc;
         } else if (entry.bytes != null) {
           try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
-            final Document doc = XMLUtils.getDocumentBuilder().parse(in, f.toString());
+            final Document doc = xmlUtils.getDocumentBuilder().parse(in, f.toString());
             put(f, new Entry(doc, null, entry.bytes));
             return doc;
           } catch (SAXException e) {
@@ -224,7 +224,7 @@ public class CacheStore extends AbstractStore implements Store {
           try (InputStream in = new ByteArrayInputStream(entry.bytes)) {
             final InputSource inputSource = new InputSource(in);
             inputSource.setSystemId(f.toString());
-            final Document doc = XMLUtils.getDocumentBuilder().parse(inputSource);
+            final Document doc = xmlUtils.getDocumentBuilder().parse(inputSource);
             put(f, new Entry(doc, entry.node, entry.bytes));
             return doc;
           } catch (SAXException e) {

--- a/src/main/java/org/dita/dost/store/StreamStore.java
+++ b/src/main/java/org/dita/dost/store/StreamStore.java
@@ -68,7 +68,7 @@ public class StreamStore extends AbstractStore implements Store {
   public Document getDocument(final URI path) throws IOException {
     if (LOG) System.err.println("  getDocument:" + path);
     try {
-      return XMLUtils.getDocumentBuilder().parse(path.toString());
+      return xmlUtils.getDocumentBuilder().parse(path.toString());
     } catch (final Exception e) {
       throw new IOException("Failed to read document: " + e.getMessage(), e);
     }

--- a/src/main/java/org/dita/dost/util/CatalogUtils.java
+++ b/src/main/java/org/dita/dost/util/CatalogUtils.java
@@ -11,6 +11,7 @@ package org.dita.dost.util;
 import static org.dita.dost.util.Constants.FILE_NAME_CATALOG;
 
 import java.io.File;
+import org.xml.sax.InputSource;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.XMLResolverConfiguration;
@@ -66,7 +67,7 @@ public final class CatalogUtils {
       config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
       config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
       config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
-      config.addCatalog(catalogFilePath.toURI().toASCIIString());
+      config.addCatalog(catalogFilePath.toURI(), new InputSource(catalogFilePath.toURI().toString()));
       catalogResolver = new Resolver(config);
     }
 

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -976,7 +976,7 @@ public final class XMLUtils {
     if (Configuration.DEBUG) {
       builder = new DebugDocumentBuilder(builder);
     }
-    builder.setEntityResolver(CatalogUtils.getCatalogResolver());
+    builder.setEntityResolver(catalogResolver);
     return builder;
   }
 

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -966,7 +966,7 @@ public final class XMLUtils {
    * @return DOM document builder instance.
    * @throws RuntimeException if instantiating DocumentBuilder failed
    */
-  public static DocumentBuilder getDocumentBuilder() {
+  public DocumentBuilder getDocumentBuilder() {
     DocumentBuilder builder;
     try {
       builder = factory.newDocumentBuilder();

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -981,6 +981,20 @@ public final class XMLUtils {
   }
 
   /**
+   * Create new DOM document.
+   *
+   * @return empty DOM document
+   * @throws RuntimeException if instantiating DocumentBuilder failed
+   */
+  public Document newDocument() {
+    try {
+      return factory.newDocumentBuilder().newDocument();
+    } catch (final ParserConfigurationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Write DOM document to file.
    *
    * @param doc document to store
@@ -1410,7 +1424,7 @@ public final class XMLUtils {
    */
   public Document cloneDocument(final XdmNode node) throws IOException {
     try {
-      final Document doc = XMLUtils.getDocumentBuilder().newDocument();
+      final Document doc = newDocument();
       final DOMDestination destination = new DOMDestination(doc);
       final Receiver receiver = destination.getReceiver(
         getProcessor().getUnderlyingConfiguration().makePipelineConfiguration(),

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -168,6 +168,10 @@ public final class XMLUtils {
     this.logger = logger;
   }
 
+  public Resolver getCatalogResolver() {
+    return catalogResolver;
+  }
+
   /**
    * Convert DOM NodeList to List.
    */

--- a/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/ConvertLang.java
+++ b/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/ConvertLang.java
@@ -7,28 +7,16 @@
  */
 package org.dita.dost.ant;
 
-import static org.apache.commons.io.FileUtils.*;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.io.FileUtils.moveFile;
 import static org.dita.dost.util.Constants.*;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.dita.dost.log.DITAOTAntLogger;
@@ -83,6 +71,7 @@ public final class ConvertLang extends Task {
   private String exceptionCharset;
 
   private DITAOTLogger logger;
+  private XMLUtils xmlUtils;
 
   /**
    * Executes the Ant task.
@@ -137,7 +126,7 @@ public final class ConvertLang extends Task {
 
   private void createCharsetMap() {
     try (InputStream in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/util/codepages.xml")) {
-      final DocumentBuilder builder = XMLUtils.getDocumentBuilder();
+      final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
       final Document doc = builder.parse(in);
       final Element root = doc.getDocumentElement();
       final NodeList childNodes = root.getChildNodes();

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/MultilanguagePreprocessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/MultilanguagePreprocessor.java
@@ -4,7 +4,6 @@ import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilder;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
 
@@ -46,6 +45,7 @@ public class MultilanguagePreprocessor {
   private static final String CHAR_SET = "char-set";
 
   private final Configuration configuration;
+  private XMLUtils xmlUtils;
 
   public MultilanguagePreprocessor(final Configuration theTheConfiguration) {
     if (null == theTheConfiguration) {
@@ -54,10 +54,12 @@ public class MultilanguagePreprocessor {
     this.configuration = theTheConfiguration;
   }
 
-  public Document process(final Document theInput) throws ProcessException {
-    final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
+  public void setXmlUtils(XMLUtils xmlUtils) {
+    this.xmlUtils = xmlUtils;
+  }
 
-    final Document doc = documentBuilder.newDocument();
+  public Document process(final Document theInput) throws ProcessException {
+    final Document doc = xmlUtils.newDocument();
 
     final Node rootElement = theInput.getDocumentElement();
 

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/PreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/PreprocessorTask.java
@@ -1,7 +1,6 @@
 package com.idiominc.ws.opentopic.fo.i18n;
 
-import static org.dita.dost.util.Constants.ANT_REFERENCE_JOB;
-import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
+import static org.dita.dost.util.Constants.*;
 
 import java.io.File;
 import java.net.URI;
@@ -16,7 +15,6 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.XMLCatalog;
 import org.dita.dost.ant.XMLCatalogAdapter;
-import org.dita.dost.util.CatalogUtils;
 import org.dita.dost.util.ChainedURIResolver;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
@@ -82,7 +80,7 @@ public class PreprocessorTask extends Task {
         final XsltCompiler xsltCompiler = xmlUtils.getProcessor().newXsltCompiler();
         final URIResolver catalogResolver = xmlcatalog != null
           ? new XMLCatalogAdapter(xmlcatalog)
-          : CatalogUtils.getCatalogResolver();
+          : xmlUtils.getCatalogResolver();
         final URIResolver resolver = new ChainedURIResolver(job.getStore(), catalogResolver);
         xsltCompiler.setURIResolver(resolver);
         final XsltExecutable compile = xsltCompiler.compile(job.getStore().getSource(style));

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/PreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/i18n/PreprocessorTask.java
@@ -1,6 +1,7 @@
 package com.idiominc.ws.opentopic.fo.i18n;
 
-import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Constants.ANT_REFERENCE_JOB;
+import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
 
 import java.io.File;
 import java.net.URI;
@@ -57,22 +58,24 @@ public class PreprocessorTask extends Task {
   private URI output = null;
   private URI style = null;
   private XMLCatalog xmlcatalog;
+  private XMLUtils xmlUtils;
 
   @Override
   public void execute() throws BuildException {
     final Job job = getProject().getReference(ANT_REFERENCE_JOB);
-    final XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
+    xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
 
     checkParameters();
 
     log("Processing " + input + " to " + output, Project.MSG_INFO);
     try {
-      final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
+      final DocumentBuilder documentBuilder = xmlUtils.getDocumentBuilder();
       documentBuilder.setEntityResolver(xmlcatalog);
 
       final Document doc = job.getStore().getDocument(input);
       final Document conf = documentBuilder.parse(config);
       final MultilanguagePreprocessor preprocessor = new MultilanguagePreprocessor(new Configuration(conf));
+      preprocessor.setXmlUtils(xmlUtils);
       final Document document = preprocessor.process(doc);
 
       if (style != null) {

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessor.java
@@ -7,7 +7,6 @@ import com.idiominc.ws.opentopic.fo.index2.configuration.IndexConfiguration;
 import com.idiominc.ws.opentopic.fo.index2.util.IndexDitaProcessor;
 import com.idiominc.ws.opentopic.fo.index2.util.IndexStringProcessor;
 import java.util.*;
-import javax.xml.parsers.DocumentBuilder;
 import org.dita.dost.log.DITAOTLogger;
 import org.dita.dost.util.XMLUtils;
 import org.w3c.dom.*;
@@ -58,6 +57,7 @@ public final class IndexPreprocessor {
   private final IndexGroupProcessor indexGroupProcessor;
   private boolean includeDraft = false;
   private DITAOTLogger logger;
+  private XMLUtils xmlUtils;
   private static final String elIndexRangeStartName = "start";
   private static final String elIndexRangeEndName = "end";
   private static final String hashPrefix = "indexid";
@@ -84,6 +84,10 @@ public final class IndexPreprocessor {
     indexGroupProcessor.setLogger(logger);
   }
 
+  public void setXmlUtils(final XMLUtils xmlUtils) {
+    this.xmlUtils = xmlUtils;
+  }
+
   /**
    * Process index terms.
    *
@@ -92,8 +96,7 @@ public final class IndexPreprocessor {
    * @throws ProcessException if processing index terms failed
    */
   public IndexPreprocessResult process(final Document theInput) throws ProcessException {
-    final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
-    final Document doc = documentBuilder.newDocument();
+    final Document doc = xmlUtils.newDocument();
 
     final Node rootElement = theInput.getDocumentElement();
 

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
@@ -1,6 +1,7 @@
 package com.idiominc.ws.opentopic.fo.index2;
 
-import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
+import static org.dita.dost.util.Constants.ARGS_DRAFT_NO;
 
 import com.idiominc.ws.opentopic.fo.index2.configuration.IndexConfiguration;
 import java.io.FileOutputStream;
@@ -76,13 +77,16 @@ public class IndexPreprocessorTask extends Task {
   public void execute() throws BuildException {
     checkParameters();
 
+    final XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
+
     try {
-      final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
+      final DocumentBuilder documentBuilder = xmlUtils.getDocumentBuilder();
       documentBuilder.setEntityResolver(xmlcatalog);
 
       final Document doc = documentBuilder.parse(input);
       final IndexPreprocessor preprocessor = new IndexPreprocessor(prefix, namespace_url, this.draft);
       preprocessor.setLogger(new DITAOTAntLogger(getProject()));
+      preprocessor.setXmlUtils(xmlUtils);
 
       // Walks through source document and builds an array of IndexEntry and builds
       // new Document with pre-processed index entries included.

--- a/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/org/dita/dost/pdf2/VariableFileTask.java
@@ -8,6 +8,7 @@
 package org.dita.dost.pdf2;
 
 import static javax.xml.XMLConstants.XML_NS_URI;
+import static org.dita.dost.util.Constants.ANT_REFERENCE_XML_UTILS;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +44,12 @@ public final class VariableFileTask extends Task {
 
   @Override
   public void execute() throws BuildException {
+    XMLUtils xmlUtils = getProject().getReference(ANT_REFERENCE_XML_UTILS);
+    if (xmlUtils == null) {
+      getProject().log("XML utils not found from Ant project reference", Project.MSG_ERR);
+      xmlUtils = new XMLUtils();
+    }
+
     final List<File> files = new ArrayList<>();
     for (final FileSet fs : filesets) {
       final DirectoryScanner ds = fs.getDirectoryScanner(getProject());
@@ -59,7 +66,7 @@ public final class VariableFileTask extends Task {
 
     OutputStream out = null;
     try {
-      final Document d = XMLUtils.getDocumentBuilder().parse(strings);
+      final Document d = xmlUtils.getDocumentBuilder().parse(strings);
       final Element root = d.getDocumentElement();
 
       final NodeList nl = root.getElementsByTagName("lang");
@@ -85,7 +92,7 @@ public final class VariableFileTask extends Task {
         root.appendChild(lang);
       }
 
-      new XMLUtils().writeDocument(d, file);
+      xmlUtils.writeDocument(d, file);
     } catch (final SAXException | IOException e) {
       throw new BuildException("Failed to write output file: " + e.getMessage(), e);
     } finally {

--- a/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
+++ b/src/test/java/org/dita/dost/module/ChunkMapReaderTest.java
@@ -1124,6 +1124,7 @@ public class ChunkMapReaderTest {
       mapReader.setLogger(logger);
       final Job job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
       mapReader.setJob(job);
+      mapReader.setXmlUtils(new XMLUtils());
       mapReader.supportToNavigation(false);
 
       final URI path = job.getInputMap();

--- a/src/test/java/org/dita/dost/module/MergeDitavalModuleTest.java
+++ b/src/test/java/org/dita/dost/module/MergeDitavalModuleTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2024 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.module;
+
+import static org.dita.dost.TestUtils.assertXMLEqual;
+import static org.dita.dost.util.Constants.ANT_INVOKER_PARAM_DITAVAL;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Map;
+import javax.xml.parsers.ParserConfigurationException;
+import org.dita.dost.TestUtils;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.store.StreamStore;
+import org.dita.dost.util.Job;
+import org.dita.dost.util.XMLUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+class MergeDitavalModuleTest {
+
+  @TempDir
+  private File tempDir;
+
+  private MergeDitavalModule module;
+  private Job job;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    module = new MergeDitavalModule();
+    module.setLogger(new TestUtils.TestLogger());
+    job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+    module.setJob(job);
+  }
+
+  @Test
+  public void test_single()
+    throws DITAOTException, URISyntaxException, ParserConfigurationException, IOException, SAXException {
+    final Map<String, String> input = Map.of(
+      ANT_INVOKER_PARAM_DITAVAL,
+      Paths.get(getClass().getResource("/MergeDitavalModuleTest/src/base.ditaval").toURI()).toString()
+    );
+
+    module.execute(input);
+
+    assertXMLEqual(
+      new InputSource(getClass().getResource("/MergeDitavalModuleTest/exp/base.ditaval").toString()),
+      new InputSource(new File(job.getProperty("dita.input.valfile")).toURI().toString())
+    );
+  }
+
+  @Test
+  public void test_combine() throws DITAOTException, URISyntaxException {
+    final Map<String, String> input = Map.of(
+      ANT_INVOKER_PARAM_DITAVAL,
+      Paths.get(getClass().getResource("/MergeDitavalModuleTest/src/override.ditaval").toURI()) +
+      File.pathSeparator +
+      Paths.get(getClass().getResource("/MergeDitavalModuleTest/src/base.ditaval").toURI())
+    );
+
+    module.execute(input);
+
+    assertXMLEqual(
+      new InputSource(getClass().getResource("/MergeDitavalModuleTest/exp/override.ditaval").toString()),
+      new InputSource(new File(job.getProperty("dita.input.valfile")).toURI().toString())
+    );
+  }
+}

--- a/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
@@ -50,6 +50,7 @@ public class MapReaderModuleTest {
   public void setUp() {
     reader = new MapReaderModule();
     reader.setLogger(new TestUtils.TestLogger());
+    reader.setXmlUtils(new XMLUtils());
   }
 
   public static Stream<Arguments> data() {

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -53,7 +53,9 @@ public class TopicReaderModuleTest {
   public void setUp() throws SAXException, IOException, DITAOTException {
     reader = new TopicReaderModule();
     reader.setLogger(new TestUtils.TestLogger());
-    job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
+    final XMLUtils xmlUtils = new XMLUtils();
+    reader.setXmlUtils(xmlUtils);
+    job = new Job(tempDir, new StreamStore(tempDir, xmlUtils));
     job.setInputFile(ditamap);
     job.setInputMap(root.relativize(ditamap));
     job.setInputDir(root);

--- a/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
@@ -65,7 +65,9 @@ public class MapMetaReaderTest {
 
     reader = new MapMetaReader();
     reader.setLogger(new TestUtils.TestLogger());
-    reader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
+    final XMLUtils xmlUtils = new XMLUtils();
+    reader.setJob(new Job(tempDir, new StreamStore(tempDir, xmlUtils)));
+    reader.setXmlUtils(xmlUtils);
 
     db = XMLUtils.getDocumentBuilder();
     db.setEntityResolver(CatalogUtils.getCatalogResolver());

--- a/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
+++ b/src/test/java/org/dita/dost/reader/MapMetaReaderTest.java
@@ -69,8 +69,7 @@ public class MapMetaReaderTest {
     reader.setJob(new Job(tempDir, new StreamStore(tempDir, xmlUtils)));
     reader.setXmlUtils(xmlUtils);
 
-    db = XMLUtils.getDocumentBuilder();
-    db.setEntityResolver(CatalogUtils.getCatalogResolver());
+    db = xmlUtils.getDocumentBuilder();
   }
 
   @ParameterizedTest

--- a/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
+++ b/src/test/java/org/dita/dost/reader/TestConrefPushReader.java
@@ -51,7 +51,9 @@ public class TestConrefPushReader {
   public void testRead() throws IOException {
     final File filename = new File(srcDir, "conrefpush_stub.xml");
     final ConrefPushReader pushReader = new ConrefPushReader();
-    pushReader.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
+    final XMLUtils xmlUtils = new XMLUtils();
+    pushReader.setJob(new Job(tempDir, new StreamStore(tempDir, xmlUtils)));
+    pushReader.setXmlUtils(xmlUtils);
     pushReader.read(filename.getAbsoluteFile());
 
     final Map<File, Hashtable<MoveKey, DocumentFragment>> pushSet = pushReader.getPushMap();

--- a/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
+++ b/src/test/java/org/dita/dost/reader/TestKeyrefReader.java
@@ -180,9 +180,9 @@ public class TestKeyrefReader {
     }
   }
 
-  private static Document keyDefToDoc(final String key) throws Exception {
+  private Document keyDefToDoc(final String key) throws Exception {
     final InputSource inputSource = new InputSource(new StringReader(key));
-    final DocumentBuilder documentBuilder = XMLUtils.getDocumentBuilder();
+    final DocumentBuilder documentBuilder = xmlUtils.getDocumentBuilder();
     return documentBuilder.parse(inputSource);
   }
 

--- a/src/test/java/org/dita/dost/store/StreamStoreTest.java
+++ b/src/test/java/org/dita/dost/store/StreamStoreTest.java
@@ -44,7 +44,7 @@ public class StreamStoreTest {
 
   @Test
   public void getSerializer_subDirectory() throws IOException, SaxonApiException {
-    final Document doc = XMLUtils.getDocumentBuilder().newDocument();
+    final Document doc = xmlUtils.newDocument();
     doc.appendChild(doc.createElement("foo"));
     final XdmNode source = xmlUtils.getProcessor().newDocumentBuilder().wrap(doc);
 

--- a/src/test/resources/MergeDitavalModuleTest/exp/base.ditaval
+++ b/src/test/resources/MergeDitavalModuleTest/exp/base.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="audience" val="novice"/>
+  <prop action="include" att="audience" val="intermediate"/>
+  <prop action="exclude"/>
+</val>

--- a/src/test/resources/MergeDitavalModuleTest/exp/override.ditaval
+++ b/src/test/resources/MergeDitavalModuleTest/exp/override.ditaval
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="exclude" att="audience" val="intermediate"/>
+  <prop action="include" att="audience" val="novice"/>
+  <prop action="include" att="audience" val="intermediate"/>
+  <prop action="exclude"/>
+</val>

--- a/src/test/resources/MergeDitavalModuleTest/src/base.ditaval
+++ b/src/test/resources/MergeDitavalModuleTest/src/base.ditaval
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="include" att="audience" val="novice"/>
+  <prop action="include" att="audience" val="intermediate"/>
+  <prop action="exclude"/>
+</val>

--- a/src/test/resources/MergeDitavalModuleTest/src/override.ditaval
+++ b/src/test/resources/MergeDitavalModuleTest/src/override.ditaval
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop action="exclude" att="audience" val="intermediate"/>
+</val>


### PR DESCRIPTION
## Description
Change how Resolver is accessed. Instead of CatalogUtils, use XMLUtils to get Resolver instance.

## Motivation and Context
Simplify code by moving parsing related code to XMLUtils.

## How Has This Been Tested?
Existing test.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No need of end-user documentation.