### PR TITLE
Do not process topicrefs copied in chunk context

### DIFF
--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -153,7 +153,7 @@ public final class MapMetaReader extends AbstractDomFilter {
     return doc;
   }
 
-  private void collectTopicrefs(final Element topicref, final Attr chunkAttr) {
+  private void collectTopicrefs(final Element topicref, Attr chunkAttr) {
     final URI hrefAttr = Optional
       .ofNullable(topicref.getAttributeNode(ATTRIBUTE_NAME_HREF))
       .map(Node::getNodeValue)
@@ -164,13 +164,16 @@ public final class MapMetaReader extends AbstractDomFilter {
     Map<String, Element> current = Collections.emptyMap();
     final boolean hasDitaTopicTarget = hrefAttr != null && isLocalScope(scopeAttr) && isDitaFormat(formatAttr);
 
+    final Attr copyToAttr = topicref.getAttributeNode(ATTRIBUTE_NAME_COPY_TO);
+    if (chunkAttr == null || !chunkAttr.getNodeValue().equals("to-content")) {
+      chunkAttr = topicref.getAttributeNode(ATTRIBUTE_NAME_CHUNK);
+    }
+    final boolean isCopiedInChunk = copyToAttr != null &&
+        (chunkAttr != null && chunkAttr.getNodeValue().equals("to-content"));
+
     for (Element elem : XMLUtils.getChildElements(topicref, MAP_TOPICREF)) {
       collectTopicrefs(elem, chunkAttr);
     }
-
-    final Attr copyToAttr = topicref.getAttributeNode(ATTRIBUTE_NAME_COPY_TO);
-    final boolean isCopiedInChunk = copyToAttr != null &&
-        (chunkAttr != null && chunkAttr.getNodeValue().equals("to-content"));
 
     if (hasDitaTopicTarget && !isCopiedInChunk) {
       for (Element elem : XMLUtils.getChildElements(topicref, MAP_TOPICMETA)) {

--- a/src/main/java/org/dita/dost/reader/MapMetaReader.java
+++ b/src/main/java/org/dita/dost/reader/MapMetaReader.java
@@ -168,8 +168,8 @@ public final class MapMetaReader extends AbstractDomFilter {
     if (chunkAttr == null || !chunkAttr.getNodeValue().equals("to-content")) {
       chunkAttr = topicref.getAttributeNode(ATTRIBUTE_NAME_CHUNK);
     }
-    final boolean isCopiedInChunk = copyToAttr != null &&
-        (chunkAttr != null && chunkAttr.getNodeValue().equals("to-content"));
+    final boolean isCopiedInChunk =
+      copyToAttr != null && (chunkAttr != null && chunkAttr.getNodeValue().equals("to-content"));
 
     for (Element elem : XMLUtils.getChildElements(topicref, MAP_TOPICREF)) {
       collectTopicrefs(elem, chunkAttr);


### PR DESCRIPTION
## Description
When copied topicrefs are processed in chunked context, they trigger an "Error: File ... was not found."

## Motivation and Context
Fixes #4601.

## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.