### PR TITLE
Build Docker image for both linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,12 @@ jobs:
           PAT: ${{ secrets.PACKAGE_REGISTRY }}
       - name: Build image
         run: |
-          docker build --tag ghcr.io/dita-ot/dita-ot:${VERSION} --build-arg VERSION=${VERSION} .
+          docker build --platform linux/amd64,linux/arm64 --tag ghcr.io/dita-ot/dita-ot:${VERSION} --build-arg VERSION=${VERSION} .
         env:
           VERSION: ${{ env.tag }}
       - name: Deploy image
         run: |
-          docker push ghcr.io/dita-ot/dita-ot:${VERSION}
+          docker push --platform linux/amd64,linux/arm64 ghcr.io/dita-ot/dita-ot:${VERSION}
         env:
           VERSION: ${{ env.tag }}
   # Publish release to Maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jre
 ARG VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Description
Build Docker image for both linux/amd64 and linux/arm64.

## Motivation and Context
This allows running a DITA-OT docker image that corresponds to your machine architecture.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Only needs to be mentioned in release notes.

Docker will pick up the correct platform automatically, so users don't need to do anything to benefit from this enhancement. 
