### PR TITLE
Fix trademark in related links in XHTML/eclipsehelp transtypes

### DIFF
--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/dita2htmlImpl.xsl
@@ -1102,7 +1102,7 @@ See the accompanying LICENSE file for applicable license.
 <!-- process the TM tag -->
 <!-- removed priority 1 : should not be needed -->
 <xsl:template match="*[contains(@class, ' topic/tm ')]" name="topic.tm">
-
+  <xsl:param name="root" select="root()" as="document-node()" tunnel="yes"/>
   <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
   <xsl:apply-templates/> <!-- output the TM content -->
 
@@ -1122,7 +1122,7 @@ See the accompanying LICENSE file for applicable license.
         <xsl:if test="ancestor::*[contains(@class, ' topic/title ')]/parent::*[contains(@class, ' topic/topic ')]">
           <xsl:choose>
             <!-- Not the first one in a title -->
-            <xsl:when test="generate-id(.) != generate-id(key('tm', .)[1])">skip</xsl:when>
+            <xsl:when test="generate-id(.) != generate-id($root/key('tm', .)[1])">skip</xsl:when>
             <!-- First one in the topic, BUT it appears in a shortdesc or body -->
             <xsl:when test="//*[contains(@class, ' topic/shortdesc ') or contains(@class, ' topic/body ')]//*[contains(@class, ' topic/tm ')][@trademark = $tmvalue]">skip</xsl:when>
             <xsl:otherwise>use</xsl:otherwise>
@@ -1137,7 +1137,7 @@ See the accompanying LICENSE file for applicable license.
           <!-- If in a title or prolog, skip -->
           <xsl:when test="ancestor::*[contains(@class, ' topic/title ') or contains(@class, ' topic/prolog ')]/parent::*[contains(@class, ' topic/topic ')]">skip</xsl:when>
           <!-- If first in the document, use it -->
-          <xsl:when test="generate-id(.) = generate-id(key('tm', .)[1])">use</xsl:when>
+          <xsl:when test="generate-id(.) = generate-id($root/key('tm', .)[1])">use</xsl:when>
           <!-- If there is another before this that is in the body or shortdesc, skip -->
           <xsl:when test="preceding::*[contains(@class, ' topic/tm ')][@trademark = $tmvalue][ancestor::*[contains(@class, ' topic/body ') or contains(@class, ' topic/shortdesc ')]]">skip</xsl:when>
           <!-- Otherwise, any before this must be in a title or ignored section -->

--- a/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
+++ b/src/main/plugins/org.dita.xhtml/xsl/xslhtml/rel-links.xsl
@@ -195,7 +195,9 @@ See the accompanying LICENSE file for applicable license.
                                               [generate-id(.) = generate-id(key('hideduplicates', related-links:hideduplicates(.))[1])]"/>
        </xsl:apply-templates>
       </xsl:variable>
-      <xsl:apply-templates select="$unordered-links"/>
+      <xsl:apply-templates select="$unordered-links">
+        <xsl:with-param name="root" select="root()" as="document-node()" tunnel="yes"/>  
+      </xsl:apply-templates>
       <!--linklists - last but not least, create all the linklists and their links, with no sorting or re-ordering-->
       <xsl:apply-templates select="*[contains(@class, ' topic/linklist ')]"/>
     </nav>


### PR DESCRIPTION


## Description
Porting fix done on the HTML5 transform for dita-ot/dita-ot#2303 in PR https://github.com/dita-ot/dita-ot/pull/2394.

Message from original fix from @eerohele:
An intermediate tree is assigned to the $unordered-links variable, which is then applied. The root node of an intermediate tree is not a document node, which causes any calls to the key() function to fail.

The solution is to pass the original root node as a tunnel parameter and use that as the context node for any calls to key().

For issue dita-ot/dita-ot#4686

## Motivation and Context
This was fixed for HTML5 transform a long time ago, but never in the XHTML transform, which is the one the eclipsehelp transform relies on.

## How Has This Been Tested?
Yes, with the sample provided by @raducoravu in #4686, which basically an empty topic with one related link containing a linktext with a trademark. I'm not sure how to add automated tests and where to add them, but happy to do if you poinbt me the correct documentation.

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature? **None**
- Will this change affect backwards compatibility or other users' overrides? **No**

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    - [X]  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    - [X]  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    - [X]  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- [ ] I have updated the unit tests to reflect the changes in my code.
