### PR TITLE
Added check.key.duplicates.in.keyref parameter (default = no); if set…

### DIFF
--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -123,6 +123,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
 
   /** Profiling is enabled. */
   private boolean profilingEnabled;
+  /** Show key duplicates */
+  private boolean showKeyDuplicates;
   /** Absolute path for filter file. */
   private File ditavalFile;
   /** Number of directory levels base directory is adjusted. */
@@ -262,6 +264,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     keydefFilter.setLogger(logger);
     keydefFilter.setCurrentFile(rootFile);
     keydefFilter.setJob(job);
+    keydefFilter.setShowKeyDuplicates(showKeyDuplicates);
 
     nullHandler = new DefaultHandler();
   }
@@ -337,6 +340,11 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     profilingEnabled = true;
     if (input.getAttribute(ANT_INVOKER_PARAM_PROFILING_ENABLED) != null) {
       profilingEnabled = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_PARAM_PROFILING_ENABLED));
+    }
+    
+    showKeyDuplicates = true;
+    if (input.getAttribute(ANT_INVOKER_PARAM_SHOW_KEY_DUPLICATES) != null) {
+      showKeyDuplicates = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_PARAM_SHOW_KEY_DUPLICATES));
     }
 
     // create the keydef file for scheme files

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -122,6 +122,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   private boolean gramcache = true;
   /** Profiling is enabled. */
   private boolean profilingEnabled;
+  /** Show key duplicates */
+  private boolean showKeyDuplicates;
   String transtype;
   private File ditavalFile;
   FilterUtils filterUtils;
@@ -191,6 +193,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     keydefFilter.setLogger(logger);
     keydefFilter.setCurrentFile(rootFile);
     keydefFilter.setJob(job);
+    keydefFilter.setShowKeyDuplicates(showKeyDuplicates);
 
     nullHandler = new DefaultHandler();
 
@@ -317,6 +320,11 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         .orElse(true);
     if (profilingEnabled) {
       ditavalFile = Optional.of(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL)).filter(File::exists).orElse(null);
+    }
+    
+    showKeyDuplicates = true;
+    if (input.getAttribute(ANT_INVOKER_PARAM_SHOW_KEY_DUPLICATES) != null) {
+      showKeyDuplicates = Boolean.parseBoolean(input.getAttribute(ANT_INVOKER_PARAM_SHOW_KEY_DUPLICATES));
     }
   }
 

