### PR TITLE
Incorrectly resolved paths when using dita.conductor.lib.import #4692

### DIFF
--- a/src/main/java/org/dita/dost/platform/FileGenerator.java
+++ b/src/main/java/org/dita/dost/platform/FileGenerator.java
@@ -39,6 +39,7 @@ final class FileGenerator extends XMLFilterImpl {
 
   public static final String PARAM_LOCALNAME = "localname";
   public static final String PARAM_TEMPLATE = "template";
+  public static final String PARAM_DITA_DIR = "dita.dir";
 
   private static final String DITA_OT_NS = "http://dita-ot.sourceforge.net";
   private static final String TEMPLATE_PREFIX = "_template.";
@@ -51,6 +52,8 @@ final class FileGenerator extends XMLFilterImpl {
   private final Map<String, Plugin> pluginTable;
   /** Template file. */
   private File templateFile;
+  /** DITA-OT directory. */
+  private File ditaDir;
 
   /**
    * Default Constructor.
@@ -69,8 +72,18 @@ final class FileGenerator extends XMLFilterImpl {
     templateFile = null;
   }
 
+
+
   public void setLogger(final DITAOTLogger logger) {
     this.logger = logger;
+  }
+
+  /**
+   * Set the DITA-OT directory.
+   * @param ditaDir DITA-OT root directory
+   */
+  public void setDitaDir(final File ditaDir) {
+    this.ditaDir = ditaDir;
   }
 
   /**
@@ -134,6 +147,9 @@ final class FileGenerator extends XMLFilterImpl {
         final IAction action = (IAction) Class.forName(attributes.getValue(BEHAVIOR_ATTR)).newInstance();
         action.setLogger(logger);
         action.addParam(PARAM_TEMPLATE, templateFile.getAbsolutePath());
+        if (ditaDir != null) {
+          action.addParam(PARAM_DITA_DIR, ditaDir.getAbsolutePath());
+        }
         for (int i = 0; i < attributes.getLength(); i++) {
           action.addParam(attributes.getLocalName(i), attributes.getValue(i));
         }
@@ -157,6 +173,9 @@ final class FileGenerator extends XMLFilterImpl {
                 action.setLogger(logger);
                 action.setFeatures(pluginTable);
                 action.addParam(PARAM_TEMPLATE, templateFile.getAbsolutePath());
+                if (ditaDir != null) {
+                  action.addParam(PARAM_DITA_DIR, ditaDir.getAbsolutePath());
+                }
                 final List<Value> value = Stream
                   .of(attributes.getValue(i).split(Integrator.FEAT_VALUE_SEPARATOR))
                   .map(val -> new Value.StringValue(null, val))

--- a/src/main/java/org/dita/dost/platform/Integrator.java
+++ b/src/main/java/org/dita/dost/platform/Integrator.java
@@ -280,6 +280,7 @@ public final class Integrator {
     // Collect information for each feature id and generate a feature table.
     final FileGenerator fileGen = new FileGenerator(featureTable, pluginTable);
     fileGen.setLogger(logger);
+    fileGen.setDitaDir(ditaDir);
     for (final String currentPlugin : orderPlugins(pluginTable.keySet())) {
       loadPlugin(currentPlugin);
     }


### PR DESCRIPTION
## Description

Integrator.java:
    - Added call to setDitaDir() where instantiating FileGenerator, so instances will know path to dita.dir.
FileGenerator.java: 
    - Added ditaDir field, dita.dir param, and setDitaDir() method.
    - Added calls to add PARAM_DITA_DIR to the Action's parameter table (if ditaDir is set)
    - Uses ditaDir.getAbsolutePath(), so will always set PARAM_DITA_DIR to an absolute path.
ImportAntLibAction:
    - Gets ditaDirPath from PARAM_DITA_DIR
    - Uses getRelativeUnixPath to resolve library path relative to ditaDirPath
    - No longer checks for absolute or relative path - ditaDirPath is always absolute
    - Prepends URI with `${dita.dir}/` instead of `${dita.dir}${file.separator}` because this is always a forward-slash delimited path. Windows machines would incorrectly insert a backslash.


## Motivation and Context

When using _dita.conductor.lib.import_ extension point in my own plugin, I noticed paths in base plugin build.xml were incorrect. The path was relative to plugin, not dita.dir, but was prepended with ${dita.dir}, resulting in broken paths in dost.class.path like this:

`location="${dita.dir}${file.separator}../org.dita.index/lib/index.jar"`

I am currently using toolkit version 3.7.3 and fixed this to work with that toolkit, but figured I should offer up the fix to the project.

I realize that using dost.class.path is deprecated, but I figured as long as it's still there, it should be working. :-)

Fixes #4692


## How Has This Been Tested?
1. Ran included integration and e2e tests on Windows, using gradlew.
2. ran 'bin/dita install' and observed contents of base build.xml. Also checked for other generated files that may have been affected (like env.sh) and found no changes.


## Type of Changes
- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
No changes needed.

## Checklist
- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines> <-- This is a dead link, BTW
- I have updated the unit tests to reflect the changes in my code.
N/A
