### PR TITLE
add the missing unit tests to the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,8 @@ artifacts {
 test {
     useJUnitPlatform {
         filter {
+            includeTestsMatching "Test*"
+            excludeTestsMatching "TestUtils"
             includeTestsMatching "*Test"
             excludeTestsMatching "IntegrationTest*"
             excludeTestsMatching "EndToEndTest*"


### PR DESCRIPTION
## Description
Add the missing unit tests to the build.

## Motivation and Context
When browsing the folders, I noticed that most test files ended with "Test", but some started with "Test", the latter of which were not picked up.

## How Has This Been Tested?
Ran the tests locally and noted the extra tests that were picked up after the change.
In the github build it's hard to tell the difference because it doesn't tell you the number of tests run at the end.

## Type of Changes
- Bug fix

## Documentation and Compatibility
n/a