### PR TITLE
fix node executable path on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,9 +79,12 @@ node {
     version = file('.nvmrc').readLines().first().trim()
 }
 
+def nodeExec = System.getProperty('os.name').toLowerCase().contains('windows') ? '/node.exe' : '/bin/node'
+
 spotless {
     java {
         prettier(['prettier': '2.8.4', 'prettier-plugin-java': '2.1.0']).configFile('.prettierrc')
+                .nodeExecutable("${tasks.named('nodeSetup').get().nodeDir.get()}${nodeExec}")
     }
 }
 


### PR DESCRIPTION
## Description
Fix the node executable path in Gradle on Windows OS.

## Motivation and Context
I installed a new Windows version from scratch, and suddenly Gradle could not find the node executable again. The builds ran perfectly on GitHub, it was just my Windows computer. Hopefully this'll fix both.

## How Has This Been Tested?
Ran it locally and on GitHub.

## Type of Changes
- Bug fix 
 
## Documentation and Compatibility
n/a