### PR TITLE
add lines element to is-block function

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2271,6 +2271,7 @@ See the accompanying LICENSE file for applicable license.
                           contains($class, ' topic/p ') or
                           (contains($class, ' topic/image ') and $element/@placement = 'break') or
                           contains($class, ' topic/pre ') or
+                          contains($class, ' topic/lines ') or
                           contains($class, ' topic/note ') or
                           contains($class, ' topic/fig ') or
                           contains($class, ' topic/dl ') or


### PR DESCRIPTION
Add lines element (simiilar to pre element) to is-block function (see #4596)

## Description
The XSL function **dita-ot:is-block** in topics.xsl (HTML5 plugin) should contain an additional contains check for topic/lines.

The lines element should be treated same as pre elements:: https://docs.oasis-open.org/dita/v1.0/langspec/lines.html

## Motivation and Context
see #4596

## How Has This Been Tested?

Convert DITA to HTML using dita command line:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
<topic id="topic_vm3_v3z_bq">
  <title>Hello World</title>
  <body>
    <p>Text <lines>lines</lines> more text<p>
  </body>
</topic>
```

## Type of Changes
- Bug fix
- 
## Documentation and Compatibility

no updates required

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.
