### PR TITLE
add HTML5 metadata placeholders for <data>, <data-about>, and <resourceid>

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -61,6 +61,25 @@ See the accompanying LICENSE file for applicable license.
     <!-- CONTENT: Subject - prolog/metadata/keywords -->
     <xsl:apply-templates select="." mode="gen-keywords-metadata"/>
 
+    <!-- CONTENT: Resource IDs - prolog/resourceid -->
+    <xsl:apply-templates select="." mode="gen-resourceid-metadata"/>
+
+    <!-- CONTENT: User-defined - prolog/data -->
+    <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/data ')] |
+                                 *[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/data ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data ')] |
+                                 self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/data ')] |
+                                 self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data ')]" mode="gen-metadata"/>
+
+    <!-- CONTENT: User-defined - prolog/data-about -->
+    <xsl:apply-templates select="*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/data-about ')] |
+                                 *[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data-about ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/data-about ')] |
+                                 *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data-about ')] |
+                                 self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/data-about ')] |
+                                 self::dita/*[1]/*[contains(@class,' topic/prolog ')]/*[contains(@class,' topic/metadata ')]/*[contains(@class,' topic/data-about ')]" mode="gen-metadata"/>
+
     <!-- CONTENT: Relation - related-links -->
     <xsl:apply-templates select="*[contains(@class,' topic/related-links ')]/descendant::*/@href |
                                  self::dita/*/*[contains(@class,' topic/related-links ')]/descendant::*/@href" mode="gen-metadata"/>
@@ -267,6 +286,10 @@ See the accompanying LICENSE file for applicable license.
       <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
     </xsl:if>
   </xsl:template>
+
+  <!-- CONTENT: User-defined - prolog/resourceid -->
+  <xsl:template match="*[contains(@class, ' topic/topic ')]" mode="gen-resourceid-metadata"/>
+  <xsl:template match="*[contains(@class, ' map/map ')]" mode="gen-resourceid-metadata"/>
 
   <!--  Rights - prolog/copyright -->
   <xsl:template match="*[contains(@class,' topic/copyright ')]" mode="gen-metadata">


### PR DESCRIPTION
## Description
Adds placeholders for `<data>`, `<data-about>`, and `<resourceid>` elements in the `mode="getMeta"` template that creates HTML5 metadata.

## Motivation and Context
Fixes #4532.

## How Has This Been Tested?
I created the following testcase:

[4532.zip](https://github.com/user-attachments/files/17612586/4532.zip)

which can be run with the following DITA-OT plugin that makes use of the new placeholders:

[com.synopsys.test-metadata.zip](https://github.com/user-attachments/files/17612588/com.synopsys.test-metadata.zip)

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

There is no change to the default behavior.

## Documentation and Compatibility
No documentation change is needed.

A release notes entry is needed. A draft write could be as follows:

> In previous releases, the HTML5 transformation did not provide provisions for creating HTML5 metadata from `<data>`, `<data-about>`, and `<resourceid>` elements. In this release, placeholders for these elements have been added to the `mode="getMeta"` processing mode. No metadata is created for these elements by default, but DITA-OT plugins can override the placeholders as needed.
