### PR TITLE
Keyref with only whitespace is processed

### DIFF
--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -22,5 +22,5 @@ registry = https://plugins.dita-ot.org/
 org.dita.pdf2.i18n.enabled = true
 
 # Compatibility modes
-# Threat keyref elements that contain only whitespace as empty.
-compatibility.keyref.treat-whitespace-only-as-empty=true
+# Treat keyref elements that contain only whitespace as empty.
+compatibility.keyref.treat-blank-as-empty=true

--- a/src/main/config/configuration.properties
+++ b/src/main/config/configuration.properties
@@ -20,3 +20,7 @@ registry = https://plugins.dita-ot.org/
 
 # PDF2 defaults
 org.dita.pdf2.i18n.enabled = true
+
+# Compatibility modes
+# Threat keyref elements that contain only whitespace as empty.
+compatibility.keyref.treat-whitespace-only-as-empty=true

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -177,6 +177,10 @@ public final class KeyrefPaser extends AbstractXMLFilter {
   private Set<URI> normalProcessingRoleTargets;
   private MergeUtils mergeUtils;
 
+  private boolean compatibilityMode = Boolean.parseBoolean(
+    Configuration.configuration.get("compatibility.keyref.treat-whitespace-only-as-empty")
+  );
+
   /**
    * Constructor.
    */
@@ -237,9 +241,17 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     getContentHandler().startDocument();
   }
 
