### PR TITLE
node cache optimisation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.gradle/nodejs
+            .gradle/nodejs
             build/spotless-*
             build/tmp/spotless-register-dependencies
           key: ${{ runner.os }}-${{ hashFiles('.prettierrc') }}-${{ hashFiles('.nvmrc') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            build/nodejs
+            ~/.gradle/nodejs
             build/spotless-*
             build/tmp/spotless-register-dependencies
           key: ${{ runner.os }}-${{ hashFiles('.prettierrc') }}-${{ hashFiles('.nvmrc') }}

--- a/build.gradle
+++ b/build.gradle
@@ -76,15 +76,11 @@ dependencies {
 node {
     download = true
     version = file('.nvmrc').readLines().first().trim()
-    workDir = file("${gradle.gradleUserHomeDir}/nodejs")
 }
-
-def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'
 
 spotless {
     java {
         prettier(['prettier': '2.8.4', 'prettier-plugin-java': '2.1.0']).configFile('.prettierrc')
-                .nodeExecutable("${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,7 @@ dependencies {
 node {
     download = true
     version = file('.nvmrc').readLines().first().trim()
-    workDir = file("${buildDir}/nodejs")
-    distBaseUrl = 'https://nodejs.org/dist'
+    workDir = file("${gradle.gradleUserHomeDir}/nodejs")
 }
 
 def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'

--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,8 @@ dependencies {
 node {
     download = true
     version = file('.nvmrc').readLines().first().trim()
-    // when setting both these directories, npm and node will be in separate directories
     workDir = file("${buildDir}/nodejs")
+    distBaseUrl = 'https://nodejs.org/dist'
 }
 
 def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'


### PR DESCRIPTION
## Description
Simplified the nodejs configuration. Turns out the default works just fine.

## Motivation and Context
Before this, in GHA, Gradle kept downloading nodejs even though it was already there.

## How Has This Been Tested?
Ran the build twice and noted the lack of download in the second one.

## Type of Changes
- Bug fix (internal)

## Documentation and Compatibility
n/a