--- a/src/main/java/org/dita/dost/reader/KeydefFilter.java
+++ b/src/main/java/org/dita/dost/reader/KeydefFilter.java
@@ -38,6 +38,8 @@ public final class KeydefFilter extends AbstractXMLFilter {
 
   /** Basedir of the current parsing file */
   private URI currentDir = null;
+  /** Specifies whether key duplicates should be shown in the log */
+  private boolean showKeyDuplicates = true;
   /** Map of key definitions */
   private final Map<String, KeyDef> keysDefMap;
   /** Map to store multi-level keyrefs */
@@ -67,6 +69,15 @@ public final class KeydefFilter extends AbstractXMLFilter {
    */
   public void setCurrentDir(final URI dir) {
     currentDir = dir;
+  }
+
+  /**
+   * Set the showKeyDuplicates property.
+   *
+   * @param showKeyDuplicates true if key duplicates should be shown in the log
+   */
+  public void setShowKeyDuplicates(final boolean showKeyDuplicates) {
+    this.showKeyDuplicates = showKeyDuplicates;
   }
 
   /**
@@ -148,7 +159,8 @@ public final class KeydefFilter extends AbstractXMLFilter {
             keysDefMap.put(key, new KeyDef(key, null, null, null, null, null));
           }
         } else {
-          logger.info(MessageUtils.getMessage("DOTJ045I", key).setLocation(atts).toString());
+          if (showKeyDuplicates)
+            logger.info(MessageUtils.getMessage("DOTJ045I", key).setLocation(atts).toString());
         }
       }
     }

--- a/src/main/java/org/dita/dost/util/Constants.java
+++ b/src/main/java/org/dita/dost/util/Constants.java
@@ -1448,6 +1448,8 @@ public final class Constants {
   public static final String ANT_INVOKER_PARAM_MAPLINKS = "maplinks";
   /** Argument name for enabling profiling. */
   public static final String ANT_INVOKER_PARAM_PROFILING_ENABLED = "profiling.enable";
+  /** Argument name for showing key duplicates. */
+  public static final String ANT_INVOKER_PARAM_SHOW_KEY_DUPLICATES = "show.key.duplicates";
 
   /**Constants for extensive params used in ant invoker(targetext).*/
   public static final String ANT_INVOKER_EXT_PARAM_TARGETEXT = "targetext";

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -150,6 +150,10 @@ See the accompanying LICENSE file for applicable license.
   
   <target name="map-reader"
     description="Read input map files to temporary store">
+    <condition property="show.key.duplicates.in.gen-maps" value="false" else="true">
+      <istrue value="${check.key.duplicates.in.keyref}"/>
+    </condition>
+  	 
     <pipeline message="Generate maps" taskname="map-reader"
               inputmap="${args.input}">
       <module class="org.dita.dost.module.reader.MapReaderModule">
@@ -165,6 +169,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="setsystemid" value="${args.xml.systemid.set}"/>
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        <param name="show.key.duplicates" value="${show.key.duplicates.in.gen-maps}"/>
         <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
@@ -203,6 +208,15 @@ See the accompanying LICENSE file for applicable license.
   <target name="map-keyref"
     unless="preprocess.keyref.skip"
     description="Resolve input map files keyref">
+    <pipeline message="Check for key duplicates in generated map"
+  	          taskname="check-key-duplicates"
+  	          unless:true="${show.key.duplicates.in.gen-maps}">
+      <xslt basedir="${dita.temp.dir}"
+        style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/check-key-duplicates.xsl"
+        filenameparameter="file-being-processed">
+        <ditafileset format="ditamap" input="true"/>
+      </xslt>
+    </pipeline>
     <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.KeyrefModule" parallel="${parallel}">
         <ditafileset format="ditamap" input="true"/>

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -124,6 +124,10 @@ See the accompanying LICENSE file for applicable license.
     dita:depends="{depend.preprocess.gen-list.pre}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     description="Generate file list">
+    <condition property="show.key.duplicates.in.gen-list" value="false" else="true">
+      <istrue value="${check.key.duplicates.in.keyref}"/>
+    </condition>
+    
     <pipeline message="Generate list." taskname="gen-list"
       inputmap="${args.input}">
       <module class="org.dita.dost.module.GenMapAndTopicListModule">
@@ -142,6 +146,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="profiling.enable" value="${filter-on-parse}" unless:set="filter-on-parse"/>
         <param name="generate-debug-attributes" value="${generate-debug-attributes}" if:set="generate-debug-attributes"/>
         <param name="processing-mode" value="${processing-mode}" if:set="processing-mode"/>
+        <param name="show.key.duplicates" value="${show.key.duplicates.in.gen-list}"/>
       </module>
     </pipeline>
   </target>
@@ -315,6 +320,15 @@ See the accompanying LICENSE file for applicable license.
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
     unless="preprocess.keyref.skip"
     description="Resolve keyref">
+    <pipeline message="Check for key duplicates in generated map"
+  	  taskname="check-key-duplicates"
+      unless:true="${show.key.duplicates.in.gen-list}">
+      <xslt basedir="${dita.temp.dir}"
+            style="${dita.plugin.org.dita.base.dir}/xsl/preprocess/check-key-duplicates.xsl"
+            filenameparameter="file-being-processed">
+        <ditafileset format="ditamap" input="true"/>
+      </xslt>
+    </pipeline>
     <pipeline message="Resolve keyref." taskname="keyref">
       <module class="org.dita.dost.module.KeyrefModule" parallel="${parallel}">
       </module>

--- a/src/main/plugins/org.dita.base/plugin.xml
+++ b/src/main/plugins/org.dita.base/plugin.xml
@@ -110,6 +110,10 @@ See the accompanying LICENSE file for applicable license.
       <val>TITLE</val>
       <val>NUMTITLE</val>
     </param>
+    <param name="check.key.duplicates.in.keyref" desc="Specifies whether key duplication is checked for in keyref processing instead of at the beginning." type="enum">
+      <val>yes</val>
+      <val default="true">no</val>
+    </param>
     <param name="link-crawl" desc="Specifies whether to crawl only those topic links found in maps, or all discovered topic links." type="enum">
       <val>map</val>
       <val default="true">topic</val>

--- a/src/main/plugins/org.dita.base/xsl/preprocess/check-key-duplicates.xsl
+++ b/src/main/plugins/org.dita.base/xsl/preprocess/check-key-duplicates.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    <xd:doc>
+        <xd:desc>This stylesheet processes the expanded input ditamap as generated in the temp folder (with submap elements) and checks for duplicate keys in the same submap.</xd:desc>
+    </xd:doc>    
+    
+    <!-- include error message template -->
+    <xsl:import href="../common/dita-utilities.xsl"/>
+    <xsl:include href="../common/output-message.xsl"/>
+    
+    <xsl:template match="/">
+        <!-- construct keydef elements with attributes needed to determine duplicates -->
+        <xsl:variable name="keydefs">
+            <root>
+                <xsl:for-each select="//*[contains(@class, ' mapgroup-d/keydef ')]">
+                    <keydef keys="{@keys}" map="{ancestor::*[contains(@class, ' ditaot-d/submap ')][1]/generate-id(.)}"/>
+                </xsl:for-each>
+            </root>
+        </xsl:variable>
+        
+        <xsl:for-each select="$keydefs/*/*">
+            <xsl:variable name="keydef" select="."/>
+            <xsl:for-each select="tokenize(@keys)">
+                <!-- a key is deemed a duplicate if it is defined more than once in the same submap (beware: NOT in a nested submap, though - this is the same behavior as in gen-list target) -->
+                <xsl:if test="$keydef/preceding-sibling::*[current() = tokenize(@keys) and @map eq $keydef/@map]">
+                    <!-- same message is generated as in gen-list target -->
+                    <xsl:call-template name="output-message">
+                        <xsl:with-param name="ctx" select="$keydef" tunnel="yes"/>
+                        <xsl:with-param name="id" select="'DOTJ045I'"/>
+                        <xsl:with-param name="msgparams">%1=<xsl:value-of select="."/></xsl:with-param>
+                    </xsl:call-template>
+                </xsl:if>
+            </xsl:for-each>
+        </xsl:for-each>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+	 
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+	 
+</xsl:stylesheet>


### PR DESCRIPTION
… to yes then key duplication is checked for in keyref processing instead of at the beginning

## Description
A parameter was added that allows key duplication to be checked for after filtering (in keyref target [preprocess] and map-keyref [preprocess2]  to be exact). The parameter is _check.key.duplicates.in.keyref_ and it defaults to "no" which means that by default the current behavior doesn't change. To change it the parameter must be explicitly set to "yes".

## Motivation and Context
The key duplication currently reports keys as duplicated even when the duplicates are filtered out in filtering stage. One of our clients is having problems because of that as for them a key duplication warning is fatal and they quit the processing if that warning is logged.

## How Has This Been Tested?
The test suite was executed with gradlew check. One of the test cases failed, but after trying the original forked code it failed in the same test case; therefore, the failure is not due to the new code. The following test case fails in 4.3.1 HEAD (as forked a week ago) on my machine (Windows 11):

IntegrationTestPreprocess2 > testconref() FAILED
    org.apache.tools.ant.BuildException at ExtensibleAntInvoker.java:214
        Caused by: org.dita.dost.exception.DITAOTException at CopyToModule.java:72
            Caused by: org.dita.dost.exception.DITAOTException at AbstractStore.java:113

The change should be backward compatible and it has no impact on the output. It just potentially changes the log.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
The change requires addition of a new parameter here: <https://www.dita-ot.org/dev/parameters/parameters-base>. The parameter was already added to org.dita.base/plugin.xml.

The change shouldn't affect backwards compatibility or other users' overrides. 

## Checklist

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- Please note I _did not_ update the unit tests as the changes only effect the log and I'm not sure how to test that in unit tests.

