### PR TITLE
add a CSS comment explaining why 'display: inline' is applied to note body (#4629)

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_notes.scss
+++ b/src/main/plugins/org.dita.html5/sass/_notes.scss
@@ -22,6 +22,8 @@
   }
 
   .note__body {
+    /* Note body is a <div> to keep HTML5 valid for block element children;
+       "display: inline" allows one-line rendering if children are inline (#3955) */
     display: inline;
   }
 }


### PR DESCRIPTION
## Description
Adds a CSS comment explaining why 'display: inline' is applied to note body.

## Motivation and Context
Fixes #4629.

## How Has This Been Tested?
No testing needed.

## Type of Changes
- Comment - A single comment was added to the HTML5 CSS.

## Documentation and Compatibility
No documentation is needed.

A release notes entry could be as follows:

> In HTML5 transformations, note bodies are `<div>` elements that have a `display: inline` applied to allow for single-line note rendering for inline note content. A comment is added to the CSS to explain this.