### PR TITLE
Fix subcommand backwards compatibility bug

### DIFF
--- a/src/main/java/org/dita/dost/invoker/ArgumentParser.java
+++ b/src/main/java/org/dita/dost/invoker/ArgumentParser.java
@@ -88,7 +88,7 @@ final class ArgumentParser {
    */
   public Arguments processArgs(final String[] arguments) {
     for (final String subcommand : arguments) {
-      switch (getName(subcommand)) {
+      switch (subcommand) {
         case "help":
           return new HelpArguments().parse(arguments);
         case "plugins":
@@ -107,6 +107,20 @@ final class ArgumentParser {
           return new UninstallArguments().parse(arguments);
         case "init":
           return new InitArguments().parse(arguments);
+      }
+      // Deprecated since 4.3
+      // Backwards compatibility for pre 3.5
+      switch (getName(subcommand)) {
+        case "plugins":
+          return new PluginsArguments().parse(arguments);
+        case "version":
+          return new VersionArguments().parse(arguments);
+        case "transtypes":
+          return new TranstypesArguments().parse(arguments);
+        case "install":
+          return new InstallArguments().parse(arguments);
+        case "uninstall":
+          return new UninstallArguments().parse(arguments);
       }
     }
     return new ConversionArguments().parse(arguments);

--- a/src/main/java/org/dita/dost/invoker/ArgumentParser.java
+++ b/src/main/java/org/dita/dost/invoker/ArgumentParser.java
@@ -83,8 +83,7 @@ final class ArgumentParser {
    * Process command line arguments. When ant is started from Launcher,
    * launcher-only arguments do not get passed through to this routine.
    *
-   * @param arguments the command line arguments.
-   * @since Ant 1.6
+   * @param arguments the command line arguments
    */
   public Arguments processArgs(final String[] arguments) {
     for (final String subcommand : arguments) {

--- a/src/test/java/org/dita/dost/invoker/ArgumentParserTest.java
+++ b/src/test/java/org/dita/dost/invoker/ArgumentParserTest.java
@@ -150,14 +150,6 @@ public class ArgumentParserTest {
   }
 
   @Test
-  public void deliverablesSubcommand__optionForm() {
-    final DeliverablesArguments act = (DeliverablesArguments) parser.processArgs(
-      new String[] { "--deliverables", "-p", "project.json" }
-    );
-    assertEquals(new File("project.json").getAbsoluteFile(), act.projectFile);
-  }
-
-  @Test
   public void initSubcommand() {
     final InitArguments act = (InitArguments) parser.processArgs(new String[] { "init", "template" });
     assertEquals("template", act.template);


### PR DESCRIPTION
## Description
Fix subcommand backwards compatibility bug where new subcommands added after 3.5 are have support for the legacy option format. Because `validate` subcommand was not available before 3.5, there should not be backwards compatibility support for `-validate` or `--validate` option format.

## Motivation and Context
Fixes #4602
## How Has This Been Tested?
Unit tests
## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Note in release notes, no change in expected behaviour.