### PR TITLE
JSON logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,11 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
     implementation group: 'org.relaxng', name: 'jing', version: '20220510'
     implementation group: 'org.apache.ant', name: 'ant-apache-resolver', version:'1.10.15'
-    testImplementation  group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
+    testImplementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.16.1'
+    testImplementation group: 'nu.validator.htmlparser', name: 'htmlparser', version:'1.4'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.2'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.10.2'
-    testImplementation  group: 'org.xmlunit', name: 'xmlunit-core', version: '2.9.1'
+    testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.9.1'
 }
 
 jar {

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -126,7 +126,7 @@ abstract class Arguments {
     } else if (isLongForm(arg, "-listener")) {
       handleArgListener(args);
     } else if (isLongForm(arg, "-logger")) {
-      handleArgLogger(args);
+      handleArgLogger(arg, args);
     } else if (isLongForm(arg, "-no-color")) {
       useColor = false;
     } else {
@@ -181,13 +181,15 @@ abstract class Arguments {
   /**
    * Handle the --logger argument.
    */
-  private void handleArgLogger(final Deque<String> args) {
-    if (loggerClassname != null) {
-      throw new BuildException("Only one logger class may be specified.");
+  private void handleArgLogger(String arg, final Deque<String> args) {
+    final Map.Entry<String, String> entry = parse(arg, args);
+    if (entry.getValue() == null || entry.getValue().isBlank()) {
+      throw new BuildException("Missing value for logger  " + entry.getKey());
     }
-    loggerClassname = args.pop();
-    if (loggerClassname == null) {
-      throw new BuildException("You must specify a classname when using the -logger argument");
+    if (entry.getValue().equals("json")) {
+      loggerClassname = JsonLogger.class.getCanonicalName();
+    } else {
+      loggerClassname = entry.getValue();
     }
   }
 

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -188,6 +188,7 @@ abstract class Arguments {
     }
     if (entry.getValue().equals("json")) {
       loggerClassname = JsonLogger.class.getCanonicalName();
+      useColor = false;
     } else {
       loggerClassname = entry.getValue();
     }

--- a/src/main/java/org/dita/dost/invoker/Arguments.java
+++ b/src/main/java/org/dita/dost/invoker/Arguments.java
@@ -188,7 +188,6 @@ abstract class Arguments {
     }
     if (entry.getValue().equals("json")) {
       loggerClassname = JsonLogger.class.getCanonicalName();
-      useColor = false;
     } else {
       loggerClassname = entry.getValue();
     }

--- a/src/main/java/org/dita/dost/invoker/ConversionArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ConversionArguments.java
@@ -126,8 +126,6 @@ public class ConversionArguments extends Arguments {
         handleArgListener(args);
       } else if (arg.startsWith("-D")) {
         definedProps.putAll(handleArgDefine(arg, args));
-      } else if (isLongForm(arg, "-logger")) {
-        handleArgLogger(args);
       } else if (isLongForm(arg, "-inputhandler")) {
         handleArgInputHandler(args);
       } else if (isLongForm(arg, "-emacs") || arg.equals("-e")) {
@@ -303,19 +301,6 @@ public class ConversionArguments extends Arguments {
   }
 
   /**
-   * Handle the --logger argument.
-   */
-  private void handleArgLogger(final Deque<String> args) {
-    if (loggerClassname != null) {
-      throw new BuildException("Only one logger class may be specified.");
-    }
-    loggerClassname = args.pop();
-    if (loggerClassname == null) {
-      throw new BuildException("You must specify a classname when using the -logger argument");
-    }
-  }
-
-  /**
    * Handle the --inputhandler argument.
    */
   private void handleArgInputHandler(final Deque<String> args) {
@@ -427,6 +412,7 @@ public class ConversionArguments extends Arguments {
       buf
         .options(null, "deliverable", "name", locale.getString("conversion.option.deliverable"))
         .options("l", "logfile", "file", locale.getString("conversion.option.logfile"))
+        .options(null, "logger", "json|className", locale.getString("conversion.option.logger"))
         .options(null, "propertyfile", "file", locale.getString("conversion.option.propertyfile"))
         .options(null, "repeat", "num", locale.getString("conversion.option.repeat"))
         .options("t", "temp", "dir", locale.getString("conversion.option.temp"));

--- a/src/main/java/org/dita/dost/invoker/DefaultLogger.java
+++ b/src/main/java/org/dita/dost/invoker/DefaultLogger.java
@@ -355,6 +355,27 @@ class DefaultLogger extends AbstractLogger implements BuildLogger {
     // Filter out messages based on priority
     if (priority <= msgOutputLevel) {
       final StringBuilder message = new StringBuilder();
+
+      if (!legacyFormat) {
+        if (priority == Project.MSG_ERR) {
+          if (useColor) {
+            message.append(ANSI_RED);
+          }
+          message.append(Main.locale.getString("error_msg").formatted(""));
+          if (useColor) {
+            message.append(ANSI_RESET);
+          }
+        } else if (priority == Project.MSG_WARN) {
+          if (useColor) {
+            message.append(ANSI_YELLOW);
+          }
+          message.append(Main.locale.getString("warn_msg").formatted(""));
+          if (useColor) {
+            message.append(ANSI_RESET);
+          }
+        }
+      }
+
       if (event.getTask() != null && !emacsMode) {
         // Print out the name of the task if we're in one
         final String name = event.getTask().getTaskName();

--- a/src/main/java/org/dita/dost/invoker/JsonLogger.java
+++ b/src/main/java/org/dita/dost/invoker/JsonLogger.java
@@ -69,7 +69,7 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
 
   @Override
   public int getMessageOutputLevel() {
-    return BuildLogger.super.getMessageOutputLevel();
+    return msgOutputLevel;
   }
 
   @Override
@@ -125,7 +125,7 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
       } else {
         writeStart(MessageBean.Type.FATAL);
         if (error instanceof DITAOTException) { //  && msgOutputLevel < Project.MSG_INFO
-          generator.writeStringField(FIELD_MSG, removeLevelPrefix(error.getMessage()).toString());
+          generator.writeStringField(FIELD_MSG, removeLevelPrefix(error.getMessage()));
         } else {
           try (var buf = new StringWriter(); var printWriter = new PrintWriter(buf, true)) {
             error.printStackTrace(printWriter);

--- a/src/main/java/org/dita/dost/invoker/JsonLogger.java
+++ b/src/main/java/org/dita/dost/invoker/JsonLogger.java
@@ -8,8 +8,6 @@
 
 package org.dita.dost.invoker;
 
-import static org.apache.tools.ant.util.DateUtils.formatElapsedTime;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -131,13 +129,6 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
           }
         }
       }
-      writeEnd();
-
-      writeStart("info");
-      generator.writeStringField(
-        "msg",
-        "Total time: " + formatElapsedTime(clock.instant().getEpochSecond() - timestampStack.peek())
-      );
       generator.writeStringField(
         "duration",
         Duration.ofSeconds(clock.instant().getEpochSecond() - timestampStack.pop()).toString()
@@ -196,7 +187,12 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
       timestampStack.push(clock.instant().getEpochSecond());
       try {
         writeStart(toLevel(event));
-        generator.writeStringField("msg", "Started target %s: %s".formatted(target.getName(), target.getDescription()));
+        generator.writeStringField(
+          "msg",
+          target.getDescription() != null
+            ? "Started target %s: %s".formatted(target.getName(), target.getDescription())
+            : "Started target %s".formatted(target.getName())
+        );
         writeEnd();
       } catch (IOException e) {
         throw new RuntimeException("Failed to write JSON: " + e.getMessage(), e);
@@ -229,7 +225,9 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
         writeStart(toLevel(event));
         generator.writeStringField(
           "msg",
-          "Finished target %s: %s".formatted(target.getName(), target.getDescription())
+          target.getDescription() != null
+            ? "Finished target %s: %s".formatted(target.getName(), target.getDescription())
+            : "Finished target %s".formatted(target.getName())
         );
         generator.writeStringField(
           "duration",

--- a/src/main/java/org/dita/dost/invoker/JsonLogger.java
+++ b/src/main/java/org/dita/dost/invoker/JsonLogger.java
@@ -9,6 +9,7 @@
 package org.dita.dost.invoker;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -91,7 +92,9 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
   public void buildStarted(final BuildEvent event) {
     timestampStack.push(clock.instant().toEpochMilli());
     try {
-      generator = new ObjectMapper().createGenerator(out);
+      var prettyPrinter = new MinimalPrettyPrinter();
+      prettyPrinter.setRootValueSeparator(System.lineSeparator());
+      generator = new ObjectMapper().createGenerator(out).setPrettyPrinter(prettyPrinter);
     } catch (IOException e) {
       throw new RuntimeException("Failed to open JSON generator: " + e.getMessage(), e);
     }
@@ -166,10 +169,6 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
   private void writeEnd() throws IOException {
     generator.writeEndObject();
     generator.flush();
-    if (!isArray) {
-      out.append(System.lineSeparator());
-      out.flush();
-    }
   }
 
   private boolean evaluate(final Project project, final String condition) {

--- a/src/main/java/org/dita/dost/invoker/JsonLogger.java
+++ b/src/main/java/org/dita/dost/invoker/JsonLogger.java
@@ -1,0 +1,374 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2013 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dita.dost.invoker;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.BuildLogger;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.util.DateUtils;
+import org.apache.tools.ant.util.StringUtils;
+import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.AbstractLogger;
+
+/**
+ * Writes build events to a output stream as JSON objects.
+ */
+class JsonLogger extends AbstractLogger implements BuildLogger {
+
+  // CheckStyle:VisibilityModifier OFF - bc
+  /** PrintStream to write non-error messages to */
+  private PrintStream out;
+
+  /** PrintStream to write error messages to */
+  private PrintStream err;
+
+  //** Lowest level of message to write out */
+  //  private int msgOutputLevel = Project.MSG_ERR;
+
+  /** Time of the start of the build */
+  private long startTime = System.currentTimeMillis();
+
+  /**
+   * Sole constructor.
+   */
+  public JsonLogger() {
+    msgOutputLevel = Project.MSG_ERR;
+  }
+
+  @Override
+  public void setMessageOutputLevel(final int level) {
+    msgOutputLevel = level;
+  }
+
+  @Override
+  public int getMessageOutputLevel() {
+    return BuildLogger.super.getMessageOutputLevel();
+  }
+
+  /**
+   * Sets the output stream to which this logger is to send its output.
+   *
+   * @param output The output stream for the logger. Must not be
+   *            <code>null</code>.
+   */
+  @Override
+  public void setOutputPrintStream(final PrintStream output) {
+    out = new PrintStream(output, true);
+  }
+
+  @Override
+  public void setEmacsMode(boolean emacsMode) {
+    // Ignore
+  }
+
+  /**
+   * Sets the output stream to which this logger is to send error messages.
+   *
+   * @param err The error stream for the logger. Must not be <code>null</code>
+   *            .
+   */
+  @Override
+  public void setErrorPrintStream(final PrintStream err) {
+    this.err = new PrintStream(err, true);
+  }
+
+  private JsonGenerator generator;
+
+  /**
+   * Responds to a build being started by just remembering the current time.
+   *
+   * @param event Ignored.
+   */
+  @Override
+  public void buildStarted(final BuildEvent event) {
+    startTime = System.currentTimeMillis();
+    try {
+      generator = new ObjectMapper().createGenerator(out);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to open JSON generator: " + e.getMessage(), e);
+    }
+  }
+
+  //  private static void throwableMessage(final StringBuilder m, final Throwable error, final boolean verbose) {
+  //    String msg = error.getMessage();
+  //    final int i = msg.indexOf(": ");
+  //    if (i != -1) {
+  //      msg = msg.substring(i + 1).trim();
+  //    }
+  //    m.append(msg);
+  //    //        m.append(lSep);
+  //  }
+
+  /**
+   * Prints whether the build succeeded or failed, any errors the occurred
+   * during the build, and how long the build took.
+   *
+   * @param event An event with any relevant extra information. Must not be
+   *            <code>null</code>.
+   */
+  @Override
+  public void buildFinished(final BuildEvent event) {
+    Throwable error = event.getException();
+    for (var e = error; e != null; e = e.getCause()) {
+      if (e instanceof DITAOTException) {
+        error = e;
+        break;
+      }
+    }
+    try {
+      final StringBuilder message = new StringBuilder();
+      if (error == null) {
+        if (msgOutputLevel >= Project.MSG_INFO) {
+          //          generator.writeStartObject();
+          //          generator.writeNumberField("duration", System.currentTimeMillis() - startTime);
+          //          generator.writeEndObject();
+          //          out.append(System.lineSeparator());
+          //          return;
+        }
+      } else {
+        message.append(Main.locale.getString("error_msg").formatted(""));
+        if (error instanceof DITAOTException && msgOutputLevel < Project.MSG_INFO) {
+          message.append(Main.locale.getString("exception_msg").formatted(error.getMessage()));
+        } else {
+          try (var buf = new StringWriter(); var printWriter = new PrintWriter(buf)) {
+            error.printStackTrace(printWriter);
+            printWriter.flush();
+            message.append(Main.locale.getString("exception_msg").formatted(buf));
+          } catch (IOException e) {
+            // Failed to print stack trace
+          }
+        }
+
+        if (msgOutputLevel >= Project.MSG_INFO) { //
+          //          message.append(StringUtils.LINE_SEP);
+          //          message.append("BUILD FAILED");
+          //          message.append(" in ").append(formatTime(System.currentTimeMillis() - startTime));
+        }
+      }
+      // message.append(StringUtils.LINE_SEP);
+      // message.append("Total time: ");
+      // message.append(formatTime(System.currentTimeMillis() - startTime));
+
+      generator.writeStartObject();
+      generator.writeStringField("level", "info");
+      generator.writeNumberField("duration", System.currentTimeMillis() - startTime);
+      generator.writeEndObject();
+      generator.flush();
+      out.append(System.lineSeparator());
+      out.flush();
+
+      if (!message.isEmpty()) {
+        generator.writeStartObject();
+        generator.writeStringField("level", "info");
+        if (error == null) {
+          generator.writeStringField("msg", message.toString());
+          //          out.println(msg);
+        } else {
+          generator.writeStringField("msg", removeLevelPrefix(message).toString());
+          //          err.println(removeLevelPrefix(message));
+        }
+        generator.writeEndObject();
+        generator.flush();
+        out.append(System.lineSeparator());
+        out.flush();
+      }
+      //      log(message.toString());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to write JSON: " + e.getMessage(), e);
+    } finally {
+      try {
+        generator.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to close JSON generator: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  private boolean evaluate(final Project project, final String condition) {
+    final String value = project.replaceProperties(condition);
+    return switch (value) {
+      case "true" -> true;
+      case "false" -> false;
+      default -> project.getProperty(value) != null || project.getUserProperty(value) != null;
+    };
+  }
+
+  /**
+   * Logs a message to say that the target has started if this logger allows
+   * information-level messages.
+   *
+   * @param event An event with any relevant extra information. Must not be
+   *            <code>null</code>.
+   */
+  @Override
+  public void targetStarted(final BuildEvent event) {
+    if (event.getTarget().getIf() != null && !evaluate(event.getProject(), event.getTarget().getIf())) {
+      return;
+    }
+    if (event.getTarget().getUnless() != null && evaluate(event.getProject(), event.getTarget().getUnless())) {
+      return;
+    }
+    if (Project.MSG_INFO <= msgOutputLevel && !event.getTarget().getName().equals("")) {
+      try {
+        generator.writeStartObject();
+        generator.writeStringField(
+          "level",
+          switch (event.getPriority()) {
+            case Project.MSG_ERR -> "error";
+            case Project.MSG_WARN -> "warn";
+            case Project.MSG_INFO -> "info";
+            case Project.MSG_VERBOSE -> "debug";
+            case Project.MSG_DEBUG -> "trace";
+            default -> throw new IllegalArgumentException("Unexpected value: " + event.getPriority());
+          }
+        );
+        generator.writeStringField("target", event.getTarget().getName());
+        generator.writeStringField("msg", event.getTarget().getDescription());
+        generator.writeEndObject();
+        generator.flush();
+        out.append(System.lineSeparator());
+        out.flush();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to write JSON: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  /**
+   * No-op implementation.
+   *
+   * @param event Ignored.
+   */
+  @Override
+  public void targetFinished(final BuildEvent event) {}
+
+  /**
+   * No-op implementation.
+   *
+   * @param event Ignored.
+   */
+  @Override
+  public void taskStarted(final BuildEvent event) {}
+
+  /**
+   * No-op implementation.
+   *
+   * @param event Ignored.
+   */
+  @Override
+  public void taskFinished(final BuildEvent event) {}
+
+  /**
+   * Logs a message, if the priority is suitable. In non-emacs mode, task
+   * level messages are prefixed by the task name which is right-justified.
+   *
+   * @param event A BuildEvent containing message information. Must not be
+   *            <code>null</code>.
+   */
+  @Override
+  public void messageLogged(final BuildEvent event) {
+    final int priority = event.getPriority();
+    // Filter out messages based on priority
+    if (priority <= msgOutputLevel) {
+      try {
+        generator.writeStartObject();
+        generator.writeStringField("level", "info");
+        final StringBuilder message = new StringBuilder(event.getMessage());
+        if (event.getTask() != null) {
+          generator.writeStringField("task", event.getTask().getTaskName());
+        }
+        final Throwable ex = event.getException();
+        if (Project.MSG_VERBOSE <= msgOutputLevel && ex != null) {
+          generator.writeStringField("stacktrace", StringUtils.getStackTrace(ex));
+        }
+        generator.writeStringField("msg", removeLevelPrefix(message).toString());
+        generator.writeEndObject();
+        generator.flush();
+        out.append(System.lineSeparator());
+        out.flush();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to write JSON: " + e.getMessage(), e);
+      }
+      //      log(msg);
+    }
+  }
+
+  /**
+   * Convenience method to format a specified length of time.
+   *
+   * @param millis Length of time to format, in milliseconds.
+   *
+   * @return the time as a formatted string.
+   *
+   * @see DateUtils#formatElapsedTime(long)
+   */
+  protected static String formatTime(final long millis) {
+    return DateUtils.formatElapsedTime(millis);
+  }
+
+  /**
+   * Empty implementation which allows subclasses to receive the same output
+   * that is generated here.
+   *
+   * @param message Message being logged. Should not be <code>null</code>.
+   */
+  private void log(final String message) {}
+
+  //  /**
+  //   * Get the current time.
+  //   *
+  //   * @return the current time as a formatted string.
+  //   * @since Ant1.7.1
+  //   */
+  //  protected String getTimestamp() {
+  //    final Date date = new Date(System.currentTimeMillis());
+  //    final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT);
+  //    return formatter.format(date);
+  //  }
+
+  //  /**
+  //   * Get the project name or null
+  //   *
+  //   * @param event the event
+  //   * @return the project that raised this event
+  //   * @since Ant1.7.1
+  //   */
+  //  protected String extractProjectName(final BuildEvent event) {
+  //    final Project project = event.getProject();
+  //    return (project != null) ? project.getName() : null;
+  //  }
+
+  @Override
+  public void log(String msg, Throwable t, int level) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/org/dita/dost/invoker/JsonLogger.java
+++ b/src/main/java/org/dita/dost/invoker/JsonLogger.java
@@ -308,15 +308,21 @@ public class JsonLogger extends AbstractLogger implements BuildLogger {
   }
 
   private static final Pattern LOCATION_PREFIX = Pattern.compile(
-    "^(.+):(\\d+):(\\d+):\\s+(?:\\[(\\w+)])?(?:\\[(\\w+)])?:?\\s+"
+    "^(?:(.+):(\\d+):(\\d+):\\s+)?(?:\\[(\\w+)])?(?:\\[(\\w+)])?:?\\s+"
   );
 
   private void extractLocation(StringBuilder message) throws IOException {
     final Matcher matcher = LOCATION_PREFIX.matcher(message);
     if (matcher.find()) {
-      generator.writeStringField("location", matcher.group(1));
-      generator.writeNumberField("line", Integer.parseInt(matcher.group(2)));
-      generator.writeNumberField("row", Integer.parseInt(matcher.group(3)));
+      if (matcher.group(1) != null) {
+        generator.writeStringField("location", matcher.group(1));
+      }
+      if (matcher.group(2) != null) {
+        generator.writeNumberField("line", Integer.parseInt(matcher.group(2)));
+      }
+      if (matcher.group(3) != null) {
+        generator.writeNumberField("row", Integer.parseInt(matcher.group(3)));
+      }
       for (int i = 4; i <= matcher.groupCount(); i++) {
         if (matcher.group(i) != null) {
           switch (matcher.group(i).toUpperCase()) {

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -42,6 +42,8 @@ import com.google.common.base.Strings;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDateTime;
@@ -448,7 +450,12 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
     if (args.logFile != null) {
       PrintStream logTo;
       try {
-        logTo = new PrintStream(new FileOutputStream(args.logFile));
+        logTo =
+          new PrintStream(
+            Files.newOutputStream(args.logFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.CREATE),
+            false,
+            StandardCharsets.UTF_8
+          );
       } catch (final IOException ioe) {
         throw new CliException(
           "Cannot write to the specified log file. Make sure the path exists and you have write permissions."
@@ -1174,6 +1181,10 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       logger = new org.apache.tools.ant.DefaultLogger();
     } else {
       logger = new DefaultLogger().useColor(args.useColor).setPrintStacktrace(args.printStacktrace);
+    }
+
+    if (logger instanceof JsonLogger && args.logFile != null) {
+      ((JsonLogger) logger).setArray(true);
     }
 
     logger.setMessageOutputLevel(args.msgOutputLevel);

--- a/src/main/java/org/dita/dost/invoker/Main.java
+++ b/src/main/java/org/dita/dost/invoker/Main.java
@@ -39,10 +39,12 @@ import static org.dita.dost.util.XMLUtils.toList;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -1183,8 +1185,8 @@ public class Main extends org.apache.tools.ant.Main implements AntMain {
       logger = new DefaultLogger().useColor(args.useColor).setPrintStacktrace(args.printStacktrace);
     }
 
-    if (logger instanceof JsonLogger && args.logFile != null) {
-      ((JsonLogger) logger).setArray(true);
+    if (logger instanceof JsonLogger jsonLogger && args.logFile != null) {
+      jsonLogger.setArray(true);
     }
 
     logger.setMessageOutputLevel(args.msgOutputLevel);

--- a/src/main/java/org/dita/dost/log/AbstractLogger.java
+++ b/src/main/java/org/dita/dost/log/AbstractLogger.java
@@ -11,7 +11,6 @@ import java.text.MessageFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.tools.ant.Project;
-import org.dita.dost.invoker.Main;
 import org.dita.dost.util.Configuration;
 import org.slf4j.helpers.MarkerIgnoringBase;
 
@@ -232,27 +231,6 @@ public abstract class AbstractLogger extends MarkerIgnoringBase implements DITAO
       return;
     }
     StringBuilder buf = null;
-    if (!legacyFormat) {
-      if (level == Project.MSG_ERR) {
-        buf = new StringBuilder();
-        if (useColor) {
-          buf.append(ANSI_RED);
-        }
-        buf.append(Main.locale.getString("error_msg").formatted(""));
-        if (useColor) {
-          buf.append(ANSI_RESET);
-        }
-      } else if (level == Project.MSG_WARN) {
-        buf = new StringBuilder();
-        if (useColor) {
-          buf.append(ANSI_YELLOW);
-        }
-        buf.append(Main.locale.getString("warn_msg").formatted(""));
-        if (useColor) {
-          buf.append(ANSI_RESET);
-        }
-      }
-    }
     if (args.length > 0) {
       if (buf == null) {
         buf = new StringBuilder();

--- a/src/main/java/org/dita/dost/log/MessageBean.java
+++ b/src/main/java/org/dita/dost/log/MessageBean.java
@@ -34,6 +34,7 @@ public final class MessageBean {
     WARN,
     INFO,
     DEBUG,
+    TRACE,
   }
 
   public static final String FATAL = Type.FATAL.name();
@@ -41,6 +42,7 @@ public final class MessageBean {
   public static final String WARN = Type.WARN.name();
   public static final String INFO = Type.INFO.name();
   public static final String DEBUG = Type.DEBUG.name();
+  public static final String TRACE = Type.TRACE.name();
 
   public final String id;
   public final Type type;

--- a/src/main/resources/cli_en_US.properties
+++ b/src/main/resources/cli_en_US.properties
@@ -75,6 +75,7 @@ conversion.option.filter=Filter and flagging files. This option can be passed mu
 conversion.option.output=Output directory
 conversion.option.logfile=Write log messages to file
 conversion.option.deliverable=Project deliverable name. This option can be passed multiple times.
+conversion.option.logger=Log format
 conversion.option.propertyfile=Load all properties from file
 conversion.option.repeat=Performs the transformation N times
 conversion.repeatDuration=%d %dms

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -17,10 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
@@ -97,13 +94,13 @@ class JsonLoggerTest {
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertArrayEquals(
       new LogEntry[] {
-        new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null),
-        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", null, null),
-        new LogEntry(ZonedDateTime.now(clock), "info", "Total time: 0 seconds", null, null),
+        new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null, null),
+        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", null, null, null),
+        new LogEntry(ZonedDateTime.now(clock), "info", "Total time: 0 seconds", Duration.ofSeconds(0), null, null),
       },
       act
     );
-    //    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);
+    //    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);é
     //    assertEquals(
     //      new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null),
     //      act[1]
@@ -126,12 +123,19 @@ class JsonLoggerTest {
     System.out.println(new String(buf.toByteArray()));
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "message", null, "task"), act[0]);
+    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "message", null, null, "task"), act[0]);
   }
 
   private LogEntry entry(String level, String msg) {
-    return new LogEntry(ZonedDateTime.now(clock), level, msg, null, null);
+    return new LogEntry(ZonedDateTime.now(clock), level, msg, null, null, null);
   }
 
-  private record LogEntry(ZonedDateTime timestamp, String level, String msg, String target, String task) {}
+  private record LogEntry(
+    ZonedDateTime timestamp,
+    String level,
+    String msg,
+    Duration duration,
+    String target,
+    String task
+  ) {}
 }

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -169,34 +169,93 @@ class JsonLoggerTest {
     return List.of(
       Arguments.of(
         "[DOTJ037W][INFO] Message",
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "[DOTJ037W] Message", null, null, "task")
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Message",
+          null,
+          null,
+          "task",
+          "DOTJ037W",
+          null,
+          null,
+          null
+        )
       ),
       Arguments.of(
         "[DOTJ037W][INFO]: Message",
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "[DOTJ037W]: Message", null, null, "task")
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Message",
+          null,
+          null,
+          "task",
+          "DOTJ037W",
+          null,
+          null,
+          null
+        )
       ),
       Arguments.of(
         "[DOTJ037W] Message",
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "[DOTJ037W] Message", null, null, "task")
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Message",
+          null,
+          null,
+          "task",
+          "DOTJ037W",
+          null,
+          null,
+          null
+        )
       ),
       Arguments.of(
         "[DOTJ037W][Warning]: Message",
         new LogEntry(
           ZonedDateTime.now(clock),
           MessageBean.Type.INFO,
-          "[DOTJ037W][Warning]: Message",
+          "Message",
           null,
           null,
-          "task"
+          "task",
+          "DOTJ037W",
+          null,
+          null,
+          null
         )
       ),
       Arguments.of(
         "[WARN][DOTJ037W]: Message",
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "[WARN][DOTJ037W]: Message", null, null, "task")
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Message",
+          null,
+          null,
+          "task",
+          "DOTJ037W",
+          null,
+          null,
+          null
+        )
       ),
       Arguments.of(
         "[WARN] Message",
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "[WARN] Message", null, null, "task")
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Message",
+          null,
+          null,
+          "task",
+          null,
+          null,
+          null,
+          null
+        )
       ),
       Arguments.of(
         "file:/src/path.dita:2:3: [DOTJ037W][INFO] Message",

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -88,7 +88,7 @@ class JsonLoggerTest {
   @Test
   void target() throws IOException {
     var event = new BuildEvent(createTarget());
-    event.setMessage("message", Project.MSG_INFO);
+    event.setMessage("message", Project.MSG_DEBUG);
 
     logger.targetStarted(event);
     logger.targetFinished(event);
@@ -102,7 +102,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Started target target: description",
           null,
-          null,
+          "target",
           null
         ),
         new LogEntry(
@@ -110,7 +110,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Finished target target: description",
           Duration.ZERO,
-          null,
+          "target",
           null
         ),
         new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
@@ -122,7 +122,8 @@ class JsonLoggerTest {
   @Test
   void task() throws IOException {
     var event = new BuildEvent(createTask());
-    event.setMessage("message", Project.MSG_INFO);
+    event.setMessage("message", Project.MSG_DEBUG);
+    logger.setOutputLevel(Project.MSG_DEBUG);
 
     logger.taskStarted(event);
     logger.taskFinished(event);
@@ -133,19 +134,19 @@ class JsonLoggerTest {
       new LogEntry[] {
         new LogEntry(
           ZonedDateTime.now(clock),
-          MessageBean.Type.INFO,
+          MessageBean.Type.TRACE,
           "Started task task: description",
           null,
-          null,
-          null
+          "target",
+          "task"
         ),
         new LogEntry(
           ZonedDateTime.now(clock),
-          MessageBean.Type.INFO,
+          MessageBean.Type.TRACE,
           "Finished task task: description",
           Duration.ZERO,
-          null,
-          null
+          "target",
+          "task"
         ),
         new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
       },
@@ -162,7 +163,10 @@ class JsonLoggerTest {
     logger.buildFinished(new BuildEvent(createProject()));
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "message", null, null, "task"), act[0]);
+    assertEquals(
+      new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "message", null, "target", "task"),
+      act[0]
+    );
   }
 
   static List<Arguments> removeLevelPrefix() {
@@ -174,7 +178,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           null,
@@ -189,7 +193,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           null,
@@ -204,7 +208,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           null,
@@ -219,7 +223,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           null,
@@ -234,7 +238,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           null,
@@ -249,7 +253,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           null,
           null,
@@ -264,7 +268,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           "file:/src/path.dita",
@@ -279,7 +283,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           "file:/src/path.dita",
@@ -294,7 +298,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           "file:/src/path.dita",
@@ -309,7 +313,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           "file:/src/path.dita",
@@ -324,7 +328,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           "DOTJ037W",
           "file:/src/path.dita",
@@ -339,7 +343,7 @@ class JsonLoggerTest {
           MessageBean.Type.INFO,
           "Message",
           null,
-          null,
+          "target",
           "task",
           null,
           "file:/src/path.dita",

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the DITA Open Toolkit project.
+ *
+ * Copyright 2025 Jarno Elovirta
+ *
+ * See the accompanying LICENSE file for applicable license.
+ */
+
+package org.dita.dost.invoker;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Target;
+import org.apache.tools.ant.Task;
+import org.dita.dost.exception.DITAOTException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JsonLoggerTest {
+
+  private final ObjectReader objectReader = new ObjectMapper()
+    .findAndRegisterModules()
+    .readerForArrayOf(LogEntry.class);
+  private final Clock clock = Clock.fixed(Instant.now(), ZoneId.of("Z"));
+  private JsonLogger logger;
+  private ByteArrayOutputStream buf;
+  private PrintStream out;
+
+  @BeforeEach
+  void setUp() {
+    logger = new JsonLogger();
+    buf = new ByteArrayOutputStream();
+    out = new PrintStream(buf, true, StandardCharsets.UTF_8);
+    logger.setOutputPrintStream(out);
+    logger.setMessageOutputLevel(Project.MSG_INFO);
+    logger.setArray(true);
+    logger.setClock(clock);
+
+    logger.buildStarted(new BuildEvent(new Project()));
+  }
+
+  @AfterEach
+  void tearDown() {
+    out.close();
+  }
+
+  @Test
+  void buildFinished() throws IOException {
+    var event = new BuildEvent(new Project());
+
+    logger.buildFinished(event);
+
+    final LogEntry[] act = objectReader.readValue(buf.toByteArray());
+    assertArrayEquals(new LogEntry[] { entry("info", "BUILD SUCCESSFUL") }, act);
+  }
+
+  @Test
+  void buildFinished_error() throws IOException {
+    var event = new BuildEvent(new Project());
+    event.setException(new DITAOTException("test"));
+
+    logger.buildFinished(event);
+
+    final LogEntry[] act = objectReader.readValue(buf.toByteArray());
+    assertEquals(2, act.length);
+    assertEquals(entry("fatal", "BUILD SUCCESSFUL"), act[0]);
+    assertEquals("info", act[1].level);
+  }
+
+  @Test
+  void targetStarted() throws IOException {
+    final Target target = new Target();
+    target.setName("target");
+    target.setDescription("description");
+    var event = new BuildEvent(target);
+    event.setMessage("message", Project.MSG_INFO);
+
+    logger.targetStarted(event);
+    logger.buildFinished(new BuildEvent(new Project()));
+
+    System.out.println(new String(buf.toByteArray()));
+
+    final LogEntry[] act = objectReader.readValue(buf.toByteArray());
+    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);
+  }
+
+  @Test
+  void messageLogged() throws IOException {
+    var target = new Target();
+    target.setName("target");
+    final Task task = new Task() {};
+    task.setTaskName("task");
+    task.setOwningTarget(target);
+    var event = new BuildEvent(task);
+    event.setMessage("message", Project.MSG_INFO);
+
+    logger.messageLogged(event);
+    logger.buildFinished(new BuildEvent(new Project()));
+
+    System.out.println(new String(buf.toByteArray()));
+
+    final LogEntry[] act = objectReader.readValue(buf.toByteArray());
+    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "message", null, "task"), act[0]);
+  }
+
+  private LogEntry entry(String level, String msg) {
+    return new LogEntry(ZonedDateTime.now(clock), level, msg, null, null);
+  }
+
+  private record LogEntry(ZonedDateTime timestamp, String level, String msg, String target, String task) {}
+}

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -17,7 +17,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
-import java.time.*;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.Project;
@@ -68,7 +71,7 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(
-      new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+      new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "Build successful", 0L, null, null),
       act[0]
     );
   }
@@ -82,7 +85,7 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(MessageBean.Type.FATAL, act[0].level);
-    assertEquals(Duration.ZERO, act[0].duration);
+    assertEquals(0L, act[0].duration);
   }
 
   @Test
@@ -109,11 +112,11 @@ class JsonLoggerTest {
           ZonedDateTime.now(clock),
           MessageBean.Type.INFO,
           "Finished target target: description",
-          Duration.ZERO,
+          0L,
           "target",
           null
         ),
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "Build successful", 0L, null, null),
       },
       act
     );
@@ -144,11 +147,11 @@ class JsonLoggerTest {
           ZonedDateTime.now(clock),
           MessageBean.Type.TRACE,
           "Finished task task: description",
-          Duration.ZERO,
+          0L,
           "target",
           "task"
         ),
-        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "Build successful", 0L, null, null),
       },
       act
     );
@@ -392,7 +395,7 @@ class JsonLoggerTest {
     ZonedDateTime timestamp,
     MessageBean.Type level,
     String msg,
-    Duration duration,
+    Long duration,
     String target,
     String task,
     String code,
@@ -400,14 +403,7 @@ class JsonLoggerTest {
     Integer line,
     Integer row
   ) {
-    LogEntry(
-      ZonedDateTime timestamp,
-      MessageBean.Type level,
-      String msg,
-      Duration duration,
-      String target,
-      String task
-    ) {
+    LogEntry(ZonedDateTime timestamp, MessageBean.Type level, String msg, Long duration, String target, String task) {
       this(timestamp, level, msg, duration, target, task, null, null, null, null);
     }
   }

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -8,6 +8,7 @@
 
 package org.dita.dost.invoker;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,7 +66,7 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(2, act.length);
-    assertEquals(entry("info", "BUILD SUCCESSFUL"), act[0]);
+    assertEquals(entry("debug", "BUILD SUCCESSFUL"), act[0]);
   }
 
   @Test
@@ -91,10 +92,22 @@ class JsonLoggerTest {
     logger.targetStarted(event);
     logger.buildFinished(new BuildEvent(new Project()));
 
-    System.out.println(new String(buf.toByteArray()));
+    //    System.out.println(new String(buf.toByteArray()));
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);
+    assertArrayEquals(
+      new LogEntry[] {
+        new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null),
+        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", null, null),
+        new LogEntry(ZonedDateTime.now(clock), "info", "Total time: 0 seconds", null, null),
+      },
+      act
+    );
+    //    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);
+    //    assertEquals(
+    //      new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null),
+    //      act[1]
+    //    );
   }
 
   @Test

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -62,8 +62,10 @@ class JsonLoggerTest {
     logger.buildFinished(event);
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(2, act.length);
-    assertEquals(entry("debug", "BUILD SUCCESSFUL"), act[0]);
+    assertEquals(
+      new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", Duration.ofSeconds(0), null, null),
+      act[0]
+    );
   }
 
   @Test
@@ -74,8 +76,8 @@ class JsonLoggerTest {
     logger.buildFinished(event);
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(2, act.length);
     assertEquals("fatal", act[0].level);
+    assertEquals(Duration.ZERO, act[0].duration);
   }
 
   @Test
@@ -89,22 +91,14 @@ class JsonLoggerTest {
     logger.targetStarted(event);
     logger.buildFinished(new BuildEvent(new Project()));
 
-    //    System.out.println(new String(buf.toByteArray()));
-
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertArrayEquals(
       new LogEntry[] {
         new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null, null),
-        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", null, null, null),
-        new LogEntry(ZonedDateTime.now(clock), "info", "Total time: 0 seconds", Duration.ofSeconds(0), null, null),
+        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", Duration.ZERO, null, null),
       },
       act
     );
-    //    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "description", "target", null), act[0]);é
-    //    assertEquals(
-    //      new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null),
-    //      act[1]
-    //    );
   }
 
   @Test
@@ -124,10 +118,6 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "message", null, null, "task"), act[0]);
-  }
-
-  private LogEntry entry(String level, String msg) {
-    return new LogEntry(ZonedDateTime.now(clock), level, msg, null, null, null);
   }
 
   private record LogEntry(

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -8,7 +8,6 @@
 
 package org.dita.dost.invoker;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,7 +64,8 @@ class JsonLoggerTest {
     logger.buildFinished(event);
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertArrayEquals(new LogEntry[] { entry("info", "BUILD SUCCESSFUL") }, act);
+    assertEquals(2, act.length);
+    assertEquals(entry("info", "BUILD SUCCESSFUL"), act[0]);
   }
 
   @Test
@@ -77,8 +77,7 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(2, act.length);
-    assertEquals(entry("fatal", "BUILD SUCCESSFUL"), act[0]);
-    assertEquals("info", act[1].level);
+    assertEquals("fatal", act[0].level);
   }
 
   @Test

--- a/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
+++ b/src/test/java/org/dita/dost/invoker/JsonLoggerTest.java
@@ -23,6 +23,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
 import org.dita.dost.exception.DITAOTException;
+import org.dita.dost.log.MessageBean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ class JsonLoggerTest {
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertEquals(
-      new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+      new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
       act[0]
     );
   }
@@ -76,7 +77,7 @@ class JsonLoggerTest {
     logger.buildFinished(event);
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals("fatal", act[0].level);
+    assertEquals(MessageBean.Type.FATAL, act[0].level);
     assertEquals(Duration.ZERO, act[0].duration);
   }
 
@@ -95,16 +96,23 @@ class JsonLoggerTest {
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertArrayEquals(
       new LogEntry[] {
-        new LogEntry(ZonedDateTime.now(clock), "info", "Started target target: description", null, null, null),
         new LogEntry(
           ZonedDateTime.now(clock),
-          "info",
+          MessageBean.Type.INFO,
+          "Started target target: description",
+          null,
+          null,
+          null
+        ),
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
           "Finished target target: description",
           Duration.ZERO,
           null,
           null
         ),
-        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
       },
       act
     );
@@ -128,9 +136,23 @@ class JsonLoggerTest {
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
     assertArrayEquals(
       new LogEntry[] {
-        new LogEntry(ZonedDateTime.now(clock), "info", "Started task task: description", null, null, null),
-        new LogEntry(ZonedDateTime.now(clock), "info", "Finished task task: description", Duration.ZERO, null, null),
-        new LogEntry(ZonedDateTime.now(clock), "debug", "BUILD SUCCESSFUL", Duration.ZERO, null, null),
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Started task task: description",
+          null,
+          null,
+          null
+        ),
+        new LogEntry(
+          ZonedDateTime.now(clock),
+          MessageBean.Type.INFO,
+          "Finished task task: description",
+          Duration.ZERO,
+          null,
+          null
+        ),
+        new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "BUILD SUCCESSFUL", Duration.ZERO, null, null),
       },
       act
     );
@@ -152,12 +174,12 @@ class JsonLoggerTest {
     System.out.println(new String(buf.toByteArray()));
 
     final LogEntry[] act = objectReader.readValue(buf.toByteArray());
-    assertEquals(new LogEntry(ZonedDateTime.now(clock), "info", "message", null, null, "task"), act[0]);
+    assertEquals(new LogEntry(ZonedDateTime.now(clock), MessageBean.Type.INFO, "message", null, null, "task"), act[0]);
   }
 
   private record LogEntry(
     ZonedDateTime timestamp,
-    String level,
+    MessageBean.Type level,
     String msg,
     Duration duration,
     String target,


### PR DESCRIPTION
## Description
Add JSON logging format with `--logger=json`. When log is output to standard out, the log format is row based where each row is a JSON object. When log is output to a file, the log format is a JSON array with JSON objects.

## Open issues

- [ ] What should the format and accuracy of `duration` be?

## Motivation and Context
A structured log format allows for easier log processing and introspection.

## How Has This Been Tested?
New unit tests.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
New section to https://www.dita-ot.org/dev/topics/logging about structured logging. This only applies to CLI.
