### PR TITLE
WIP: Update XSL modules for DITA 2.0 navtitle

### DIFF
--- a/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/clean-map.xsl
@@ -33,7 +33,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:template match="@filter-copy-to"/>
 
-  <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle ')]">
+  <xsl:template match="*[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' topic/navtitle ')] |
+    *[contains(@class, ' mapgroup-d/topicgroup ')]/*/*[contains(@class, ' alternativeTitles-d/navtitle ')]">
     <xsl:call-template name="output-message">
       <xsl:with-param name="id" select="'DOTX072I'"/>
     </xsl:call-template>


### PR DESCRIPTION
## Description

Starting PR with the first small update, more to come:
* Update `clean-map` so that it removes the DITA 2.0 `<navtitle>` from `<topicgroup>`, as with the DITA 1.x processing

## Motivation and Context

DITA 2.0 changes the class attribute for `<navtitle>`, and slightly changes expectations.

When specified, it is to be used as a navigation title -- there is no more `@locktitle` attribute to check. The old "ignore this navigation title" behavior is fulfilled by `<titlehint>`.

## How Has This Been Tested?

Testing locally, need to update unit / integration tests as appropriate

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility

- What documentation changes are needed for this feature?

For release notes, will need to note that this adds some support for DITA 2.0 `<navtitle>` processing. Uncertain at this point how complete it will be, as navigation titles also include Java processing.

- Will this change affect backwards compatibility or other users' overrides?

Not exactly, but overrides that work with `<navtitle>` will need comparable updates if they are to work with DITA 2.0 maps.

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
