### PR TITLE
Support HTML5 attribute group passthrough (#4488)

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -107,7 +107,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:choose>
     </xsl:variable>
     
-  <xsl:variable name="FILTERDOC"
+  <xsl:variable name="FILTERDOC" as="document-node()?"
                 select="if (string-length($FILTERFILEURL) > 0)
                         then document($FILTERFILEURL, /)
                         else ()"/>
@@ -1846,35 +1846,7 @@ See the accompanying LICENSE file for applicable license.
     <xsl:apply-templates select="." mode="set-output-class">
       <xsl:with-param name="default" select="string-join($default-output-class, ' ')"/>
     </xsl:apply-templates>
-    <xsl:choose>
-      <xsl:when test="exists($passthrough-attrs[empty(@att) and empty(@value)])">
-        <xsl:variable name="specializations" as="xs:string*">
-          <xsl:for-each select="ancestor-or-self::*[@domains][1]/@domains">
-            <xsl:analyze-string select="normalize-space(.)" regex="a\(props (.+?)\)">
-              <xsl:matching-substring>
-                <xsl:sequence select="tokenize(regex-group(1), '\s+')"/>
-              </xsl:matching-substring>
-            </xsl:analyze-string>
-          </xsl:for-each>
-        </xsl:variable>
-        <xsl:for-each select="@props |
-                              @audience |
-                              @platform |
-                              @product |
-                              @otherprops |
-                              @deliveryTarget |
-                              @*[local-name() = $specializations]">
-          <xsl:attribute name="data-{name()}" select="."/>
-        </xsl:for-each>
-      </xsl:when>
-      <xsl:when test="exists($passthrough-attrs)">
-        <xsl:for-each select="@*">
-          <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
-            <xsl:attribute name="data-{name()}" select="."/>
-          </xsl:if>
-        </xsl:for-each>
-      </xsl:when>
-    </xsl:choose>
+    <xsl:apply-templates select="." mode="create-passthrough-attributes"/>
   </xsl:template>
   
   <!-- Set the class attribute on the resulting output element. The default for a class of elements
@@ -1988,6 +1960,41 @@ See the accompanying LICENSE file for applicable license.
     <xsl:attribute name="dir" select="."/>
   </xsl:template>
   
+  <!-- Create HTML5 data-* passthrough attributes if specified by DITAVAL -->
+  <xsl:mode name="create-passthrough-attributes" on-no-match="deep-skip"/>
+
+  <xsl:template match="*" mode="create-passthrough-attributes">
+    <xsl:choose>
+      <xsl:when test="exists($passthrough-attrs[empty(@att) and empty(@value)])">
+        <xsl:variable name="specializations" as="xs:string*">
+          <xsl:for-each select="ancestor-or-self::*[@domains][1]/@domains">
+            <xsl:analyze-string select="normalize-space(.)" regex="a\(props (.+?)\)">
+              <xsl:matching-substring>
+                <xsl:sequence select="tokenize(regex-group(1), '\s+')"/>
+              </xsl:matching-substring>
+            </xsl:analyze-string>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:for-each select="@props |
+                              @audience |
+                              @platform |
+                              @product |
+                              @otherprops |
+                              @deliveryTarget |
+                              @*[local-name() = $specializations]">
+          <xsl:attribute name="data-{name()}" select="."/>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:when test="exists($passthrough-attrs)">
+        <xsl:for-each select="@*">
+          <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
+            <xsl:attribute name="data-{name()}" select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template name="setscale">
     <xsl:if test="@scale">
   <!--    <xsl:attribute name="style">font-size: <xsl:value-of select="@scale"/>%;</xsl:attribute> -->

--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1963,36 +1963,80 @@ See the accompanying LICENSE file for applicable license.
   <!-- Create HTML5 data-* passthrough attributes if specified by DITAVAL -->
   <xsl:mode name="create-passthrough-attributes" on-no-match="deep-skip"/>
 
-  <xsl:template match="*" mode="create-passthrough-attributes">
-    <xsl:choose>
-      <xsl:when test="exists($passthrough-attrs[empty(@att) and empty(@value)])">
-        <xsl:variable name="specializations" as="xs:string*">
-          <xsl:for-each select="ancestor-or-self::*[@domains][1]/@domains">
-            <xsl:analyze-string select="normalize-space(.)" regex="a\(props (.+?)\)">
-              <xsl:matching-substring>
-                <xsl:sequence select="tokenize(regex-group(1), '\s+')"/>
-              </xsl:matching-substring>
-            </xsl:analyze-string>
-          </xsl:for-each>
-        </xsl:variable>
-        <xsl:for-each select="@props |
-                              @audience |
-                              @platform |
-                              @product |
-                              @otherprops |
-                              @deliveryTarget |
-                              @*[local-name() = $specializations]">
-          <xsl:attribute name="data-{name()}" select="."/>
-        </xsl:for-each>
-      </xsl:when>
-      <xsl:when test="exists($passthrough-attrs)">
-        <xsl:for-each select="@*">
-          <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
-            <xsl:attribute name="data-{name()}" select="."/>
-          </xsl:if>
-        </xsl:for-each>
-      </xsl:when>
-    </xsl:choose>
+  <xsl:template match="*[exists($passthrough-attrs)]" mode="create-passthrough-attributes">
+    <!-- Get specialized profiling attribute names, if defined -->
+    <xsl:variable name="specialized-attr-names" as="xs:string*">
+      <xsl:for-each select="ancestor-or-self::*[@domains][1]/@domains">
+        <xsl:analyze-string select="normalize-space(.)" regex="a\(props (.+?)\)">
+          <xsl:matching-substring>
+            <xsl:sequence select="tokenize(regex-group(1), '\s+')"/>
+          </xsl:matching-substring>
+        </xsl:analyze-string>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Get all profiling attributes for this element -->
+    <xsl:variable name="profiling-attrs" as="attribute()*">
+      <xsl:sequence select="@props | @audience | @platform | @product | @otherprops | @deliveryTarget"/>
+      <xsl:sequence select="@*[local-name(.) = $specialized-attr-names]"/>
+    </xsl:variable>
+
+    <!-- Ungroup and organize all profiling attribute values for this element. For example, the values for:
+
+           <p product="v1 grpA(Av2) v3 grpB(Bv3 Bv4)"/>
+
+         would be stored in an <ATTVAL> element sequence as follows:
+
+           <ATTVAL att="product"  group="product"  values="v1"/>
+           <ATTVAL att="product"  group="product"  values="v3"/>
+           <ATTVAL att="product"  group="grpA"     values="Av2"/>
+           <ATTVAL att="product"  group="grpB"     values="Bv3"/>
+           <ATTVAL att="product"  group="grpB"     values="Bv4"/> -->
+    <xsl:variable name="all-attvals" as="element()*">
+      <xsl:for-each select="$profiling-attrs">
+        <xsl:variable name="attr-name" select="local-name(.)"/>
+        <!-- Regex pattern tries to match "group(val val)" first, "val" second -->
+        <xsl:analyze-string select="." regex="([^\s(]+)\(([^)]*)\)|(\S+)">
+          <xsl:matching-substring>
+            <xsl:choose>
+              <xsl:when test="regex-group(1) and regex-group(2)">
+                <!-- Explicit group value: @att="group(val val)" -->
+                <xsl:for-each select="tokenize(regex-group(2))">
+                  <ATTVAL att="{$attr-name}" group="{regex-group(1)}" val="{.}"/>
+                </xsl:for-each>
+              </xsl:when>
+              <xsl:when test="regex-group(3)">
+                <!-- Implicit group value: @att="val" (group name is attribute name)-->
+                <ATTVAL att="{$attr-name}" group="{$attr-name}" val="{regex-group(3)}"/>
+              </xsl:when>
+            </xsl:choose>
+          </xsl:matching-substring>
+        </xsl:analyze-string>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Get all <ATTVAL> entries that match passthrough actions. An <ATTVAL> entry matches if:
+
+         * A passthrough action exists without an @att value (matches all attributes)
+         * A passthrough action exists with an @att value matching the <ATTVAL> @att or @group value, and
+           * The passthrough action has no @val value (matches all values), or
+           * The passthrough action has a @val value that matches the <ATTVAL> @val value -->
+    <xsl:variable name="matching-attvals" as="element()*">
+      <xsl:for-each select="$all-attvals">
+        <xsl:variable name="attval" select="."/>
+        <xsl:if test="$passthrough-attrs[empty(@att) or (@att = $attval/(@att, @group) and (empty(@val) or @val = $attval/@val))]">
+          <xsl:sequence select="$attval"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Create HTML5 data-* passthrough attributes.
+
+         Passthrough attributes are always named by group name (implicit or explicit) regardless of
+         how their values were matched by passthrough actions. -->
+    <xsl:for-each-group select="$matching-attvals" group-by="@group">
+      <xsl:attribute name="data-{current-grouping-key()}" select="sort(distinct-values(current-group()/@val))"/>
+    </xsl:for-each-group>
   </xsl:template>
 
   <xsl:template name="setscale">

--- a/src/test/java/org/dita/dost/IntegrationTestHtml5.java
+++ b/src/test/java/org/dita/dost/IntegrationTestHtml5.java
@@ -116,4 +116,17 @@ public class IntegrationTestHtml5 extends AbstractIntegrationTest {
       .warnCount(1)
       .test();
   }
+
+  @Test
+  public void html5_ditaval_passthrough_groups_all() throws Throwable {
+    final File srcDir = new File(resourceDir, "html5_ditaval_groups" + File.separator + "src");
+    builder()
+      .name("html5_ditaval_groups")
+      .transtype(HTML5)
+      .input(Paths.get("all.dita"))
+      .put("validate", "no")
+      .put("dita.input.valfile", new File(srcDir, "all.ditaval").getAbsolutePath())
+      .warnCount(1)
+      .test();
+  }
 }

