### PR TITLE
Process software elements as keywords #4540 

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
@@ -44,26 +44,18 @@ See the accompanying LICENSE file for applicable license.
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' sw-d/cmdname ')]" name="topic.sw-d.cmdname">
-   <span>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:call-template name="setidaname"/>
-    <xsl:next-match/>
-   </span>
+   <xsl:next-match/>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' sw-d/msgnum ')]" name="topic.sw-d.msgnum">
-   <span>
-    <xsl:call-template name="commonattributes"/>
-    <xsl:call-template name="setidaname"/>
-    <xsl:next-match/>
-   </span>
+   <xsl:next-match/>
   </xsl:template>
   
   <xsl:template match="*[contains(@class,' sw-d/varname ')]" name="topic.sw-d.varname">
    <var>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
-    <xsl:next-match/>
+    <xsl:apply-templates/>
    </var>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/sw-d.xsl
@@ -47,7 +47,7 @@ See the accompanying LICENSE file for applicable license.
    <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
-    <xsl:apply-templates/>
+    <xsl:next-match/>
    </span>
   </xsl:template>
   
@@ -55,7 +55,7 @@ See the accompanying LICENSE file for applicable license.
    <span>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
-    <xsl:apply-templates/>
+    <xsl:next-match/>
    </span>
   </xsl:template>
   
@@ -63,7 +63,7 @@ See the accompanying LICENSE file for applicable license.
    <var>
     <xsl:call-template name="commonattributes"/>
     <xsl:call-template name="setidaname"/>
-    <xsl:apply-templates/>
+    <xsl:next-match/>
    </var>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
@@ -47,26 +47,18 @@ See the accompanying LICENSE file for applicable license.
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/cmdname ')]" name="topic.sw-d.cmdname">
- <span>
-  <xsl:call-template name="commonattributes"/>
-  <xsl:call-template name="setidaname"/>
-  <xsl:next-match/>
- </span>
+ <xsl:next-match/>
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/msgnum ')]" name="topic.sw-d.msgnum">
- <span>
-  <xsl:call-template name="commonattributes"/>
-  <xsl:call-template name="setidaname"/>
-  <xsl:next-match/>
- </span>
+ <xsl:next-match/>
 </xsl:template>
 
 <xsl:template match="*[contains(@class,' sw-d/varname ')]" name="topic.sw-d.varname">
  <var>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
-  <xsl:next-match/>
+  <xsl:apply-templates/>
  </var>
 </xsl:template>
 

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/sw-d.xsl
@@ -50,7 +50,7 @@ See the accompanying LICENSE file for applicable license.
  <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
-  <xsl:apply-templates/>
+  <xsl:next-match/>
  </span>
 </xsl:template>
 
@@ -58,7 +58,7 @@ See the accompanying LICENSE file for applicable license.
  <span>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
-  <xsl:apply-templates/>
+  <xsl:next-match/>
  </span>
 </xsl:template>
 
@@ -66,7 +66,7 @@ See the accompanying LICENSE file for applicable license.
  <var>
   <xsl:call-template name="commonattributes"/>
   <xsl:call-template name="setidaname"/>
-  <xsl:apply-templates/>
+  <xsl:next-match/>
  </var>
 </xsl:template>
 


### PR DESCRIPTION
## Description
Use next-match so `<cmdname>`/`<msgnum>`/`<varname>` also pass into keyword template and generates a link.

## Motivation and Context
Fixes #4540

## How Has This Been Tested?
Tested with the sample from #4540.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.