### PR TITLE
Clean CleanPreprocessModule 

### DIFF
--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -9,11 +9,11 @@
 package org.dita.dost.module;
 
 import static java.util.Collections.emptyMap;
-import static org.dita.dost.util.Constants.*;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITA;
+import static org.dita.dost.util.Constants.ATTR_FORMAT_VALUE_DITAMAP;
 import static org.dita.dost.util.Job.USER_INPUT_FILE_LIST_FILE;
 import static org.dita.dost.util.XMLUtils.toErrorReporter;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -96,7 +96,7 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     mapFilter.setLogger(logger);
     topicFilter.setLogger(logger);
 
-    tempBase = getBaseDir();
+    tempBase = job.getBaseDir();
   }
 
   private static Boolean getUseResultFilename(Map<String, String> input) {
@@ -340,64 +340,6 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     final URI rel = base.relativize(job.getInputFile());
     final int count = rel.toString().split("/").length - 1;
     return IntStream.range(0, count).boxed().map(i -> "../").collect(Collectors.joining(""));
-  }
-
-  /**
-   * Get common base directory for all files
-   */
-  @VisibleForTesting
-  URI getBaseDir() {
-    final Collection<FileInfo> fis = job.getFileInfo();
-    URI baseDir = job.getFileInfo(fi -> fi.isInput).iterator().next().result.resolve(".");
-    for (final FileInfo fi : fis) {
-      if (fi.result != null && !fi.isResourceOnly) {
-        final URI res = fi.result.resolve(".");
-        baseDir = Optional.ofNullable(getCommonBase(baseDir, res)).orElse(baseDir);
-      }
-    }
-
-    return baseDir;
-  }
-
-  @VisibleForTesting
-  URI getCommonBase(final URI left, final URI right) {
-    assert left.isAbsolute();
-    assert right.isAbsolute();
-    if (!left.getScheme().equals(right.getScheme())) {
-      return null;
-    }
-    final URI l = left.resolve(".");
-    final URI r = right.resolve(".");
-    final String lp = l.getPath();
-    final String rp = r.getPath();
-    if (lp.equals(rp)) {
-      return l;
-    }
-    if (lp.startsWith(rp)) {
-      return r;
-    }
-    if (rp.startsWith(lp)) {
-      return l;
-    }
-    final String[] la = left.getPath().split("/");
-    final String[] ra = right.getPath().split("/");
-    int i = 0;
-    final int len = Math.min(la.length, ra.length);
-    for (; i < len; i++) {
-      if (la[i].equals(ra[i])) {
-        //
-      } else {
-        final int common = Math.max(0, i);
-        final List<String> commons = Arrays.asList(la).subList(0, common);
-        if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS) && commons.size() <= 1) {
-          return null;
-        } else {
-          final String path = String.join("/", commons) + "/";
-          return URLUtils.setPath(left, path);
-        }
-      }
-    }
-    return null;
   }
 
   private List<XMLFilter> getProcessingPipe(final FileInfo fileInfo, final File srcFile, final File destFile) {

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -16,8 +16,10 @@ import static org.dita.dost.util.XMLUtils.toErrorReporter;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -32,6 +34,7 @@ import net.sf.saxon.trans.UncheckedXPathException;
 import org.apache.commons.io.FileUtils;
 import org.dita.dost.exception.DITAOTException;
 import org.dita.dost.pipeline.AbstractPipelineOutput;
+import org.dita.dost.util.Constants;
 import org.dita.dost.util.Job;
 import org.dita.dost.util.Job.FileInfo;
 import org.dita.dost.util.URLUtils;
@@ -52,117 +55,118 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
   private static final String PARAM_USE_RESULT_FILENAME = "use-result-filename";
 
-  private final LinkFilter filter = new LinkFilter();
+  private final LinkFilter linkFilter = new LinkFilter();
   private final MapCleanFilter mapFilter = new MapCleanFilter();
   private final TopicCleanFilter topicFilter = new TopicCleanFilter();
 
   private boolean useResultFilename;
   private XsltTransformer rewriteTransformer;
   private RewriteRule rewriteClass;
+  private URI tempBase;
+  private Collection<FileInfo> fileInfosFromJob;
+  private Job tempJob;
 
-  private void init(final Map<String, String> input) {
-    useResultFilename =
-      Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME)).map(Boolean::parseBoolean).orElse(false);
-    final Resolver catalogResolver = xmlUtils.getCatalogResolver();
-    rewriteTransformer =
-      Optional
-        .ofNullable(input.get("result.rewrite-rule.xsl"))
-        .map(file -> {
-          try {
-            return catalogResolver.resolve(URLUtils.toURI(file).toString(), null);
-          } catch (TransformerException e) {
-            throw new RuntimeException(e.getMessage(), e);
-          }
-        })
-        .map(f -> {
-          try {
-            final Processor processor = xmlUtils.getProcessor();
-            final XsltCompiler xsltCompiler = processor.newXsltCompiler();
-            xsltCompiler.setErrorReporter(toErrorReporter(logger));
-            final XsltExecutable xsltExecutable = xsltCompiler.compile(f);
-            return xsltExecutable.load();
-          } catch (UncheckedXPathException e) {
-            throw new RuntimeException("Failed to compile XSLT: " + e.getXPathException().getMessageAndLocation(), e);
-          } catch (SaxonApiException e) {
-            throw new RuntimeException("Failed to compile XSLT: " + e.getMessage(), e);
-          }
-        })
-        .orElse(null);
-    rewriteClass =
-      Optional
-        .ofNullable(input.get("result.rewrite-rule.class"))
-        .map(c -> {
-          try {
-            final Class<RewriteRule> cls = (Class<RewriteRule>) Class.forName(c);
-            return cls.newInstance();
-          } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-          }
-        })
-        .orElse(null);
+  private void init() {
+    linkFilter.setJob(job);
+    linkFilter.setLogger(logger);
 
-    filter.setLogger(logger);
-
+    mapFilter.setJob(job);
     mapFilter.setLogger(logger);
+
+    topicFilter.setJob(job);
     topicFilter.setLogger(logger);
   }
 
   @Override
   public AbstractPipelineOutput execute(final Map<String, String> input) throws DITAOTException {
     init(input);
-    final URI base = getBaseDir();
-    if (useResultFilename) {
-      // collect and relativize result
-      final Collection<FileInfo> original = job
-        .getFileInfo()
-        .stream()
-        .filter(fi -> fi.result != null)
-        .map(fi -> FileInfo.builder(fi).result(base.relativize(fi.result)).build())
-        .collect(Collectors.toList());
-      original.forEach(fi -> job.remove(fi));
-      // rewrite results
-      final Collection<FileInfo> rewritten = rewrite(original);
-      // move temp files and update links
-      final Job tempJob = new Job(job, emptyMap(), rewritten);
-      filter.setJob(tempJob);
-      mapFilter.setJob(tempJob);
-      topicFilter.setJob(tempJob);
-      for (final FileInfo fi : rewritten) {
+    cleanFiles();
+    updateProperties();
+    fixInputMap();
+    writeJobFile();
+    return null;
+  }
+
+  private void init(final Map<String, String> input) {
+    useResultFilename = getUseResultFilename(input);
+    rewriteTransformer = getRewriteTransformerExtension(input);
+    rewriteClass = getRewriteClassExtension(input);
+
+    linkFilter.setLogger(logger);
+    mapFilter.setLogger(logger);
+    topicFilter.setLogger(logger);
+
+    tempBase = getBaseDir();
+  }
+
+  private static Boolean getUseResultFilename(Map<String, String> input) {
+    return Optional.ofNullable(input.get(PARAM_USE_RESULT_FILENAME)).map(Boolean::parseBoolean).orElse(false);
+  }
+
+  private XsltTransformer getRewriteTransformerExtension(Map<String, String> input) {
+    final Resolver catalogResolver = xmlUtils.getCatalogResolver();
+    return Optional
+      .ofNullable(input.get("result.rewrite-rule.xsl"))
+      .map(file -> {
         try {
-          assert !fi.result.isAbsolute();
-          if (fi.format != null && (fi.format.equals("coderef") || fi.format.equals("image"))) {
-            logger.debug("Skip format " + fi.format);
-          } else {
-            final File srcFile = new File(job.tempDirURI.resolve(fi.uri));
-            if (job.getStore().exists(srcFile.toURI())) {
-              final File destFile = new File(job.tempDirURI.resolve(fi.result));
-              final List<XMLFilter> processingPipe = getProcessingPipe(fi, srcFile, destFile);
-              if (!processingPipe.isEmpty()) {
-                logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
-                job.getStore().transform(srcFile.toURI(), destFile.toURI(), processingPipe);
-                if (!srcFile.equals(destFile)) {
-                  logger.debug("Deleting " + srcFile.toURI());
-                  FileUtils.deleteQuietly(srcFile);
-                }
-              } else if (!srcFile.equals(destFile)) {
-                logger.info("Moving " + srcFile.toURI() + " to " + destFile.toURI());
-                FileUtils.moveFile(srcFile, destFile);
-              }
-            }
-          }
-          final FileInfo res = FileInfo.builder(fi).uri(fi.result).result(base.resolve(fi.result)).build();
-          job.add(res);
-        } catch (final IOException e) {
-          logger.error("Failed to clean " + job.tempDirURI.resolve(fi.uri) + ": " + e.getMessage(), e);
+          return catalogResolver.resolve(URLUtils.toURI(file).toString(), null);
+        } catch (TransformerException e) {
+          throw new RuntimeException(e.getMessage(), e);
         }
-      }
+      })
+      .map(f -> {
+        try {
+          final Processor processor = xmlUtils.getProcessor();
+          final XsltCompiler xsltCompiler = processor.newXsltCompiler();
+          xsltCompiler.setErrorReporter(toErrorReporter(logger));
+          final XsltExecutable xsltExecutable = xsltCompiler.compile(f);
+          return xsltExecutable.load();
+        } catch (UncheckedXPathException e) {
+          throw new RuntimeException("Failed to compile XSLT: " + e.getXPathException().getMessageAndLocation(), e);
+        } catch (SaxonApiException e) {
+          throw new RuntimeException("Failed to compile XSLT: " + e.getMessage(), e);
+        }
+      })
+      .orElse(null);
+  }
+
+  private static RewriteRule getRewriteClassExtension(Map<String, String> input) {
+    return Optional
+      .ofNullable(input.get("result.rewrite-rule.class"))
+      .map(c -> {
+        try {
+          final Class<RewriteRule> cls = (Class<RewriteRule>) Class.forName(c);
+          return cls.getDeclaredConstructor().newInstance();
+        } catch (
+          ClassNotFoundException
+          | InstantiationException
+          | IllegalAccessException
+          | NoSuchMethodException
+          | InvocationTargetException e
+        ) {
+          throw new RuntimeException(e);
+        }
+      })
+      .orElse(null);
+  }
+
+  private void cleanFiles() throws DITAOTException {
+    if (useResultFilename) {
+      extractFilesFromMainJob();
+      rewriteFilesViaExtensions();
+      rewriteFilesViaInternal();
     }
+  }
 
-    job.setProperty("uplevels", getUplevels(base));
-    job.setInputDir(base);
+  private void updateProperties() {
+    job.setProperty("uplevels", getUplevels(tempBase));
+    job.setInputDir(tempBase);
+  }
 
+  private void fixInputMap() {
     // start map
     final FileInfo start = job.getFileInfo(f -> f.isInput).iterator().next();
+
     if (start != null) {
       job.setInputMap(start.uri);
 
@@ -173,48 +177,165 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
         throw new RuntimeException(e);
       }
     }
+  }
 