--- a/src/test/resources/html5_ditaval/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval/exp/html5/all.html
@@ -15,9 +15,8 @@
         <div class="body">
           <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel"
             data-product="notepad" data-os="win"></p>
-          <p class="p"
-            data-props="audience(expert) deliveryTarget(print) platform(intel) product(notepad) os(win)"
-          ></p>
+          <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel"
+            data-product="notepad" data-os="win"></p>
         </div>
       </article>
     </main>

--- a/src/test/resources/html5_ditaval_groups/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval_groups/exp/html5/all.html
@@ -13,9 +13,9 @@
       <article role="article" aria-labelledby="ariaid-title1">
         <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
         <div class="body">
-          <p class="p"></p>
-          <p class="p"></p>
-          <p class="p"></p>
+          <p class="p" data-group1="val1-1 val1-2 val1-3"></p>
+          <p class="p" data-group2="val2-1 val2-3"></p>
+          <p class="p" data-group3="val3-1 val3-3"></p>
         </div>
       </article>
     </main>

--- a/src/test/resources/html5_ditaval_groups/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval_groups/exp/html5/all.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html
+  SYSTEM "about:legacy-compat">
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="copyright" content="(C) Copyright 2021">
+    <meta name="generator" content="DITA-OT">
+    <title>Topic title</title>
+    <link rel="stylesheet" type="text/css" href="commonltr.css">
+  </head>
+  <body id="topic-1">
+    <main role="main">
+      <article role="article" aria-labelledby="ariaid-title1">
+        <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
+        <div class="body">
+          <p class="p"></p>
+          <p class="p"></p>
+          <p class="p"></p>
+        </div>
+      </article>
+    </main>
+  </body>
+</html>

