### PR TITLE
Fix combine chunk behaviour

### DIFF
--- a/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
+++ b/src/test/java/org/dita/dost/chunk/ChunkModuleTest.java
@@ -38,7 +38,7 @@ public class ChunkModuleTest extends AbstractModuleTest {
 
   public static Stream<Arguments> data() {
     return Stream.of(
-      Arguments.of("combine", Collections.emptyMap(), 2),
+      Arguments.of("combine", Collections.emptyMap(), 1),
       Arguments.of("duplicate", Collections.emptyMap(), 0),
       Arguments.of("override", Map.of("root-chunk-override", "combine"), 0),
       Arguments.of("dita", Collections.emptyMap(), 0),

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/.job.xml
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/.job.xml
@@ -4,6 +4,7 @@
   </property>
   <files>
     <file src="file:/a.dita" uri="a.dita" path="a.dita" format="dita" target="true"/>
+    <file src="file:/c.dita" uri="c.dita" path="c.dita" format="dita" target="true"/>
     <file src="file:/combine.ditamap" uri="combine.ditamap" path="combine.ditamap" format="ditamap" input="true"/>
   </files>
 </job>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/a.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/a.dita
@@ -11,13 +11,6 @@
       <body class="- topic/body ">
         <p class="- topic/p ">b</p>
       </body>
-      <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-        ditaarch:DITAArchVersion="2.0" id="topic_c">
-        <title class="- topic/title ">c</title>
-        <body class="- topic/body ">
-          <p class="- topic/p ">c</p>
-        </body>
-      </topic>
     </topic>
   </topic>
 </dita>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/c.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/c.dita
@@ -1,14 +1,16 @@
-<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " id="topic_c"
-  ditaarch:DITAArchVersion="2.0">
-  <title class="- topic/title ">c</title>
-  <body class="- topic/body ">
-    <p class="- topic/p ">c</p>
-  </body>
-  <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
-    ditaarch:DITAArchVersion="2.0" id="topic_d">
-    <title class="- topic/title ">d</title>
+<dita xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" ditaarch:DITAArchVersion="2.0">
+  <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " id="topic_c"
+    ditaarch:DITAArchVersion="2.0">
+    <title class="- topic/title ">c</title>
     <body class="- topic/body ">
-      <p class="- topic/p ">d</p>
+      <p class="- topic/p ">c</p>
     </body>
+    <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+      ditaarch:DITAArchVersion="2.0" id="topic_d">
+      <title class="- topic/title ">d</title>
+      <body class="- topic/body ">
+        <p class="- topic/p ">d</p>
+      </body>
+    </topic>
   </topic>
-</topic>
+</dita>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/c.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/c.dita
@@ -1,0 +1,14 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " id="topic_c"
+  ditaarch:DITAArchVersion="2.0">
+  <title class="- topic/title ">c</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">c</p>
+  </body>
+  <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+    ditaarch:DITAArchVersion="2.0" id="topic_d">
+    <title class="- topic/title ">d</title>
+    <body class="- topic/body ">
+      <p class="- topic/p ">d</p>
+    </body>
+  </topic>
+</topic>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/combine.ditamap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/combine.ditamap
@@ -2,7 +2,7 @@
      ditaarch:DITAArchVersion="2.0">
   <topicref class="- map/topicref " href="a.dita#topic_a">
     <topicref class="- map/topicref " href="a.dita#topic_b">
-      <topicref class="- map/topicref " href="a.dita#topic_c"/>
+      <topicref class="- map/topicref " href="c.dita#topic_c"/>
     </topicref>
   </topicref>
 </map>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/combine.ditamap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/exp/combine/combine.ditamap
@@ -1,8 +1,10 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map "
-     ditaarch:DITAArchVersion="2.0">
+  ditaarch:DITAArchVersion="2.0">
   <topicref class="- map/topicref " href="a.dita#topic_a">
     <topicref class="- map/topicref " href="a.dita#topic_b">
-      <topicref class="- map/topicref " href="c.dita#topic_c"/>
+      <topicref class="- map/topicref " href="c.dita#topic_c">
+        <topicref class="- map/topicref " href="c.dita#topic_d"/>
+      </topicref>
     </topicref>
   </topicref>
 </map>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine/combine.ditamap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine/combine.ditamap
@@ -3,7 +3,9 @@
      ditaarch:DITAArchVersion="2.0">
    <topicref class="- map/topicref " href="a.dita" chunk="combine">
       <topicref class="- map/topicref " href="b.dita" chunk="split">
-         <topicref class="- map/topicref " href="c.dita" chunk="combine"/>
+         <topicref class="- map/topicref " href="c.dita" chunk="combine">
+            <topicref class="- map/topicref " href="d.dita"/>
+         </topicref>
       </topicref>
    </topicref>
 </map>

--- a/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine/d.dita
+++ b/src/test/resources/org/dita/dost/chunk/ChunkModuleTest/src/combine/d.dita
@@ -1,0 +1,7 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " id="topic_d"
+  ditaarch:DITAArchVersion="2.0">
+  <title class="- topic/title ">d</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">d</p>
+  </body>
+</topic>


### PR DESCRIPTION
## Description
Fix DITA 2.0 combine chunk behaviour to match spec.

In the original implementation, when combine chunk branch contained combine chunks, those nested chunks were ignored. The spec intend, however, is to allow them. Now nested combine chunks are allowed. Nested split chunks are still not allowed, they are ignored with `DOTJ087W` log message.

## Motivation and Context
Original combine chunk implementation was incorrect because of misunderstanding of the [draft spec text] that is not clear.

[draft spec text]: https://github.com/oasis-tcs/dita/blob/1c5fc15/specification/archSpec/base/chunk-attribute-combine.dita#L40

## How Has This Been Tested?
Existing tests.

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

