### PR TITLE
Support @height, @width on videos

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1573,11 +1573,33 @@ See the accompanying LICENSE file for applicable license.
     </audio>
   </xsl:template>
   
+  <xsl:template match="*[contains(@class, ' topic/video ')]/@height">
+    <xsl:variable name="height-in-pixel">
+      <xsl:call-template name="length-to-pixels">
+        <xsl:with-param name="dimen" select="."/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:if test="not($height-in-pixel = '100%')">
+      <xsl:attribute name="height" select="number($height-in-pixel)"/>
+    </xsl:if>  
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class, ' topic/video ')]/@width">
+    <xsl:variable name="width-in-pixel">
+      <xsl:call-template name="length-to-pixels">
+        <xsl:with-param name="dimen" select="."/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:if test="not($width-in-pixel = '100%')">
+      <xsl:attribute name="width" select="number($width-in-pixel)"/>
+    </xsl:if>  
+  </xsl:template>
+  
   <xsl:template match="*[contains(@class,' topic/video ')]">
     <video>
       <xsl:call-template name="commonattributes"/>
       <xsl:apply-templates select="@autoplay | @controls | @loop | @muted" mode="boolean-media-attribute"/>
-      <xsl:apply-templates select="@tabindex | @href | @format"/>
+      <xsl:apply-templates select="@tabindex | @href | @format | @height | @width"/>
       <xsl:apply-templates select="@poster"/>
       <xsl:call-template name="setid"/>
       <xsl:apply-templates select="*[contains(@class,' topic/media-source ')],


### PR DESCRIPTION
## Description

Adds support for `video/@height` and `video/@width` for HTML5

## Motivation and Context

Testing the DITA 2.0 video element, found that the video was way too large for the screen. Added height but it was ignored.

Copied the existing templates for `image/@height` and `image/@width`, for use with video. We could alternatively have the same template match both, as they are identical right now.

## How Has This Been Tested?

Tested with video element:
`<video href="catvideo.mp4" format="video/mp4" height="400px"/>`

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

Release notes should note that we added support for `@height` and `@width` on the DITA 2.0 video element
