### PR TITLE
make prettier run on Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "fmt": "prettier --write '**/*.java'",
-    "check-fmt": "prettier --check '**/*.java'"
+    "fmt": "prettier --write \"**/*.java\"",
+    "check-fmt": "prettier --check \"**/*.java\""
   },
   "devDependencies": {
     "prettier-plugin-java": "^2.1.0"


### PR DESCRIPTION
## Description
replacing single quotes with escaped double quotes for compatibility

## Motivation and Context
`npm run` doesn't expand `'**/*.java'` on Windows apparently, it requires `"**/*.java"`, hence the change

## How Has This Been Tested?
`npm run` in the gitlab pipeline is still running as expected, and it works in my local linux and windows based repositories too

## Type of Changes
- Bug fix

## Documentation and Compatibility
n/a