### PR TITLE
Add deprecation to outputFile.base

### DIFF
--- a/src/main/plugins/org.dita.pdf2/plugin.xml
+++ b/src/main/plugins/org.dita.pdf2/plugin.xml
@@ -22,7 +22,7 @@ See the accompanying LICENSE file for applicable license.
   <!-- extensions -->
   <feature extension="dita.conductor.lib.import" file="lib/fo.jar"/>
   <transtype name="pdf" desc="PDF">
-    <param name="outputFile.base" desc="Specifies the base file name of the generated PDF file."/>
+    <param name="outputFile.base" deprecated="true" desc="Specifies the base file name of the generated PDF file."/>
     <param name="args.artlbl" desc="Specifies whether to generate a label for each image; the label will contain the image file name." type="enum">
       <val>yes</val>
       <val default="true">no</val>


### PR DESCRIPTION
## Description
Add deprecation for PDF2 parameter `outputFile.base`.

## Motivation and Context
Fixes dita-ot/docs#648


## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility
Automatically pulled to documentation.

