### PR TITLE
Add stacktrace CLI option

### DIFF
--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -77,6 +77,7 @@ abstract class Arguments {
   boolean justPrintUsage;
   boolean justPrintVersion;
   boolean justPrintDiagnostics;
+  boolean printStacktrace = false;
   final Map<String, Object> definedProps = new HashMap<>();
   int repeat = 1;
 
@@ -114,6 +115,8 @@ abstract class Arguments {
       msgOutputLevel = Project.MSG_VERBOSE;
     } else if (isLongForm(arg, "-debug") || arg.equals("-d")) {
       msgOutputLevel = Project.MSG_DEBUG;
+    } else if (isLongForm(arg, "-stacktrace")) {
+      printStacktrace = true;
     } else if (isLongForm(arg, "-emacs") || arg.equals("-e")) {
       emacsMode = true;
     } else if (isLongForm(arg, "-logfile") || arg.equals("-l")) {

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -72,6 +72,8 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
   /** Whether or not to use emacs-style output */
   private boolean emacsMode = false;
 
+  private boolean printStacktrace = false;
+
   //  private boolean useColor = false;
 
   // CheckStyle:VisibilityModifier ON
@@ -136,8 +138,14 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
     this.emacsMode = emacsMode;
   }
 
-  public void useColor(final boolean useColor) {
+  public DefaultLogger useColor(final boolean useColor) {
     this.useColor = useColor;
+    return this;
+  }
+
+  public DefaultLogger setPrintStacktrace(final boolean printStacktrace) {
+    this.printStacktrace = printStacktrace;
+    return this;
   }
 
   /**
@@ -199,7 +207,7 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
       }
       if (error instanceof DITAOTException && msgOutputLevel < Project.MSG_INFO) {
         message.append(Main.locale.getString("exception_msg").formatted(error.getMessage()));
-      } else {
+      } else if (printStacktrace) {
         try (var buf = new StringWriter(); var printWriter = new PrintWriter(buf)) {
           error.printStackTrace(printWriter);
           printWriter.flush();
@@ -207,6 +215,8 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
         } catch (IOException e) {
           // Failed to print stack trace
         }
+      } else {
+        message.append(Main.locale.getString("exception_msg").formatted(error.getMessage()));
       }
 
       if (msgOutputLevel >= Project.MSG_INFO) {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -1162,8 +1162,7 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     } else if (Configuration.configuration.getOrDefault("cli.log-format", "legacy").equals("legacy")) {
       logger = new org.apache.tools.ant.DefaultLogger();
     } else {
-      logger = new DefaultLogger();
-      ((DefaultLogger) logger).useColor(args.useColor);
+      logger = new DefaultLogger().useColor(args.useColor).setPrintStacktrace(args.printStacktrace);
     }
 
     logger.setMessageOutputLevel(args.msgOutputLevel);

--- a/src/main/java/org/dita/dost/invoker/UsageBuilder.java
+++ b/src/main/java/org/dita/dost/invoker/UsageBuilder.java
@@ -30,6 +30,7 @@ public class UsageBuilder {
     if (!compact) {
       options("d", "debug", null, locale.getString("help.option.debug"));
       options("v", "verbose", null, locale.getString("help.option.verbose"));
+      options(null, "stacktrace", null, locale.getString("help.option.stacktrace"));
       options(null, "no-color", null, locale.getString("help.option.no-color"));
     }
   }

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -107,7 +107,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     } catch (final RuntimeException e) {
       throw e;
     } catch (final Exception e) {
-      e.printStackTrace();
+      //      e.printStackTrace();
       throw new DITAOTException("Exception doing debug and filter module processing: " + e.getMessage(), e);
     }
 

--- a/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
+++ b/src/main/plugins/org.dita.pdf2/src/com/idiominc/ws/opentopic/fo/index2/IndexPreprocessorTask.java
@@ -131,7 +131,7 @@ public class IndexPreprocessorTask extends Task {
       transformer.transform(new DOMSource(resultDoc), streamResult);
       out.close();
     } catch (final Exception e) {
-      e.printStackTrace();
+      //      e.printStackTrace();
       throw new BuildException(e);
     }
   }

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -12,6 +12,7 @@ help.error.unsupported_argument=Unsupported option %s
 help.option.help=Print help information
 help.option.debug=Enable debug logging
 help.option.verbose=Enable verbose logging
+help.option.stacktrace=Print Java stack trace on error
 help.option.no-color=Disable color in terminal
 # Version subcommand
 version=DITA-OT version %s


### PR DESCRIPTION
## Description
Add `--stacktrace` CLI option to print out Java stack trace on error.

## Motivation and Context
Most end-users don't need the stack traces by default in verbose logging,. Disable stack trace print and add a way to enable it with an option.

## How Has This Been Tested?
<!-- Include details of your testing environment, and the tests that you ran -->
<!-- to verify the effect your changes will have on other areas of the code. -->

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_
