### PR TITLE
Support format option for validate

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ValidateArguments.java
+++ b/src/main/java/org/dita/dost/invoker/ValidateArguments.java
@@ -56,14 +56,14 @@ class ValidateArguments extends Arguments {
       final String arg = args.pop();
       if (arg.equals("validate")) {
         definedProps.put("transtype", "validate");
-        break;
-      } else if (arg.startsWith("-")) {
-        parseCommonOptions(arg, args);
-      }
-    }
-    while (!args.isEmpty()) {
-      final String arg = args.pop();
-      if (isLongForm(arg, "-project") || arg.equals("-p")) {
+      } else if (isLongForm(arg, "-format") || arg.equals("-f")) {
+        final Map.Entry<String, String> entry = parse(arg, args);
+        if (entry.getValue().equals("validate")) {
+          definedProps.put("transtype", "validate");
+        } else {
+          // Ignore, this only happens when both validate subcommand and --format option are used and the --format option is not validate.
+        }
+      } else if (isLongForm(arg, "-project") || arg.equals("-p")) {
         handleArgProject(arg, args);
       } else if (isLongForm(arg, "-input") || arg.equals("-i")) {
         handleArgInput(arg, args, ARGUMENTS.get(getArgumentName(arg)));


### PR DESCRIPTION
## Description
Support `--format=validate` as a fallback.

## Motivation and Context
The correct way to run validation is using the `validate` subcommand, but support running validation via `--format=validate` when users attempt to use validation with `--format` option.

Fixes #4590

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
This is a fallback behaviour which users should not use. Thus this should not be documented as a feature.