### PR TITLE
Bump commons.io to 2.14.0 for security CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
     }
 }
 dependencies {
-    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
     implementation group: 'xerces', name: 'xercesImpl', version:'2.12.2'
     implementation group: 'xml-apis', name: 'xml-apis', version:'1.4.01'
     implementation group: 'xml-resolver', name: 'xml-resolver', version:'1.2'


### PR DESCRIPTION
## Description

Bumps version of commons.io due to security issue reported in http://github.com/advisories/GHSA-78wr-2p64-hpwj

## Motivation and Context

Fixes https://nvd.nist.gov/vuln/detail/CVE-2024-47554

## How Has This Been Tested?

Tested local build, package still builds successfully

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

n/a

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