+  private void writeJobFile() throws DITAOTException {
     try {
       job.write();
     } catch (IOException e) {
       throw new DITAOTException();
     }
-
-    return null;
   }
 
-  private Collection<FileInfo> rewrite(final Collection<FileInfo> fis) throws DITAOTException {
+  private void extractFilesFromMainJob() {
+    // collect and relativize result
+    fileInfosFromJob =
+      job
+        .getFileInfo()
+        .stream()
+        .filter(fileInfo -> fileInfo.result != null)
+        .map(fi -> FileInfo.builder(fi).result(tempBase.relativize(fi.result)).build())
+        .collect(Collectors.toList());
+    fileInfosFromJob.forEach(fi -> job.remove(fi));
+  }
+
+  /**
+   * Rewrites files using internal filters and adds them back to the main job.
+   * @throws DITAOTException       if an error occurs during the rewriting process
+   */
+  private void rewriteFilesViaInternal() throws DITAOTException {
+    configureTempJob(fileInfosFromJob);
+    for (final FileInfo fileInfo : fileInfosFromJob) {
+      rewriteFileAndAddToMainJob(fileInfo);
+    }
+  }
+
+  /**
+   * Sets up a temporary {@link Job} for further processing.
+   * @param fileInfoCollection     a collection of {@link FileInfo} objects to be processed
+   */
+  private void configureTempJob(Collection<FileInfo> fileInfoCollection) {
+    HashMap<String, Object> tempProp = new HashMap<>();
+    tempProp.put(Constants.ANT_INVOKER_EXT_PARAM_GENERATECOPYOUTTER, job.getGeneratecopyouter());
+    tempJob = new Job(job, tempProp, fileInfoCollection);
+    linkFilter.setJob(tempJob);
+    mapFilter.setJob(tempJob);
+    topicFilter.setJob(tempJob);
+  }
+
+  /**
+   * Rewrites/cleans a file and adds it back to the main job if successful.
+   * @param fileInfo               the file to be cleaned
+   * @throws DITAOTException       if an error occurs during the rewriting process
+   */
+  private void rewriteFileAndAddToMainJob(FileInfo fileInfo) throws DITAOTException {
+    try {
+      if ("coderef".equals(fileInfo.format) || "image".equals(fileInfo.format)) {
+        logger.debug("Skip format " + fileInfo.format);
+      } else {
+        rewriteFile(fileInfo);
+      }
+
+      job.add(finalizeFileInfo(fileInfo));
+    } catch (final IOException e) {
+      logger.error("Failed to clean " + job.tempDirURI.resolve(fileInfo.uri) + ": " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Finalizes the relative URI and result URI.
+   * @param fileInfo               the file info to process
+   * @return                       a new {@link FileInfo} with updated URIs
+   */
+  private FileInfo finalizeFileInfo(FileInfo fileInfo) {
+    URI finalUri = fileInfo.result;
+    URI finalResult = tempBase.resolve(fileInfo.result);
+
+    return FileInfo.builder(fileInfo).uri(finalUri).result(finalResult).build();
+  }
+
+  /**
+   * Transforms a file through the processing pipeline
+   * or if there's no pipeline then simply moves it to its destination.
+   * @param fileInfo               the file to process
+   * @throws DITAOTException       if an error occurs during the transformation
+   * @throws IOException           if an I/O error occurs
+   */
+  private void rewriteFile(FileInfo fileInfo) throws DITAOTException, IOException {
+    final File srcFile = new File(tempJob.tempDirURI.resolve(fileInfo.uri));
+    if (tempJob.getStore().exists(srcFile.toURI())) {
+      final File destFile = new File(tempJob.tempDirURI.resolve(tempBase.relativize(fileInfo.result)));
+      final List<XMLFilter> processingPipe = getProcessingPipe(fileInfo, srcFile, destFile);
+      if (!processingPipe.isEmpty()) {
+        logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
+        tempJob.getStore().transform(srcFile.toURI(), destFile.toURI(), processingPipe);
+        if (!srcFile.equals(destFile)) {
+          logger.debug("Deleting " + srcFile.toURI());
+          FileUtils.deleteQuietly(srcFile);
+        }
+      } else if (!srcFile.equals(destFile)) {
+        logger.info("Moving " + srcFile.toURI() + " to " + destFile.toURI());
+        FileUtils.moveFile(srcFile, destFile);
+      }
+    }
+  }
+
+  /**
+   * Checks if the result URI is an outer file, that is not located in the input directory.
+   * @param resultUri              the URI to check
+   * @return                       true if the file is an outer file, false otherwise
+   */
+  private boolean isOuterFile(URI resultUri) {
+    return !Paths.get(resultUri).startsWith(Paths.get(job.getInputDir()));
+  }
+
+  /**
+   * Rewrites files using plugins/extensions.
+   * Supports both XSLT and Java-based rewrite rules.
+   * @throws DITAOTException       if an error occurs during the rewriting process
+   */
+  private void rewriteFilesViaExtensions() throws DITAOTException {
     if (rewriteClass != null) {
-      return rewriteClass.rewrite(fis);
+      fileInfosFromJob = rewriteClass.rewrite(fileInfosFromJob);
     }
     if (rewriteTransformer != null) {
       try {
-        final DOMSource source = new DOMSource(serialize(fis));
+        final DOMSource source = new DOMSource(serialize(fileInfosFromJob));
         final Map<URI, FileInfo> files = new HashMap<>();
         final Destination result = new SAXDestination(new Job.JobHandler(new HashMap<>(), files));
         rewriteTransformer.setSource(source);
         rewriteTransformer.setDestination(result);
         rewriteTransformer.transform();
-        return files.values();
+        fileInfosFromJob = files.values();
       } catch (IOException | SaxonApiException e) {
         throw new DITAOTException(e);
       }
     }
-    return fis;
   }
 
-  private Document serialize(final Collection<FileInfo> fis) throws IOException {
+  /**
+   * Serializes a set of files into a single DOM for further processing.
+   * @param fileInfoCollection     the collection to serialize
+   * @return                       a DOM containing the serialized data
+   * @throws IOException           if an error occurs during serialization
+   */
+  private Document serialize(final Collection<FileInfo> fileInfoCollection) throws IOException {
     try {
       final Document doc = xmlUtils.newDocument();
       final DOMResult result = new DOMResult(doc);
       XMLStreamWriter out = XMLOutputFactory.newInstance().createXMLStreamWriter(result);
-      job.serialize(out, emptyMap(), fis);
+      job.serialize(out, emptyMap(), fileInfoCollection);
       return (Document) result.getNode();
     } catch (final XMLStreamException e) {
       throw new IOException("Failed to serialize job file: " + e.getMessage());
     }
   }
 
+  /**
+   * If the input file is in a subdirectory of the base directory,
+   * returns a relative path to the base directory.
+   * This is not used by this class for cleaning the files.
+   */
   String getUplevels(final URI base) {
     final URI rel = base.relativize(job.getInputFile());
     final int count = rel.toString().split("/").length - 1;
@@ -279,44 +400,41 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     return null;
   }
 
-  private void init() {
-    filter.setJob(job);
-    filter.setLogger(logger);
+  private List<XMLFilter> getProcessingPipe(final FileInfo fileInfo, final File srcFile, final File destFile) {
+    final List<XMLFilter> xmlFilterList = new ArrayList<>();
 
-    mapFilter.setJob(job);
-    mapFilter.setLogger(logger);
+    final String format = fileInfo.format;
+    final boolean isDita = ATTR_FORMAT_VALUE_DITA.equals(format);
+    final boolean isMap = ATTR_FORMAT_VALUE_DITAMAP.equals(format);
+    final boolean isUnknown = format == null;
 
-    topicFilter.setJob(job);
-    topicFilter.setLogger(logger);
-  }
-
-  private List<XMLFilter> getProcessingPipe(final FileInfo fi, final File srcFile, final File destFile) {
-    final List<XMLFilter> res = new ArrayList<>();
-
-    if (fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA) || fi.format.equals(ATTR_FORMAT_VALUE_DITAMAP)) {
-      filter.setCurrentFile(srcFile.toURI());
-      filter.setDestFile(destFile.toURI());
-      res.add(filter);
+    // add link filter for all DITA
+    if (isDita || isMap || isUnknown) {
+      linkFilter.setCurrentFile(srcFile.toURI());
+      linkFilter.setDestFile(destFile.toURI());
+      xmlFilterList.add(linkFilter);
     }
 
-    if (fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {
-      topicFilter.setFileInfo(fi);
-      res.add(topicFilter);
-    } else if (fi.format.equals(ATTR_FORMAT_VALUE_DITAMAP)) {
-      res.add(mapFilter);
+    // add topic filter for topics and map filter for maps
+    if (isDita || isUnknown) {
+      topicFilter.setFileInfo(fileInfo);
+      xmlFilterList.add(topicFilter);
+    } else if (isMap) {
+      xmlFilterList.add(mapFilter);
     }
 
-    for (final XmlFilterModule.FilterPair p : filters) {
-      if (p.predicate.test(fi)) {
-        final AbstractXMLFilter f = p.newInstance();
-        logger.debug("Configure filter " + f.getClass().getCanonicalName());
-        f.setCurrentFile(srcFile.toURI());
-        f.setJob(job);
-        f.setLogger(logger);
-        res.add(f);
+    // add remaining filters
+    for (final XmlFilterModule.FilterPair filterPair : filters) {
+      if (filterPair.predicate.test(fileInfo)) {
+        final AbstractXMLFilter xmlFilter = filterPair.newInstance();
+        logger.debug("Configure filter " + xmlFilter.getClass().getCanonicalName());
+        xmlFilter.setCurrentFile(srcFile.toURI());
+        xmlFilter.setJob(job);
+        xmlFilter.setLogger(logger);
+        xmlFilterList.add(xmlFilter);
       }
     }
 
-    return res;
+    return xmlFilterList;
   }
 }

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -11,6 +11,7 @@ import static org.dita.dost.util.Configuration.configuration;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.*;
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -1146,5 +1147,62 @@ public final class Job {
     }
     tempFileNameScheme.setBaseDir(getInputDir());
     return tempFileNameScheme;
+  }
+
+  /**
+   * Get common base directory for all files
+   */
+  public URI getBaseDir() {
+    final Collection<FileInfo> fis = getFileInfo();
+    URI baseDir = getFileInfo(fi -> fi.isInput).iterator().next().result.resolve(".");
+    for (final FileInfo fi : fis) {
+      if (fi.result != null && !fi.isResourceOnly) {
+        final URI res = fi.result.resolve(".");
+        baseDir = Optional.ofNullable(getCommonBase(baseDir, res)).orElse(baseDir);
+      }
+    }
+
+    return baseDir;
+  }
+
+  @VisibleForTesting
+  URI getCommonBase(final URI left, final URI right) {
+    assert left.isAbsolute();
+    assert right.isAbsolute();
+    if (!left.getScheme().equals(right.getScheme())) {
+      return null;
+    }
+    final URI l = left.resolve(".");
+    final URI r = right.resolve(".");
+    final String lp = l.getPath();
+    final String rp = r.getPath();
+    if (lp.equals(rp)) {
+      return l;
+    }
+    if (lp.startsWith(rp)) {
+      return r;
+    }
+    if (rp.startsWith(lp)) {
+      return l;
+    }
+    final String[] la = left.getPath().split("/");
+    final String[] ra = right.getPath().split("/");
+    int i = 0;
+    final int len = Math.min(la.length, ra.length);
+    for (; i < len; i++) {
+      if (la[i].equals(ra[i])) {
+        //
+      } else {
+        final int common = Math.max(0, i);
+        final List<String> commons = Arrays.asList(la).subList(0, common);
+        if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS) && commons.size() <= 1) {
+          return null;
+        } else {
+          final String path = String.join("/", commons) + "/";
+          return URLUtils.setPath(left, path);
+        }
+      }
+    }
+    return null;
   }
 }

--- a/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
+++ b/src/test/java/org/dita/dost/module/CleanPreprocessModuleTest.java
@@ -8,22 +8,16 @@
 
 package org.dita.dost.module;
 
-import static java.net.URI.create;
-import static org.dita.dost.util.Constants.OS_NAME;
-import static org.dita.dost.util.Constants.OS_NAME_WINDOWS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import org.dita.dost.TestUtils;
 import org.dita.dost.TestUtils.TestLogger;
 import org.dita.dost.store.StreamStore;
 import org.dita.dost.util.Job;
-import org.dita.dost.util.Job.FileInfo.Builder;
 import org.dita.dost.util.XMLUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,111 +38,6 @@ public class CleanPreprocessModuleTest {
     xmlUtils = new XMLUtils();
     job = new Job(tempDir, new StreamStore(tempDir, xmlUtils));
     module.setJob(job);
-  }
-
-  @Test
-  public void getCommonBase_unix() {
-    if (!OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-      assertEquals(
-        create("file:/foo/bar/"),
-        module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/bar/b"))
-      );
-      assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/a"), create("file:/foo/bar/b")));
-      assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/b")));
-      assertEquals(create("file:/foo/"), module.getCommonBase(create("file:/foo/bar/a"), create("file:/foo/baz/b")));
-      assertEquals(create("file:/"), module.getCommonBase(create("file:/foo/a/b/c"), create("file:/bar/b/c/d")));
-      assertEquals(null, module.getCommonBase(create("file:/foo/bar/a"), create("https://example.com/baz/b")));
-    }
-  }
-
-  @Test
-  public void getCommonBase_windows() {
-    if (OS_NAME.toLowerCase().contains(OS_NAME_WINDOWS)) {
-      assertEquals(create("file:/F:/bar/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/bar/b")));
-      assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/a"), create("file:/F:/bar/b")));
-      assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/b")));
-      assertEquals(create("file:/F:/"), module.getCommonBase(create("file:/F:/bar/a"), create("file:/F:/baz/b")));
-      assertEquals(null, module.getCommonBase(create("file:/C:/a"), create("file:/D:/b")));
-      assertEquals(null, module.getCommonBase(create("file:/f:/bar/a"), create("https://example.com/baz/b")));
-    }
-  }
-
-  @Test
-  public void getBaseDir() throws Exception {
-    job.setInputDir(URI.create("file:/foo/bar/"));
-    job.add(new Builder().uri(create("map.ditamap")).isInput(true).result(create("file:/foo/bar/map.ditamap")).build());
-    job.add(new Builder().uri(create("topics/topic.dita")).result(create("file:/foo/bar/topics/topic.dita")).build());
-    job.add(new Builder().uri(create("topics/null.dita")).build());
-    job.add(new Builder().uri(create("topics/task.dita")).result(create("file:/foo/bar/topics/task.dita")).build());
-    job.add(new Builder().uri(create("common/topic.dita")).result(create("file:/foo/bar/common/topic.dita")).build());
-
-    assertEquals(create("file:/foo/bar/"), module.getBaseDir());
-  }
-
-  @Test
-  public void getBaseDirExternal() throws Exception {
-    job.setInputDir(URI.create("file:/foo/bar/"));
-    job.add(new Builder().uri(create("map.ditamap")).isInput(true).result(create("file:/foo/bar/map.ditamap")).build());
-    job.add(
-      new Builder()
-        .uri(create("topics/topic.dita"))
-        .result(create("https://example.com/topics/bar/topics/topic.dita"))
-        .build()
-    );
-
-    assertEquals(create("file:/foo/bar/"), module.getBaseDir());
-  }
-
-  @Test
-  public void getBaseDirSubdir() throws Exception {
-    job.setInputDir(URI.create("file:/foo/bar/maps/"));
-    job.add(
-      new Builder()
-        .uri(create("maps/map.ditamap"))
-        .isInput(true)
-        .result(create("file:/foo/bar/maps/map.ditamap"))
-        .build()
-    );
-    job.add(new Builder().uri(create("topics/topic.dita")).result(create("file:/foo/bar/topics/topic.dita")).build());
-
-    assertEquals(create("file:/foo/bar/"), module.getBaseDir());
-  }
-
-  @Test
-  public void getBaseDirSupdir() throws Exception {
-    job.setInputDir(URI.create("file:/foo/bar/maps/"));
-    job.add(
-      new Builder()
-        .uri(create("maps/map.ditamap"))
-        .isInput(true)
-        .result(create("file:/foo/bar/maps/map.ditamap"))
-        .build()
-    );
-    job.add(new Builder().uri(create("topics/topic.dita")).result(create("file:/foo/bar/topic.dita")).build());
-
-    assertEquals(create("file:/foo/bar/"), module.getBaseDir());
-  }
-
-  @Test
-  public void getBaseDirResourceOnly() throws Exception {
-    job.setInputDir(URI.create("file:/main/maps/"));
-    job.add(
-      new Builder()
-        .uri(create("main/maps/map.ditamap"))
-        .isInput(true)
-        .result(create("file:/main/maps/map.ditamap"))
-        .build()
-    );
-    job.add(new Builder().uri(create("main/topics/topic.dita")).result(create("file:/main/topics/topic.dita")).build());
-    job.add(
-      new Builder()
-        .uri(create("reuse/reuse.dita"))
-        .result(create("file:/reuse/reuse.dita"))
-        .isResourceOnly(true)
-        .build()
-    );
-
-    assertEquals(create("file:/main/"), module.getBaseDir());
   }
 
   @Test


### PR DESCRIPTION
## Description
- organize code for better readability
- move methods to more appropriate locations

## Motivation and Context
- CleanPreprocessModule took me a long time to understand when I first encountered it. I wanted to make it easier to navigate, especially as a new contributor.
- I found that getBasedir only operated on objects that belonged to Job, so I moved it. This'll make development smoother later.

## How Has This Been Tested?
All the tests pass still (the moved ones too).

## Type of Changes
- New feature (internal)

## Documentation and Compatibility
n/a