### PR TITLE
fix missing task description in xhtml build

### DIFF
--- a/src/main/plugins/org.dita.xhtml/build_general_template.xml
+++ b/src/main/plugins/org.dita.xhtml/build_general_template.xml
@@ -159,7 +159,8 @@ See the accompanying LICENSE file for applicable license.
     </sequential>
   </macrodef>
   
-  <target name="dita.topics.html.common" unless="noTopic" if="old.transform">
+  <target name="dita.topics.html.common" unless="noTopic" if="old.transform"
+          description="Build HTML">
     <topics.html>
       <dita:extension id="dita.conductor.xhtml.param" behavior="org.dita.dost.platform.InsertAction"/>
       <dita:extension id="dita.conductor.html.param" behavior="org.dita.dost.platform.InsertAction"/>
@@ -170,12 +171,13 @@ See the accompanying LICENSE file for applicable license.
   <!--To generate&copy inner files-->
   <!--requirement 1,2-->
   
-  <target name="dita.inner.topics.html.common" unless="noTopic" if="inner.transform">
+  <target name="dita.inner.topics.html.common" unless="noTopic" if="inner.transform"
+          description="Build HTML">
     <topics.html>
       <dita:extension id="dita.conductor.xhtml.param" behavior="org.dita.dost.platform.InsertAction"/>
       <dita:extension id="dita.conductor.html.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper classname="org.dita.dost.ant.types.JobMapper" to="${out.ext}"/>
     </topics.html>
   </target>
-  
+
 </project>


### PR DESCRIPTION
## Description
Added the missing description on `dita.topics.html.common` and `dita.inner.topics.html.common`.

## Motivation and Context
Just to make the debug output a bit easier to navigate for XHTML. The HTML5 transformation already had the these descriptions.

## How Has This Been Tested?
Ran a build with --debug and noted the new header.

## Type of Changes
- Bug fix (internal)

## Documentation and Compatibility
n/a