### PR TITLE
publish test results in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,8 @@ jobs:
       - name: Stop Gradle Daemon
         if: always()
         run: ./gradlew --stop
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: (!cancelled())
+        with:
+          files: build/test-results/**/*.xml


### PR DESCRIPTION
## Description
Add github action that scans test results and publishes them to the build summary as well as the pull request.

## Motivation and Context
When everything's fine you don't need this. But when a test or two fails for some reason, it's nice to have a quick way to check which ones did. 

## How Has This Been Tested?
I tried a couple different publishers. There is no perfect solution, but I found this one slightly easier to use than the others.
* marketplace link: https://github.com/marketplace/actions/publish-test-results 
* example failing build: https://github.com/thendarion/dita-ot/actions/runs/16026276390
* example PR: https://github.com/thendarion/dita-ot/pull/1

## Type of Changes
- New feature (internal)

## Documentation and Compatibility
n/a