### PR TITLE
Update logback version for security fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.12'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.14'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.17'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.16.1'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.1'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'


### PR DESCRIPTION
## Description

Updates `logback-core` to latest version, to address CVE-2024-12798

## Motivation and Context

Fixes https://nvd.nist.gov/vuln/detail/CVE-2024-12798

## How Has This Been Tested?

Unit tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

Doc update should note new version of dependency
