### PR TITLE
docs: fix grammatical omission in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,7 +96,7 @@ for every pull request.
 
 ### Formatting code
 
-Prettier is used retain consistent Java formatting.
+Prettier is used to retain consistent Java formatting.
 
 1.  Run Prettier:
     ```shell


### PR DESCRIPTION
Description: Added the missing infinitive marker "to" in the README formatting section: "Prettier is used to retain..."

Type of change:

[x] Documentation fix