+  private boolean isEmpty(final char[] ch, final int start, final int length) {
+    if (compatibilityMode) {
+      return length == 0 || new String(ch, start, length).isBlank();
+    } else {
+      return length == 0;
+    }
+  }
+
   @Override
   public void characters(final char[] ch, final int start, final int length) throws SAXException {
-    if (keyrefLevel != 0 && (length == 0 || new String(ch, start, length).trim().isEmpty())) {
+    if (keyrefLevel != 0 && isEmpty(ch, start, length)) {
       if (!hasChecked) {
         empty = true;
       }

--- a/src/main/java/org/dita/dost/writer/KeyrefPaser.java
+++ b/src/main/java/org/dita/dost/writer/KeyrefPaser.java
@@ -177,9 +177,7 @@ public final class KeyrefPaser extends AbstractXMLFilter {
   private Set<URI> normalProcessingRoleTargets;
   private MergeUtils mergeUtils;
 
-  private boolean compatibilityMode = Boolean.parseBoolean(
-    Configuration.configuration.get("compatibility.keyref.treat-whitespace-only-as-empty")
-  );
+  private boolean compatibilityMode;
 
   /**
    * Constructor.
@@ -193,6 +191,8 @@ public final class KeyrefPaser extends AbstractXMLFilter {
     elemName = new ArrayDeque<>();
     hasSubElem = new ArrayDeque<>();
     mergeUtils = new MergeUtils();
+    compatibilityMode =
+      Boolean.parseBoolean(Configuration.configuration.get("compatibility.keyref.treat-blank-as-empty"));
   }
 
   @Override
@@ -205,6 +205,13 @@ public final class KeyrefPaser extends AbstractXMLFilter {
   public void setJob(final Job job) {
     super.setJob(job);
     mergeUtils.setJob(job);
+  }
+
+  /**
+   * Set compatibility mode for {@code compatibility.keyref.treat-blank-as-empty}.
+   */
+  public void setCompatibilityMode(boolean compatibilityMode) {
+    this.compatibilityMode = compatibilityMode;
   }
 
   public void setKeyDefinition(final KeyScope definitionMap) {
@@ -242,11 +249,13 @@ public final class KeyrefPaser extends AbstractXMLFilter {
   }
 
   private boolean isEmpty(final char[] ch, final int start, final int length) {
-    if (compatibilityMode) {
-      return length == 0 || new String(ch, start, length).isBlank();
-    } else {
-      return length == 0;
+    if (length == 0) {
+      return true;
     }
+    if (compatibilityMode) {
+      return new String(ch, start, length).isBlank();
+    }
+    return false;
   }
 
   @Override

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -31,6 +31,7 @@ import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.KeyScope;
 import org.dita.dost.util.XMLUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -81,6 +82,28 @@ public class KeyrefPaserTest {
       Arguments.of(Paths.get("d.ditamap"), Paths.get("keys.ditamap")),
       Arguments.of(Paths.get("copy-to-keys.ditamap"), Paths.get("keys.ditamap")),
       Arguments.of(Paths.get("subdir", "c.ditamap"), Paths.get("subdir", "c.ditamap"))
+    );
+  }
+
+  @Test
+  public void compatibulityMode() throws Exception {
+    Path file = Paths.get("compatibility.xml");
+    Path map = Paths.get("keys.ditamap");
+
+    TestUtils.copy(srcDir, tempDir);
+
+    final KeyScope keyDefinition = readKeyMap(map);
+    final KeyrefPaser parser = new KeyrefPaser();
+    parser.setLogger(new TestUtils.TestLogger());
+    parser.setJob(new Job(tempDir, new StreamStore(tempDir, new XMLUtils())));
+    parser.setKeyDefinition(keyDefinition);
+    parser.setCurrentFile(Paths.get(tempDir.getAbsolutePath(), file.toString()).toUri());
+    parser.setCompatibilityMode(false);
+    parser.write(Paths.get(tempDir.getAbsolutePath(), file.toString()).toFile());
+
+    assertXMLEqual(
+      new InputSource(Paths.get(expDir.getAbsolutePath(), file.toString()).toUri().toString()),
+      new InputSource(Paths.get(tempDir.getAbsolutePath(), file.toString()).toUri().toString())
     );
   }
 

--- a/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
+++ b/src/test/java/org/dita/dost/writer/KeyrefPaserTest.java
@@ -72,6 +72,7 @@ public class KeyrefPaserTest {
 
   private static Stream<Arguments> testWriteArguments() {
     return Stream.of(
+      Arguments.of(Paths.get("whitespace.xml"), Paths.get("keys.ditamap")),
       Arguments.of(Paths.get("a.xml"), Paths.get("keys.ditamap")),
       Arguments.of(Paths.get("subdir", "subdirtopic.xml"), Paths.get("keys.ditamap")),
       Arguments.of(Paths.get("id.xml"), Paths.get("keys.ditamap")),

--- a/src/test/resources/KeyrefPaserTest/exp/compatibility.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/compatibility.xml
@@ -1,0 +1,10 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="a" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Whitespace</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="keyword"> </keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/exp/whitespace.xml
+++ b/src/test/resources/KeyrefPaserTest/exp/whitespace.xml
@@ -1,0 +1,10 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="a" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Whitespace</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="keyword">keyword keyword</keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/compatibility.xml
+++ b/src/test/resources/KeyrefPaserTest/src/compatibility.xml
@@ -1,0 +1,10 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="a" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Whitespace</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="keyword"> </keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/KeyrefPaserTest/src/whitespace.xml
+++ b/src/test/resources/KeyrefPaserTest/src/whitespace.xml
@@ -1,0 +1,10 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic hi-d)                             (topic ut-d)                             (topic indexing-d)                            (topic hazard-d)                            (topic abbrev-d)                            (topic pr-d)                             (topic sw-d)                            (topic ui-d)    "
+  id="a" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">Whitespace</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">
+      <keyword class="- topic/keyword " keyref="keyword"> </keyword>
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -14,3 +14,6 @@ plugin.ignores =
 # PDF2 defaults
 org.dita.pdf2.index.frame-markup = false
 org.dita.pdf2.i18n.enabled = true
+
+# Compatibility modes
+compatibility.keyref.treat-whitespace-only-as-empty=true

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -16,4 +16,4 @@ org.dita.pdf2.index.frame-markup = false
 org.dita.pdf2.i18n.enabled = true
 
 # Compatibility modes
-compatibility.keyref.treat-whitespace-only-as-empty=true
+compatibility.keyref.treat-blank-as-empty=true


### PR DESCRIPTION
## Description
Keyref with only whitespace is processed when it should be skipped.

## Motivation and Context
Fixes #4543 

## How Has This Been Tested?
New unit tests.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
This configuration needs to be documented in release notes and in [The `configuration.properties` file](https://github.com/dita-ot/docs/blob/hotfix/4.2.4/parameters/configuration-properties-file.dita) topic.

The key thing in release notes is that this bug has been fixed in 4.2.4, but because it may break existing content, the fix has not been enabled. This is a really old bug and a lot of content has been written with this is place. So common exception _may_ be that whitespace only content is not treated as something that a key can replace.

This toggle will be enabled by default in the next minor or major release, but even then the toggle will be retained for those who need to disable the fix.

