### PR TITLE
use gradle daemon in test GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,18 @@ jobs:
             build/spotless-*
             build/tmp/spotless-register-dependencies
           key: ${{ runner.os }}-${{ hashFiles('.prettierrc') }}-${{ hashFiles('.nvmrc') }}
+      - name: Start Gradle Daemon
+        run: ./gradlew --dry-run
       - name: Check formatting
-        run: ./gradlew spotlessCheck --info --stacktrace --no-daemon
+        run: ./gradlew spotlessCheck --info --stacktrace
       - name: Build with Gradle
-        run: ./gradlew --info --stacktrace --no-daemon
+        run: ./gradlew --info --stacktrace
       - name: Run unit tests
-        run: ./gradlew test --info --stacktrace --no-daemon
+        run: ./gradlew test --info --stacktrace
       - name: Run end to end tests
-        run: ./gradlew e2eTest --info --stacktrace --no-daemon
+        run: ./gradlew e2eTest --info --stacktrace
       - name: Run integration tests
-        run: ./gradlew integrationTest --info --stacktrace --no-daemon
+        run: ./gradlew integrationTest --info --stacktrace
+      - name: Stop Gradle Daemon
+        if: always()
+        run: ./gradlew --stop


### PR DESCRIPTION
## Description
daemon make build go zoom

## Motivation and Context
It's good practice to not leave rogue daemons running about, but IMHO it's better to kill them when they're no longer useful than to create new ones all the time. In the test build where there's multiple subsequent gradlew calls, not having to initialise everything every time can reduce build times by 20-25%.

## How Has This Been Tested?
ran the test build with the new changes to see the daemon in action
also ran the test build on a failing branch to make sure that the daemon is always stopped 

## Type of Changes
- New feature

## Documentation and Compatibility
n/a