### PR TITLE
unify @BeforeAll method names in tests

### DIFF
--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -201,7 +201,7 @@ public abstract class AbstractIntegrationTest {
   }
 
   @BeforeAll
-  public static void setUpBeforeClass() throws Exception {
+  public static void setUpAll() throws Exception {
     final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     dbf.setNamespaceAware(true);
     db = dbf.newDocumentBuilder();

--- a/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
+++ b/src/test/java/org/dita/dost/ant/types/JobSourceSetTest.java
@@ -36,7 +36,7 @@ public class JobSourceSetTest {
   private JobSourceSet jobSourceSet;
 
   @BeforeAll
-  public static void setUpClass() throws Exception {
+  public static void setUpAll() throws Exception {
     tempDir = TestUtils.createTempDir(JobSourceSetTest.class);
     job = new Job(tempDir, new StreamStore(tempDir, new XMLUtils()));
     for (String ext : Arrays.asList("dita", "ditamap", "jpg", "html")) {

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -42,7 +42,7 @@ public class DebugAndFilterModuleTest {
   private File inputDir;
 
   @BeforeAll
-  public static void setUpClass() {
+  public static void setUpAll() {
     CatalogUtils.setDitaDir(new File("src" + File.separator + "main").getAbsoluteFile());
   }
 

--- a/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
@@ -40,7 +40,7 @@ public class ImageMetadataModuleTest {
   private static File tempDir;
 
   @BeforeAll
-  public static void setup() throws IOException {
+  public static void setUpAll() throws IOException {
     tempDir = TestUtils.createTempDir(ImageMetadataModuleTest.class);
   }
 

--- a/src/test/java/org/dita/dost/platform/FeaturesTest.java
+++ b/src/test/java/org/dita/dost/platform/FeaturesTest.java
@@ -29,7 +29,7 @@ public class FeaturesTest {
   private static Document doc;
 
   @BeforeAll
-  public static void setUp() throws Exception {
+  public static void setUpAll() throws Exception {
     doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
   }
 

--- a/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
+++ b/src/test/java/org/dita/dost/reader/MergeTopicParserTest.java
@@ -44,7 +44,7 @@ public class MergeTopicParserTest {
   private MergeTopicParser parser;
 
   @BeforeAll
-  public static void setupClass() {
+  public static void setUpAll() {
     final TransformerFactory tf = TransformerFactory.newInstance();
     if (!tf.getFeature(SAXTransformerFactory.FEATURE)) {
       throw new RuntimeException("SAX transformation factory not supported");

--- a/src/test/java/org/dita/dost/util/DITAOTCopyTest.java
+++ b/src/test/java/org/dita/dost/util/DITAOTCopyTest.java
@@ -27,7 +27,7 @@ public class DITAOTCopyTest {
   private static File tempDir;
 
   @BeforeAll
-  public static void setUp() throws IOException {
+  public static void setUpAll() throws IOException {
     tempDir = TestUtils.createTempDir(DITAOTCopyTest.class);
   }
 

--- a/src/test/java/org/dita/dost/util/FileUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/FileUtilsTest.java
@@ -26,7 +26,7 @@ public class FileUtilsTest {
   private static File tempDir;
 
   @BeforeAll
-  public static void setUp() throws IOException {
+  public static void setUpAll() throws IOException {
     tempDir = TestUtils.createTempDir(FileUtilsTest.class);
   }
 

--- a/src/test/java/org/dita/dost/util/MergeUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/MergeUtilsTest.java
@@ -31,7 +31,7 @@ public class MergeUtilsTest {
   public static MergeUtils mergeUtils;
 
   @BeforeAll
-  public static void setUp() throws IOException {
+  public static void setUpAll() throws IOException {
     mergeUtils = new MergeUtils();
     mergeUtils.setJob(new Job(srcDir, new StreamStore(srcDir, new XMLUtils())));
   }

--- a/src/test/java/org/dita/dost/util/XMLUtilsTest.java
+++ b/src/test/java/org/dita/dost/util/XMLUtilsTest.java
@@ -63,7 +63,7 @@ public class XMLUtilsTest {
   private static File tempDir;
 
   @BeforeAll
-  public static void setUp() throws IOException {
+  public static void setUpAll() throws IOException {
     tempDir = TestUtils.createTempDir(XMLUtilsTest.class);
   }
 

--- a/src/test/java/org/dita/dost/util/XSpecTest.java
+++ b/src/test/java/org/dita/dost/util/XSpecTest.java
@@ -48,7 +48,7 @@ public class XSpecTest {
   }
 
   @BeforeAll
-  public static void setUpClass() throws TransformerException {
+  public static void setUpAll() throws TransformerException {
     var transformerFactory = TransformerFactory.newInstance();
     final File ditaDir = new File(
       Optional.ofNullable(System.getProperty("dita.dir")).orElse("src" + File.separator + "main")

--- a/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
+++ b/src/test/java/org/dita/dost/writer/ImageMetadataFilterTest.java
@@ -40,7 +40,7 @@ public class ImageMetadataFilterTest {
   private static File tempDir;
 
   @BeforeAll
-  public static void setup() throws IOException {
+  public static void setUpAll() throws IOException {
     tempDir = TestUtils.createTempDir(ImageMetadataFilterTest.class);
   }
 


### PR DESCRIPTION
## Description
In Java tests, @BeforeAll methods now all have the same name.

## Motivation and Context
Suite setup method names were all over the place. I chose the one that was last used on `develop` and updated all others to improve readability.

## How Has This Been Tested?
The tests still run.

## Type of Changes
- New feature (internal)

## Documentation and Compatibility
n/a