### PR TITLE
support HTML5 attribute passthrough on root topic elements (#4464)

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -2619,6 +2619,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:if>
     </xsl:if>
     <xsl:call-template name="setid"/>
+    <xsl:apply-templates select="." mode="create-passthrough-attributes"/>
     <xsl:apply-templates select="." mode="addAttributesToBody"/>
   </xsl:template>
 

--- a/src/test/resources/html5_ditaval/exp/html5/all.html
+++ b/src/test/resources/html5_ditaval/exp/html5/all.html
@@ -8,11 +8,13 @@
     <title>Topic title</title>
     <link rel="stylesheet" type="text/css" href="commonltr.css">
   </head>
-  <body id="topic-1">
+  <body id="topic-1" data-audience="expert-topic" data-deliveryTarget="print-topic" data-platform="intel-topic"
+          data-product="notepad-topic" data-os="win-topic">
     <main role="main">
       <article role="article" aria-labelledby="ariaid-title1">
         <h1 class="title topictitle1" id="ariaid-title1">Topic title</h1>
-        <div class="body">
+        <div class="body" data-audience="expert-body" data-deliveryTarget="print-body" data-platform="intel-body"
+          data-product="notepad-body" data-os="win-body">
           <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel"
             data-product="notepad" data-os="win"></p>
           <p class="p" data-audience="expert" data-deliveryTarget="print" data-platform="intel"

--- a/src/test/resources/html5_ditaval/src/all.dita
+++ b/src/test/resources/html5_ditaval/src/all.dita
@@ -1,9 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <topic id="topic-1"
-       domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) a(props os) (topic markup-d xml-d)">
+       domains="(topic abbrev-d) a(props deliveryTarget) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic sw-d) (topic svg-d) (topic ui-d) (topic ut-d) a(props os) (topic markup-d xml-d)"
+       audience="expert-topic"
+       deliveryTarget="print-topic"
+       platform="intel-topic"
+       product="notepad-topic"
+       os="win-topic">
   <title>Topic title</title>
-  <body>
+  <body audience="expert-body"
+        deliveryTarget="print-body"
+        platform="intel-body"
+        product="notepad-body"
+        os="win-body">
     <p audience="expert"
        deliveryTarget="print"
        platform="intel"


### PR DESCRIPTION
## Description
Updates the root-topic HTML5 template to generate DITAVAL-specified passthrough attributes.

## Motivation and Context
Fixes #4464.

The reason the passthrough attributes are created on the HTML5 `<body>` element instead of the root `<article>` element is to be consistent with the existing `@outputclass` value passthrough behavior.

## How Has This Been Tested?
I used the testcase provided in #4464.

I updated the existing HTML5 passthrough unit test to include this case (plus DITA `<body>` profiling).

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No documentation is needed.

A release notes entry could be as follows:

> In previous releases, DITAVAL passthrough actions in HTML5 transformations were not applied to root topic elements. In this release, passthrough support is extended to root topic elements.