### PR TITLE
Fix basedir with uplevels resource-only resources

### DIFF
--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -35,7 +35,6 @@ import org.dita.dost.pipeline.AbstractPipelineOutput;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
-import org.dita.dost.util.XMLUtils;
 import org.dita.dost.writer.AbstractXMLFilter;
 import org.dita.dost.writer.LinkFilter;
 import org.dita.dost.writer.MapCleanFilter;
@@ -230,7 +229,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     final Collection<FileInfo> fis = job.getFileInfo();
     URI baseDir = job.getFileInfo(fi -> fi.isInput).iterator().next().result.resolve(".");
     for (final FileInfo fi : fis) {
-      if (fi.result != null) {
+      if (fi.result != null && !fi.isResourceOnly) {
         final URI res = fi.result.resolve(".");
         baseDir = Optional.ofNullable(getCommonBase(baseDir, res)).orElse(baseDir);
       }

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -130,6 +130,28 @@ public class CleanPreprocessModuleTest {
   }
 
   @Test
+  public void getBaseDirResourceOnly() throws Exception {
+    job.setInputDir(URI.create("file:/main/maps/"));
+    job.add(
+      new Builder()
+        .uri(create("main/maps/map.ditamap"))
+        .isInput(true)
+        .result(create("file:/main/maps/map.ditamap"))
+        .build()
+    );
+    job.add(new Builder().uri(create("main/topics/topic.dita")).result(create("file:/main/topics/topic.dita")).build());
+    job.add(
+      new Builder()
+        .uri(create("reuse/reuse.dita"))
+        .result(create("file:/reuse/reuse.dita"))
+        .isResourceOnly(true)
+        .build()
+    );
+
+    assertEquals(create("file:/"), module.getBaseDir());
+  }
+
+  @Test
   public void RewriteRule_WhenStylesheetNotFound_ShouldThrowException() throws Exception {
     assertThrows(
       RuntimeException.class,

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -148,7 +148,7 @@ public class CleanPreprocessModuleTest {
         .build()
     );
 
-    assertEquals(create("file:/"), module.getBaseDir());
+    assertEquals(create("file:/main/"), module.getBaseDir());
   }
 
   @Test


### PR DESCRIPTION
## Description
When input uses a resource-only topic that is uplevels compared to all other topics, the shared directory is used as the base directory. Fix the base directory calculation to ignore resource-only topics.

## Motivation and Context
Base directory is incorrectly calculated and resource-only topics should not be included in the calculation.

## How Has This Been Tested?
Unit tests

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_


