### PR TITLE
Improve integration test results

### DIFF
--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -500,18 +500,12 @@ public abstract class AbstractIntegrationTest {
   }
 
   private Document parseHtml(final File f) throws SAXException, IOException {
-    if (!f.exists()) {
-      throw new AssertionError(new FileNotFoundException(f.toString()));
-    }
     Document d = htmlb.parse(f);
     d = removeCopyright(d);
     return rewriteIds(d, htmlIdPattern);
   }
 
   private Document parseXml(final File f) throws SAXException, IOException {
-    if (!f.exists()) {
-      throw new AssertionError(new FileNotFoundException(f.toString()));
-    }
     final Document d = db.parse(f);
     final NodeList elems = d.getElementsByTagName("*");
     for (int i = 0; i < elems.getLength(); i++) {

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -420,16 +420,6 @@ public abstract class AbstractIntegrationTest {
     }
   }
 
-  private int getMessageCount(final Project project, final String type) {
-    int errorCount = 0;
-    if (isWindows() && project.getProperty("exp.message-count." + type + ".windows") != null) {
-      errorCount = Integer.parseInt(project.getProperty("exp.message-count." + type + ".windows"));
-    } else if (project.getProperty("exp.message-count." + type) != null) {
-      errorCount = Integer.parseInt(project.getProperty("exp.message-count." + type));
-    }
-    return errorCount;
-  }
-
   private void compare(final File expDir, final File actDir) throws Throwable {
     final Collection<String> files = getFiles(expDir, actDir);
     for (final String name : files) {

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -440,14 +440,18 @@ public abstract class AbstractIntegrationTest {
   }
 
   private void compareFileContents(File exp, File act) {
-    var message = "Failed comparing " + exp.getAbsolutePath() + " and " + act.getAbsolutePath() + ": ";
+    String message = "Failed comparing " + exp.getAbsolutePath() + " and " + act.getAbsolutePath() + ": ";
     final String ext = FileUtils.getExtension(exp.getName());
-    if (ext == null) {} else if (ext.equals("html") || ext.equals("htm") || ext.equals("xhtml") || ext.equals("hhk")) {
-      compareResults.add(() -> assertXMLEqual(parseHtml(exp), parseHtml(act), message));
-    } else if (ext.equals("xml") || ext.equals("dita") || ext.equals("ditamap") || ext.equals("fo")) {
-      compareResults.add(() -> assertXMLEqual(parseXml(exp), parseXml(act), message));
-    } else if (ext.equals("txt")) {
-      compareResults.add(() -> assertArrayEquals(readTextFile(exp), readTextFile(act), message));
+    if (ext != null) {
+      // prettier-ignore
+      switch (ext) {
+        case "html", "htm", "xhtml", "hhk" ->
+          compareResults.add(() -> assertXMLEqual(parseHtml(exp), parseHtml(act), message));
+        case "xml", "dita", "ditamap", "fo" ->
+          compareResults.add(() -> assertXMLEqual(parseXml(exp), parseXml(act), message));
+        case "txt" ->
+          compareResults.add(() -> assertArrayEquals(readTextFile(exp), readTextFile(act), message));
+      }
     }
   }
 

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -486,9 +486,7 @@ public abstract class AbstractIntegrationTest {
    */
   private String[] readTextFile(final File f) throws IOException {
     final List<String> buf = new ArrayList<>();
-    try (
-      final BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8))
-    ) {
+    try (final BufferedReader r = Files.newBufferedReader(f.toPath(), StandardCharsets.UTF_8)) {
       String l;
       while ((l = r.readLine()) != null) {
         buf.add(l);

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -431,12 +431,16 @@ public abstract class AbstractIntegrationTest {
         if (exp.exists() && act.exists()) {
           compareFileContents(exp, act);
         } else {
-          compareResults.add(() ->
-            fail("Missing file: " + (!exp.exists() ? exp.getAbsolutePath() : act.getAbsolutePath()))
-          );
+          reportMissingFile(exp, act);
         }
       }
     }
+  }
+
+  private void reportMissingFile(File exp, File act) {
+    String errorMessage = "Missing file: " + (!exp.exists() ? exp.getAbsolutePath() : act.getAbsolutePath()) + "\n";
+    System.out.print(errorMessage);
+    compareResults.add(() -> fail(errorMessage));
   }
 
   private void compareFileContents(File exp, File act) {

--- a/src/test/java/org/dita/dost/TestUtils.java
+++ b/src/test/java/org/dita/dost/TestUtils.java
@@ -264,8 +264,9 @@ public class TestUtils {
 
   public static void assertXMLEqual(Document exp, Document act, String message) {
     final Diff diff = DiffBuilder
-      .compare(ignoreComments(exp))
-      .withTest(ignoreComments(act))
+      .compare(exp)
+      .withTest(act)
+      .ignoreComments()
       .ignoreWhitespace()
       .normalizeWhitespace()
       .withNodeFilter(node -> node.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE)

--- a/src/test/java/org/dita/dost/TestUtils.java
+++ b/src/test/java/org/dita/dost/TestUtils.java
@@ -9,6 +9,7 @@ package org.dita.dost;
 
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.xmlunit.util.IterableNodeList.asList;
 
 import java.io.*;
@@ -272,8 +273,8 @@ public class TestUtils {
       .withNodeFilter(node -> node.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE)
       .build();
     if (diff.hasDifferences()) {
-      var errorMessage = message + System.lineSeparator() + diff + System.lineSeparator();
-      System.out.print("-" + System.lineSeparator() + errorMessage);
+      var errorMessage = message + System.lineSeparator() + diff.fullDescription() + System.lineSeparator();
+      System.out.print(errorMessage);
       var expWriter = new StringWriter();
       var actWriter = new StringWriter();
       try {
@@ -284,7 +285,7 @@ public class TestUtils {
         transformer.transform(new DOMSource(exp), new StreamResult(expWriter));
         transformer.transform(new DOMSource(act), new StreamResult(actWriter));
       } catch (TransformerException ex) {
-        throw new AssertionError(errorMessage);
+        fail(errorMessage);
       }
       assertEquals(expWriter, actWriter, errorMessage);
     }


### PR DESCRIPTION
## Description
 - report all missing/different files not just the first one
 - report extra files in the output even if they're in a directory that doesn't exist in exp (bugfix)
 - print all findings at the top first (previously it was file contents)
 - the diff is included in the test report now
 - IDEs can pick up on the assertion and show a side-by-side comparison

## Motivation and Context
Make integration tests more informative.

## How Has This Been Tested?
I developed a version of this as I was doing some other things, and I felt like it was ready to share.

## Type of Changes
- New feature and bug fix (internal)

## Documentation and Compatibility
n/a