### PR TITLE
Remove stale `args.logdir` reference from test code

### DIFF
--- a/src/test/resources/plugins.xml
+++ b/src/test/resources/plugins.xml
@@ -295,8 +295,6 @@ public IDs and system IDs for any DTD modules included in this plugin. -->
     </param>
     <param desc="Specifies the master file for your documentation project." name="args.input" required="true" type="file"/>
     <param desc="Specifies the base directory for your documentation project." name="args.input.dir" type="dir"/>
-    <!-- Deprecated since 2.5 -->
-    <param deprecated="true" desc="Specifies the location where DITA-OT places log files for your project." name="args.logdir" type="dir"/>
     <param desc="Specifies the name of the output file without file extension." name="args.output.base" type="string"/>
     <param desc="Specifies how cross references to tables are styled." name="args.tablelink.style" type="enum">
       <val>NUMBER</val>


### PR DESCRIPTION
The `args.logdir` parameter has been deprecated since DITA-OT 2.5, and was removed in 3.4 with #3399 for #3398.

See https://www.dita-ot.org/3.4/release-notes/#v3.4__3399:

> The `args.logdir` parameter (deprecated since DITA-OT 2.5) has been removed. 
> To write the log to a file, use `dita --logfile=file` or `ant -l file` and specify the path to the log file.

Also removed from docs for 3.4 with https://github.com/dita-ot/docs/commit/dbb1487.

> [!NOTE]
>
> Discovered while searching for `deprecated="true"` in https://github.com/dita-ot/dita-ot/pull/4732#pullrequestreview-3574503704.