### PR TITLE
Display indexterms in HTML5 <meta>

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -269,7 +269,7 @@ See the accompanying LICENSE file for applicable license.
                   select="descendant::*[contains(@class,' topic/prolog ')]/
                             *[contains(@class,' topic/metadata ')]/
                               *[contains(@class,' topic/keywords ')]/
-                                *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+                                descendant::*[normalize-space()]"/>
     <xsl:if test="exists($keywords)">
       <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
     </xsl:if>
@@ -281,7 +281,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="keywords" as="element()*"
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
                             *[contains(@class,' topic/keywords ')]/
-                              *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+                              descendant::*[normalize-space()]"/>
     <xsl:if test="exists($keywords)">
       <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
     </xsl:if>


### PR DESCRIPTION
## Description
Get all `<keywords>` descendant, not only `<keyword>`.

## Motivation and Context
Fixes #4528

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.