### PR TITLE
Initialize Job during project init

### DIFF
--- a/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
+++ b/src/main/java/org/dita/dost/ant/InitializeProjectTask.java
@@ -11,6 +11,8 @@ import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toFile;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 import java.util.ServiceLoader;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -19,6 +21,8 @@ import org.dita.dost.log.DITAOTAntLogger;
 import org.dita.dost.store.Store;
 import org.dita.dost.store.StoreBuilder;
 import org.dita.dost.util.CatalogUtils;
+import org.dita.dost.util.Configuration;
+import org.dita.dost.util.Job;
 import org.dita.dost.util.XMLUtils;
 
 /**
@@ -48,6 +52,14 @@ public final class InitializeProjectTask extends Task {
     }
     final Store store = getStore(xmlUtils);
     getProject().addReference(ANT_REFERENCE_STORE, store);
+
+    try {
+      final Job job = new Job(new File(getProject().getProperty("dita.temp.dir")), store);
+      job.setProperty("temp-file-name-scheme", Configuration.configuration.get("temp-file-name-scheme"));
+      getProject().addReference(ANT_REFERENCE_JOB, job);
+    } catch (final IOException e) {
+      throw new BuildException("Failed to initialize project: " + e.getMessage(), e);
+    }
   }
 
   private Store getStore(XMLUtils xmlUtils) {

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -115,13 +115,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- TODO: change property initialization to not use physical files -->
     <mkdir dir="${dita.temp.dir}"/>
-    <echoxml file="${dita.temp.dir}/.job.xml">
-      <job>
-        <property name="temp-file-name-scheme">
-          <string>org.dita.dost.module.reader.HashTempFileScheme</string>
-        </property>
-      </job>
-    </echoxml>
+
     <condition property="map.filter-on-parse" value="true" else="false">
       <equals arg1="${filter-stage}" arg2="early"/>
     </condition>

--- a/src/main/plugins/org.dita.base/build_preprocess2_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess2_template.xml
@@ -162,12 +162,11 @@ See the accompanying LICENSE file for applicable license.
         <dita:extension id="dita.preprocess.map-reader.param" behavior="org.dita.dost.platform.InsertAction"/>
       </module>
     </pipeline>
-    <local name="inputMapPath"/>
-    <pathconvert property="inputMapPath">
-      <ditafileset format="ditamap" input="true"/>
-    </pathconvert>
+
     <condition property="noMap">
-      <equals arg1="${inputMapPath}" arg2=""/>
+      <resourcecount count="0" when="equal">
+        <ditafileset format="ditamap" input="true"/>
+      </resourcecount>
     </condition>
   </target>
 

--- a/src/main/plugins/org.dita.base/build_preprocess_template.xml
+++ b/src/main/plugins/org.dita.base/build_preprocess_template.xml
@@ -171,12 +171,10 @@ See the accompanying LICENSE file for applicable license.
     <dirname property="_dita.map.output.dir" file="${dita.output.dir}/${user.input.file}" />
     <dirname property="_dita.map.temp.dir" file="${dita.temp.dir}/${user.input.file}" />
     <property name="dita.map.output.dir" location="${_dita.map.output.dir}/${uplevels}"/>
-    <local name="inputMapPath"/>
-    <pathconvert property="inputMapPath">
-      <ditafileset format="ditamap" input="true"/>
-    </pathconvert>
     <condition property="noMap">
-      <equals arg1="${inputMapPath}" arg2=""/>
+      <resourcecount count="0" when="equal">
+        <ditafileset format="ditamap" input="true"/>
+      </resourcecount>
     </condition>
   </target>
 


### PR DESCRIPTION
## Description
Initialize Job during project init instead of writing XML to disk.

## Motivation and Context
Don't write anything to temp directory on disk during initialization, as in-memory store does not read it.

## How Has This Been Tested?
Existing tests.

## Type of Changes

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No user facing changes.
