### PR TITLE
Fix support for logical grouping in unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ tasks.named("test") {
     useJUnitPlatform {
         filter {
             includeTestsMatching "*Test"
+            includeTestsMatching "*Test\$*"
             excludeTestsMatching "IT*"
             excludeTestsMatching "EndToEndTest*"
         }


### PR DESCRIPTION
## Description
Fix test filtering in Gradle so that you can reference nested classes in unit tests.

## Motivation and Context
Sometimes you want to run a subset of tests in a class. Nested classes are great for that.
It works in integration tests, but the filtering in `build.gradle` prevented us from using it in unit tests too, hence this change.

## How Has This Been Tested?
* on the command line, ran  ```gradlew.bat :test --tests "org.dita.dost.util.JobTest$GetResultBaseDir"```
* clicked the run test on the class in IntelliJ (and it ran the command above)

## Type of Changes
- Bug fix (internal)

## Documentation and Compatibility
n/a
