### PR TITLE
 Display indexterms and nested elements in HTML5 <meta>

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -271,7 +271,8 @@ See the accompanying LICENSE file for applicable license.
                               *[contains(@class,' topic/keywords ')]/
                                 child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]"/>
     <xsl:if test="exists($keywords)">
-      <meta name="keywords" content="{string-join($keywords//text()/normalize-space()[string-length() > 0], ', ')}"/>
+      <xsl:variable name="keywords-content" select="$keywords//text()/normalize-space()[string-length() > 0]"/>
+      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
     </xsl:if>
   </xsl:template>
 
@@ -283,7 +284,8 @@ See the accompanying LICENSE file for applicable license.
                             *[contains(@class,' topic/keywords ')]/
                               child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]"/>
     <xsl:if test="exists($keywords)">
-      <meta name="keywords" content="{string-join($keywords//text()/normalize-space()[string-length() > 0], ', ')}"/>
+      <xsl:variable name="keywords-content" select="$keywords//text()/normalize-space()[string-length() > 0]"/>
+      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -270,12 +270,12 @@ See the accompanying LICENSE file for applicable license.
                             *[contains(@class,' topic/metadata ')]/
                               *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:for-each select="$keywords">
-        <xsl:variable name="keywords-content">
+      <xsl:variable name="keywords-content">
+        <xsl:for-each select="$keywords">
           <xsl:apply-templates select="current()" mode="#current"/>
-        </xsl:variable>
-        <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
-      </xsl:for-each>
+        </xsl:for-each>
+      </xsl:variable>
+      <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
     </xsl:if>
   </xsl:template>
 
@@ -286,12 +286,12 @@ See the accompanying LICENSE file for applicable license.
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
                             *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:for-each select="$keywords">
-        <xsl:variable name="keywords-content">
+      <xsl:variable name="keywords-content">
+        <xsl:for-each select="$keywords">
           <xsl:apply-templates select="current()" mode="#current"/>
-        </xsl:variable>
-        <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
-      </xsl:for-each>
+        </xsl:for-each>
+      </xsl:variable>
+      <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
     </xsl:if>
   </xsl:template>
 

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -268,10 +268,14 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="keywords" as="element()*"
                   select="descendant::*[contains(@class,' topic/prolog ')]/
                             *[contains(@class,' topic/metadata ')]/
-                              *[contains(@class,' topic/keywords ')]/
-                                *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+                              *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
+      <xsl:for-each select="$keywords">
+        <xsl:variable name="keywords-content">
+          <xsl:apply-templates select="current()" mode="#current"/>
+        </xsl:variable>
+        <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
+      </xsl:for-each>
     </xsl:if>
   </xsl:template>
 
@@ -280,11 +284,26 @@ See the accompanying LICENSE file for applicable license.
                   select="*[contains(@class,' map/topicmeta ')]"/>
     <xsl:variable name="keywords" as="element()*"
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
-                            *[contains(@class,' topic/keywords ')]/
-                              *[contains(@class,' topic/keyword ')][normalize-space()]"/>
+                            *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <meta name="keywords" content="{string-join(distinct-values($keywords/normalize-space()), ', ')}"/>
+      <xsl:for-each select="$keywords">
+        <xsl:variable name="keywords-content">
+          <xsl:apply-templates select="current()" mode="#current"/>
+        </xsl:variable>
+        <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
+      </xsl:for-each>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]" mode="gen-keywords-metadata">
+    <xsl:choose>
+      <xsl:when test="child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]">
+        <xsl:apply-templates select="child::node()" mode="#current"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="normalize-space()"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- CONTENT: User-defined - prolog/resourceid -->

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -270,12 +270,12 @@ See the accompanying LICENSE file for applicable license.
                             *[contains(@class,' topic/metadata ')]/
                               *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:variable name="keywords-content">
-        <xsl:for-each select="$keywords">
+      <xsl:variable name="keywords-content" as="xs:string*">
+        <xsl:for-each select="$keywords/normalize-space()">
           <xsl:apply-templates select="current()" mode="#current"/>
         </xsl:for-each>
       </xsl:variable>
-      <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
+      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
     </xsl:if>
   </xsl:template>
 
