### PR TITLE
Passthrough support for `@importance`

### DIFF
--- a/src/main/plugins/org.dita.html5/xsl/topic.xsl
+++ b/src/main/plugins/org.dita.html5/xsl/topic.xsl
@@ -1977,7 +1977,7 @@ See the accompanying LICENSE file for applicable license.
 
     <!-- Get all profiling attributes for this element -->
     <xsl:variable name="profiling-attrs" as="attribute()*">
-      <xsl:sequence select="@props | @audience | @platform | @product | @otherprops | @deliveryTarget"/>
+      <xsl:sequence select="@props | @audience | @platform | @product | @otherprops | @deliveryTarget | @importance"/>
       <xsl:sequence select="@*[local-name(.) = $specialized-attr-names]"/>
     </xsl:variable>
 


### PR DESCRIPTION
## Description
Allow HTML5 pass `@importance` attribute through to output HTML.

## Motivation and Context
The spec doesn't disallow this, so makes sense to add support.

## How Has This Been Tested?
Existing tests and manual testing.
## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
We don't have explicit documentation for filtering, so there is likely not a place to document this.

