### PR TITLE
make errorCount and warnCount failures more informative

### DIFF
--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -245,8 +245,8 @@ public abstract class AbstractIntegrationTest {
 
     try {
       this.log = runOt(testDir, transtype, tempDir, outDir, params, targets);
-      assertEquals(warnCount, countMessages(log, Project.MSG_WARN));
-      assertEquals(errorCount, countMessages(log, Project.MSG_ERR));
+      assertEquals(warnCount, countMessages(log, Project.MSG_WARN), "warnCount");
+      assertEquals(errorCount, countMessages(log, Project.MSG_ERR), "errorCount");
 
       this.actDir = transtype.compareTemp ? tempDir : outDir;
     } catch (final RuntimeException e) {

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -244,8 +244,8 @@ public abstract class AbstractIntegrationTest {
 
     try {
       this.log = runOt(testDir, transtype, tempDir, outDir, params, targets);
-      List<TestListener.Message> warnings = getMessages(log, Project.MSG_WARN);
-      List<TestListener.Message> errors = getMessages(log, Project.MSG_ERR);
+      final List<TestListener.Message> warnings = getMessages(log, Project.MSG_WARN);
+      final List<TestListener.Message> errors = getMessages(log, Project.MSG_ERR);
       assertAll(
         () -> assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"),
         () -> assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n")

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -11,8 +11,7 @@ package org.dita.dost;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.dita.dost.TestUtils.assertXMLEqual;
 import static org.dita.dost.util.Constants.*;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.*;
 import java.net.URI;
@@ -245,12 +244,12 @@ public abstract class AbstractIntegrationTest {
 
     try {
       this.log = runOt(testDir, transtype, tempDir, outDir, params, targets);
-      List<Executable> testResults = new ArrayList<>();
       List<TestListener.Message> warnings = getMessages(log, Project.MSG_WARN);
       List<TestListener.Message> errors = getMessages(log, Project.MSG_ERR);
-      testResults.add(() -> assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"));
-      testResults.add(() -> assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n"));
-      assertAll(testResults);
+      assertAll(
+        () -> assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"),
+        () -> assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n")
+      );
       this.actDir = transtype.compareTemp ? tempDir : outDir;
     } catch (final RuntimeException e) {
       throw e;

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -248,8 +248,8 @@ public abstract class AbstractIntegrationTest {
       List<Executable> testResults = new ArrayList<>();
       List<TestListener.Message> warnings = getMessages(log, Project.MSG_WARN);
       List<TestListener.Message> errors = getMessages(log, Project.MSG_ERR);
-      testResults.add(()->assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"));
-      testResults.add(()->assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n"));
+      testResults.add(() -> assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"));
+      testResults.add(() -> assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n"));
       assertAll(testResults);
       this.actDir = transtype.compareTemp ? tempDir : outDir;
     } catch (final RuntimeException e) {

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -245,9 +245,12 @@ public abstract class AbstractIntegrationTest {
 
     try {
       this.log = runOt(testDir, transtype, tempDir, outDir, params, targets);
-      assertEquals(warnCount, countMessages(log, Project.MSG_WARN), "warnCount");
-      assertEquals(errorCount, countMessages(log, Project.MSG_ERR), "errorCount");
-
+      List<Executable> testResults = new ArrayList<>();
+      List<TestListener.Message> warnings = getMessages(log, Project.MSG_WARN);
+      List<TestListener.Message> errors = getMessages(log, Project.MSG_ERR);
+      testResults.add(()->assertEquals(warnCount, warnings.size(), "warnCount mismatch: " + warnings + "\n"));
+      testResults.add(()->assertEquals(errorCount, errors.size(), "errorCount mismatch: " + errors + "\n"));
+      assertAll(testResults);
       this.actDir = transtype.compareTemp ? tempDir : outDir;
     } catch (final RuntimeException e) {
       throw e;
@@ -307,8 +310,8 @@ public abstract class AbstractIntegrationTest {
     System.err.println("Log end");
   }
 
-  private int countMessages(final List<TestListener.Message> messages, final int level) {
-    int count = 0;
+  private List<TestListener.Message> getMessages(final List<TestListener.Message> messages, final int level) {
+    List<TestListener.Message> filteredMessages = new ArrayList<>();
     final Set<String> duplicates = new HashSet<>();
     messages:for (final TestListener.Message m : messages) {
       if (m.level == level) {
@@ -321,10 +324,10 @@ public abstract class AbstractIntegrationTest {
             }
           }
         }
-        count++;
+        filteredMessages.add(m);
       }
     }
-    return count;
+    return filteredMessages;
   }
 
   /**
@@ -613,7 +616,7 @@ public abstract class AbstractIntegrationTest {
     private final Pattern infoPattern = Pattern.compile("\\[\\w+I\\]");
     private final Pattern debugPattern = Pattern.compile("\\[\\w+D\\]");
 
-    public final List<TestListener.Message> messages = new ArrayList<>();
+    public final List<Message> messages = new ArrayList<>();
     final PrintStream out;
     final PrintStream err;
 
@@ -624,32 +627,32 @@ public abstract class AbstractIntegrationTest {
 
     @Override
     public void buildStarted(BuildEvent event) {
-      messages.add(new TestListener.Message(-1, "build started: " + event.getMessage()));
+      messages.add(new Message(-1, "build started: " + event.getMessage()));
     }
 
     @Override
     public void buildFinished(BuildEvent event) {
-      messages.add(new TestListener.Message(-1, "build finished: " + event.getMessage()));
+      messages.add(new Message(-1, "build finished: " + event.getMessage()));
     }
 
     @Override
     public void targetStarted(BuildEvent event) {
-      messages.add(new TestListener.Message(-1, event.getTarget().getName() + ":"));
+      messages.add(new Message(-1, event.getTarget().getName() + ":"));
     }
 
     @Override
     public void targetFinished(BuildEvent event) {
-      messages.add(new TestListener.Message(-1, "target finished: " + event.getTarget().getName()));
+      messages.add(new Message(-1, "target finished: " + event.getTarget().getName()));
     }
 
     @Override
     public void taskStarted(BuildEvent event) {
-      messages.add(new TestListener.Message(Project.MSG_DEBUG, "task started: " + event.getTask().getTaskName()));
+      messages.add(new Message(Project.MSG_DEBUG, "task started: " + event.getTask().getTaskName()));
     }
 
     @Override
     public void taskFinished(BuildEvent event) {
-      messages.add(new TestListener.Message(Project.MSG_DEBUG, "task finished: " + event.getTask().getTaskName()));
+      messages.add(new Message(Project.MSG_DEBUG, "task finished: " + event.getTask().getTaskName()));
     }
 
     @Override
@@ -681,7 +684,7 @@ public abstract class AbstractIntegrationTest {
         //                    err.println(message);
       }
 
-      messages.add(new TestListener.Message(level, message));
+      messages.add(new Message(level, message));
     }
 
     record Message(int level, String message) {}


### PR DESCRIPTION
## Description
Before: 
`Case test failed: expected: <0> but was: <2>`
After: 
`Case test failed: errorCount mismatch: [[message1],[message2]]  ==> expected: <0> but was: <2>`

## Motivation and Context
I like to know what went wrogn 😅 

## How Has This Been Tested?
Made a test case fail and noted the difference.

## Type of Changes
- Bug fix 

## Documentation and Compatibility
n/a