### PR TITLE
Protect against billion laughs attack

### DIFF
--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -65,11 +65,13 @@ import org.xmlresolver.Resolver;
  */
 public final class XMLUtils {
 
+  private static final SecurityManager securityManager = new SecurityManager();
   private static final DocumentBuilderFactory factory;
 
   static {
     factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);
+    factory.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
   }
 
   private static final SAXParserFactory saxParserFactory;
@@ -912,10 +914,9 @@ public final class XMLUtils {
     try {
       final XMLReader reader = saxParserFactory.newSAXParser().getXMLReader();
       try {
-        SecurityManager securityManager = new SecurityManager();
         reader.setProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
       } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
-        // Some readers, especially non-XML, do not support security-manager property.
+        // Ignore
       }
       return Configuration.DEBUG ? new DebugXMLReader(reader) : reader;
     } catch (ParserConfigurationException e) {
@@ -960,7 +961,6 @@ public final class XMLUtils {
             // Ignore
           }
           try {
-            SecurityManager securityManager = new SecurityManager();
             r.setProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
           } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
             // Ignore
@@ -983,8 +983,6 @@ public final class XMLUtils {
   public DocumentBuilder getDocumentBuilder() {
     DocumentBuilder builder;
     try {
-      SecurityManager securityManager = new SecurityManager();
-      factory.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
       builder = factory.newDocumentBuilder();
     } catch (final ParserConfigurationException e) {
       throw new RuntimeException(e);

--- a/src/main/java/org/dita/dost/util/XMLUtils.java
+++ b/src/main/java/org/dita/dost/util/XMLUtils.java
@@ -79,12 +79,6 @@ public final class XMLUtils {
     saxParserFactory.setNamespaceAware(true);
   }
 
-  private static final SecurityManager securityManager;
-
-  static {
-    securityManager = new SecurityManager();
-  }
-
   private DITAOTLogger logger;
   private final Resolver catalogResolver;
   private final Processor processor;
@@ -918,6 +912,7 @@ public final class XMLUtils {
     try {
       final XMLReader reader = saxParserFactory.newSAXParser().getXMLReader();
       try {
+        SecurityManager securityManager = new SecurityManager();
         reader.setProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
       } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
         // Some readers, especially non-XML, do not support security-manager property.
@@ -965,6 +960,7 @@ public final class XMLUtils {
             // Ignore
           }
           try {
+            SecurityManager securityManager = new SecurityManager();
             r.setProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
           } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
             // Ignore
@@ -987,6 +983,7 @@ public final class XMLUtils {
   public DocumentBuilder getDocumentBuilder() {
     DocumentBuilder builder;
     try {
+      SecurityManager securityManager = new SecurityManager();
       factory.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY, securityManager);
       builder = factory.newDocumentBuilder();
     } catch (final ParserConfigurationException e) {

--- a/src/test/java/org/dita/dost/reader/CustomXMLReader.java
+++ b/src/test/java/org/dita/dost/reader/CustomXMLReader.java
@@ -35,7 +35,7 @@ public class CustomXMLReader extends XMLFilterImpl {
           };
         break;
       case Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY:
-    	throw new SAXNotSupportedException();
+        throw new SAXNotSupportedException();
       default:
         throw new IllegalArgumentException("%s=%s".formatted(name, value));
     }

--- a/src/test/java/org/dita/dost/reader/CustomXMLReader.java
+++ b/src/test/java/org/dita/dost/reader/CustomXMLReader.java
@@ -11,7 +11,6 @@ package org.dita.dost.reader;
 import static org.dita.dost.util.Constants.*;
 
 import java.util.Collection;
-
 import org.apache.xerces.impl.Constants;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;

--- a/src/test/java/org/dita/dost/reader/CustomXMLReader.java
+++ b/src/test/java/org/dita/dost/reader/CustomXMLReader.java
@@ -8,7 +8,11 @@
 
 package org.dita.dost.reader;
 
+import static org.dita.dost.util.Constants.*;
+
 import java.util.Collection;
+
+import org.apache.xerces.impl.Constants;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.helpers.XMLFilterImpl;
@@ -20,10 +24,10 @@ public class CustomXMLReader extends XMLFilterImpl {
 
   public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
     switch (name) {
-      case "https://dita-ot.org/property/formats":
+      case PROPERTY_FORMATS:
         formats = (Collection<String>) value;
         break;
-      case "https://dita-ot.org/property/processing-mode":
+      case PROPERTY_PROCESSING_MODE:
         processingMode =
           switch ((String) value) {
             case "skip" -> throw new SAXNotRecognizedException();
@@ -31,6 +35,8 @@ public class CustomXMLReader extends XMLFilterImpl {
             default -> (String) value;
           };
         break;
+      case Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY:
+    	throw new SAXNotSupportedException();
       default:
         throw new IllegalArgumentException("%s=%s".formatted(name, value));
     }


### PR DESCRIPTION
## Description
Adding Xerces SecurityManager stops the parsing if there's more than 100000 entities expanded.
"The parser has encountered more than "100,000" entity expansions in this document; this is the limit imposed by the application." will appear in the console.

## Motivation and Context
Fixes #4542.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.