### PR TITLE
Windows command fails if subcommand contains double quote (")

### DIFF
--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -47,9 +47,10 @@ rem and for NT handling to skip to.
 :doneStart
 
 rem No plug-in libraries in classpath
-set CLASSPATH=""
-if "%DITA_CMD_SUBCOMMAND%" == "install" goto checkJava
-if "%DITA_CMD_SUBCOMMAND%" == "uninstall" goto checkJava
+setlocal enabledelayedexpansion
+if "!DITA_CMD_SUBCOMMAND!" == "install" goto checkJava
+if "!DITA_CMD_SUBCOMMAND!" == "uninstall" goto checkJava
+endlocal
 
 rem Set environment variables
 call "%DITA_HOME%\config\env.bat"

--- a/src/main/bin/dita.bat
+++ b/src/main/bin/dita.bat
@@ -67,7 +67,7 @@ if "%_JAVACMD%" == "" set _JAVACMD=java.exe
 
 :runAnt
 rem sun.io.useCanonCaches improves performance in Java 12+ (see https://bugs.openjdk.java.net/browse/JDK-8207005)
-"%_JAVACMD%" %ANT_OPTS% -Djava.awt.headless=true -Dcli.log-format=fancy -Dcli.color=true -Dsun.io.useCanonCaches=true -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
+"%_JAVACMD%" -Djava.awt.headless=true -Dcli.log-format=fancy -Dcli.color=true -Dsun.io.useCanonCaches=true %ANT_OPTS% -classpath "%DITA_HOME%\lib\ant-launcher.jar;%DITA_HOME%\config" "-Dant.home=%DITA_HOME%"  "-Ddita.dir=%DITA_HOME%" org.apache.tools.ant.launch.Launcher %ANT_ARGS% -cp "%CLASSPATH%" %DITA_CMD_LINE_ARGS% -buildfile "%DITA_HOME%\build.xml" -main "org.dita.dost.invoker.Main"
 rem Check the error code of the Ant build
 if not "%OS%"=="Windows_NT" goto onError
 set ANT_ERROR=%ERRORLEVEL%


### PR DESCRIPTION
## Description
Added enabledelayedexpansion so that DITA_CMD_SUBCOMMAND is expanded at runtime.
Move ANT_OPTS so that it can be use to override cli parameters

## Motivation and Context
Fixes #4525

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.