### PR TITLE
Upgrade logback core for security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
         exclude group: 'org.jspecify', module: 'jspecify'
     }
     implementation "org.slf4j:slf4j-api:2.0.17"
-    implementation "ch.qos.logback:logback-classic:1.5.18"
+    implementation "ch.qos.logback:logback-classic:1.5.19"
     implementation "com.fasterxml.jackson.core:jackson-core:2.19.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.19.0"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.0"


### PR DESCRIPTION
## Description

Version bump for logback dependency

## Motivation and Context

Fixes: https://github.com/advisories/GHSA-25qh-j22f-pwp8

## How Has This Been Tested?

Relying on test suite

## Type of Changes

- Bug fix _(non-breaking change which fixes an issue)_

## Documentation and Compatibility

Will require an update to the keys that list dependency versions
