### PR TITLE
Enhance LinkFilter to support the copy-to attribute as priority over href attribute

### DIFF
--- a/src/main/java/org/dita/dost/writer/LinkFilter.java
+++ b/src/main/java/org/dita/dost/writer/LinkFilter.java
@@ -38,6 +38,9 @@ public class LinkFilter extends AbstractXMLFilter {
       final AttributesImpl resAtts = new AttributesImpl(atts);
       int i = atts.getIndex(ATTRIBUTE_NAME_IMAGEREF);
       if (i == -1) {
+        i = atts.getIndex(ATTRIBUTE_NAME_COPY_TO);
+      }
+      if (i == -1) {
         i = atts.getIndex(ATTRIBUTE_NAME_HREF);
       }
       if (i == -1) {

--- a/src/main/java/org/dita/dost/writer/LinkFilter.java
+++ b/src/main/java/org/dita/dost/writer/LinkFilter.java
@@ -38,7 +38,11 @@ public class LinkFilter extends AbstractXMLFilter {
       final AttributesImpl resAtts = new AttributesImpl(atts);
       int i = atts.getIndex(ATTRIBUTE_NAME_IMAGEREF);
       if (i == -1) {
-        i = atts.getIndex(ATTRIBUTE_NAME_COPY_TO);
+        int j = atts.getIndex(ATTRIBUTE_NAME_COPY_TO);
+        if (j != -1) {
+          final URI resCopyTo = getHref(toURI(atts.getValue(j)));
+          addOrSetAttribute(resAtts, ATTRIBUTE_NAME_COPY_TO, resCopyTo.toString());
+        }
       }
       if (i == -1) {
         i = atts.getIndex(ATTRIBUTE_NAME_HREF);

--- a/src/main/java/org/dita/dost/writer/LinkFilter.java
+++ b/src/main/java/org/dita/dost/writer/LinkFilter.java
@@ -38,13 +38,6 @@ public class LinkFilter extends AbstractXMLFilter {
       final AttributesImpl resAtts = new AttributesImpl(atts);
       int i = atts.getIndex(ATTRIBUTE_NAME_IMAGEREF);
       if (i == -1) {
-        int j = atts.getIndex(ATTRIBUTE_NAME_COPY_TO);
-        if (j != -1) {
-          final URI resCopyTo = getHref(toURI(atts.getValue(j)));
-          addOrSetAttribute(resAtts, ATTRIBUTE_NAME_COPY_TO, resCopyTo.toString());
-        }
-      }
-      if (i == -1) {
         i = atts.getIndex(ATTRIBUTE_NAME_HREF);
       }
       if (i == -1) {
@@ -54,6 +47,12 @@ public class LinkFilter extends AbstractXMLFilter {
         final URI resHref = getHref(toURI(atts.getValue(i)));
         addOrSetAttribute(resAtts, atts.getQName(i), resHref.toString());
         res = resAtts;
+      }
+
+      int copyToIndex = atts.getIndex(ATTRIBUTE_NAME_COPY_TO);
+      if (copyToIndex != -1) {
+        final URI resCopyTo = getHref(toURI(atts.getValue(copyToIndex)));
+        addOrSetAttribute(resAtts, ATTRIBUTE_NAME_COPY_TO, resCopyTo.toString());
       }
     }
 

--- a/src/test/java/org/dita/dost/writer/LinkFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/LinkFilterTest.java
@@ -80,10 +80,7 @@ public class LinkFilterTest {
         @Override
         public void startElement(String uri, String localName, String qName, Attributes atts) {
           assertEquals(URI.create("../topics/topic.dita"), URI.create(atts.getValue(ATTRIBUTE_NAME_HREF)));
-          assertEquals(
-            URI.create("9905ee35-8276-4a95-bf97-33d5a05b1f60.dita"),
-            URI.create(atts.getValue(ATTRIBUTE_NAME_COPY_TO))
-          );
+          assertEquals(URI.create("../topics/topic_copy.dita"), URI.create(atts.getValue(ATTRIBUTE_NAME_COPY_TO)));
         }
       }
     );


### PR DESCRIPTION


## Description
In map cleanup the copy-to attribute (when it exists) is used to build the final index.html file in the html5 output was not converting back to the original filename. The code I added updates the copy-to value as priority over the href value. I don't think it would hurt to update both the href and copy-to attributes in the cleanup but I was not sure how best to accomplish that.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Fixes #4564

## How Has This Been Tested?
I ran against test source code provided in #4564
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature? **None**
- Will this change affect backwards compatibility or other users' overrides? **No**

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