@@ -286,12 +286,12 @@ See the accompanying LICENSE file for applicable license.
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
                             *[contains(@class,' topic/keywords ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:variable name="keywords-content">
-        <xsl:for-each select="$keywords">
+      <xsl:variable name="keywords-content" as="xs:string*">
+        <xsl:for-each select="$keywords/normalize-space()">
           <xsl:apply-templates select="current()" mode="#current"/>
         </xsl:for-each>
       </xsl:variable>
-      <meta name="keywords" content="{string-join(tokenize($keywords-content/normalize-space(), ' '), ', ')}"/>
+      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
     </xsl:if>
   </xsl:template>
 
@@ -301,7 +301,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:apply-templates select="child::node()" mode="#current"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="normalize-space()"/>
+        <xsl:sequence select="normalize-space()"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/get-meta.xsl
@@ -268,14 +268,10 @@ See the accompanying LICENSE file for applicable license.
     <xsl:variable name="keywords" as="element()*"
                   select="descendant::*[contains(@class,' topic/prolog ')]/
                             *[contains(@class,' topic/metadata ')]/
-                              *[contains(@class,' topic/keywords ')]"/>
+                              *[contains(@class,' topic/keywords ')]/
+                                child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:variable name="keywords-content" as="xs:string*">
-        <xsl:for-each select="$keywords/normalize-space()">
-          <xsl:apply-templates select="current()" mode="#current"/>
-        </xsl:for-each>
-      </xsl:variable>
-      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
+      <meta name="keywords" content="{string-join($keywords//text()/normalize-space()[string-length() > 0], ', ')}"/>
     </xsl:if>
   </xsl:template>
 
@@ -284,26 +280,11 @@ See the accompanying LICENSE file for applicable license.
                   select="*[contains(@class,' map/topicmeta ')]"/>
     <xsl:variable name="keywords" as="element()*"
                   select="($topicmeta | $topicmeta/*[contains(@class,' topic/metadata ')])/
-                            *[contains(@class,' topic/keywords ')]"/>
+                            *[contains(@class,' topic/keywords ')]/
+                              child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]"/>
     <xsl:if test="exists($keywords)">
-      <xsl:variable name="keywords-content" as="xs:string*">
-        <xsl:for-each select="$keywords/normalize-space()">
-          <xsl:apply-templates select="current()" mode="#current"/>
-        </xsl:for-each>
-      </xsl:variable>
-      <meta name="keywords" content="{string-join($keywords-content, ', ')}"/>
+      <meta name="keywords" content="{string-join($keywords//text()/normalize-space()[string-length() > 0], ', ')}"/>
     </xsl:if>
-  </xsl:template>
-
-  <xsl:template match="*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]" mode="gen-keywords-metadata">
-    <xsl:choose>
-      <xsl:when test="child::*[contains(@class,' topic/keyword ') or contains(@class,' topic/indexterm ')]">
-        <xsl:apply-templates select="child::node()" mode="#current"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="normalize-space()"/>
-      </xsl:otherwise>
-    </xsl:choose>
   </xsl:template>
 
   <!-- CONTENT: User-defined - prolog/resourceid -->

--- a/src/test/resources/html5/exp/html5/index.html
+++ b/src/test/resources/html5/exp/html5/index.html
@@ -19,6 +19,7 @@
       <li class="topicref"><a href="reference.html">Reference</a></li>
     </ul>
     </li>
+    <li class="topicref"><a href="nested.html">Nested</a></li>
   </ul>
 </nav>
 </body>

--- a/src/test/resources/html5/exp/html5/nested.html
+++ b/src/test/resources/html5/exp/html5/nested.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="copyright" content="(C) Copyright 2024">
+  <meta name="generator" content="DITA-OT">
+  <meta content="indexterm, nested_indexterm, nested_keyword" name="keywords" />
+  <title>Nested</title>
+  <link href="commonltr.css" rel="stylesheet" type="text/css" />
+</head>
+<body id="nested">
+<main role="main">
+  <article aria-labelledby="ariaid-title1" role="article">
+  <h1 class="title topictitle1" id="ariaid-title1">Nested</h1>
+  <div class="body">
+    <p class="p">Body.</p>
+  </div>
+  </article>
+</main>
+</body>
+</html>

--- a/src/test/resources/html5/src/map.ditamap
+++ b/src/test/resources/html5/src/map.ditamap
@@ -40,4 +40,5 @@
       </topicmeta>
     </topicref>
   </topicref>
+  <topicref href="nested.dita"/>
 </map>

--- a/src/test/resources/html5/src/nested.dita
+++ b/src/test/resources/html5/src/nested.dita
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="nested">
+  <title>Nested</title>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>indexterm
+          <indexterm>nested_indexterm</indexterm>
+          <keyword>nested_keyword</keyword>
+        </indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body>
+    <p>Body.</p>
+  </body>
+</topic>


### PR DESCRIPTION
## Description
Get both `<keyword>` and `<indexterm>` and include nested elements.
For example:
```
<topic id="topic">
    <title>Topic</title>
    <prolog>
        <metadata>
            <keywords>
                <keyword>normal_kw</keyword>
                <indexterm>normal_idx
                    <keyword>nested_kw</keyword>
                    <indexterm>nested_idx
                        <keyword>nested_nested_kw</keyword>
                    </indexterm>
                </indexterm>
            </keywords>
        </metadata>
    </prolog>
    <body>
        <p/>
    </body>
</topic>
```

## Motivation and Context
Fixes #4528

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.