### PR TITLE
Fix compatibility check for chunking with copy-to

### DIFF
--- a/src/main/java/org/dita/dost/chunk/ChunkUtils.java
+++ b/src/main/java/org/dita/dost/chunk/ChunkUtils.java
@@ -10,6 +10,7 @@ package org.dita.dost.chunk;
 
 import static org.dita.dost.reader.ChunkMapReader.*;
 import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_CHUNK;
+import static org.dita.dost.util.Constants.ATTRIBUTE_NAME_COPY_TO;
 import static org.dita.dost.util.Constants.MAP_TOPICREF;
 import static org.dita.dost.util.XMLUtils.getChildElements;
 
@@ -43,6 +44,9 @@ public class ChunkUtils {
    * @return {@code true} if map can be rewritten to DITA 2.x
    */
   public static boolean isCompatible(Document doc, Set<String> override) {
+    if (hasCopyToWithChunk(doc.getDocumentElement())) {
+      return false;
+    }
     var chunkTree = getChunkTree(doc);
     // Has chunks
     if (chunkTree.isEmpty() && (override == null || override.isEmpty())) {
@@ -107,6 +111,18 @@ public class ChunkUtils {
     List<RoseTree<Set<String>>> res = new ArrayList<>();
     collectChunkTreeTokens(doc.getDocumentElement(), res);
     return res;
+  }
+
+  private static boolean hasCopyToWithChunk(Element elem) {
+    if (elem.hasAttribute(ATTRIBUTE_NAME_CHUNK) && elem.hasAttribute(ATTRIBUTE_NAME_COPY_TO)) {
+      return true;
+    }
+    for (Element child : getChildElements(elem, MAP_TOPICREF)) {
+      if (hasCopyToWithChunk(child)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static void collectChunkTreeTokens(Element elem, List<RoseTree<Set<String>>> dst) {

--- a/src/test/java/org/dita/dost/chunk/ChunkUtilsTest.java
+++ b/src/test/java/org/dita/dost/chunk/ChunkUtilsTest.java
@@ -42,7 +42,14 @@ class ChunkUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { "select.ditamap", "to-navigation.ditamap", "nested-by-topic-inside-to-content.ditamap" })
+  @ValueSource(
+    strings = {
+      "select.ditamap",
+      "to-navigation.ditamap",
+      "nested-by-topic-inside-to-content.ditamap",
+      "chunk-with-copy-to.ditamap",
+    }
+  )
   void isNotCompatible(String file) throws IOException, SAXException {
     try (var in = getClass().getClassLoader().getResourceAsStream("org/dita/dost/chunk/ChunkUtilsTest/" + file)) {
       var doc = documentBuilder.parse(in);

--- a/src/test/resources/org/dita/dost/chunk/ChunkUtilsTest/chunk-with-copy-to.ditamap
+++ b/src/test/resources/org/dita/dost/chunk/ChunkUtilsTest/chunk-with-copy-to.ditamap
@@ -1,0 +1,8 @@
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+     class="- map/map "
+     ditaarch:DITAArchVersion="1.3">
+   <topicref class="- map/topicref " href="topic.dita" chunk="to-content" copy-to="super_topic.dita">
+      <topicref class="- map/topicref " href="s1.dita"/>
+      <topicref class="- map/topicref " href="s2.dita"/>
+   </topicref>
+</map>


### PR DESCRIPTION
When both chunk and copy-to attributes are used together, the DITA 2.x rewrite produces wrong indices. This adds an early check in isCompatible() to detect this combination and prevent the rewrite. Fixes #4755.