### PR TITLE
fix overlapping paths in integration test folders

### DIFF
--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -230,8 +230,8 @@ public abstract class AbstractIntegrationTest {
   protected File run() throws Throwable {
     final File testDir = Paths.get("src", "test", "resources").resolve(name).toFile();
     final File srcDir = new File(testDir, SRC_DIR);
-    final File outDir = new File(baseTempDir, testDir.getName() + File.separator + "out");
-    final File tempDir = new File(baseTempDir, testDir.getName() + File.separator + "temp");
+    final File outDir = new File(baseTempDir, name + File.separator + "out");
+    final File tempDir = new File(baseTempDir, name + File.separator + "temp");
 
     final Map<String, String> builder = new HashMap<>();
     args.forEach((k, v) -> {


### PR DESCRIPTION
## Description
- `outDir` and `tempDir` use the name field as expected
- `keyref/basic`, `copyto/basic`, and `conref/basic` are writing in their separate folders now

## Motivation and Context
Prevent clashes and confusion.

## How Has This Been Tested?
Ran the tests locally and noted the new structure.

## Type of Changes
- Bug fix (internal)

## Documentation and Compatibility
n/a