### PR TITLE
allow @ character in plugin directory

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -612,29 +612,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       pluginInstall.setForce(Boolean.parseBoolean(installArgs.definedProps.get("force").toString()));
     }
     if (installArgs.installFile != null) {
-      final File f = new File(installArgs.installFile.replace('/', File.separatorChar)).getAbsoluteFile();
-      final String pluginFile = f.exists() ? f.getAbsolutePath() : installArgs.installFile;
-      try {
-        pluginInstall.setPluginFile(Paths.get(pluginFile));
-      } catch (InvalidPathException e) {
-        // Ignore
-      }
-      try {
-        final URI uri = new URI(pluginFile);
-        if (uri.isAbsolute()) {
-          pluginInstall.setPluginUri(uri);
-        }
-      } catch (URISyntaxException e) {
-        // Ignore
-      }
-      if (pluginFile.contains("@")) {
-        final String[] tokens = pluginFile.split("@");
-        pluginInstall.setPluginName(tokens[0]);
-        pluginInstall.setPluginVersion(new SemVerMatch(tokens[1]));
-      } else {
-        pluginInstall.setPluginName(pluginFile);
-        pluginInstall.setPluginVersion(null);
-      }
+      parseInstallFile(installArgs.installFile, pluginInstall);
     }
 
     try {
@@ -643,6 +621,37 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       throw e;
     } catch (Exception e) {
       throw new CliException(e.getMessage(), e);
+    }
+  }
+
+  private void parseInstallFile(String installFile, PluginInstall pluginInstall) {
+    final File pluginFile = new File(installFile.replace('/', File.separatorChar)).getAbsoluteFile();
+    if (pluginFile.exists()) {
+      try {
+        pluginInstall.setPluginFile(pluginFile.toPath());
+        return;
+      } catch (InvalidPathException e) {
+        // Ignore
+      }
+    }
+
+    try {
+      final URI uri = new URI(installFile);
+      if (uri.isAbsolute()) {
+        pluginInstall.setPluginUri(uri);
+        return;
+      }
+    } catch (URISyntaxException e) {
+      // Ignore
+    }
+
+    if (installFile.contains("@")) {
+      final String[] tokens = installFile.split("@");
+      pluginInstall.setPluginName(tokens[0]);
+      pluginInstall.setPluginVersion(new SemVerMatch(tokens[1]));
+    } else {
+      pluginInstall.setPluginName(installFile);
+      pluginInstall.setPluginVersion(null);
     }
   }
 


### PR DESCRIPTION
installing plugins that are located in directories that contain the '@' character does not lead to an InvalidArgumentException anymore

## Description
A zipped plugin file may or may not have a version number given in the form of filename@1.2.3. The current install mechanism splits up the whole path into /path/to/filename and 1.2.3.
If the path contains the '@' character e.g. /path@to/filename@1.2.3 it is split up into /path and to/filename@1.2.3 which leads to an InvalidArgumentException as described in #4354

As I already state in the issue: as far as I understand the version information is not further processed but if it will be in the future my approach should work as expected.

## Motivation and Context
Both Windows and Linux allow the '@' character in directory names.
This PR fixes #4354 

## How Has This Been Tested?
locate a file `plugin.zip` in a directory /test@test
install with `dita install /test@test/plugin.zip`  (dita version 4.2.4) --> fails
install with `dita install /test@test/plugin.zip`  (dita version local build with fix) --> successful

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_


## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->
No documentation changes required