--- a/src/test/resources/html5_ditaval_groups/src/all.dita
+++ b/src/test/resources/html5_ditaval_groups/src/all.dita
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<topic id="topic-1"
+       domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) a(props os) (topic markup-d xml-d)">
+  <title>Topic title</title>
+  <body>
+    <p product="group1(val1-3 val1-2) foo(bar) group1(val1-1) baz"/>
+    <p product="group2(val2-3 val2-2) foo(bar) group2(val2-1) baz"/>
+    <p product="group3(val3-3 val3-2) foo(bar) group3(val3-1) baz"/>
+  </body>
+</topic>

--- a/src/test/resources/html5_ditaval_groups/src/all.ditaval
+++ b/src/test/resources/html5_ditaval_groups/src/all.ditaval
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<val>
+  <prop att="group1" action="passthrough"/>
+  <prop att="group2" val="val2-3" action="passthrough"/>
+  <prop att="group2" val="val2-1" action="passthrough"/>
+  <prop att="product" val="val3-3" action="passthrough"/>
+  <prop att="product" val="val3-1" action="passthrough"/>
+</val>


### PR DESCRIPTION
## Description
Extends DITAVAL `passthrough` actions in HTML5 output to support profiling attribute groups. (Previously, it supported only simple profiling attribute values.)

Per DITA 2.0 specification sections 7.4.5 and 9.8.2.3, the implementation is as follows:

* The `att` value of a `passthrough` action can match either a profiling attribute name or a group name.
* Ungrouped values belong to an implicit group named after the attribute.
* HTML5 `data-*` attributes are always named after their group (explicit or implicit).

## Motivation and Context
Fixes #4488.

## How Has This Been Tested?
I used an extended version of the testcase from #4488 that included more attributes and more values. I also compared the new `passthrough` behavior against the existing `flag` behavior (which does support attribute groups).

A unit test failed because it expected a `@props` value with groups to be passed through as a literal string. However, per this statement in the draft DITA 2.0 specification, grouping syntax also applies within `@props`:

> The grouping syntax exactly matches the syntax used for generalized attributes, making it valid inside `@props` and any attribute specialized from `@props`, including those integrated by default in the OASIS-provided document-type shells: `@audience`, `@deliveryTarget`, `@platform`, `@product`, `@otherprops`.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
The change is backwards compatible (no change in passthrough behavior for ungrouped values).

I did not find any DITA-OT documentation on passthrough behaviors to update.

A release notes description could be as follows:

> In previous releases, DITAVAL `passthrough` actions in HTML5 transformations supported only simple (ungrouped) profiling attribute values. In this release, passthrough support is extended to profiling attribute groups. When an HTML5 `data-*` passthrough attribute is created for a value in a group, it is named after the group name.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
- I have updated the unit tests to reflect the changes in my code.
