### PR TITLE
Remove hard-coded text color for section titles

### DIFF
--- a/src/main/plugins/org.dita.html5/sass/_headings.scss
+++ b/src/main/plugins/org.dita.html5/sass/_headings.scss
@@ -43,7 +43,6 @@
 }
 
 .sectiontitle {
-  color: $text-color;
   font-size: 1.17em;
   font-weight: bold;
   margin-bottom: 0;


### PR DESCRIPTION
While testing a dark mode theme for HTML output, I noticed that section titles do not inherit the inverted color scheme.

No other heading levels specify text color, so this PR removes the color property to allow themes to modify section title color along with other headings and text.

<img width="342" height="242" alt="Hard-coded black text color on section title: Preview Init subcommand" src="https://github.com/user-attachments/assets/bf5cef38-34dd-4506-a5ba-8254ad97a160" title="Hard-coded black text color on section title: Preview Init subcommand" />

### History 

Turns out this color property has been present in the `.sectiontitle` styling since the [commonltr.css](https://github.com/dita-ot/dita-ot/blob/770b40a/resource/commonltr.css#L44) file was first added to the repository in 770b40a on March 3, 2005.