### PR TITLE
#4475 ignore submaps and resource-only references when processing chunks

### DIFF
--- a/src/main/java/org/dita/dost/chunk/ChunkModule.java
+++ b/src/main/java/org/dita/dost/chunk/ChunkModule.java
@@ -459,10 +459,10 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
   private void rewriteTopicrefs(final URI mapFile, final List<ChunkOperation> chunks) {
     for (ChunkOperation chunk : chunks) {
       final URI dst = getRelativePath(mapFile.resolve("."), chunk.dst());
-      if (!MAP_MAP.matches(chunk.topicref())) {
+      if (!MAP_MAP.matches(chunk.topicref()) && !SUBMAP.matches(chunk.topicref())) {
         chunk.topicref().setAttribute(ATTRIBUTE_NAME_HREF, dst.toString());
       }
-      if (MAPGROUP_D_TOPICGROUP.matches(chunk.topicref())) {
+      if (MAPGROUP_D_TOPICGROUP.matches(chunk.topicref()) && !SUBMAP.matches(chunk.topicref())) {
         chunk.topicref().setAttribute(ATTRIBUTE_NAME_CLASS, MAP_TOPICREF.toString());
       }
       rewriteTopicrefs(mapFile, chunk.children());
@@ -710,7 +710,11 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
     throws IOException {
     for (ChunkOperation child : chunk.children()) {
       Element added;
-      if (child.src() != null) {
+      if (
+        !isDitaFormat(child.topicref()) || !isNormalProcessRole(child.topicref()) || SUBMAP.matches(child.topicref())
+      ) {
+        mergeTopic(rootChunk, child, dstTopic);
+      } else if (child.src() != null) {
         final Element root = getElement(child.src());
         if (root.getNodeName().equals(ELEMENT_NAME_DITA)) {
           final List<Element> rootTopics = getChildElements(root, TOPIC_TOPIC);

--- a/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
+++ b/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
@@ -63,7 +63,8 @@ public class ChunkModuleTest extends AbstractModuleTest {
       Arguments.of("split-map", Collections.emptyMap(), 0),
       Arguments.of("chunk-combine-within-split", Collections.emptyMap(), 0),
       Arguments.of("managing-links", Collections.emptyMap(), 0),
-      Arguments.of("managing-links-duplicates", Collections.emptyMap(), 0)
+      Arguments.of("managing-links-duplicates", Collections.emptyMap(), 0),
+      Arguments.of("combine-bookmap", Collections.emptyMap(), 0)
     );
   }
 

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/.job.xml
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/.job.xml
@@ -1,0 +1,10 @@
+<job>
+    <property name="user.input.dir.uri">
+        <string>file:/</string>
+    </property>
+    <files>
+        <file src="file:/guide.bookmap" uri="guide.bookmap" path="guide.bookmap" format="ditamap" input="true"/>
+        <file src="file:/map.ditamap" uri="map.ditamap" path="map.ditamap" format="ditamap" input="true"/>
+        <file uri="guide.dita" format="dita"/>
+    </files>
+</job>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/guide.bookmap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/guide.bookmap
@@ -1,0 +1,17 @@
+<bookmap xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+         class="- map/map bookmap/bookmap "
+         ditaarch:DITAArchVersion="2.0">
+    <booktitle class="- topic/title bookmap/booktitle ">
+        <mainbooktitle class="- topic/ph bookmap/mainbooktitle ">Guide</mainbooktitle>
+    </booktitle>
+    <part class="- map/topicref bookmap/part ">
+        <keydef href="guide.dita#topic_resource" keys="lib" class="+ map/topicref mapgroup-d/keydef " processing-role="resource-only"/>
+        <submap xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" dita-ot:orig-class="+ map/topicref mapgroup-d/mapref "
+                dita-ot:orig-format="ditamap" dita-ot:orig-href="map.ditamap" class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap " dita-ot:submap-id="map">
+            <submap-topicmeta class="+ map/topicmeta ditaot-d/submap-topicmeta ">
+                <submap-title class="+ topic/navtitle ditaot-d/submap-title " dita-ot:submap-class="- topic/title ">Map</submap-title>
+            </submap-topicmeta>
+            <topicref class="- map/topicref " href="guide.dita#topic_content"/>
+        </submap>
+    </part>
+</bookmap>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/guide.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine-bookmap/guide.dita
@@ -1,0 +1,11 @@
+<dita xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="2.0">
+    <topic class="- topic/topic " id="topic_content" ditaarch:DITAArchVersion="2.0">
+        <title class="- topic/title ">Topic</title>
+        <body class="- topic/body ">
+            <p class="- topic/p ">Topic content</p>
+            <p class="- topic/p ">
+                <ph class="- topic/ph ">RESOLVED KEY</ph>
+            </p>
+        </body>
+    </topic>
+</dita>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/.job.xml
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/.job.xml
@@ -1,0 +1,11 @@
+<job>
+    <property name="user.input.dir.uri">
+        <string>file:/</string>
+    </property>
+    <files>
+        <file src="file:/guide.bookmap" uri="guide.bookmap" path="guide.bookmap" format="ditamap" input="true"/>
+        <file src="file:/map.ditamap" uri="map.ditamap" path="map.ditamap" format="ditamap" input="true"/>
+        <file src="file:/topic.dita" uri="topic.dita" path="topic.dita" format="dita" target="true"/>
+        <file src="file:/lib.dita" uri="lib.dita" path="lib.dita" format="dita" target="true"/>
+    </files>
+</job>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/guide.bookmap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/guide.bookmap
@@ -1,0 +1,19 @@
+<bookmap xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map bookmap/bookmap "
+     ditaarch:DITAArchVersion="2.0"
+     chunk="combine">
+   <booktitle class="- topic/title bookmap/booktitle ">
+      <mainbooktitle class="- topic/ph bookmap/mainbooktitle ">Guide</mainbooktitle>
+   </booktitle>
+   <part class="- map/topicref bookmap/part ">
+      <keydef href="lib.dita" keys="lib" class="+ map/topicref mapgroup-d/keydef " processing-role="resource-only"/>
+      <submap xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot" dita-ot:orig-class="+ map/topicref mapgroup-d/mapref "
+              dita-ot:orig-format="ditamap" dita-ot:orig-href="map.ditamap" dita-ot:submap-id="map"
+              class="+ map/topicref mapgroup-d/topicgroup ditaot-d/submap ">
+         <submap-topicmeta class="+ map/topicmeta ditaot-d/submap-topicmeta ">
+            <submap-title class="+ topic/navtitle ditaot-d/submap-title " dita-ot:submap-class="- topic/title ">Map</submap-title>
+         </submap-topicmeta>
+         <topicref class="- map/topicref " href="topic.dita"/>
+      </submap>
+   </part>
+</bookmap>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/lib.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/lib.dita
@@ -1,0 +1,9 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+       class="- topic/topic "
+       id="topic_resource"
+       ditaarch:DITAArchVersion="2.0">
+   <title class="- topic/title ">Lib</title>
+   <body class="- topic/body ">
+      <p class="- topic/p " id="test">RESOLVED KEY</p>
+   </body>
+</topic>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/map.ditamap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/map.ditamap
@@ -1,0 +1,7 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map "
+     ditaarch:DITAArchVersion="2.0"
+     id="map">
+   <title class="- topic/title ">Map</title>
+   <topicref class="- map/topicref " href="topic.dita"/>
+</map>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/topic.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine-bookmap/topic.dita
@@ -1,0 +1,12 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+       class="- topic/topic "
+       id="topic_content"
+       ditaarch:DITAArchVersion="2.0">
+   <title class="- topic/title ">Topic</title>
+   <body class="- topic/body ">
+      <p class="- topic/p ">Topic content</p>
+       <p class="- topic/p ">
+           <ph class="- topic/ph ">RESOLVED KEY</ph>
+       </p>
+   </body>
+</topic>


### PR DESCRIPTION
## Description

Ignore submaps and resource-only references when processing chunks

## Motivation and Context

Fixes #4475

## How Has This Been Tested?

Test case added in existing unit tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

