### PR TITLE
Add  getters for job item

### DIFF
--- a/src/main/java/org/dita/dost/ant/DITAOTCopy.java
+++ b/src/main/java/org/dita/dost/ant/DITAOTCopy.java
@@ -133,7 +133,11 @@ public final class DITAOTCopy extends Task {
   private List<String> getIncludes() throws IOException {
     if (includes == null && includesFile == null) {
       final Job job = getProject().getReference(ANT_REFERENCE_JOB);
-      return job.getFileInfo(fi -> fi.isFlagImage).stream().map(fi -> fi.file.toString()).collect(Collectors.toList());
+      return job
+        .getFileInfo(Job.FileInfo::isFlagImage)
+        .stream()
+        .map(fi -> fi.file().toString())
+        .collect(Collectors.toList());
     }
     if (includesFile != null) {
       final List<String> res = new ArrayList<>();

--- a/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
+++ b/src/main/java/org/dita/dost/ant/ExtensibleAntInvoker.java
@@ -694,11 +694,11 @@ public final class ExtensibleAntInvoker extends Task {
 
     public Predicate<FileInfo> toFilter() {
       return f ->
-        (formats.isEmpty() || formats.contains(f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA)) &&
-        (hasConref == null || f.hasConref == hasConref) &&
-        (isInput == null || f.isInput == isInput) &&
-        (isInputResource == null || f.isInputResource == isInputResource) &&
-        (isResourceOnly == null || f.isResourceOnly == isResourceOnly);
+        (formats.isEmpty() || formats.contains(f.format() != null ? f.format() : ATTR_FORMAT_VALUE_DITA)) &&
+        (hasConref == null || f.hasConref() == hasConref) &&
+        (isInput == null || f.isInput() == isInput) &&
+        (isInputResource == null || f.isInputResource() == isInputResource) &&
+        (isResourceOnly == null || f.isResourceOnly() == isResourceOnly);
     }
   }
 

--- a/src/main/java/org/dita/dost/ant/types/JobMapper.java
+++ b/src/main/java/org/dita/dost/ant/types/JobMapper.java
@@ -69,13 +69,13 @@ public class JobMapper implements FileNameMapper {
     }
     final String res =
       switch (type) {
-        case TEMP -> fi.file.getPath();
+        case TEMP -> fi.file().getPath();
         case RESULT -> {
-          if (fi.result == null) {
+          if (fi.result() == null) {
             yield sourceFileName;
           } else {
             final URI base = job.getInputDir();
-            final URI rel = base.relativize(fi.result);
+            final URI rel = base.relativize(fi.result());
             yield toFile(rel).getPath();
           }
         }

--- a/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
+++ b/src/main/java/org/dita/dost/ant/types/JobSourceSet.java
@@ -57,26 +57,26 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
       final Job job = getJob();
       res = new ArrayList<>();
       for (final FileInfo f : job.getFileInfo(this::filter)) {
-        log("Scanning for " + f.file.getPath(), Project.MSG_VERBOSE);
-        final File tempFile = new File(job.tempDirURI.resolve(f.uri));
+        log("Scanning for " + f.file().getPath(), Project.MSG_VERBOSE);
+        final File tempFile = new File(job.tempDirURI.resolve(f.uri()));
         if (job.getStore().exists(tempFile.toURI())) {
           log("Found temporary directory file " + tempFile, Project.MSG_VERBOSE);
-          res.add(new StoreResource(job, job.tempDirURI.relativize(f.uri)));
-        } else if (f.src != null && Objects.equals(f.src.getScheme(), "file")) {
-          final File srcFile = new File(URLUtils.setQuery(f.src, null));
+          res.add(new StoreResource(job, job.tempDirURI.relativize(f.uri())));
+        } else if (f.src() != null && Objects.equals(f.src().getScheme(), "file")) {
+          final File srcFile = new File(URLUtils.setQuery(f.src(), null));
           if (srcFile.exists()) {
             log("Found source directory file " + srcFile, Project.MSG_VERBOSE);
             final File rel = FileUtils.getRelativePath(new File(new File(job.getInputDir()), "dummy"), srcFile);
             res.add(new FileResource(toFile(job.getInputDir()), rel.getPath()));
           } else {
-            log("File " + f.src + " not found", Project.MSG_ERR);
+            log("File " + f.src() + " not found", Project.MSG_ERR);
           }
-        } else if (f.src != null && Objects.equals(f.src.getScheme(), "data")) {
+        } else if (f.src() != null && Objects.equals(f.src().getScheme(), "data")) {
           log("Ignore data URI", Project.MSG_VERBOSE);
         } else {
-          log("Found source URI " + f.src, Project.MSG_VERBOSE);
+          log("Found source URI " + f.src(), Project.MSG_VERBOSE);
           try {
-            final JobResource r = new JobResource(job.getInputDir().toURL(), f.uri.toString());
+            final JobResource r = new JobResource(job.getInputDir().toURL(), f.uri().toString());
             res.add(r);
           } catch (final MalformedURLException e) {
             throw new IllegalArgumentException(e);
@@ -161,13 +161,13 @@ public class JobSourceSet extends AbstractFileSet implements ResourceCollection 
   }
 
   private boolean filter(final FileInfo f, final SelectorElem incl) {
-    final String format = f.format != null ? f.format : ATTR_FORMAT_VALUE_DITA;
+    final String format = f.format() != null ? f.format() : ATTR_FORMAT_VALUE_DITA;
     return (
       (incl.formats.isEmpty() || (incl.formats.contains(format))) &&
-      (incl.hasConref == null || f.hasConref == incl.hasConref) &&
-      (incl.isInput == null || f.isInput == incl.isInput) &&
-      (incl.isInputResource == null || f.isInputResource == incl.isInputResource) &&
-      (incl.isResourceOnly == null || f.isResourceOnly == incl.isResourceOnly)
+      (incl.hasConref == null || f.hasConref() == incl.hasConref) &&
+      (incl.isInput == null || f.isInput() == incl.isInput) &&
+      (incl.isInputResource == null || f.isInputResource() == incl.isInputResource) &&
+      (incl.isResourceOnly == null || f.isResourceOnly() == incl.isResourceOnly)
     );
   }
 

--- a/src/main/java/org/dita/dost/chunk/ChunkModule.java
+++ b/src/main/java/org/dita/dost/chunk/ChunkModule.java
@@ -66,8 +66,8 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
     init(input);
     try {
-      final FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-      final URI mapFile = job.tempDirURI.resolve(in.uri);
+      final FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+      final URI mapFile = job.tempDirURI.resolve(in.uri());
       final Document mapDoc = getInputMap(mapFile);
       final Float ditaVersion = getDitaVersion(mapDoc.getDocumentElement());
       if (ditaVersion == null || ditaVersion < 2.0f) {
@@ -139,7 +139,7 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
       final Collection<FileInfo> topics = job.getFileInfo(DitaUtils::isDitaFormat);
       (parallel ? topics.parallelStream() : topics.stream()).forEach(fi -> {
           try {
-            final URI uri = job.tempDirURI.resolve(fi.uri);
+            final URI uri = job.tempDirURI.resolve(fi.uri());
             final Document doc = job.getStore().getDocument(uri);
             rewriteTopicLinks(doc, uri, rewriteMapAll);
             job.getStore().writeDocument(doc, uri);
@@ -290,10 +290,10 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
     throws IOException {
     logger.info("Write {0}", chunk.dst());
     if (chunk.dst() != null && !Objects.equals(chunk.src(), chunk.dst())) {
-      final URI src = job.tempDirURI.resolve(fileInfo.uri);
+      final URI src = job.tempDirURI.resolve(fileInfo.uri());
       final URI dst = chunk.dst();
       final URI tmp = job.tempDirURI.relativize(dst);
-      final URI result = addSuffixToPath(fileInfo.result, SPLIT_CHUNK_DUPLICATE_SUFFIX);
+      final URI result = addSuffixToPath(fileInfo.result(), SPLIT_CHUNK_DUPLICATE_SUFFIX);
       final FileInfo adoptedFileInfo = new Builder(fileInfo).uri(tmp).result(result).build();
       job.add(adoptedFileInfo);
     }
@@ -355,10 +355,10 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
         final Element adoptedNestedTopic = (Element) doc.adoptNode(removedNestedTopic);
         doc.appendChild(adoptedNestedTopic);
         cascadeNamespaces(adoptedNestedTopic, topic);
-        final URI src = job.tempDirURI.resolve(fileInfo.uri);
+        final URI src = job.tempDirURI.resolve(fileInfo.uri());
         final URI dst = addSuffixToPath(src, id);
         final URI tmp = job.tempDirURI.relativize(dst);
-        final URI result = addSuffixToPath(fileInfo.result, id);
+        final URI result = addSuffixToPath(fileInfo.result(), id);
         final FileInfo adoptedFileInfo = new Builder(fileInfo).uri(tmp).result(result).build();
         job.add(adoptedFileInfo);
         try {
@@ -453,8 +453,13 @@ public class ChunkModule extends AbstractPipelineModuleImpl {
           .orElse(null);
         final Builder builder = src != null ? FileInfo.builder(src) : FileInfo.builder();
         final URI dstRel = job.tempDirURI.relativize(tmp);
-        if (src != null && src.result != null && src.isInput && Objects.equals(src.format, ATTR_FORMAT_VALUE_DITAMAP)) {
-          var result = URI.create(replaceExtension(src.result.toString(), FILE_EXTENSION_DITA));
+        if (
+          src != null &&
+          src.result() != null &&
+          src.isInput() &&
+          Objects.equals(src.format(), ATTR_FORMAT_VALUE_DITAMAP)
+        ) {
+          var result = URI.create(replaceExtension(src.result().toString(), FILE_EXTENSION_DITA));
           builder.result(result).isInput(false);
         }
         //                final URI result = src != null && src.result != null ? src.result.resolve(tmp) : toDirURI(job.getOutputDir()).resolve(tmp);

--- a/src/main/java/org/dita/dost/module/BranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/BranchFilterModule.java
@@ -96,9 +96,9 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
 
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-    final Collection<FileInfo> fis = job.getFileInfo(fi -> fi.isInput || fi.isInputResource);
+    final Collection<FileInfo> fis = job.getFileInfo(fi -> fi.isInput() || fi.isInputResource());
     for (FileInfo fi : fis) {
-      processMap(fi.uri);
+      processMap(fi.uri());
     }
 
     try {
@@ -201,9 +201,9 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
               final URI absTarget = stripFragment(currentFile.resolve(attr.getValue()));
               final FileInfo hrefFileInfo = job.getFileInfo(absTarget);
               if (hrefFileInfo != null) {
-                final URI newResult = addSuffix(hrefFileInfo.result, suffix);
+                final URI newResult = addSuffix(hrefFileInfo.result(), suffix);
                 final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).uri(dstUri).result(newResult);
-                if (hrefFileInfo.format == null) {
+                if (hrefFileInfo.format() == null) {
                   dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
                 }
                 final FileInfo dstFileInfo = dstBuilder.build();
@@ -466,7 +466,7 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
     final URI href = toURI(ditavalRef.getAttribute(ATTRIBUTE_NAME_HREF));
     final URI tmp = currentFile.resolve(href);
     final FileInfo fi = job.getFileInfo(tmp);
-    final URI ditaval = fi.src;
+    final URI ditaval = fi.src();
     FilterUtils f = filterCache.get(ditaval);
     if (f == null) {
       ditaValReader.filterReset();
@@ -622,19 +622,19 @@ public class BranchFilterModule extends AbstractPipelineModuleImpl {
       final String scope = getCascadeValue(elem, ATTRIBUTE_NAME_SCOPE);
       if ((!href.isEmpty() || !copyTo.isEmpty()) && !isExternalScope(scope)) {
         final FileInfo hrefFileInfo = job.getFileInfo(currentFile.resolve(href));
-        if (isDitaFormat(hrefFileInfo.format)) {
+        if (isDitaFormat(hrefFileInfo.format())) {
           final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;
           final URI dstSource;
-          dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result, filter);
+          dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result(), filter);
           final URI dstTemp = tempFileNameScheme.generateTempFileName(dstSource);
           final String dstPathFromMap = !copyTo.isEmpty() ? FilenameUtils.getPath(copyTo) : FilenameUtils.getPath(href);
           final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).result(dstSource).uri(dstTemp);
-          if (dstBuilder.build().format == null) {
+          if (dstBuilder.build().format() == null) {
             dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
           }
-          if (hrefFileInfo.src == null && href != null) {
+          if (hrefFileInfo.src() == null && href != null) {
             if (copyToFileInfo != null) {
-              dstBuilder.src(copyToFileInfo.src);
+              dstBuilder.src(copyToFileInfo.src());
             }
           }
           final FileInfo dstFileInfo = dstBuilder.build();

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -71,12 +71,12 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     }
 
     try {
-      final Job.FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-      final File mapFile = new File(job.tempDirURI.resolve(in.uri));
+      final Job.FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+      final File mapFile = new File(job.tempDirURI.resolve(in.uri()));
       if (transtype.equals(INDEX_TYPE_ECLIPSEHELP) && isEclipseMap(mapFile.toURI())) {
         for (final FileInfo f : job.getFileInfo()) {
-          if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
-            mapReader.read(new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile());
+          if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format())) {
+            mapReader.read(new File(job.tempDirURI.resolve(f.uri())).getAbsoluteFile());
           }
         }
       } else {
@@ -143,9 +143,9 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     topicRefWriter.setup(conflictTable);
     try {
       for (final FileInfo f : job.getFileInfo()) {
-        if (ATTR_FORMAT_VALUE_DITA.equals(f.format) || ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
-          topicRefWriter.setFixpath(relativePath2fix.get(f.uri));
-          final File tmp = new File(job.tempDirURI.resolve(f.uri));
+        if (ATTR_FORMAT_VALUE_DITA.equals(f.format()) || ATTR_FORMAT_VALUE_DITAMAP.equals(f.format())) {
+          topicRefWriter.setFixpath(relativePath2fix.get(f.uri()));
+          final File tmp = new File(job.tempDirURI.resolve(f.uri()));
           topicRefWriter.write(tmp);
         }
       }
@@ -167,15 +167,15 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     final Set<URI> hrefTopics = new HashSet<>();
     final Set<URI> chunkTopicSet = mapReader.getChunkTopicSet();
     for (final FileInfo f : job.getFileInfo()) {
-      final URI abs = job.tempDirURI.resolve(f.uri);
-      if (f.isTarget && !chunkTopicSet.contains(abs)) {
-        hrefTopics.add(f.uri);
+      final URI abs = job.tempDirURI.resolve(f.uri());
+      if (f.isTarget() && !chunkTopicSet.contains(abs)) {
+        hrefTopics.add(f.uri());
       }
     }
     for (final FileInfo f : job.getFileInfo()) {
-      final URI abs = job.tempDirURI.resolve(f.uri);
+      final URI abs = job.tempDirURI.resolve(f.uri());
       if (chunkTopicSet.contains(abs)) {
-        final URI s = f.uri;
+        final URI s = f.uri();
         if (s.getFragment() == null) {
           // This entry does not have an anchor, we assume that this
           // topic will
@@ -193,8 +193,8 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     final Set<URI> topicList = new LinkedHashSet<>(128);
     final Set<URI> oldTopicList = new HashSet<>();
     for (final FileInfo f : job.getFileInfo()) {
-      if (ATTR_FORMAT_VALUE_DITA.equals(f.format)) {
-        oldTopicList.add(f.uri);
+      if (ATTR_FORMAT_VALUE_DITA.equals(f.format())) {
+        oldTopicList.add(f.uri());
       }
     }
     for (final URI t : hrefTopics) {
@@ -206,8 +206,8 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
     final Set<URI> chunkedDitamapSet = new LinkedHashSet<>(128);
     final Set<URI> ditamapList = new HashSet<>();
     for (final FileInfo f : job.getFileInfo()) {
-      if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format)) {
-        ditamapList.add(f.uri);
+      if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format())) {
+        ditamapList.add(f.uri());
       }
     }
     for (final Map.Entry<URI, URI> entry : changeTable.entrySet()) {

--- a/src/main/java/org/dita/dost/module/ChunkModule.java
+++ b/src/main/java/org/dita/dost/module/ChunkModule.java
@@ -311,26 +311,33 @@ public final class ChunkModule extends AbstractPipelineModuleImpl {
       }
     }
 
+    var buf = new HashMap<URI, FileInfo.Builder>();
     for (final URI file : topicList) {
       // FIXME
-      final FileInfo ff = job.getOrCreateFileInfo(stripFragment(file));
-      ff.format = ATTR_FORMAT_VALUE_DITA;
+      final FileInfo.Builder b = FileInfo.builder(job.getOrCreateFileInfo(stripFragment(file)));
+      b.format(ATTR_FORMAT_VALUE_DITA);
+      buf.put(file, b);
     }
     for (final URI file : ditamapList) {
-      final FileInfo ff = job.getOrCreateFileInfo(file);
-      ff.format = ATTR_FORMAT_VALUE_DITAMAP;
+      final FileInfo.Builder b = buf.computeIfAbsent(file, f -> FileInfo.builder(job.getOrCreateFileInfo(f)));
+      b.format(ATTR_FORMAT_VALUE_DITAMAP);
+      buf.put(file, b);
     }
 
     for (final URI file : chunkedDitamapSet) {
-      final FileInfo f = job.getOrCreateFileInfo(file);
-      f.format = ATTR_FORMAT_VALUE_DITAMAP;
-      f.isResourceOnly = false;
+      final FileInfo.Builder b = buf.computeIfAbsent(file, f -> FileInfo.builder(job.getOrCreateFileInfo(f)));
+      b.format(ATTR_FORMAT_VALUE_DITAMAP).isResourceOnly(false);
+      buf.put(file, b);
     }
     for (final URI file : chunkedTopicSet) {
       // FIXME
-      final FileInfo f = job.getOrCreateFileInfo(stripFragment(file));
-      f.format = ATTR_FORMAT_VALUE_DITA;
-      f.isResourceOnly = false;
+      final FileInfo.Builder b = buf.computeIfAbsent(file, f -> FileInfo.builder(job.getOrCreateFileInfo(f)));
+      b.format(ATTR_FORMAT_VALUE_DITA).isResourceOnly(false);
+      buf.put(file, b);
+    }
+
+    for (FileInfo.Builder b : buf.values()) {
+      job.add(b.build());
     }
 
     try {

--- a/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
+++ b/src/main/java/org/dita/dost/module/CleanPreprocessModule.java
@@ -147,13 +147,13 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
    */
   @Deprecated
   private void writeInputMapList() {
-    final FileInfo start = job.getFileInfo(f -> f.isInput).iterator().next();
+    final FileInfo start = job.getFileInfo(FileInfo::isInput).iterator().next();
     if (start != null) {
-      job.setInputMap(start.uri);
+      job.setInputMap(start.uri());
 
       final File inputfile = new File(job.tempDir, USER_INPUT_FILE_LIST_FILE);
       try {
-        Files.writeString(inputfile.toPath(), start.file.getPath());
+        Files.writeString(inputfile.toPath(), start.file().getPath());
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -171,13 +171,13 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
 
     for (final FileInfo fi : rewritten) {
       try {
-        assert !fi.result.isAbsolute();
-        if (fi.format != null && (fi.format.equals("coderef") || fi.format.equals("image"))) {
-          logger.debug("Skip format " + fi.format);
+        assert !fi.result().isAbsolute();
+        if (fi.format() != null && (fi.format().equals("coderef") || fi.format().equals("image"))) {
+          logger.debug("Skip format " + fi.format());
         } else {
-          final File srcFile = new File(job.tempDirURI.resolve(fi.uri));
+          final File srcFile = new File(job.tempDirURI.resolve(fi.uri()));
           if (job.getStore().exists(srcFile.toURI())) {
-            final File destFile = new File(job.tempDirURI.resolve(fi.result));
+            final File destFile = new File(job.tempDirURI.resolve(fi.result()));
             final List<XMLFilter> processingPipe = getProcessingPipe(fi, srcFile, destFile);
             if (!processingPipe.isEmpty()) {
               logger.info("Processing " + srcFile.toURI() + " to " + destFile.toURI());
@@ -192,10 +192,10 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
             }
           }
         }
-        final FileInfo res = FileInfo.builder(fi).uri(fi.result).result(base.resolve(fi.result)).build();
+        final FileInfo res = FileInfo.builder(fi).uri(fi.result()).result(base.resolve(fi.result())).build();
         job.add(res);
       } catch (final IOException e) {
-        logger.error("Failed to clean " + job.tempDirURI.resolve(fi.uri) + ": " + e.getMessage(), e);
+        logger.error("Failed to clean " + job.tempDirURI.resolve(fi.uri()) + ": " + e.getMessage(), e);
       }
     }
   }
@@ -208,8 +208,8 @@ public class CleanPreprocessModule extends AbstractPipelineModuleImpl {
     final Collection<FileInfo> original = job
       .getFileInfo()
       .stream()
-      .filter(fi -> fi.result != null)
-      .map(fi -> FileInfo.builder(fi).result(base.relativize(fi.result)).build())
+      .filter(fi -> fi.result() != null)
+      .map(fi -> FileInfo.builder(fi).result(base.relativize(fi.result())).build())
       .collect(Collectors.toList());
     original.forEach(fi -> job.remove(fi));
     return original;

--- a/src/main/java/org/dita/dost/module/ConrefPushModule.java
+++ b/src/main/java/org/dita/dost/module/ConrefPushModule.java
@@ -28,14 +28,14 @@ final class ConrefPushModule extends AbstractPipelineModuleImpl {
 
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) {
-    final Collection<FileInfo> fis = job.getFileInfo(fileInfoFilter).stream().filter(f -> f.isConrefPush).toList();
+    final Collection<FileInfo> fis = job.getFileInfo(fileInfoFilter).stream().filter(FileInfo::isConrefPush).toList();
     if (!fis.isEmpty()) {
       final ConrefPushReader reader = new ConrefPushReader();
       reader.setLogger(logger);
       reader.setJob(job);
       reader.setXmlUtils(xmlUtils);
       for (final FileInfo f : fis) {
-        final File file = new File(job.tempDirURI.resolve(f.uri));
+        final File file = new File(job.tempDirURI.resolve(f.uri()));
         logger.info("Reading " + file.toURI());
         //FIXME: this reader calculate parent directory
         reader.read(file.getAbsoluteFile());

--- a/src/main/java/org/dita/dost/module/CopyToModule.java
+++ b/src/main/java/org/dita/dost/module/CopyToModule.java
@@ -80,7 +80,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
    * Process start map to read copy-to map and write unique topic references.
    */
   private void processMap() throws DITAOTException {
-    final URI in = job.tempDirURI.resolve(job.getFileInfo(fi -> fi.isInput).iterator().next().uri);
+    final URI in = job.tempDirURI.resolve(job.getFileInfo(FileInfo::isInput).iterator().next().uri());
 
     final List<XMLFilter> pipe = getProcessingPipe(in);
 
@@ -132,7 +132,7 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
       final FileInfo sourceFi = job.getFileInfo(source);
       // Filter when copy-to was ignored (so target is not in job),
       // or where target is used directly
-      if (targetFi == null || (targetFi != null && targetFi.src != null)) {
+      if (targetFi == null || (targetFi != null && targetFi.src() != null)) {
         continue;
       }
       copyToMap.put(targetFi, sourceFi);
@@ -148,24 +148,24 @@ public final class CopyToModule extends AbstractPipelineModuleImpl {
    */
   private void performCopytoTask(final Map<FileInfo, FileInfo> copyToMap) {
     for (final Map.Entry<FileInfo, FileInfo> entry : copyToMap.entrySet()) {
-      final URI copytoTarget = entry.getKey().uri;
-      final URI copytoSource = entry.getValue().uri;
+      final URI copytoTarget = entry.getKey().uri();
+      final URI copytoSource = entry.getValue().uri();
       final URI srcFile = job.tempDirURI.resolve(copytoSource);
       final URI targetFile = job.tempDirURI.resolve(copytoTarget);
 
       if (job.getStore().exists(targetFile)) {
         logger.warn(MessageUtils.getMessage("DOTX064W", copytoTarget.getPath()).toString());
       } else {
-        final FileInfo input = job.getFileInfo(fi -> fi.isInput).iterator().next();
-        final URI inputMapInTemp = job.tempDirURI.resolve(input.uri);
+        final FileInfo input = job.getFileInfo(FileInfo::isInput).iterator().next();
+        final URI inputMapInTemp = job.tempDirURI.resolve(input.uri());
         copyFileWithPIReplaced(srcFile, targetFile, copytoTarget, inputMapInTemp);
         // add new file info into job
         final FileInfo src = job.getFileInfo(copytoSource);
         assert src != null;
         final FileInfo dst = job.getFileInfo(copytoTarget);
         assert dst != null;
-        final URI dstTemp = tempFileNameScheme.generateTempFileName(dst.result);
-        final FileInfo res = new FileInfo.Builder(src).result(dst.result).uri(dstTemp).build();
+        final URI dstTemp = tempFileNameScheme.generateTempFileName(dst.result());
+        final FileInfo res = new FileInfo.Builder(src).result(dst.result()).uri(dstTemp).build();
         job.add(res);
       }
     }

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -100,7 +100,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
       job
         .getFileInfo()
         .stream()
-        .filter(f -> isFormatDita(f.format) || ATTR_FORMAT_VALUE_DITAMAP.equals(f.format))
+        .filter(f -> isFormatDita(f.format()) || ATTR_FORMAT_VALUE_DITAMAP.equals(f.format()))
         .forEach(this::processFile);
 
       job.write();
@@ -115,18 +115,18 @@ public final class DebugAndFilterModule extends SourceReaderModule {
   }
 
   private void processFile(final FileInfo f) {
-    currentFile = f.src;
-    if (f.src == null || !exists(f.src) || !f.src.equals(f.result)) {
-      logger.warn("Ignoring a copy-to file " + f.result);
+    currentFile = f.src();
+    if (f.src() == null || !exists(f.src()) || !f.src().equals(f.result())) {
+      logger.warn("Ignoring a copy-to file " + f.result());
       return;
-    } else if (f.uri.isAbsolute() && !f.uri.toString().startsWith(job.tempDirURI.toString())) {
+    } else if (f.uri().isAbsolute() && !f.uri().toString().startsWith(job.tempDirURI.toString())) {
       //The file is outside the temp dir, we cannot write to itself
-      throw new RuntimeException("Cannot write outside of the temporary files folder: " + f.uri);
+      throw new RuntimeException("Cannot write outside of the temporary files folder: " + f.uri());
     }
-    outputFile = new File(job.tempDirURI.resolve(f.uri));
-    logger.info("Processing " + f.src + " to " + outputFile.toURI());
+    outputFile = new File(job.tempDirURI.resolve(f.uri()));
+    logger.info("Processing " + f.src() + " to " + outputFile.toURI());
 
-    final Set<URI> schemaSet = dic.get(f.uri);
+    final Set<URI> schemaSet = dic.get(f.uri());
     if (schemaSet != null && !schemaSet.isEmpty()) {
       logger.debug("Loading subject schemes");
       subjectSchemeReader.reset();
@@ -149,7 +149,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     try {
       reader.setErrorHandler(new DITAOTXMLErrorHandler(currentFile.toString(), logger, processingMode));
 
-      XMLReader parser = XMLUtils.getXmlReader(f.format, processingMode).orElse(reader);
+      XMLReader parser = XMLUtils.getXmlReader(f.format(), processingMode).orElse(reader);
       XMLReader xmlSource = parser;
       for (final XMLFilter filter : getProcessingPipe(currentFile)) {
         filter.setParent(xmlSource);
@@ -165,7 +165,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         parser.setFeature("http://xml.org/sax/features/lexical-handler", true);
       } catch (final SAXNotRecognizedException e) {}
 
-      in = new InputSource(f.src.toString());
+      in = new InputSource(f.src().toString());
 
       final ContentHandler result = job.getStore().getContentHandler(outputFile.toURI());
 
@@ -183,7 +183,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
       }
     }
 
-    if (isFormatDita(f.format)) {
+    if (isFormatDita(f.format())) {
       if (typeFilter.getDitaClass() == null) {
         f.format = ATTR_FORMAT_VALUE_DITA;
       } else {
@@ -360,7 +360,7 @@ public final class DebugAndFilterModule extends SourceReaderModule {
         final File tmprel = new File(FileUtils.resolve(job.tempDir, parent) + SUBJECT_SCHEME_EXTENSION);
         final Document parentRoot;
         if (!tmprel.exists()) {
-          final URI src = job.getFileInfo(parent).src;
+          final URI src = job.getFileInfo(parent).src();
           parentRoot = job.getStore().getDocument(src);
         } else {
           parentRoot = job.getStore().getDocument(tmprel.toURI());

--- a/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
+++ b/src/main/java/org/dita/dost/module/DebugAndFilterModule.java
@@ -184,15 +184,15 @@ public final class DebugAndFilterModule extends SourceReaderModule {
     }
 
     if (isFormatDita(f.format())) {
+      String format;
       if (typeFilter.getDitaClass() == null) {
-        f.format = ATTR_FORMAT_VALUE_DITA;
+        format = ATTR_FORMAT_VALUE_DITA;
+      } else if (MAP_MAP.matches(typeFilter.getDitaClass())) {
+        format = ATTR_FORMAT_VALUE_DITAMAP;
       } else {
-        if (MAP_MAP.matches(typeFilter.getDitaClass())) {
-          f.format = ATTR_FORMAT_VALUE_DITAMAP;
-        } else {
-          f.format = ATTR_FORMAT_VALUE_DITA;
-        }
+        format = ATTR_FORMAT_VALUE_DITA;
       }
+      job.add(FileInfo.builder(f).format(format).build());
     }
   }
 

--- a/src/main/java/org/dita/dost/module/FilterModule.java
+++ b/src/main/java/org/dita/dost/module/FilterModule.java
@@ -77,11 +77,11 @@ final class FilterModule extends AbstractPipelineModuleImpl {
     }
 
     for (final FileInfo f : job.getFileInfo(fileInfoFilter)) {
-      final File file = new File(job.tempDir, f.file.getPath());
+      final File file = new File(job.tempDir, f.file().getPath());
       logger.info("Processing " + file.getAbsolutePath());
 
       subjectSchemeReader.reset();
-      final Set<URI> schemaSet = dic.get(f.uri);
+      final Set<URI> schemaSet = dic.get(f.uri());
       if (schemaSet != null && !schemaSet.isEmpty()) {
         logger.info("Loading subject schemes");
         for (final URI schema : schemaSet) {

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -59,7 +59,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
   private boolean genDebugInfo;
   private Mode processingMode;
   /** FileInfos keyed by src. */
-  private final Map<URI, FileInfo> fileinfos = new HashMap<>();
+  private final Map<URI, FileInfo.Builder> fileinfos = new HashMap<>();
   /** Set of all topic files */
   private final Set<URI> fullTopicSet;
 
@@ -808,89 +808,88 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     }
 
     for (final URI file : outDitaFilesSet) {
-      getOrCreateFileInfo(fileinfos, file).isOutDita = true;
+      getOrCreateFileInfo(fileinfos, file).isOutDita(true);
     }
     for (final URI file : fullTopicSet) {
-      final FileInfo ff = getOrCreateFileInfo(fileinfos, file);
+      final FileInfo.Builder ff = getOrCreateFileInfo(fileinfos, file);
       if (ff.format() == null) {
-        ff.format = sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITA);
+        ff.format(sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITA));
       }
     }
     for (final URI file : fullMapSet) {
-      final FileInfo ff = getOrCreateFileInfo(fileinfos, file);
+      final FileInfo.Builder ff = getOrCreateFileInfo(fileinfos, file);
       if (ff.format() == null) {
-        ff.format = sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITAMAP);
+        ff.format(sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITAMAP));
       }
     }
     for (final URI file : hrefTopicSet) {
-      final FileInfo f = getOrCreateFileInfo(fileinfos, file);
-      f.hasLink = true;
+      final FileInfo.Builder f = getOrCreateFileInfo(fileinfos, file);
+      f.hasLink(true);
       if (f.format() == null && sourceFormat.containsKey(f.src())) {
-        f.format = sourceFormat.get(f.src());
+        f.format(sourceFormat.get(f.src()));
       }
     }
     for (final URI file : conrefSet) {
-      getOrCreateFileInfo(fileinfos, file).hasConref = true;
+      getOrCreateFileInfo(fileinfos, file).hasConref(true);
     }
     for (final Reference file : formatSet) {
-      getOrCreateFileInfo(fileinfos, file.filename).format = file.format;
+      getOrCreateFileInfo(fileinfos, file.filename).format(file.format);
     }
     for (final URI file : flagImageSet) {
-      final FileInfo f = getOrCreateFileInfo(fileinfos, file);
-      f.isFlagImage = true;
-      f.format = ATTR_FORMAT_VALUE_IMAGE;
+      final FileInfo.Builder f = getOrCreateFileInfo(fileinfos, file);
+      f.isFlagImage(true);
+      f.format(ATTR_FORMAT_VALUE_IMAGE);
     }
     for (final String format : htmlSet.keySet()) {
       for (final URI file : htmlSet.get(format)) {
-        getOrCreateFileInfo(fileinfos, file).format = format;
+        getOrCreateFileInfo(fileinfos, file).format(format);
       }
     }
     for (final URI file : hrefTargetSet) {
-      final FileInfo f = getOrCreateFileInfo(fileinfos, file);
-      f.isTarget = true;
+      final FileInfo.Builder f = getOrCreateFileInfo(fileinfos, file);
+      f.isTarget(true);
       if (f.format() == null && sourceFormat.containsKey(f.src())) {
-        f.format = sourceFormat.get(f.src());
+        f.format(sourceFormat.get(f.src()));
       }
     }
     for (final URI file : schemeSet) {
-      getOrCreateFileInfo(fileinfos, file).isSubjectScheme = true;
+      getOrCreateFileInfo(fileinfos, file).isSubjectScheme(true);
     }
     for (final URI file : coderefTargetSet) {
-      final FileInfo f = getOrCreateFileInfo(fileinfos, file);
-      f.isSubtarget = true;
+      final FileInfo.Builder f = getOrCreateFileInfo(fileinfos, file);
+      f.isSubtarget(true);
       if (f.format() == null) {
-        f.format = PR_D_CODEREF.localName;
+        f.format(PR_D_CODEREF.localName);
       }
     }
     for (final URI file : conrefpushSet) {
-      getOrCreateFileInfo(fileinfos, file).isConrefPush = true;
+      getOrCreateFileInfo(fileinfos, file).isConrefPush(true);
     }
     for (final URI file : keyrefSet) {
-      getOrCreateFileInfo(fileinfos, file).hasKeyref = true;
+      getOrCreateFileInfo(fileinfos, file).hasKeyref(true);
     }
     for (final URI file : coderefSet) {
-      getOrCreateFileInfo(fileinfos, file).hasCoderef = true;
+      getOrCreateFileInfo(fileinfos, file).hasCoderef(true);
     }
     for (final URI file : resourceOnlySet) {
-      getOrCreateFileInfo(fileinfos, file).isResourceOnly = true;
+      getOrCreateFileInfo(fileinfos, file).isResourceOnly(true);
     }
     for (final URI resource : resources) {
-      getOrCreateFileInfo(fileinfos, resource).isInputResource = true;
+      getOrCreateFileInfo(fileinfos, resource).isInputResource(true);
     }
 
     addFlagImagesSetToProperties(job, relFlagImagesSet);
 
     final Map<URI, URI> filteredCopyTo = filterConflictingCopyTo(copyTo, fileinfos.values());
 
-    for (final FileInfo fs : fileinfos.values()) {
+    for (final FileInfo.Builder fs : fileinfos.values()) {
       if (!failureList.contains(fs.src())) {
         final URI src = filteredCopyTo.get(fs.src());
         // correct copy-to
         if (src != null) {
-          final FileInfo corr = new FileInfo.Builder(fs).src(src).build();
-          job.add(corr);
+          job.add(fs.src(src).build());
         } else {
-          job.add(fs);
+          job.add(fs.build());
         }
       }
     }
@@ -931,11 +930,14 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
   }
 
   /** Filter copy-to where target is used directly. */
-  private Map<URI, URI> filterConflictingCopyTo(final Map<URI, URI> copyTo, final Collection<FileInfo> fileInfos) {
+  private Map<URI, URI> filterConflictingCopyTo(
+    final Map<URI, URI> copyTo,
+    final Collection<FileInfo.Builder> fileInfos
+  ) {
     final Set<URI> fileinfoTargets = fileInfos
       .stream()
-      .filter(fi -> fi.src().equals(fi.result()))
-      .map(FileInfo::result)
+      .filter(fi -> Objects.equals(fi.src(), fi.result()))
+      .map(FileInfo.Builder::result)
       .collect(Collectors.toSet());
     return copyTo
       .entrySet()
@@ -979,19 +981,18 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     return res;
   }
 
-  private FileInfo getOrCreateFileInfo(final Map<URI, FileInfo> fileInfos, final URI file) {
+  private FileInfo.Builder getOrCreateFileInfo(final Map<URI, FileInfo.Builder> fileInfos, final URI file) {
     assert file.getFragment() == null;
     final URI f = file.normalize();
     FileInfo.Builder b;
     if (fileInfos.containsKey(f)) {
-      b = new FileInfo.Builder(fileInfos.get(f));
+      b = fileInfos.get(f);
     } else {
       b = new FileInfo.Builder().src(file);
     }
     b = b.uri(tempFileNameScheme.generateTempFileName(file));
-    final FileInfo i = b.build();
-    fileInfos.put(i.src(), i);
-    return i;
+    fileInfos.put(b.src(), b);
+    return b;
   }
 
   /**

--- a/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
+++ b/src/main/java/org/dita/dost/module/GenMapAndTopicListModule.java
@@ -812,21 +812,21 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     }
     for (final URI file : fullTopicSet) {
       final FileInfo ff = getOrCreateFileInfo(fileinfos, file);
-      if (ff.format == null) {
-        ff.format = sourceFormat.getOrDefault(ff.src, ATTR_FORMAT_VALUE_DITA);
+      if (ff.format() == null) {
+        ff.format = sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITA);
       }
     }
     for (final URI file : fullMapSet) {
       final FileInfo ff = getOrCreateFileInfo(fileinfos, file);
-      if (ff.format == null) {
-        ff.format = sourceFormat.getOrDefault(ff.src, ATTR_FORMAT_VALUE_DITAMAP);
+      if (ff.format() == null) {
+        ff.format = sourceFormat.getOrDefault(ff.src(), ATTR_FORMAT_VALUE_DITAMAP);
       }
     }
     for (final URI file : hrefTopicSet) {
       final FileInfo f = getOrCreateFileInfo(fileinfos, file);
       f.hasLink = true;
-      if (f.format == null && sourceFormat.containsKey(f.src)) {
-        f.format = sourceFormat.get(f.src);
+      if (f.format() == null && sourceFormat.containsKey(f.src())) {
+        f.format = sourceFormat.get(f.src());
       }
     }
     for (final URI file : conrefSet) {
@@ -848,8 +848,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     for (final URI file : hrefTargetSet) {
       final FileInfo f = getOrCreateFileInfo(fileinfos, file);
       f.isTarget = true;
-      if (f.format == null && sourceFormat.containsKey(f.src)) {
-        f.format = sourceFormat.get(f.src);
+      if (f.format() == null && sourceFormat.containsKey(f.src())) {
+        f.format = sourceFormat.get(f.src());
       }
     }
     for (final URI file : schemeSet) {
@@ -858,7 +858,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     for (final URI file : coderefTargetSet) {
       final FileInfo f = getOrCreateFileInfo(fileinfos, file);
       f.isSubtarget = true;
-      if (f.format == null) {
+      if (f.format() == null) {
         f.format = PR_D_CODEREF.localName;
       }
     }
@@ -883,8 +883,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     final Map<URI, URI> filteredCopyTo = filterConflictingCopyTo(copyTo, fileinfos.values());
 
     for (final FileInfo fs : fileinfos.values()) {
-      if (!failureList.contains(fs.src)) {
-        final URI src = filteredCopyTo.get(fs.src);
+      if (!failureList.contains(fs.src())) {
+        final URI src = filteredCopyTo.get(fs.src());
         // correct copy-to
         if (src != null) {
           final FileInfo corr = new FileInfo.Builder(fs).src(src).build();
@@ -934,8 +934,8 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
   private Map<URI, URI> filterConflictingCopyTo(final Map<URI, URI> copyTo, final Collection<FileInfo> fileInfos) {
     final Set<URI> fileinfoTargets = fileInfos
       .stream()
-      .filter(fi -> fi.src.equals(fi.result))
-      .map(fi -> fi.result)
+      .filter(fi -> fi.src().equals(fi.result()))
+      .map(FileInfo::result)
       .collect(Collectors.toSet());
     return copyTo
       .entrySet()
@@ -990,7 +990,7 @@ public final class GenMapAndTopicListModule extends SourceReaderModule {
     }
     b = b.uri(tempFileNameScheme.generateTempFileName(file));
     final FileInfo i = b.build();
-    fileInfos.put(i.src, i);
+    fileInfos.put(i.src(), i);
     return i;
   }
 

--- a/src/main/java/org/dita/dost/module/ImageMetadataModule.java
+++ b/src/main/java/org/dita/dost/module/ImageMetadataModule.java
@@ -49,13 +49,13 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
       throw new IllegalStateException("Logger not set");
     }
     final Collection<FileInfo> images = job.getFileInfo(f ->
-      ATTR_FORMAT_VALUE_IMAGE.equals(f.format) || ATTR_FORMAT_VALUE_HTML.equals(f.format)
+      ATTR_FORMAT_VALUE_IMAGE.equals(f.format()) || ATTR_FORMAT_VALUE_HTML.equals(f.format())
     );
     if (!images.isEmpty()) {
       final File outputDir = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_OUTPUTDIR));
       final Predicate<FileInfo> filter = fileInfoFilter != null
         ? fileInfoFilter
-        : f -> !f.isResourceOnly && ATTR_FORMAT_VALUE_DITA.equals(f.format);
+        : f -> !f.isResourceOnly() && ATTR_FORMAT_VALUE_DITA.equals(f.format());
       final Map<URI, Attributes> cache = new ConcurrentHashMap<>();
 
       if (parallel) {
@@ -69,7 +69,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
           .getFileInfo(filter)
           .stream()
           .parallel()
-          .map(f -> new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile())
+          .map(f -> new File(job.tempDirURI.resolve(f.uri())).getAbsoluteFile())
           .forEach(filename -> {
             final ImageMetadataFilter writer = pool.borrowObject();
             try {
@@ -83,7 +83,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
         writer.setLogger(logger);
         writer.setJob(job);
         for (final FileInfo f : job.getFileInfo(filter)) {
-          writer.write(new File(job.tempDirURI.resolve(f.uri)).getAbsoluteFile());
+          writer.write(new File(job.tempDirURI.resolve(f.uri())).getAbsoluteFile());
         }
       }
 
@@ -110,7 +110,7 @@ final class ImageMetadataModule extends AbstractPipelineModuleImpl {
       }
       final FileInfo fi = job.getFileInfo(rel);
       if (fi != null) {
-        logger.debug("Set " + fi.uri + " format to " + ATTR_FORMAT_VALUE_IMAGE);
+        logger.debug("Set " + fi.uri() + " format to " + ATTR_FORMAT_VALUE_IMAGE);
         job.add(new FileInfo.Builder(fi).format(ATTR_FORMAT_VALUE_IMAGE).build());
       }
     }

--- a/src/main/java/org/dita/dost/module/IndexTermExtractModule.java
+++ b/src/main/java/org/dita/dost/module/IndexTermExtractModule.java
@@ -87,8 +87,8 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
     final String encoding = input.getAttribute(ANT_INVOKER_EXT_PARAM_ENCODING);
     final String indextype = input.getAttribute(ANT_INVOKER_EXT_PARAM_INDEXTYPE);
     final String indexclass = input.getAttribute(ANT_INVOKER_EXT_PARAM_INDEXCLASS);
-    final FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-    inputMap = new File(job.tempDirURI.resolve(in.uri));
+    final FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+    inputMap = new File(job.tempDirURI.resolve(in.uri()));
     targetExt = input.getAttribute(ANT_INVOKER_EXT_PARAM_TARGETEXT);
 
     /*
@@ -96,14 +96,14 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
      */
     topicList = new ArrayList<>();
     for (final FileInfo f : job.getFileInfo()) {
-      if (ATTR_FORMAT_VALUE_DITA.equals(f.format) && !f.isResourceOnly) {
-        topicList.add(job.tempDirURI.resolve(f.uri));
+      if (ATTR_FORMAT_VALUE_DITA.equals(f.format()) && !f.isResourceOnly()) {
+        topicList.add(job.tempDirURI.resolve(f.uri()));
       }
     }
     ditamapList = new ArrayList<>();
     for (final FileInfo f : job.getFileInfo()) {
-      if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format) && !f.isResourceOnly) {
-        ditamapList.add(job.tempDirURI.resolve(f.uri));
+      if (ATTR_FORMAT_VALUE_DITAMAP.equals(f.format()) && !f.isResourceOnly()) {
+        ditamapList.add(job.tempDirURI.resolve(f.uri()));
       }
     }
 
@@ -127,8 +127,8 @@ public class IndexTermExtractModule extends AbstractPipelineModuleImpl {
     final DitamapIndexTermReader ditamapIndexTermReader = new DitamapIndexTermReader(indexTermCollection, true);
     ditamapIndexTermReader.setLogger(logger);
 
-    final FileInfo fileInfo = job.getFileInfo(f -> f.isInput).iterator().next();
-    final URI tempInputMap = job.tempDirURI.resolve(fileInfo.uri);
+    final FileInfo fileInfo = job.getFileInfo(FileInfo::isInput).iterator().next();
+    final URI tempInputMap = job.tempDirURI.resolve(fileInfo.uri());
     for (final URI aTopicList : topicList) {
       URI target;
       String targetPathFromMap;

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -164,8 +164,8 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
       for (final URI file : normalProcessingRole) {
         final FileInfo f = job.getFileInfo(file);
         if (f != null) {
-          f.isResourceOnly = false;
-          job.add(f);
+          var b = FileInfo.builder(f).isResourceOnly(false);
+          job.add(b.build());
         }
       }
 

--- a/src/main/java/org/dita/dost/module/KeyrefModule.java
+++ b/src/main/java/org/dita/dost/module/KeyrefModule.java
@@ -81,12 +81,15 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
     if (fileInfoFilter == null) {
       fileInfoFilter =
-        f -> f.format == null || f.format.equals(ATTR_FORMAT_VALUE_DITA) || f.format.equals(ATTR_FORMAT_VALUE_DITAMAP);
+        f ->
+          f.format() == null ||
+          f.format().equals(ATTR_FORMAT_VALUE_DITA) ||
+          f.format().equals(ATTR_FORMAT_VALUE_DITAMAP);
     }
     final Collection<FileInfo> fis = job
       .getFileInfo(fileInfoFilter)
       .stream()
-      .filter(f -> f.hasKeyref)
+      .filter(FileInfo::hasKeyref)
       .collect(Collectors.toSet());
     if (!fis.isEmpty()) {
       try {
@@ -103,8 +106,8 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
       final KeyrefReader reader = new KeyrefReader();
       reader.setLogger(logger);
       reader.setXmlUtils(xmlUtils);
-      final Job.FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-      final URI mapFile = in.uri;
+      final Job.FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+      final URI mapFile = in.uri();
       final XdmNode doc = readMap(in);
       logger.info("Reading " + job.tempDirURI.resolve(mapFile));
       reader.read(job.tempDirURI.resolve(mapFile), doc);
@@ -113,19 +116,19 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
       // Read resources maps
       final Collection<FileInfo> resourceMapFis = job.getFileInfo(fi ->
-        fi.isInputResource && Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITAMAP)
+        fi.isInputResource() && Objects.equals(fi.format(), ATTR_FORMAT_VALUE_DITAMAP)
       );
       final KeyScope rootScope = resourceMapFis
         .stream()
         .map(fi -> {
           try {
             final XdmNode d = readMap(fi);
-            logger.info("Reading " + job.tempDirURI.resolve(fi.uri));
+            logger.info("Reading " + job.tempDirURI.resolve(fi.uri()));
             final KeyrefReader r = new KeyrefReader();
             r.setLogger(logger);
-            r.read(job.tempDirURI.resolve(fi.uri), d);
+            r.read(job.tempDirURI.resolve(fi.uri()), d);
             final KeyScope s = r.getKeyDefinition();
-            logger.debug("Writing " + job.tempDirURI.resolve(fi.uri));
+            logger.debug("Writing " + job.tempDirURI.resolve(fi.uri()));
             writeMap(fi, d);
             return s;
           } catch (DITAOTException e) {
@@ -142,7 +145,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
         })
         .collect(Collectors.toSet());
       final Collection<FileInfo> resourceTopicsFis = job.getFileInfo(fi ->
-        !topicsInMap.contains(fi.uri) && (Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITA) || fi.format == null)
+        !topicsInMap.contains(fi.uri()) && (Objects.equals(fi.format(), ATTR_FORMAT_VALUE_DITA) || fi.format() == null)
       );
       final Collection<FileInfo> resourceFis = Stream
         .concat(resourceMapFis.stream(), resourceTopicsFis.stream())
@@ -190,7 +193,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
     Destination destination = null;
     try {
-      final URI file = job.tempDirURI.resolve(map.uri);
+      final URI file = job.tempDirURI.resolve(map.uri());
       logger.debug("Writing " + file);
       destination = job.getStore().getDestination(file);
       final PipelineConfiguration pipe = doc.getUnderlyingNode().getConfiguration().makePipelineConfiguration();
@@ -210,8 +213,8 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
     // Collect topics not in map and map itself
     for (final FileInfo f : fis) {
-      if (!usage.containsKey(f.uri)) {
-        res.add(processTopic(f, rootScope, f.isResourceOnly));
+      if (!usage.containsKey(f.uri())) {
+        res.add(processTopic(f, rootScope, f.isResourceOnly()));
       }
     }
 
@@ -232,7 +235,10 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     return renames
       .stream()
       .collect(
-        Collectors.groupingBy(rt -> rt.scope, Collectors.toMap(rt -> rt.in.uri, Function.identity(), (rt1, rt2) -> rt1))
+        Collectors.groupingBy(
+          rt -> rt.scope,
+          Collectors.toMap(rt -> rt.in.uri(), Function.identity(), (rt1, rt2) -> rt1)
+        )
       )
       .values()
       .stream()
@@ -254,7 +260,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
         .stream()
         // FIXME this should be filtered out earlier
         .filter(t -> t.out != null)
-        .collect(toMap(t -> t.in.uri, t -> t.out.uri));
+        .collect(toMap(t -> t.in.uri(), t -> t.out.uri()));
       final KeyScope resScope = rewriteScopeTargets(scope, rewrites);
       tasks.stream().map(t -> new ResolveTask(resScope, t.in, t.out)).forEach(res::add);
     }
@@ -349,20 +355,20 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
             URI referenceValue = toURI(node.getAttributeValue(rewriteAttrName));
             if (referenceValue != null) {
               for (final KeyScope s : ss) {
-                final URI resolved = map.uri.resolve(referenceValue);
+                final URI resolved = map.uri().resolve(referenceValue);
                 final String fragment = resolved.getFragment();
                 final URI href = stripFragment(resolved);
                 final FileInfo fi = job.getFileInfo(href);
-                if (fi != null && fi.hasKeyref) {
-                  final int count = usage.getOrDefault(fi.uri, 0);
+                if (fi != null && fi.hasKeyref()) {
+                  final int count = usage.getOrDefault(fi.uri(), 0);
                   final Optional<ResolveTask> existing = res
                     .stream()
-                    .filter(rt -> rt.scope.equals(s) && rt.in.uri.equals(fi.uri))
+                    .filter(rt -> rt.scope.equals(s) && rt.in.uri().equals(fi.uri()))
                     .findAny();
                   if (count != 0 && existing.isPresent()) {
                     final ResolveTask resolveTask = existing.get();
                     if (resolveTask.out != null) {
-                      referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
+                      referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result());
                       if (fragment != null && referenceValue.getFragment() == null) {
                         referenceValue = setFragment(referenceValue, fragment);
                       }
@@ -370,10 +376,10 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
                   } else {
                     final ResolveTask resolveTask = processTopic(fi, s, isResourceOnly(node));
                     res.add(resolveTask);
-                    final Integer used = usage.get(fi.uri);
+                    final Integer used = usage.get(fi.uri());
                     if (used > 1) {
-                      referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result);
-                      fixKeyDefRefs(s, fi.uri, referenceValue);
+                      referenceValue = tempFileNameScheme.generateTempFileName(resolveTask.out.result());
+                      fixKeyDefRefs(s, fi.uri(), referenceValue);
                       if (fragment != null && referenceValue.getFragment() == null) {
                         referenceValue = setFragment(referenceValue, fragment);
                       }
@@ -468,12 +474,12 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
    * @return key reference processing
    */
   private ResolveTask processTopic(final FileInfo f, final KeyScope scope, final boolean isResourceOnly) {
-    final int increment = isResourceOnly && !isFormatDita(f.format) ? 0 : 1;
-    final Integer used = usage.containsKey(f.uri) ? usage.get(f.uri) + increment : increment;
-    usage.put(f.uri, used);
+    final int increment = isResourceOnly && !isFormatDita(f.format()) ? 0 : 1;
+    final int used = usage.getOrDefault(f.uri(), 0) + increment;
+    usage.put(f.uri(), used);
 
     if (used > 1) {
-      final URI result = addSuffix(f.result, "-" + (used - 1));
+      final URI result = addSuffix(f.result(), "-" + (used - 1));
       final URI out = tempFileNameScheme.generateTempFileName(result);
       final FileInfo fo = new FileInfo.Builder(f).uri(out).result(result).build();
       // TODO: Should this be added when content is actually generated?
@@ -495,7 +501,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     conkeyrefFilter.setLogger(logger);
     conkeyrefFilter.setJob(job);
     conkeyrefFilter.setKeyDefinitions(r.scope);
-    conkeyrefFilter.setCurrentFile(job.tempDirURI.resolve(r.in.uri));
+    conkeyrefFilter.setCurrentFile(job.tempDirURI.resolve(r.in.uri()));
     filters.add(conkeyrefFilter);
 
     final TopicFragmentFilter topicFragmentFilter = new TopicFragmentFilter(
@@ -508,18 +514,18 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
     parser.setLogger(logger);
     parser.setJob(job);
     parser.setKeyDefinition(r.scope);
-    parser.setCurrentFile(job.tempDirURI.resolve(r.in.uri));
+    parser.setCurrentFile(job.tempDirURI.resolve(r.in.uri()));
     parser.setTopicIdCache(topicIdCache);
     filters.add(parser);
 
     try {
       logger.debug("Using " + (r.scope.name() != null ? r.scope.name() + " scope" : "root scope"));
       if (r.out != null) {
-        logger.info("Processing " + job.tempDirURI.resolve(r.in.uri) + " to " + job.tempDirURI.resolve(r.out.uri));
-        job.getStore().transform(job.tempDirURI.resolve(r.in.uri), job.tempDirURI.resolve(r.out.uri), filters);
+        logger.info("Processing " + job.tempDirURI.resolve(r.in.uri()) + " to " + job.tempDirURI.resolve(r.out.uri()));
+        job.getStore().transform(job.tempDirURI.resolve(r.in.uri()), job.tempDirURI.resolve(r.out.uri()), filters);
       } else {
-        logger.info("Processing " + job.tempDirURI.resolve(r.in.uri));
-        job.getStore().transform(job.tempDirURI.resolve(r.in.uri), filters);
+        logger.info("Processing " + job.tempDirURI.resolve(r.in.uri()));
+        job.getStore().transform(job.tempDirURI.resolve(r.in.uri()), filters);
       }
       // validate resource-only list
       normalProcessingRole.addAll(parser.getNormalProcessingRoleTargets());
@@ -530,7 +536,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
   private XdmNode readMap(final FileInfo input) throws DITAOTException {
     try {
-      final URI in = job.tempDirURI.resolve(input.uri);
+      final URI in = job.tempDirURI.resolve(input.uri());
       return job.getStore().getImmutableNode(in);
     } catch (final Exception e) {
       throw new DITAOTException("Failed to parse map: " + e.getMessage(), e);
@@ -539,7 +545,7 @@ final class KeyrefModule extends AbstractPipelineModuleImpl {
 
   private void writeMap(final FileInfo in, final XdmNode doc) throws DITAOTException {
     try {
-      final URI file = job.tempDirURI.resolve(in.uri);
+      final URI file = job.tempDirURI.resolve(in.uri());
       //            doc.setDocumentURI(file.toString());
       job.getStore().writeDocument(doc, file);
     } catch (final IOException e) {

--- a/src/main/java/org/dita/dost/module/MaprefModule.java
+++ b/src/main/java/org/dita/dost/module/MaprefModule.java
@@ -68,7 +68,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
     if (fileInfoFilter == null) {
-      fileInfoFilter = fileInfo -> fileInfo.format != null && fileInfo.format.equals(ATTR_FORMAT_VALUE_DITAMAP);
+      fileInfoFilter = fileInfo -> fileInfo.format() != null && fileInfo.format().equals(ATTR_FORMAT_VALUE_DITAMAP);
     }
     final Collection<FileInfo> fileInfos = job.getFileInfo(fileInfoFilter);
     if (fileInfos.isEmpty()) {
@@ -103,7 +103,7 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
    * Process map references in a map and store the result to temporary file.
    */
   private void processMap(final FileInfo input) throws DITAOTException {
-    final File inputFile = new File(job.tempDirURI.resolve(input.uri));
+    final File inputFile = new File(job.tempDirURI.resolve(input.uri()));
     final File outputFile = new File(inputFile.getAbsolutePath() + FILE_EXTENSION_TEMP);
 
     logger.info("Processing " + inputFile.toURI());
@@ -154,14 +154,14 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
   private FileInfo collectJobInfo(FileInfo fileInfo, Document doc) {
     final FileInfo.Builder builder = new FileInfo.Builder(fileInfo);
     final List<Element> elements = XMLUtils.toList(doc.getElementsByTagName("*"));
-    if (!fileInfo.hasConref) {
+    if (!fileInfo.hasConref()) {
       builder.hasConref(
         elements
           .stream()
           .anyMatch(e -> e.hasAttribute(ATTRIBUTE_NAME_CONREF) || e.hasAttribute(ATTRIBUTE_NAME_CONKEYREF))
       );
     }
-    if (!fileInfo.hasKeyref) {
+    if (!fileInfo.hasKeyref()) {
       builder.hasKeyref(
         elements
           .stream()
@@ -186,8 +186,8 @@ final class MaprefModule extends AbstractPipelineModuleImpl {
    * Store result map file to store.
    */
   private void replace(final FileInfo input) throws DITAOTException {
-    final File inputFile = new File(job.tempDirURI.resolve(input.uri + FILE_EXTENSION_TEMP));
-    final File outputFile = new File(job.tempDirURI.resolve(input.uri));
+    final File inputFile = new File(job.tempDirURI.resolve(input.uri() + FILE_EXTENSION_TEMP));
+    final File outputFile = new File(job.tempDirURI.resolve(input.uri()));
     try {
       job.getStore().move(inputFile.toURI(), outputFile.toURI());
     } catch (final IOException e) {

--- a/src/main/java/org/dita/dost/module/MoveLinksModule.java
+++ b/src/main/java/org/dita/dost/module/MoveLinksModule.java
@@ -48,11 +48,11 @@ final class MoveLinksModule extends AbstractPipelineModuleImpl {
    */
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-    final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
-    if (!ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+    final FileInfo fi = job.getFileInfo(FileInfo::isInput).iterator().next();
+    if (!ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
       return null;
     }
-    final File inputFile = new File(job.tempDirURI.resolve(fi.uri));
+    final File inputFile = new File(job.tempDirURI.resolve(fi.uri()));
     final File styleFile = new File(input.getAttribute(ANT_INVOKER_EXT_PARAM_STYLE));
 
     Document doc;

--- a/src/main/java/org/dita/dost/module/MoveMetaModule.java
+++ b/src/main/java/org/dita/dost/module/MoveMetaModule.java
@@ -54,7 +54,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
    */
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-    final Collection<FileInfo> fis = job.getFileInfo(fi -> fi.isInput);
+    final Collection<FileInfo> fis = job.getFileInfo(FileInfo::isInput);
     if (!fis.isEmpty()) {
       final Map<URI, Map<String, Element>> mapSet = getMapMetadata(fis);
       pushMetadata(mapSet);
@@ -81,7 +81,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
     }
 
     for (final FileInfo f : fis) {
-      final File inputFile = new File(job.tempDirURI.resolve(f.uri));
+      final File inputFile = new File(job.tempDirURI.resolve(f.uri()));
       final File tmp = new File(inputFile.getAbsolutePath() + ".tmp" + Long.toString(System.currentTimeMillis()));
       logger.info("Processing " + inputFile.toURI());
       logger.debug("Processing " + inputFile.toURI() + " to " + tmp.toURI());
@@ -143,9 +143,9 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
           logger.error("File " + job.tempDirURI.resolve(key) + " was not found.");
           continue;
         }
-        final URI targetFileName = job.tempDirURI.resolve(fi.uri);
+        final URI targetFileName = job.tempDirURI.resolve(fi.uri());
         assert targetFileName.isAbsolute();
-        if (fi.format != null && ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+        if (fi.format() != null && ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
           mapInserter.setMetaTable(entry.getValue());
           if (job.getStore().exists(targetFileName)) {
             try {
@@ -169,9 +169,9 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
           logger.error("File " + job.tempDirURI.resolve(key) + " was not found.");
           continue;
         }
-        final URI targetFileName = job.tempDirURI.resolve(fi.uri);
+        final URI targetFileName = job.tempDirURI.resolve(fi.uri());
         assert targetFileName.isAbsolute();
-        if (fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {
+        if (fi.format() == null || fi.format().equals(ATTR_FORMAT_VALUE_DITA)) {
           final String topicid = entry.getKey().getFragment();
           topicInserter.setTopicId(topicid);
           topicInserter.setMetaTable(entry.getValue());
@@ -194,7 +194,7 @@ final class MoveMetaModule extends AbstractPipelineModuleImpl {
     metaReader.setJob(job);
     metaReader.setXmlUtils(xmlUtils);
     for (final FileInfo f : fis) {
-      final File mapFile = job.tempDir.toPath().resolve(f.file.toPath()).toFile();
+      final File mapFile = job.tempDir.toPath().resolve(f.file().toPath()).toFile();
       //FIXME: this reader gets the parent path of input file
       try {
         metaReader.read(mapFile);

--- a/src/main/java/org/dita/dost/module/ProfileModule.java
+++ b/src/main/java/org/dita/dost/module/ProfileModule.java
@@ -45,7 +45,7 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
     init(input);
 
     for (final FileInfo f : job.getFileInfo(fileInfoFilter)) {
-      final URI file = job.tempDirURI.resolve(f.uri);
+      final URI file = job.tempDirURI.resolve(f.uri());
       logger.info("Processing {0}", file);
 
       try {
@@ -157,13 +157,13 @@ public final class ProfileModule extends AbstractPipelineModuleImpl {
 
   private XdmNode getMapDocument() throws DITAOTException {
     final Collection<FileInfo> fis = job.getFileInfo(f ->
-      f.isInput && Objects.equals(f.format, ATTR_FORMAT_VALUE_DITAMAP)
+      f.isInput() && Objects.equals(f.format(), ATTR_FORMAT_VALUE_DITAMAP)
     );
     if (fis.isEmpty()) {
       return null;
     }
     final FileInfo fi = fis.iterator().next();
-    final URI currentFile = job.tempDirURI.resolve(fi.uri);
+    final URI currentFile = job.tempDirURI.resolve(fi.uri());
     try {
       logger.debug("Reading {0}", currentFile);
       return job.getStore().getImmutableNode(currentFile);

--- a/src/main/java/org/dita/dost/module/TopicMergeModule.java
+++ b/src/main/java/org/dita/dost/module/TopicMergeModule.java
@@ -53,8 +53,8 @@ final class TopicMergeModule extends AbstractPipelineModuleImpl {
     if (logger == null) {
       throw new IllegalStateException("Logger not set");
     }
-    final FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-    final File ditaInput = new File(job.tempDirURI.resolve(in.uri));
+    final FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+    final File ditaInput = new File(job.tempDirURI.resolve(in.uri()));
     if (!job.getStore().exists(ditaInput.toURI())) {
       logger.error(MessageUtils.getMessage("DOTJ025E").toString());
       return null;

--- a/src/main/java/org/dita/dost/module/XmlFilterModule.java
+++ b/src/main/java/org/dita/dost/module/XmlFilterModule.java
@@ -41,7 +41,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
         .stream()
         .parallel()
         .forEach(f -> {
-          final URI file = job.tempDirURI.resolve(f.uri);
+          final URI file = job.tempDirURI.resolve(f.uri());
           logger.info("Processing " + file);
           try {
             job.getStore().transform(file, getProcessingPipe(f));
@@ -51,7 +51,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
         });
     } else {
       for (final FileInfo f : fis) {
-        final URI file = job.tempDirURI.resolve(f.uri);
+        final URI file = job.tempDirURI.resolve(f.uri());
         logger.info("Processing " + file);
         try {
           job.getStore().transform(file, getProcessingPipe(f));
@@ -69,7 +69,7 @@ public final class XmlFilterModule extends AbstractPipelineModuleImpl {
    * @param fi current file being processed
    */
   private List<XMLFilter> getProcessingPipe(final FileInfo fi) {
-    final URI fileToParse = job.tempDirURI.resolve(fi.uri);
+    final URI fileToParse = job.tempDirURI.resolve(fi.uri());
     assert fileToParse.isAbsolute();
     return filters
       .stream()

--- a/src/main/java/org/dita/dost/module/XsltModule.java
+++ b/src/main/java/org/dita/dost/module/XsltModule.java
@@ -78,7 +78,7 @@ public final class XsltModule extends AbstractPipelineModuleImpl {
       final Collection<Job.FileInfo> res = job.getFileInfo(fileInfoFilter);
       includes = new ArrayList<>(res.size());
       for (final Job.FileInfo f : res) {
-        includes.add(f.file);
+        includes.add(f.file());
       }
       baseDir = job.tempDir;
     }

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -144,10 +144,10 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
 
   void addFlagImagesSetToProperties(final Job prop, final Set<URI> set) {
     for (final URI file : flagImageSet) {
-      final FileInfo f = getOrCreateFileInfo(file);
-      f.isFlagImage = true;
-      f.format = ATTR_FORMAT_VALUE_IMAGE;
-      job.add(f);
+      final FileInfo.Builder f = getOrCreateFileInfo(file);
+      f.isFlagImage(true);
+      f.format(ATTR_FORMAT_VALUE_IMAGE);
+      job.add(f.build());
     }
 
     final Set<URI> newSet = new LinkedHashSet<>(128);
@@ -181,7 +181,7 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
     prop.setProperty(REL_FLAGIMAGE_LIST, newSet.stream().map(URI::toString).collect(Collectors.joining(COMMA)));
   }
 
-  private FileInfo getOrCreateFileInfo(final URI file) {
+  private FileInfo.Builder getOrCreateFileInfo(final URI file) {
     assert file.isAbsolute();
     assert file.getFragment() == null;
     final URI f = file.normalize();
@@ -189,7 +189,6 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
       .ofNullable(job.getFileInfo(f))
       .map(FileInfo.Builder::new)
       .orElse(new FileInfo.Builder().src(file))
-      .uri(tempFileNameScheme.generateTempFileName(file))
-      .build();
+      .uri(tempFileNameScheme.generateTempFileName(file));
   }
 }

--- a/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/AbstractBranchFilterModule.java
@@ -116,7 +116,7 @@ public abstract class AbstractBranchFilterModule extends AbstractPipelineModuleI
     final URI href = toURI(ditavalRef.getAttribute(ATTRIBUTE_NAME_HREF));
     final URI tmp = currentFile.resolve(href);
     final FileInfo fi = job.getFileInfo(tmp);
-    final URI ditaval = fi.src;
+    final URI ditaval = fi.src();
     return filterCache.computeIfAbsent(ditaval, this::getFilterUtils);
   }
 

--- a/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/MapBranchFilterModule.java
@@ -59,8 +59,8 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
 
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-    final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
-    if (!ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+    final FileInfo fi = job.getFileInfo(FileInfo::isInput).iterator().next();
+    if (!ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
       return null;
     }
     processMap(fi);
@@ -78,7 +78,7 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
    * Process map for branch replication.
    */
   protected void processMap(final FileInfo fi) {
-    this.map = fi.uri;
+    this.map = fi.uri();
     currentFile = job.tempDirURI.resolve(map);
     ditavalFile =
       Optional.of(new File(job.tempDir, FILE_NAME_MERGED_DITAVAL)).filter(File::exists).map(File::toURI).orElse(null);
@@ -161,9 +161,9 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
               final URI absTarget = stripFragment(currentFile.resolve(attr.getValue()));
               final FileInfo hrefFileInfo = job.getFileInfo(absTarget);
               if (hrefFileInfo != null) {
-                final URI newResult = addSuffix(hrefFileInfo.result, suffix);
+                final URI newResult = addSuffix(hrefFileInfo.result(), suffix);
                 final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).uri(dstUri).result(newResult);
-                if (hrefFileInfo.format == null) {
+                if (hrefFileInfo.format() == null) {
                   dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
                 }
                 final FileInfo dstFileInfo = dstBuilder.build();
@@ -353,15 +353,15 @@ public class MapBranchFilterModule extends AbstractBranchFilterModule {
         final FileInfo copyToFileInfo = !copyTo.isEmpty() ? job.getFileInfo(currentFile.resolve(copyTo)) : null;
 
         final URI dstSource;
-        dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result, filter);
+        dstSource = generateCopyTo((copyToFileInfo != null ? copyToFileInfo : hrefFileInfo).result(), filter);
         final URI dstTemp = tempFileNameScheme.generateTempFileName(dstSource);
         final FileInfo.Builder dstBuilder = new FileInfo.Builder(hrefFileInfo).result(dstSource).uri(dstTemp);
-        if (dstBuilder.build().format == null) {
+        if (dstBuilder.build().format() == null) {
           dstBuilder.format(ATTR_FORMAT_VALUE_DITA);
         }
-        if (hrefFileInfo.src == null && href != null) {
+        if (hrefFileInfo.src() == null && href != null) {
           if (copyToFileInfo != null) {
-            dstBuilder.src(copyToFileInfo.src);
+            dstBuilder.src(copyToFileInfo.src());
           }
         }
         final FileInfo dstFileInfo = dstBuilder.build();

--- a/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
+++ b/src/main/java/org/dita/dost/module/filter/TopicBranchFilterModule.java
@@ -55,8 +55,8 @@ public class TopicBranchFilterModule extends AbstractBranchFilterModule {
 
   @Override
   public AbstractPipelineOutput execute(final AbstractPipelineInput input) throws DITAOTException {
-    final FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-    processMap(in.uri);
+    final FileInfo in = job.getFileInfo(FileInfo::isInput).iterator().next();
+    processMap(in.uri());
 
     addFlagImagesSetToProperties(job, relFlagImagesSet);
 

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -57,7 +57,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
 
   Predicate<String> formatFilter;
   /** FileInfos keyed by src. */
-  private final Map<URI, Collection<FileInfo>> fileinfos = new ConcurrentHashMap<>();
+  private final Map<URI, Collection<FileInfo.Builder>> fileinfos = new ConcurrentHashMap<>();
   /** Set of all topic files */
   final Set<URI> fullTopicSet = ConcurrentHashMap.newKeySet();
   /** Set of all map files */
@@ -576,11 +576,10 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       final URI f = currentFile.normalize();
       if (!isFormatDita(ref.format)) {
         if (!fileinfos.containsKey(f)) {
-          final FileInfo i = new FileInfo.Builder()
+          final FileInfo.Builder i = new FileInfo.Builder()
             .uri(tempFileNameScheme.generateTempFileName(currentFile))
             .src(currentFile)
-            .format(ref.format)
-            .build();
+            .format(ref.format);
           fileinfos.put(i.src(), Collections.singletonList(i));
         }
       } else {
@@ -701,14 +700,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     resourceOnlySet.addAll(res);
 
     for (final URI file : outDitaFilesSet) {
-      createOrUpdateFileInfo(file, fi -> fi.isOutDita = true);
+      createOrUpdateFileInfo(file, fi -> fi.isOutDita(true));
     }
     for (final URI file : fullTopicSet) {
       createOrUpdateFileInfo(
         file,
         fi -> {
           if (isFormatDita(fi.format())) {
-            fi.format = ATTR_FORMAT_VALUE_DITA;
+            fi.format(ATTR_FORMAT_VALUE_DITA);
           }
         }
       );
@@ -718,65 +717,65 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         file,
         fi -> {
           if (fi.format() == null) {
-            fi.format = ATTR_FORMAT_VALUE_DITAMAP;
+            fi.format(ATTR_FORMAT_VALUE_DITAMAP);
           }
         }
       );
     }
     for (final URI file : hrefTopicSet) {
-      createOrUpdateFileInfo(file, fi -> fi.hasLink = true);
+      createOrUpdateFileInfo(file, fi -> fi.hasLink(true));
     }
     for (final URI file : conrefSet) {
-      createOrUpdateFileInfo(file, fi -> fi.hasConref = true);
+      createOrUpdateFileInfo(file, fi -> fi.hasConref(true));
     }
     for (final Reference file : formatSet) {
-      createOrUpdateFileInfo(file.filename, fi -> fi.format = file.format);
+      createOrUpdateFileInfo(file.filename, fi -> fi.format(file.format));
     }
     for (final URI file : flagImageSet) {
       createOrUpdateFileInfo(
         file,
         fi -> {
-          fi.isFlagImage = true;
-          fi.format = ATTR_FORMAT_VALUE_IMAGE;
+          fi.isFlagImage(true);
+          fi.format(ATTR_FORMAT_VALUE_IMAGE);
         }
       );
     }
     for (final String format : htmlSet.keySet()) {
       for (final URI file : htmlSet.get(format)) {
-        createOrUpdateFileInfo(file, fi -> fi.format = format);
+        createOrUpdateFileInfo(file, fi -> fi.format(format));
       }
     }
     for (final URI file : hrefTargetSet) {
-      createOrUpdateFileInfo(file, fi -> fi.isTarget = true);
+      createOrUpdateFileInfo(file, fi -> fi.isTarget(true));
     }
     for (final URI file : schemeSet) {
-      createOrUpdateFileInfo(file, fi -> fi.isSubjectScheme = true);
+      createOrUpdateFileInfo(file, fi -> fi.isSubjectScheme(true));
     }
     for (final URI file : coderefTargetSet) {
       createOrUpdateFileInfo(
         file,
         fi -> {
-          fi.isSubtarget = true;
+          fi.isSubtarget(true);
           if (fi.format() == null) {
-            fi.format = PR_D_CODEREF.localName;
+            fi.format(PR_D_CODEREF.localName);
           }
         }
       );
     }
     for (final URI file : conrefpushSet) {
-      createOrUpdateFileInfo(file, fi -> fi.isConrefPush = true);
+      createOrUpdateFileInfo(file, fi -> fi.isConrefPush(true));
     }
     for (final URI file : keyrefSet) {
-      createOrUpdateFileInfo(file, fi -> fi.hasKeyref = true);
+      createOrUpdateFileInfo(file, fi -> fi.hasKeyref(true));
     }
     for (final URI file : coderefSet) {
-      createOrUpdateFileInfo(file, fi -> fi.hasCoderef = true);
+      createOrUpdateFileInfo(file, fi -> fi.hasCoderef(true));
     }
     for (final URI file : resourceOnlySet) {
-      createOrUpdateFileInfo(file, fi -> fi.isResourceOnly = true);
+      createOrUpdateFileInfo(file, fi -> fi.isResourceOnly(true));
     }
     for (final URI resource : resources) {
-      createOrUpdateFileInfo(resource, fi -> fi.isInputResource = true);
+      createOrUpdateFileInfo(resource, fi -> fi.isInputResource(true));
     }
 
     addFlagImagesSetToProperties(job, relFlagImagesSet);
@@ -793,11 +792,9 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         final URI src = filteredCopyTo.get(fs.src());
         // correct copy-to
         if (src != null) {
-          final FileInfo corr = new FileInfo.Builder(fs).src(src).build();
-          job.add(corr);
-        } else {
-          job.add(fs);
+          fs.src(src);
         }
+        job.add(fs.build());
       });
 
     for (final URI target : filteredCopyTo.keySet()) {
@@ -813,7 +810,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     for (URI f : additionalResourcesSet) {
       final FileInfo fi = job.getFileInfo(f);
       if (!fi.isResourceOnly()) {
-        fi.isInputResource = true;
+        var b = FileInfo.builder(fi).isInputResource(true);
+        job.add(b.build());
       }
     }
 
@@ -827,13 +825,13 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
   /** Filter copy-to where target is used directly. */
   private Map<URI, URI> filterConflictingCopyTo(
     final Map<URI, URI> copyTo,
-    final Collection<Collection<FileInfo>> fileInfos
+    final Collection<Collection<FileInfo.Builder>> fileInfos
   ) {
     final Set<URI> fileinfoTargets = fileInfos
       .stream()
       .flatMap(Collection::stream)
-      .filter(fi -> fi.src().equals(fi.result()))
-      .map(FileInfo::result)
+      .filter(fi -> Objects.equals(fi.src(), fi.result()))
+      .map(FileInfo.Builder::result)
       .collect(Collectors.toSet());
     return copyTo
       .entrySet()
@@ -877,20 +875,23 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     return res;
   }
 
-  private void createOrUpdateFileInfo(final URI file, final Consumer<FileInfo> consumer) {
-    for (final FileInfo fi : getOrCreateFileInfo(fileinfos, file)) {
+  private void createOrUpdateFileInfo(final URI file, final Consumer<FileInfo.Builder> consumer) {
+    for (final FileInfo.Builder fi : getOrCreateFileInfo(fileinfos, file)) {
       consumer.accept(fi);
     }
   }
 
-  private Collection<FileInfo> getOrCreateFileInfo(final Map<URI, Collection<FileInfo>> fileInfos, final URI file) {
+  private Collection<FileInfo.Builder> getOrCreateFileInfo(
+    final Map<URI, Collection<FileInfo.Builder>> fileInfos,
+    final URI file
+  ) {
     assert file.getFragment() == null;
     final URI f = file.normalize();
 
     if (fileInfos.containsKey(f)) {
       return fileInfos.get(f);
     } else {
-      final Collection<FileInfo> prevs = job
+      final Collection<FileInfo.Builder> prevs = job
         .getFileInfo(fi -> Objects.equals(fi.src(), f))
         .stream()
         .map(prev -> {
@@ -901,15 +902,15 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
           if (prev.uri() == null) {
             b = b.uri(tempFileNameScheme.generateTempFileName(f));
           }
-          return b.build();
+          return b;
         })
         .collect(Collectors.toList());
       if (!prevs.isEmpty()) {
         fileInfos.put(f, prevs);
         return prevs;
       } else {
-        final Collection<FileInfo> fis = Collections.singletonList(
-          new FileInfo.Builder().src(f).uri(tempFileNameScheme.generateTempFileName(f)).build()
+        final Collection<FileInfo.Builder> fis = Collections.singletonList(
+          new FileInfo.Builder().src(f).uri(tempFileNameScheme.generateTempFileName(f))
         );
         fileInfos.put(f, fis);
         return fis;

--- a/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/AbstractReaderModule.java
@@ -581,7 +581,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
             .src(currentFile)
             .format(ref.format)
             .build();
-          fileinfos.put(i.src, Collections.singletonList(i));
+          fileinfos.put(i.src(), Collections.singletonList(i));
         }
       } else {
         final FileInfo fi = job.getFileInfo(f);
@@ -597,7 +597,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       }
     } else if (listFilter.isDitaMap()) {
       final FileInfo fi = job.getFileInfo(currentFile);
-      if (fi != null && !Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITAMAP)) {
+      if (fi != null && !Objects.equals(fi.format(), ATTR_FORMAT_VALUE_DITAMAP)) {
         final FileInfo i = new FileInfo.Builder(fi).format(ATTR_FORMAT_VALUE_DITAMAP).build();
         job.add(i);
       }
@@ -707,7 +707,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       createOrUpdateFileInfo(
         file,
         fi -> {
-          if (isFormatDita(fi.format)) {
+          if (isFormatDita(fi.format())) {
             fi.format = ATTR_FORMAT_VALUE_DITA;
           }
         }
@@ -717,7 +717,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       createOrUpdateFileInfo(
         file,
         fi -> {
-          if (fi.format == null) {
+          if (fi.format() == null) {
             fi.format = ATTR_FORMAT_VALUE_DITAMAP;
           }
         }
@@ -757,7 +757,7 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
         file,
         fi -> {
           fi.isSubtarget = true;
-          if (fi.format == null) {
+          if (fi.format() == null) {
             fi.format = PR_D_CODEREF.localName;
           }
         }
@@ -788,9 +788,9 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       .values()
       .stream()
       .flatMap(Collection::stream)
-      .filter(fs -> !failureList.contains(fs.src))
+      .filter(fs -> !failureList.contains(fs.src()))
       .forEach(fs -> {
-        final URI src = filteredCopyTo.get(fs.src);
+        final URI src = filteredCopyTo.get(fs.src());
         // correct copy-to
         if (src != null) {
           final FileInfo corr = new FileInfo.Builder(fs).src(src).build();
@@ -805,14 +805,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       final URI src = filteredCopyTo.get(target);
       final FileInfo fi = new FileInfo.Builder().result(target).uri(tmp).build();
       // FIXME: what's the correct value for this? Accept all?
-      if (formatFilter.test(fi.format) || fi.format == null || fi.format.equals(ATTR_FORMAT_VALUE_DITA)) {
+      if (formatFilter.test(fi.format()) || fi.format() == null || fi.format().equals(ATTR_FORMAT_VALUE_DITA)) {
         job.add(fi);
       }
     }
 
     for (URI f : additionalResourcesSet) {
       final FileInfo fi = job.getFileInfo(f);
-      if (!fi.isResourceOnly) {
+      if (!fi.isResourceOnly()) {
         fi.isInputResource = true;
       }
     }
@@ -832,8 +832,8 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
     final Set<URI> fileinfoTargets = fileInfos
       .stream()
       .flatMap(Collection::stream)
-      .filter(fi -> fi.src.equals(fi.result))
-      .map(fi -> fi.result)
+      .filter(fi -> fi.src().equals(fi.result()))
+      .map(FileInfo::result)
       .collect(Collectors.toSet());
     return copyTo
       .entrySet()
@@ -891,14 +891,14 @@ public abstract class AbstractReaderModule extends AbstractPipelineModuleImpl {
       return fileInfos.get(f);
     } else {
       final Collection<FileInfo> prevs = job
-        .getFileInfo(fi -> Objects.equals(fi.src, f))
+        .getFileInfo(fi -> Objects.equals(fi.src(), f))
         .stream()
         .map(prev -> {
           FileInfo.Builder b = new FileInfo.Builder(prev);
-          if (prev.src == null) {
+          if (prev.src() == null) {
             b = b.src(f);
           }
-          if (prev.uri == null) {
+          if (prev.uri() == null) {
             b = b.uri(tempFileNameScheme.generateTempFileName(f));
           }
           return b.build();

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -142,8 +142,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
             getStartDocuments(fi).forEach(this::addToWaitList);
           } else {
             if (isFormatDita(fi.format())) {
-              fi.format = ATTR_FORMAT_VALUE_DITA;
-              job.add(fi);
+              job.add(FileInfo.builder(fi).format(ATTR_FORMAT_VALUE_DITA).build());
             }
             addToWaitList(new Reference(resource, fi.format()));
           }
@@ -191,8 +190,7 @@ public final class TopicReaderModule extends AbstractReaderModule {
         getStartDocuments(fi).forEach(this::addToWaitList);
       } else {
         if (fi.format() == null) {
-          fi.format = ATTR_FORMAT_VALUE_DITA;
-          job.add(fi);
+          job.add(FileInfo.builder(fi).format(ATTR_FORMAT_VALUE_DITA).build());
         }
         addToWaitList(new Reference(rootFile, fi.format()));
       }

--- a/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
+++ b/src/main/java/org/dita/dost/module/reader/TopicReaderModule.java
@@ -138,14 +138,14 @@ public final class TopicReaderModule extends AbstractReaderModule {
         if (fi == null) {
           addToWaitList(new Reference(resource));
         } else {
-          if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+          if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
             getStartDocuments(fi).forEach(this::addToWaitList);
           } else {
-            if (isFormatDita(fi.format)) {
+            if (isFormatDita(fi.format())) {
               fi.format = ATTR_FORMAT_VALUE_DITA;
               job.add(fi);
             }
-            addToWaitList(new Reference(resource, fi.format));
+            addToWaitList(new Reference(resource, fi.format()));
           }
         }
       }
@@ -167,11 +167,11 @@ public final class TopicReaderModule extends AbstractReaderModule {
   }
 
   private XdmNode getMapDocument() throws DITAOTException {
-    final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
-    if (fi == null || isFormatDita(fi.format)) {
+    final FileInfo fi = job.getFileInfo(FileInfo::isInput).iterator().next();
+    if (fi == null || isFormatDita(fi.format())) {
       return null;
     }
-    final URI currentFile = job.tempDirURI.resolve(fi.uri);
+    final URI currentFile = job.tempDirURI.resolve(fi.uri());
     try {
       logger.debug("Reading " + currentFile);
       return job.getStore().getImmutableNode(currentFile);
@@ -182,27 +182,27 @@ public final class TopicReaderModule extends AbstractReaderModule {
 
   @Override
   public void readStartFile() throws DITAOTException {
-    final FileInfo fi = job.getFileInfo(f -> f.isInput).iterator().next();
+    final FileInfo fi = job.getFileInfo(FileInfo::isInput).iterator().next();
     final URI rootFile = job.getInputFile();
     if (fi == null) {
       addToWaitList(new Reference(rootFile, getFormatFromPath(rootFile)));
     } else {
-      if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+      if (ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
         getStartDocuments(fi).forEach(this::addToWaitList);
       } else {
-        if (fi.format == null) {
+        if (fi.format() == null) {
           fi.format = ATTR_FORMAT_VALUE_DITA;
           job.add(fi);
         }
-        addToWaitList(new Reference(rootFile, fi.format));
+        addToWaitList(new Reference(rootFile, fi.format()));
       }
     }
   }
 
   private List<Reference> getStartDocuments(final FileInfo startFileInfo) throws DITAOTException {
     final List<Reference> res = new ArrayList<>();
-    assert startFileInfo.src != null;
-    final URI tmp = job.tempDirURI.resolve(startFileInfo.uri);
+    assert startFileInfo.src() != null;
+    final URI tmp = job.tempDirURI.resolve(startFileInfo.uri());
     try {
       logger.info("Reading " + tmp);
       final XdmNode source = job.getStore().getImmutableNode(tmp);
@@ -213,17 +213,17 @@ public final class TopicReaderModule extends AbstractReaderModule {
         .forEach(xdmItem -> {
           final URI href = getHref(xdmItem);
           if (href != null) {
-            FileInfo fi = job.getFileInfo(startFileInfo.src.resolve(href));
+            FileInfo fi = job.getFileInfo(startFileInfo.src().resolve(href));
             if (fi == null) {
               fi = job.getFileInfo(tmp.resolve(href));
             }
-            if (fi != null && fi.src != null) {
+            if (fi != null && fi.src() != null) {
               String format = xdmItem.getAttributeValue(QNAME_ORIG_FORMAT);
               if (format == null) {
                 format = xdmItem.getAttributeValue(QNAME_FORMAT);
               }
-              res.add(new Reference(fi.src, format));
-              nonConrefCopytoTargetSet.add(fi.src);
+              res.add(new Reference(fi.src(), format));
+              nonConrefCopytoTargetSet.add(fi.src());
             }
           }
         });
@@ -232,17 +232,17 @@ public final class TopicReaderModule extends AbstractReaderModule {
         .forEach(xdmItem -> {
           getConref(xdmItem)
             .ifPresent(href -> {
-              FileInfo fi = job.getFileInfo(startFileInfo.src.resolve(href));
+              FileInfo fi = job.getFileInfo(startFileInfo.src().resolve(href));
               if (fi == null) {
                 fi = job.getFileInfo(tmp.resolve(href));
               }
-              if (fi != null && fi.src != null) {
+              if (fi != null && fi.src() != null) {
                 String format = xdmItem.getAttributeValue(QNAME_ORIG_FORMAT);
                 if (format == null) {
                   format = xdmItem.getAttributeValue(QNAME_FORMAT);
                 }
-                res.add(new Reference(fi.src, format));
-                conrefTargetSet.add(fi.src);
+                res.add(new Reference(fi.src(), format));
+                conrefTargetSet.add(fi.src());
               }
             });
         });

--- a/src/main/java/org/dita/dost/reader/ChunkMapReader.java
+++ b/src/main/java/org/dita/dost/reader/ChunkMapReader.java
@@ -522,13 +522,13 @@ public final class ChunkMapReader extends AbstractDomFilter {
 
     URI outputFileName;
     if (copyTo != null) {
-      outputFileName = curr.result.resolve(copyTo);
+      outputFileName = curr.result().resolve(copyTo);
     } else if (id != null) {
-      outputFileName = curr.result.resolve(id + FILE_EXTENSION_DITA);
+      outputFileName = curr.result().resolve(id + FILE_EXTENSION_DITA);
     } else {
-      final Set<URI> results = job.getFileInfo().stream().map(fi -> fi.result).collect(Collectors.toSet());
+      final Set<URI> results = job.getFileInfo().stream().map(FileInfo::result).collect(Collectors.toSet());
       do {
-        outputFileName = curr.result.resolve(generateFilename());
+        outputFileName = curr.result().resolve(generateFilename());
       } while (results.contains(outputFileName));
     }
     return outputFileName;

--- a/src/main/java/org/dita/dost/reader/MergeMapParser.java
+++ b/src/main/java/org/dita/dost/reader/MergeMapParser.java
@@ -246,8 +246,8 @@ public final class MergeMapParser extends XMLFilterImpl {
     // if list item not in visitedSet then call MergeTopicParser to parse it
     try {
       for (final FileInfo f : job.getFileInfo()) {
-        if (f.isTarget) {
-          String element = f.file.getPath();
+        if (f.isTarget()) {
+          String element = f.file().getPath();
           if (!dirPath.equals(tempdir)) {
             element =
               FileUtils.getRelativeUnixPath(
@@ -255,10 +255,10 @@ public final class MergeMapParser extends XMLFilterImpl {
                 tempdir.toPath().resolve(element).toAbsolutePath().toString()
               );
           }
-          final URI abs = job.tempDirURI.resolve(f.uri);
+          final URI abs = job.tempDirURI.resolve(f.uri());
           if (!util.isVisited(abs)) {
             util.visit(abs);
-            if (!f.isResourceOnly) {
+            if (!f.isResourceOnly()) {
               //ensure the file exists
               final File file = dirPath.toPath().resolve(element).toFile();
               if (job.getStore().exists(file.toURI())) {

--- a/src/main/java/org/dita/dost/util/DitaUtils.java
+++ b/src/main/java/org/dita/dost/util/DitaUtils.java
@@ -27,7 +27,7 @@ public class DitaUtils {
   }
 
   public static boolean isDitaFormat(final Job.FileInfo fi) {
-    return isDitaFormat(fi.format);
+    return isDitaFormat(fi.format());
   }
 
   // TOOD: Rename to isDitaTopic
@@ -36,7 +36,7 @@ public class DitaUtils {
   }
 
   public static boolean isDitaMap(final Job.FileInfo fi) {
-    return isDitaMap(fi.format);
+    return isDitaMap(fi.format());
   }
 
   public static boolean isDitaMap(final String format) {

--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -738,8 +738,8 @@ public final class FilterUtils {
       final Job.FileInfo flagFi = job.getFileInfo(img.href);
       if (flagFi != null) {
         final Job.FileInfo current = job.getFileInfo(currentFile);
-        final URI flag = job.tempDirURI.resolve(flagFi.uri);
-        final URI curr = job.tempDirURI.resolve(current.uri);
+        final URI flag = job.tempDirURI.resolve(flagFi.uri());
+        final URI curr = job.tempDirURI.resolve(current.uri());
         rel = URLUtils.getRelativePath(curr, flag);
       } else {
         rel = img.href;

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -1002,6 +1002,10 @@ public final class Job {
         return this;
       }
 
+      public URI src() {
+        return src;
+      }
+
       public Builder src(final URI src) {
         assert src.isAbsolute();
         this.src = src;
@@ -1020,9 +1024,17 @@ public final class Job {
         return this;
       }
 
+      public URI result() {
+        return result;
+      }
+
       public Builder result(final URI result) {
         this.result = result;
         return this;
+      }
+
+      public String format() {
+        return format;
       }
 
       public Builder format(final String format) {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -599,43 +599,62 @@ public final class Job {
    */
   public static final class FileInfo {
 
-    /** Absolute source URI. */
+    /** Absolute source URI.
+     * @deprecated use {@link #src()} instead. */
     public URI src;
-    /** File URI. */
+    /** File URI.
+     * @deprecated use {@link #uri()} instead */
     public final URI uri;
-    /** File path. */
+    /** File path.
+     * @deprecated use {@link #file()} instead */
     public final File file;
-    /** Absolute result URI. */
+    /** Absolute result URI.
+     * @deprecated use {@link #result()} instead */
     public URI result;
-    /** File format. */
+    /** File format.
+     * @deprecated use {@link #format()} instead */
     public String format;
-    /** File has a conref. */
+    /** File has a conref.
+     * @deprecated use {@link #hasConref()} instead */
     public boolean hasConref;
-    /** File is part of chunk. */
+    /** File is part of chunk.
+     * @deprecated use {@link #isChunked()} instead */
     public boolean isChunked;
-    /** File has links. Only applies to topics. */
+    /** File has links. Only applies to topics.
+     * @deprecated use {@link #hasLink()} instead */
     public boolean hasLink;
-    /** File is resource only. */
+    /** File is resource only.
+     * @deprecated use {@link #isResourceOnly()} instead */
     public boolean isResourceOnly;
-    /** File is a link target. */
+    /** File is a link target.
+     * @deprecated use {@link #isTarget()} instead */
     public boolean isTarget;
-    /** File is a push conref source. */
+    /** File is a push conref source.
+     * @deprecated use {@link #isConrefPush()} instead */
     public boolean isConrefPush;
-    /** File has a keyref. */
+    /** File has a keyref.
+     * @deprecated use {@link #hasKeyref()} instead */
     public boolean hasKeyref;
-    /** File has coderef. */
+    /** File has coderef.
+     * @deprecated use {@link #hasCoderef()} instead */
     public boolean hasCoderef;
-    /** File is a subject scheme. */
+    /** File is a subject scheme.
+     * @deprecated use {@link #isSubjectScheme()} instead */
     public boolean isSubjectScheme;
-    /** File is a coderef target. */
+    /** File is a coderef target.
+     * @deprecated use {@link #isSubtarget()} instead */
     public boolean isSubtarget;
-    /** File is a flagging image. */
+    /** File is a flagging image.
+     * @deprecated use {@link #isFlagImage()} instead */
     public boolean isFlagImage;
-    /** Source file is outside base directory. */
+    /** Source file is outside base directory.
+     * @deprecated use {@link #isOutDita()} instead */
     public boolean isOutDita;
-    /** File is input document that is used as processing root. */
+    /** File is input document that is used as processing root.
+     * @deprecated use {@link #isInput()} instead */
     public boolean isInput;
-    /** Additional input resource. */
+    /** Additional input resource.
+     * @deprecated use {@link #isInputResource()} instead */
     public boolean isInputResource;
 
     FileInfo(final URI src, final URI uri, final File file) {
@@ -752,6 +771,82 @@ public final class Job {
         isInput,
         isInputResource
       );
+    }
+
+    public URI src() {
+      return src;
+    }
+
+    public URI uri() {
+      return uri;
+    }
+
+    public File file() {
+      return file;
+    }
+
+    public URI result() {
+      return result;
+    }
+
+    public String format() {
+      return format;
+    }
+
+    public boolean hasConref() {
+      return hasConref;
+    }
+
+    public boolean isChunked() {
+      return isChunked;
+    }
+
+    public boolean hasLink() {
+      return hasLink;
+    }
+
+    public boolean isResourceOnly() {
+      return isResourceOnly;
+    }
+
+    public boolean isTarget() {
+      return isTarget;
+    }
+
+    public boolean isConrefPush() {
+      return isConrefPush;
+    }
+
+    public boolean hasKeyref() {
+      return hasKeyref;
+    }
+
+    public boolean hasCoderef() {
+      return hasCoderef;
+    }
+
+    public boolean isSubjectScheme() {
+      return isSubjectScheme;
+    }
+
+    public boolean isSubtarget() {
+      return isSubtarget;
+    }
+
+    public boolean isFlagImage() {
+      return isFlagImage;
+    }
+
+    public boolean isOutDita() {
+      return isOutDita;
+    }
+
+    public boolean isInput() {
+      return isInput;
+    }
+
+    public boolean isInputResource() {
+      return isInputResource;
     }
 
     public static Builder builder() {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -599,62 +599,84 @@ public final class Job {
    */
   public static final class FileInfo {
 
-    /** Absolute source URI.
-     * @deprecated use {@link #src()} instead. */
-    public URI src;
-    /** File URI.
-     * @deprecated use {@link #uri()} instead */
-    public final URI uri;
-    /** File path.
-     * @deprecated use {@link #file()} instead */
-    public final File file;
-    /** Absolute result URI.
-     * @deprecated use {@link #result()} instead */
-    public URI result;
+    /** Absolute source URI. */
+    private final URI src;
+    /** File URI. */
+    private final URI uri;
+    /** File path. */
+    private final File file;
+    /** Absolute result URI. */
+    private URI result;
+
     /** File format.
      * @deprecated use {@link #format()} instead */
+    @Deprecated
     public String format;
+
     /** File has a conref.
      * @deprecated use {@link #hasConref()} instead */
+    @Deprecated
     public boolean hasConref;
-    /** File is part of chunk.
-     * @deprecated use {@link #isChunked()} instead */
+
+    /** File is part of chunk. */
     public boolean isChunked;
+
     /** File has links. Only applies to topics.
      * @deprecated use {@link #hasLink()} instead */
+    @Deprecated
     public boolean hasLink;
+
     /** File is resource only.
      * @deprecated use {@link #isResourceOnly()} instead */
+    @Deprecated
     public boolean isResourceOnly;
+
     /** File is a link target.
      * @deprecated use {@link #isTarget()} instead */
+    @Deprecated
     public boolean isTarget;
+
     /** File is a push conref source.
      * @deprecated use {@link #isConrefPush()} instead */
+    @Deprecated
     public boolean isConrefPush;
+
     /** File has a keyref.
      * @deprecated use {@link #hasKeyref()} instead */
+    @Deprecated
     public boolean hasKeyref;
+
     /** File has coderef.
      * @deprecated use {@link #hasCoderef()} instead */
+    @Deprecated
     public boolean hasCoderef;
+
     /** File is a subject scheme.
      * @deprecated use {@link #isSubjectScheme()} instead */
+    @Deprecated
     public boolean isSubjectScheme;
+
     /** File is a coderef target.
      * @deprecated use {@link #isSubtarget()} instead */
+    @Deprecated
     public boolean isSubtarget;
+
     /** File is a flagging image.
      * @deprecated use {@link #isFlagImage()} instead */
+    @Deprecated
     public boolean isFlagImage;
+
     /** Source file is outside base directory.
      * @deprecated use {@link #isOutDita()} instead */
+    @Deprecated
     public boolean isOutDita;
-    /** File is input document that is used as processing root.
-     * @deprecated use {@link #isInput()} instead */
+
+    /** File is input document that is used as processing root. */
     public boolean isInput;
+
     /** Additional input resource.
      * @deprecated use {@link #isInputResource()} instead */
+    @Deprecated
     public boolean isInputResource;
 
     FileInfo(final URI src, final URI uri, final File file) {

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -157,7 +157,7 @@ public final class Job {
     this.tempDirURI = tempDir.toURI();
     this.jobFile = new File(tempDir, JOB_FILE);
     this.prop = prop;
-    this.files.putAll(files.stream().collect(Collectors.toMap(fi -> fi.uri, Function.identity())));
+    this.files.putAll(files.stream().collect(Collectors.toMap(FileInfo::uri, Function.identity())));
   }
 
   public Store getStore() {
@@ -256,7 +256,7 @@ public final class Job {
           } catch (final IllegalAccessException ex) {
             throw new RuntimeException(ex);
           }
-          files.put(i.uri, i);
+          files.put(i.uri(), i);
         }
       }
     }
@@ -378,16 +378,16 @@ public final class Job {
     out.writeStartElement(ELEMENT_FILES);
     for (final FileInfo i : fs) {
       out.writeStartElement(ELEMENT_FILE);
-      if (i.src != null) {
-        out.writeAttribute(ATTRIBUTE_SRC, i.src.toString());
+      if (i.src() != null) {
+        out.writeAttribute(ATTRIBUTE_SRC, i.src().toString());
       }
-      out.writeAttribute(ATTRIBUTE_URI, i.uri.toString());
-      out.writeAttribute(ATTRIBUTE_PATH, i.file.getPath());
-      if (i.result != null) {
-        out.writeAttribute(ATTRIBUTE_RESULT, i.result.toString());
+      out.writeAttribute(ATTRIBUTE_URI, i.uri().toString());
+      out.writeAttribute(ATTRIBUTE_PATH, i.file().getPath());
+      if (i.result() != null) {
+        out.writeAttribute(ATTRIBUTE_RESULT, i.result().toString());
       }
-      if (i.format != null) {
-        out.writeAttribute(ATTRIBUTE_FORMAT, i.format);
+      if (i.format() != null) {
+        out.writeAttribute(ATTRIBUTE_FORMAT, i.format());
       }
       try {
         for (Map.Entry<String, Field> e : attrToFieldMap.entrySet()) {
@@ -410,7 +410,7 @@ public final class Job {
    * Add file info. If file info with the same file already exists, it will be replaced.
    */
   public void add(final FileInfo fileInfo) {
-    files.put(fileInfo.uri, fileInfo);
+    files.put(fileInfo.uri(), fileInfo);
   }
 
   /**
@@ -419,7 +419,7 @@ public final class Job {
    * @return removed file info, {@code null} if not found
    */
   public FileInfo remove(final FileInfo fileInfo) {
-    return files.remove(fileInfo.uri);
+    return files.remove(fileInfo.uri());
   }
 
   /**
@@ -468,8 +468,8 @@ public final class Job {
     return files
       .values()
       .stream()
-      .filter(fi -> fi.isInput)
-      .map(fi -> getInputDir().relativize(fi.src))
+      .filter(FileInfo::isInput)
+      .map(fi -> getInputDir().relativize(fi.src()))
       .findAny()
       .orElse(null);
   }
@@ -558,7 +558,7 @@ public final class Job {
       return files
         .values()
         .stream()
-        .filter(fileInfo -> file.equals(fileInfo.src) || file.equals(fileInfo.result))
+        .filter(fileInfo -> file.equals(fileInfo.src()) || file.equals(fileInfo.result()))
         .findFirst()
         .orElse(null);
     }
@@ -670,7 +670,7 @@ public final class Job {
       this.src = null;
       this.uri = uri;
       this.file = toFile(uri);
-      this.result = src;
+      this.result = src();
     }
 
     @Override
@@ -678,44 +678,44 @@ public final class Job {
       return (
         "FileInfo{" +
         "src=" +
-        src +
+        src() +
         ", result=" +
-        result +
+        result() +
         ", uri=" +
-        uri +
+        uri() +
         ", file=" +
-        file +
+        file() +
         ", format='" +
-        format +
+        format() +
         '\'' +
         ", hasConref=" +
-        hasConref +
+        hasConref() +
         ", isChunked=" +
-        isChunked +
+        isChunked() +
         ", hasLink=" +
-        hasLink +
+        hasLink() +
         ", isResourceOnly=" +
-        isResourceOnly +
+        isResourceOnly() +
         ", isTarget=" +
-        isTarget +
+        isTarget() +
         ", isConrefPush=" +
-        isConrefPush +
+        isConrefPush() +
         ", isInput=" +
-        isInput +
+        isInput() +
         ", isInputResource=" +
-        isInputResource +
+        isInputResource() +
         ", hasKeyref=" +
-        hasKeyref +
+        hasKeyref() +
         ", hasCoderef=" +
-        hasCoderef +
+        hasCoderef() +
         ", isSubjectScheme=" +
-        isSubjectScheme +
+        isSubjectScheme() +
         ", isSubtarget=" +
-        isSubtarget +
+        isSubtarget() +
         ", isFlagImage=" +
-        isFlagImage +
+        isFlagImage() +
         ", isOutDita=" +
-        isOutDita +
+        isOutDita() +
         '}'
       );
     }
@@ -726,50 +726,50 @@ public final class Job {
       if (o == null || getClass() != o.getClass()) return false;
       FileInfo fileInfo = (FileInfo) o;
       return (
-        hasConref == fileInfo.hasConref &&
-        isChunked == fileInfo.isChunked &&
-        hasLink == fileInfo.hasLink &&
-        isResourceOnly == fileInfo.isResourceOnly &&
-        isTarget == fileInfo.isTarget &&
-        isConrefPush == fileInfo.isConrefPush &&
-        hasKeyref == fileInfo.hasKeyref &&
-        hasCoderef == fileInfo.hasCoderef &&
-        isSubjectScheme == fileInfo.isSubjectScheme &&
-        isSubtarget == fileInfo.isSubtarget &&
-        isFlagImage == fileInfo.isFlagImage &&
-        isOutDita == fileInfo.isOutDita &&
-        isInput == fileInfo.isInput &&
-        isInputResource == fileInfo.isInputResource &&
-        Objects.equals(src, fileInfo.src) &&
-        Objects.equals(uri, fileInfo.uri) &&
-        Objects.equals(file, fileInfo.file) &&
-        Objects.equals(result, fileInfo.result) &&
-        Objects.equals(format, fileInfo.format)
+        hasConref() == fileInfo.hasConref() &&
+        isChunked() == fileInfo.isChunked() &&
+        hasLink() == fileInfo.hasLink() &&
+        isResourceOnly() == fileInfo.isResourceOnly() &&
+        isTarget() == fileInfo.isTarget() &&
+        isConrefPush() == fileInfo.isConrefPush() &&
+        hasKeyref() == fileInfo.hasKeyref() &&
+        hasCoderef() == fileInfo.hasCoderef() &&
+        isSubjectScheme() == fileInfo.isSubjectScheme() &&
+        isSubtarget() == fileInfo.isSubtarget() &&
+        isFlagImage() == fileInfo.isFlagImage() &&
+        isOutDita() == fileInfo.isOutDita() &&
+        isInput() == fileInfo.isInput() &&
+        isInputResource() == fileInfo.isInputResource() &&
+        Objects.equals(src(), fileInfo.src()) &&
+        Objects.equals(uri(), fileInfo.uri()) &&
+        Objects.equals(file(), fileInfo.file()) &&
+        Objects.equals(result(), fileInfo.result()) &&
+        Objects.equals(format(), fileInfo.format())
       );
     }
 
     @Override
     public int hashCode() {
       return Objects.hash(
-        src,
-        uri,
-        file,
-        result,
-        format,
-        hasConref,
-        isChunked,
-        hasLink,
-        isResourceOnly,
-        isTarget,
-        isConrefPush,
-        hasKeyref,
-        hasCoderef,
-        isSubjectScheme,
-        isSubtarget,
-        isFlagImage,
-        isOutDita,
-        isInput,
-        isInputResource
+        src(),
+        uri(),
+        file(),
+        result(),
+        format(),
+        hasConref(),
+        isChunked(),
+        hasLink(),
+        isResourceOnly(),
+        isTarget(),
+        isConrefPush(),
+        hasKeyref(),
+        hasCoderef(),
+        isSubjectScheme(),
+        isSubtarget(),
+        isFlagImage(),
+        isOutDita(),
+        isInput(),
+        isInputResource()
       );
     }
 
@@ -882,50 +882,50 @@ public final class Job {
       public Builder() {}
 
       public Builder(final FileInfo orig) {
-        src = orig.src;
-        uri = orig.uri;
-        file = orig.file;
-        result = orig.result;
-        format = orig.format;
-        hasConref = orig.hasConref;
-        isChunked = orig.isChunked;
-        hasLink = orig.hasLink;
-        isResourceOnly = orig.isResourceOnly;
-        isTarget = orig.isTarget;
-        isConrefPush = orig.isConrefPush;
-        hasKeyref = orig.hasKeyref;
-        hasCoderef = orig.hasCoderef;
-        isSubjectScheme = orig.isSubjectScheme;
-        isSubtarget = orig.isSubtarget;
-        isFlagImage = orig.isFlagImage;
-        isOutDita = orig.isOutDita;
-        isInput = orig.isInput;
-        isInputResource = orig.isInputResource;
+        src = orig.src();
+        uri = orig.uri();
+        file = orig.file();
+        result = orig.result();
+        format = orig.format();
+        hasConref = orig.hasConref();
+        isChunked = orig.isChunked();
+        hasLink = orig.hasLink();
+        isResourceOnly = orig.isResourceOnly();
+        isTarget = orig.isTarget();
+        isConrefPush = orig.isConrefPush();
+        hasKeyref = orig.hasKeyref();
+        hasCoderef = orig.hasCoderef();
+        isSubjectScheme = orig.isSubjectScheme();
+        isSubtarget = orig.isSubtarget();
+        isFlagImage = orig.isFlagImage();
+        isOutDita = orig.isOutDita();
+        isInput = orig.isInput();
+        isInputResource = orig.isInputResource();
       }
 
       /**
        * Add file info to this builder. Only non-null and true values will be added.
        */
       public Builder add(final FileInfo orig) {
-        if (orig.src != null) src = orig.src;
-        if (orig.uri != null) uri = orig.uri;
-        if (orig.file != null) file = orig.file;
-        if (orig.result != null) result = orig.result;
-        if (orig.format != null) format = orig.format;
-        if (orig.hasConref) hasConref = orig.hasConref;
-        if (orig.isChunked) isChunked = orig.isChunked;
-        if (orig.hasLink) hasLink = orig.hasLink;
-        if (orig.isResourceOnly) isResourceOnly = orig.isResourceOnly;
-        if (orig.isTarget) isTarget = orig.isTarget;
-        if (orig.isConrefPush) isConrefPush = orig.isConrefPush;
-        if (orig.hasKeyref) hasKeyref = orig.hasKeyref;
-        if (orig.hasCoderef) hasCoderef = orig.hasCoderef;
-        if (orig.isSubjectScheme) isSubjectScheme = orig.isSubjectScheme;
-        if (orig.isSubtarget) isSubtarget = orig.isSubtarget;
-        if (orig.isFlagImage) isFlagImage = orig.isFlagImage;
-        if (orig.isOutDita) isOutDita = orig.isOutDita;
-        if (orig.isInput) isInput = orig.isInput;
-        if (orig.isInputResource) isInputResource = orig.isInputResource;
+        if (orig.src() != null) src = orig.src();
+        if (orig.uri() != null) uri = orig.uri();
+        if (orig.file() != null) file = orig.file();
+        if (orig.result() != null) result = orig.result();
+        if (orig.format() != null) format = orig.format();
+        if (orig.hasConref()) hasConref = orig.hasConref();
+        if (orig.isChunked()) isChunked = orig.isChunked();
+        if (orig.hasLink()) hasLink = orig.hasLink();
+        if (orig.isResourceOnly()) isResourceOnly = orig.isResourceOnly();
+        if (orig.isTarget()) isTarget = orig.isTarget();
+        if (orig.isConrefPush()) isConrefPush = orig.isConrefPush();
+        if (orig.hasKeyref()) hasKeyref = orig.hasKeyref();
+        if (orig.hasCoderef()) hasCoderef = orig.hasCoderef();
+        if (orig.isSubjectScheme()) isSubjectScheme = orig.isSubjectScheme();
+        if (orig.isSubtarget()) isSubtarget = orig.isSubtarget();
+        if (orig.isFlagImage()) isFlagImage = orig.isFlagImage();
+        if (orig.isOutDita()) isOutDita = orig.isOutDita();
+        if (orig.isInput()) isInput = orig.isInput();
+        if (orig.isInputResource()) isInputResource = orig.isInputResource();
         return this;
       }
 
@@ -934,15 +934,15 @@ public final class Job {
         //                if (orig.uri != null) uri = orig.uri;
         //                if (orig.file != null) file = orig.file;
         //                if (orig.result != null) result = orig.result;
-        if (orig.format != null) format = orig.format;
-        if (orig.hasConref) hasConref = orig.hasConref;
-        if (orig.isChunked) isChunked = orig.isChunked;
-        if (orig.hasLink) hasLink = orig.hasLink;
+        if (orig.format() != null) format = orig.format();
+        if (orig.hasConref()) hasConref = orig.hasConref();
+        if (orig.isChunked()) isChunked = orig.isChunked();
+        if (orig.hasLink()) hasLink = orig.hasLink();
         //                if (orig.isResourceOnly) isResourceOnly = orig.isResourceOnly;
         //                if (orig.isTarget) isTarget = orig.isTarget;
-        if (orig.isConrefPush) isConrefPush = orig.isConrefPush;
-        if (orig.hasKeyref) hasKeyref = orig.hasKeyref;
-        if (orig.hasCoderef) hasCoderef = orig.hasCoderef;
+        if (orig.isConrefPush()) isConrefPush = orig.isConrefPush();
+        if (orig.hasKeyref()) hasKeyref = orig.hasKeyref();
+        if (orig.hasCoderef()) hasCoderef = orig.hasCoderef();
         //                if (orig.isSubjectScheme) isSubjectScheme = orig.isSubjectScheme;
         //                if (orig.isSubtarget) isSubtarget = orig.isSubtarget;
         //                if (orig.isFlagImage) isFlagImage = orig.isFlagImage;
@@ -1212,8 +1212,8 @@ public final class Job {
     return files
       .values()
       .stream()
-      .filter(fi -> fi.isInput)
-      .map(fi -> fi.src)
+      .filter(FileInfo::isInput)
+      .map(FileInfo::src)
       .findAny()
       .orElseGet(() -> Optional.ofNullable((String) prop.get(PROPERTY_INPUT_MAP_URI)).map(URLUtils::toURI).orElse(null)
       );
@@ -1255,10 +1255,10 @@ public final class Job {
   @VisibleForTesting
   public URI getResultBaseDir() {
     final Collection<FileInfo> fis = getFileInfo();
-    URI baseDir = getFileInfo(fi -> fi.isInput).iterator().next().result.resolve(".");
+    URI baseDir = getFileInfo(FileInfo::isInput).iterator().next().result().resolve(".");
     for (final FileInfo fi : fis) {
-      if (fi.result != null && !fi.isResourceOnly) {
-        final URI res = fi.result.resolve(".");
+      if (fi.result() != null && !fi.isResourceOnly()) {
+        final URI res = fi.result().resolve(".");
         baseDir = Optional.ofNullable(getCommonBase(baseDir, res)).orElse(baseDir);
       }
     }

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -14,6 +14,8 @@ import static org.dita.dost.util.URLUtils.*;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.*;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -94,25 +96,51 @@ public final class Job {
   /** File name for temporary input file list file */
   public static final String USER_INPUT_FILE_LIST_FILE = "usr.input.file.list";
 
-  /** Map of serialization attributes to file info boolean fields. */
-  private static final Map<String, Field> attrToFieldMap = new HashMap<>();
+  /** Map of deserialization attributes to file info boolean fields. */
+  private static final Map<String, Method> attrToGetterMap = new HashMap<>();
 
   static {
     try {
-      attrToFieldMap.put(ATTRIBUTE_CHUNKED, FileInfo.class.getField("isChunked"));
-      attrToFieldMap.put(ATTRIBUTE_HAS_LINK, FileInfo.class.getField("hasLink"));
-      attrToFieldMap.put(ATTRIBUTE_INPUT, FileInfo.class.getField("isInput"));
-      attrToFieldMap.put(ATTRIBUTE_HAS_CONREF, FileInfo.class.getField("hasConref"));
-      attrToFieldMap.put(ATTRIBUTE_HAS_KEYREF, FileInfo.class.getField("hasKeyref"));
-      attrToFieldMap.put(ATTRIBUTE_HAS_CODEREF, FileInfo.class.getField("hasCoderef"));
-      attrToFieldMap.put(ATTRIBUTE_RESOURCE_ONLY, FileInfo.class.getField("isResourceOnly"));
-      attrToFieldMap.put(ATTRIBUTE_TARGET, FileInfo.class.getField("isTarget"));
-      attrToFieldMap.put(ATTRIBUTE_CONREF_PUSH, FileInfo.class.getField("isConrefPush"));
-      attrToFieldMap.put(ATTRIBUTE_SUBJECT_SCHEME, FileInfo.class.getField("isSubjectScheme"));
-      attrToFieldMap.put(ATTRIBUTE_OUT_DITA_FILES_LIST, FileInfo.class.getField("isOutDita"));
-      attrToFieldMap.put(ATTRIBUTE_FLAG_IMAGE_LIST, FileInfo.class.getField("isFlagImage"));
-      attrToFieldMap.put(ATTRIBUTE_SUBSIDIARY_TARGET_LIST, FileInfo.class.getField("isSubtarget"));
-    } catch (final NoSuchFieldException e) {
+      attrToGetterMap.put(ATTRIBUTE_CHUNKED, FileInfo.class.getMethod("isChunked"));
+      attrToGetterMap.put(ATTRIBUTE_HAS_LINK, FileInfo.class.getMethod("hasLink"));
+      attrToGetterMap.put(ATTRIBUTE_INPUT, FileInfo.class.getMethod("isInput"));
+      attrToGetterMap.put(ATTRIBUTE_HAS_CONREF, FileInfo.class.getMethod("hasConref"));
+      attrToGetterMap.put(ATTRIBUTE_HAS_KEYREF, FileInfo.class.getMethod("hasKeyref"));
+      attrToGetterMap.put(ATTRIBUTE_HAS_CODEREF, FileInfo.class.getMethod("hasCoderef"));
+      attrToGetterMap.put(ATTRIBUTE_RESOURCE_ONLY, FileInfo.class.getMethod("isResourceOnly"));
+      attrToGetterMap.put(ATTRIBUTE_TARGET, FileInfo.class.getMethod("isTarget"));
+      attrToGetterMap.put(ATTRIBUTE_CONREF_PUSH, FileInfo.class.getMethod("isConrefPush"));
+      attrToGetterMap.put(ATTRIBUTE_SUBJECT_SCHEME, FileInfo.class.getMethod("isSubjectScheme"));
+      attrToGetterMap.put(ATTRIBUTE_OUT_DITA_FILES_LIST, FileInfo.class.getMethod("isOutDita"));
+      attrToGetterMap.put(ATTRIBUTE_FLAG_IMAGE_LIST, FileInfo.class.getMethod("isFlagImage"));
+      attrToGetterMap.put(ATTRIBUTE_SUBSIDIARY_TARGET_LIST, FileInfo.class.getMethod("isSubtarget"));
+    } catch (final NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Map of serialization attributes to file info boolean fields. */
+  private static final Map<String, Method> attrToSetterMap = new HashMap<>();
+
+  static {
+    try {
+      attrToSetterMap.put(ATTRIBUTE_CHUNKED, FileInfo.Builder.class.getMethod("isChunked", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_HAS_LINK, FileInfo.Builder.class.getMethod("hasLink", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_INPUT, FileInfo.Builder.class.getMethod("isInput", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_HAS_CONREF, FileInfo.Builder.class.getMethod("hasConref", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_HAS_KEYREF, FileInfo.Builder.class.getMethod("hasKeyref", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_HAS_CODEREF, FileInfo.Builder.class.getMethod("hasCoderef", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_RESOURCE_ONLY, FileInfo.Builder.class.getMethod("isResourceOnly", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_TARGET, FileInfo.Builder.class.getMethod("isTarget", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_CONREF_PUSH, FileInfo.Builder.class.getMethod("isConrefPush", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_SUBJECT_SCHEME, FileInfo.Builder.class.getMethod("isSubjectScheme", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_OUT_DITA_FILES_LIST, FileInfo.Builder.class.getMethod("isOutDita", boolean.class));
+      attrToSetterMap.put(ATTRIBUTE_FLAG_IMAGE_LIST, FileInfo.Builder.class.getMethod("isFlagImage", boolean.class));
+      attrToSetterMap.put(
+        ATTRIBUTE_SUBSIDIARY_TARGET_LIST,
+        FileInfo.Builder.class.getMethod("isSubtarget", boolean.class)
+      );
+    } catch (final NoSuchMethodException e) {
       throw new RuntimeException(e);
     }
   }
@@ -249,13 +277,15 @@ public final class Job {
             i.result = src;
           }
           i.format = atts.getValue(ATTRIBUTE_FORMAT);
+          FileInfo.Builder b = FileInfo.builder(i);
           try {
-            for (Map.Entry<String, Field> e : attrToFieldMap.entrySet()) {
-              e.getValue().setBoolean(i, Boolean.parseBoolean(atts.getValue(e.getKey())));
+            for (Map.Entry<String, Method> e : attrToSetterMap.entrySet()) {
+              e.getValue().invoke(b, Boolean.parseBoolean(atts.getValue(e.getKey())));
             }
-          } catch (final IllegalAccessException ex) {
+          } catch (InvocationTargetException | IllegalAccessException ex) {
             throw new RuntimeException(ex);
           }
+          i = b.build();
           files.put(i.uri(), i);
         }
       }
@@ -390,13 +420,13 @@ public final class Job {
         out.writeAttribute(ATTRIBUTE_FORMAT, i.format());
       }
       try {
-        for (Map.Entry<String, Field> e : attrToFieldMap.entrySet()) {
-          final boolean v = e.getValue().getBoolean(i);
+        for (Map.Entry<String, Method> e : attrToGetterMap.entrySet()) {
+          final boolean v = (boolean) e.getValue().invoke(i);
           if (v) {
             out.writeAttribute(e.getKey(), Boolean.TRUE.toString());
           }
         }
-      } catch (final IllegalAccessException ex) {
+      } catch (InvocationTargetException | IllegalAccessException ex) {
         throw new RuntimeException(ex);
       }
       out.writeEndElement(); //file

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -266,18 +266,14 @@ public final class Job {
           final URI src = toURI(atts.getValue(ATTRIBUTE_SRC));
           final URI uri = toURI(atts.getValue(ATTRIBUTE_URI));
           final File path = toFile(atts.getValue(ATTRIBUTE_PATH));
-          FileInfo i;
+          final FileInfo.Builder b = FileInfo.builder().src(src);
           if (uri != null) {
-            i = new FileInfo(src, uri, toFile(uri));
+            b.uri(uri);
           } else {
-            i = new FileInfo(src, toURI(path), path);
+            b.file(path);
           }
-          i.result = toURI(atts.getValue(ATTRIBUTE_RESULT));
-          if (i.result == null) {
-            i.result = src;
-          }
-          i.format = atts.getValue(ATTRIBUTE_FORMAT);
-          FileInfo.Builder b = FileInfo.builder(i);
+          b.result(Objects.requireNonNullElse(toURI(atts.getValue(ATTRIBUTE_RESULT)), src));
+          b.format(atts.getValue(ATTRIBUTE_FORMAT));
           try {
             for (Map.Entry<String, Method> e : attrToSetterMap.entrySet()) {
               e.getValue().invoke(b, Boolean.parseBoolean(atts.getValue(e.getKey())));
@@ -285,7 +281,7 @@ public final class Job {
           } catch (InvocationTargetException | IllegalAccessException ex) {
             throw new RuntimeException(ex);
           }
-          i = b.build();
+          var i = b.build();
           files.put(i.uri(), i);
         }
       }

--- a/src/main/java/org/dita/dost/util/Job.java
+++ b/src/main/java/org/dita/dost/util/Job.java
@@ -272,7 +272,7 @@ public final class Job {
           } else {
             b.file(path);
           }
-          b.result(Objects.requireNonNullElse(toURI(atts.getValue(ATTRIBUTE_RESULT)), src));
+          b.result(Optional.ofNullable(toURI(atts.getValue(ATTRIBUTE_RESULT))).orElse(b.src));
           b.format(atts.getValue(ATTRIBUTE_FORMAT));
           try {
             for (Map.Entry<String, Method> e : attrToSetterMap.entrySet()) {
@@ -705,20 +705,99 @@ public final class Job {
     @Deprecated
     public boolean isInputResource;
 
+    /** @deprecated use {@link FileInfo#builder()} instead. */
+    @Deprecated
     FileInfo(final URI src, final URI uri, final File file) {
+      this(
+        src,
+        uri,
+        file,
+        src,
+        null,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      );
+    }
+
+    /** @deprecated use {@link FileInfo#builder()} instead. */
+    @Deprecated
+    FileInfo(final URI uri) {
+      this(
+        null,
+        uri,
+        null,
+        null,
+        null,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      );
+    }
+
+    public FileInfo(
+      URI src,
+      URI uri,
+      File file,
+      URI result,
+      String format,
+      boolean hasConref,
+      boolean isChunked,
+      boolean hasLink,
+      boolean isResourceOnly,
+      boolean isTarget,
+      boolean isConrefPush,
+      boolean hasKeyref,
+      boolean hasCoderef,
+      boolean isSubjectScheme,
+      boolean isSubtarget,
+      boolean isFlagImage,
+      boolean isOutDita,
+      boolean isInput,
+      boolean isInputResource
+    ) {
       if (uri == null && file == null) throw new IllegalArgumentException(new NullPointerException());
       this.src = src;
       this.uri = uri != null ? uri : toURI(file);
-      this.file = uri != null ? toFile(uri) : file;
-      this.result = src;
-    }
-
-    FileInfo(final URI uri) {
-      if (uri == null) throw new IllegalArgumentException(new NullPointerException());
-      this.src = null;
-      this.uri = uri;
-      this.file = toFile(uri);
-      this.result = src();
+      this.file = file != null ? file : toFile(uri);
+      this.result = result;
+      this.format = format;
+      this.hasConref = hasConref;
+      this.isChunked = isChunked;
+      this.hasLink = hasLink;
+      this.isResourceOnly = isResourceOnly;
+      this.isTarget = isTarget;
+      this.isConrefPush = isConrefPush;
+      this.hasKeyref = hasKeyref;
+      this.hasCoderef = hasCoderef;
+      this.isSubjectScheme = isSubjectScheme;
+      this.isSubtarget = isSubtarget;
+      this.isFlagImage = isFlagImage;
+      this.isOutDita = isOutDita;
+      this.isInput = isInput;
+      this.isInputResource = isInputResource;
     }
 
     @Override
@@ -1003,7 +1082,7 @@ public final class Job {
       }
 
       public Builder src(final URI src) {
-        assert src.isAbsolute();
+        assert src == null || src.isAbsolute();
         this.src = src;
         return this;
       }

--- a/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/AbstractChunkTopicParser.java
@@ -253,12 +253,12 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
 
   URI generateOutputFilename(final String id) {
     final FileInfo cfi = job.getFileInfo(stripFragment(currentParsingFile));
-    URI result = cfi.result.resolve(id + FILE_EXTENSION_DITA);
+    URI result = cfi.result().resolve(id + FILE_EXTENSION_DITA);
     URI temp = tempFileNameScheme.generateTempFileName(result);
     if (id == null || job.getStore().exists(job.tempDirURI.resolve(temp))) { //job.getFileInfo(result) != null
       final URI t = temp;
 
-      result = cfi.result.resolve(generateFilename());
+      result = cfi.result().resolve(generateFilename());
       temp = tempFileNameScheme.generateTempFileName(result);
 
       final FileInfo.Builder b = new FileInfo.Builder(cfi);
@@ -374,7 +374,7 @@ public abstract class AbstractChunkTopicParser extends AbstractXMLWriter {
    */
   URI generateOutputFile(final URI ref) {
     final FileInfo srcFi = job.getFileInfo(ref);
-    final URI newSrc = srcFi.src.resolve(generateFilename());
+    final URI newSrc = srcFi.src().resolve(generateFilename());
     final URI tmp = tempFileNameScheme.generateTempFileName(newSrc);
 
     if (job.getFileInfo(tmp) == null) {

--- a/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
+++ b/src/main/java/org/dita/dost/writer/ConkeyrefFilter.java
@@ -75,7 +75,7 @@ public final class ConkeyrefFilter extends AbstractXMLFilter {
    * @return updated href URI
    */
   private URI getRelativePath(final URI keyMap, final URI href) {
-    final URI inputMap = Optional.ofNullable(job.getFileInfo(keyMap)).map(fi -> fi.uri).orElse(null);
+    final URI inputMap = Optional.ofNullable(job.getFileInfo(keyMap)).map(Job.FileInfo::uri).orElse(null);
     final URI keyValue;
     if (inputMap != null) {
       final URI tmpMap = job.tempDirURI.resolve(inputMap);

--- a/src/main/java/org/dita/dost/writer/ConrefPushParser.java
+++ b/src/main/java/org/dita/dost/writer/ConrefPushParser.java
@@ -73,13 +73,14 @@ public final class ConrefPushParser extends AbstractDomFilter {
       final URI relativePath = toURI(
         filename.getAbsolutePath().substring(new File(normalize(tempDir.toString())).getPath().length() + 1)
       );
-      final FileInfo f = job.getOrCreateFileInfo(relativePath);
+      var f = FileInfo.builder(job.getOrCreateFileInfo(relativePath));
       if (hasConref) {
-        f.hasConref = true;
+        f.hasConref(true);
       }
       if (hasKeyref) {
-        f.hasKeyref = true;
+        f.hasKeyref(true);
       }
+      job.add(f.build());
       job.write();
     } catch (final RuntimeException e) {
       throw e;

--- a/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
+++ b/src/main/java/org/dita/dost/writer/DitaLinksWriter.java
@@ -60,8 +60,8 @@ public final class DitaLinksWriter extends AbstractXMLFilter {
   @Override
   public void setJob(final Job job) {
     super.setJob(job);
-    final Job.FileInfo in = job.getFileInfo(fi -> fi.isInput).iterator().next();
-    baseURI = job.tempDir.toURI().resolve(in.uri);
+    final Job.FileInfo in = job.getFileInfo(Job.FileInfo::isInput).iterator().next();
+    baseURI = job.tempDir.toURI().resolve(in.uri());
   }
 
   /**

--- a/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
+++ b/src/main/java/org/dita/dost/writer/DitaWriterFilter.java
@@ -236,8 +236,8 @@ public final class DitaWriterFilter extends AbstractXMLFilter {
         final FileInfo f = job.getFileInfo(current);
         if (f != null) {
           final FileInfo cfi = job.getFileInfo(currentFile);
-          final URI currrentFileTemp = job.tempDirURI.resolve(cfi.uri);
-          final URI targetTemp = job.tempDirURI.resolve(f.uri);
+          final URI currrentFileTemp = job.tempDirURI.resolve(cfi.uri());
+          final URI targetTemp = job.tempDirURI.resolve(f.uri());
           attValue = getRelativePath(currrentFileTemp, targetTemp);
         } else if (tempFileNameScheme != null) {
           final URI currrentFileTemp = job.tempDirURI.resolve(tempFileNameScheme.generateTempFileName(currentFile));

--- a/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
+++ b/src/main/java/org/dita/dost/writer/ForceUniqueFilter.java
@@ -103,7 +103,7 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
               dstFi = generateCopyToTarget(srcFi, count);
             }
             copyToMap.put(dstFi, srcFi);
-            final URI dstTempAbs = job.tempDirURI.resolve(dstFi.uri);
+            final URI dstTempAbs = job.tempDirURI.resolve(dstFi.uri());
             final URI targetRel = getRelativePath(currentFile, dstTempAbs);
             final URI target = setFragment(targetRel, href.getFragment());
 
@@ -180,9 +180,9 @@ public final class ForceUniqueFilter extends AbstractXMLFilter {
         ext.append(Integer.toString(i));
       }
       ext.append('.');
-      ext.append(getExtension(srcFi.result.toString()));
+      ext.append(getExtension(srcFi.result().toString()));
 
-      final URI dstResult = toURI(replaceExtension(srcFi.result.toString(), ext.toString()));
+      final URI dstResult = toURI(replaceExtension(srcFi.result().toString(), ext.toString()));
       final URI dstTemp = tempFileNameScheme.generateTempFileName(dstResult);
       if (job.getFileInfo(dstTemp) == null) {
         return new FileInfo.Builder(srcFi).uri(dstTemp).result(dstResult).build();

--- a/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
+++ b/src/main/java/org/dita/dost/writer/ImageMetadataFilter.java
@@ -288,7 +288,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     final URI fileName;
     final FileInfo fi = job.getFileInfo(currentFile.resolve(href));
     if (fi != null) {
-      fileName = job.getInputDir().relativize(fi.src);
+      fileName = job.getInputDir().relativize(fi.src());
     } else {
       fileName = href;
     }
@@ -306,7 +306,7 @@ public final class ImageMetadataFilter extends AbstractXMLFilter {
     }
 
     if (fi != null) {
-      final URI srcTempURI = job.tempDirURI.resolve(fi.uri);
+      final URI srcTempURI = job.tempDirURI.resolve(fi.uri());
       if (exists(srcTempURI)) {
         logger.debug("Found " + srcTempURI);
         return srcTempURI;

--- a/src/main/java/org/dita/dost/writer/LinkFilter.java
+++ b/src/main/java/org/dita/dost/writer/LinkFilter.java
@@ -98,7 +98,7 @@ public class LinkFilter extends AbstractXMLFilter {
     final FileInfo targetFileInfo = job.getFileInfo(targetAbs);
     final FileInfo sourceFileInfo = job.getFileInfo(currentFile);
     if (targetFileInfo != null && sourceFileInfo != null) {
-      final URI relTarget = URLUtils.getRelativePath(sourceFileInfo.result, targetFileInfo.result);
+      final URI relTarget = URLUtils.getRelativePath(sourceFileInfo.result(), targetFileInfo.result());
       return setFragment(relTarget, target.getFragment());
     } else {
       return target;

--- a/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
+++ b/src/main/java/org/dita/dost/writer/SeparateChunkTopicParser.java
@@ -255,9 +255,9 @@ public final class SeparateChunkTopicParser extends AbstractChunkTopicParser {
     final FileInfo srcFi = job.getFileInfo(base);
     final URI dst;
     if (file != null) {
-      dst = srcFi.result.resolve(file);
+      dst = srcFi.result().resolve(file);
     } else {
-      dst = setPath(srcFi.result, srcFi.result.getPath() + FILE_EXTENSION_CHUNK);
+      dst = setPath(srcFi.result(), srcFi.result().getPath() + FILE_EXTENSION_CHUNK);
     }
     final URI tmp = tempFileNameScheme.generateTempFileName(dst);
 

--- a/src/main/java/org/dita/dost/writer/TopicCleanFilter.java
+++ b/src/main/java/org/dita/dost/writer/TopicCleanFilter.java
@@ -37,15 +37,15 @@ public class TopicCleanFilter extends AbstractXMLFilter {
   }
 
   void calculatePathToProjectDirs() {
-    final int stepsToRootDir = fi.result.getPath().split("/").length - 1;
+    final int stepsToRootDir = fi.result().getPath().split("/").length - 1;
     pathToRootDir = stepsToRootDir == 0 ? SINGLE_URI_STEP : URI_STEP.repeat(stepsToRootDir);
     pathToMapDir =
       job
-        .getFileInfo(fi -> fi.isInput && Objects.equals(fi.format, ATTR_FORMAT_VALUE_DITAMAP))
+        .getFileInfo(fi -> fi.isInput() && Objects.equals(fi.format(), ATTR_FORMAT_VALUE_DITAMAP))
         .stream()
         .findAny()
         .map(startFile -> {
-          final String relativePath = getRelativePath(fi.uri, startFile.uri).resolve(".").getPath();
+          final String relativePath = getRelativePath(fi.uri(), startFile.uri()).resolve(".").getPath();
           //          return relativePath.getPath().split("/").length;
           return relativePath;
         })

--- a/src/main/java/org/dita/dost/writer/ValidationFilter.java
+++ b/src/main/java/org/dita/dost/writer/ValidationFilter.java
@@ -451,7 +451,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
       if (format == null && isLocalScope(scope) && href != null) {
         final URI target = currentFile.resolve(href);
         final Job.FileInfo fi = job.getFileInfo(target);
-        if (fi != null && ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format)) {
+        if (fi != null && ATTR_FORMAT_VALUE_DITAMAP.equals(fi.format())) {
           switch (processingMode) {
             case STRICT -> throw new RuntimeException(
               MessageUtils.getMessage("DOTJ061E").setLocation(locator).toString()
@@ -462,7 +462,7 @@ public final class ValidationFilter extends AbstractXMLFilter {
               if (res == null) {
                 res = new AttributesImpl(atts);
               }
-              addOrSetAttribute(res, ATTRIBUTE_NAME_FORMAT, fi.format);
+              addOrSetAttribute(res, ATTRIBUTE_NAME_FORMAT, fi.format());
             }
           }
         }

--- a/src/main/java/org/dita/dost/writer/include/IncludeText.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeText.java
@@ -84,8 +84,8 @@ final class IncludeText {
     //        if (tempFile.exists() && fi != null && PR_D_CODEREF.localName.equals(fi.format)) {
     //            return tempFile;
     //        }
-    if (fi != null && "file".equals(fi.src.getScheme())) {
-      return new File(fi.src);
+    if (fi != null && "file".equals(fi.src().getScheme())) {
+      return new File(fi.src());
     }
     return null;
   }

--- a/src/main/java/org/dita/dost/writer/include/IncludeXml.java
+++ b/src/main/java/org/dita/dost/writer/include/IncludeXml.java
@@ -42,7 +42,7 @@ final class IncludeXml {
     final URI hrefValue = toURI(atts.getValue(ATTRIBUTE_NAME_HREF));
     final Job.FileInfo fileInfo = job.getFileInfo(stripFragment(currentFile.resolve(hrefValue)));
     try {
-      final XdmNode doc = job.getStore().getImmutableNode(fileInfo.src);
+      final XdmNode doc = job.getStore().getImmutableNode(fileInfo.src());
       final XdmNode src;
       if (hrefValue.getFragment() != null) {
         final XdmItem id = XdmAtomicValue.makeAtomicValue(hrefValue.getFragment());
@@ -54,7 +54,7 @@ final class IncludeXml {
 
       job.getStore().writeDocument(src, new IncludeFilter(contentHandler));
     } catch (IOException e) {
-      logger.error("Failed to process include {}", fileInfo.src, e);
+      logger.error("Failed to process include {}", fileInfo.src(), e);
       return false;
     }
     return true;

--- a/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
+++ b/src/main/plugins/org.dita.htmlhelp/src/main/java/org/dita/dost/ant/CheckLang.java
@@ -68,8 +68,8 @@ public final class CheckLang extends Task {
       } else {
         //parse topic files
         for (final FileInfo f : job.getFileInfo()) {
-          if (ATTR_FORMAT_VALUE_DITA.equals(f.format)) {
-            final File topicFile = new File(job.tempDir, f.file.getPath());
+          if (ATTR_FORMAT_VALUE_DITA.equals(f.format())) {
+            final File topicFile = new File(job.tempDir, f.file().getPath());
             if (topicFile.exists()) {
               job.getStore().transform(topicFile.toURI(), parser);
               langCode = parser.getLangCode();

--- a/src/test/java/org/dita/dost/AbstractIntegrationTest.java
+++ b/src/test/java/org/dita/dost/AbstractIntegrationTest.java
@@ -396,8 +396,8 @@ public abstract class AbstractIntegrationTest {
       if (store instanceof CacheStore) {
         final Job job = new Job(tempDir.getAbsoluteFile(), store);
         for (Job.FileInfo fileInfo : job.getFileInfo()) {
-          if (fileInfo.uri != null) {
-            final URI f = job.tempDirURI.resolve(fileInfo.uri);
+          if (fileInfo.uri() != null) {
+            final URI f = job.tempDirURI.resolve(fileInfo.uri());
             if (store.exists(f)) {
               final Path dir = Paths.get(f).getParent();
               if (!Files.exists(dir)) {

--- a/src/test/java/org/dita/dost/module/ConrefPushModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ConrefPushModuleTest.java
@@ -102,9 +102,9 @@ public class ConrefPushModuleTest extends AbstractModuleTest {
   protected AbstractPipelineModule getModule() {
     final ConrefPushModule conrefPushModule = new ConrefPushModule();
     conrefPushModule.setFileInfoFilter(fileInfo ->
-      fileInfo.format.equals(ATTR_FORMAT_VALUE_DITA) ||
-      fileInfo.format.equals(ATTR_FORMAT_VALUE_DITAMAP) &&
-      fileInfo.isInput
+      fileInfo.format().equals(ATTR_FORMAT_VALUE_DITA) ||
+      fileInfo.format().equals(ATTR_FORMAT_VALUE_DITAMAP) &&
+      fileInfo.isInput()
     );
     return conrefPushModule;
   }

--- a/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
+++ b/src/test/java/org/dita/dost/module/DebugAndFilterModuleTest.java
@@ -57,7 +57,7 @@ public class DebugAndFilterModuleTest {
     TestUtils.copy(new File(resourceDir, "temp"), tmpDir);
     final Job job = new Job(tmpDir, new StreamStore(tmpDir, new XMLUtils()));
     for (final Job.FileInfo fi : job.getFileInfo()) {
-      job.add(new Job.FileInfo.Builder(fi).src(inputDir.toURI().resolve(fi.uri)).build());
+      job.add(new Job.FileInfo.Builder(fi).src(inputDir.toURI().resolve(fi.uri())).build());
     }
     job.setInputFile(inputMap.getAbsoluteFile().toURI());
     job.setGeneratecopyouter(NOT_GENERATEOUTTER);

--- a/src/test/java/org/dita/dost/module/GenMapAndTopicListModuleTest.java
+++ b/src/test/java/org/dita/dost/module/GenMapAndTopicListModuleTest.java
@@ -165,9 +165,9 @@ public class GenMapAndTopicListModuleTest {
 
   private void assertPaths(final FileInfo fi, final URI src, final URI path) {
     if (src != null) {
-      assertEquals(fi.src, src);
+      assertEquals(fi.src(), src);
     }
-    assertEquals(fi.uri, path);
+    assertEquals(fi.uri(), path);
   }
 
   @Test
@@ -268,11 +268,21 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of("main.ditamap", "link-from-normal.dita", "link-from-resource-only.dita", "normal.dita"),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -297,11 +307,21 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(FileInfo::isResourceOnly)
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of("main.ditamap", "normal.dita"),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -324,11 +344,21 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(FileInfo::isResourceOnly)
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of("main.ditamap", "normal.dita"),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -347,7 +377,12 @@ public class GenMapAndTopicListModuleTest {
         "conref-from-resource-only.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(FileInfo::isResourceOnly)
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of(
@@ -358,7 +393,12 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "normal.dita"
       ),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -381,7 +421,12 @@ public class GenMapAndTopicListModuleTest {
         "conref-from-resource-only.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(FileInfo::isResourceOnly)
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of(
@@ -390,7 +435,12 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "normal.dita"
       ),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -411,7 +461,12 @@ public class GenMapAndTopicListModuleTest {
         "conref-from-resource-only.dita",
         "conref-from-normal-ALSORESOURCEONLY.dita"
       ),
-      job.getFileInfo().stream().filter(f -> f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(FileInfo::isResourceOnly)
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
     assertEquals(
       Set.of(
@@ -420,7 +475,12 @@ public class GenMapAndTopicListModuleTest {
         "link-from-resource-only-ALSORESOURCEONLY.dita",
         "normal.dita"
       ),
-      job.getFileInfo().stream().filter(f -> !f.isResourceOnly).map(fi -> fi.uri.toString()).collect(Collectors.toSet())
+      job
+        .getFileInfo()
+        .stream()
+        .filter(f -> !f.isResourceOnly())
+        .map(fi -> fi.uri().toString())
+        .collect(Collectors.toSet())
     );
   }
 
@@ -444,7 +504,7 @@ public class GenMapAndTopicListModuleTest {
 
     final Job job = generate(inputDir, inputMap, outDir, tempDir);
     FileInfo fileInfo = job.getFileInfo(new URI("figures/ISO_7010_W012.svg"));
-    assertEquals("image", fileInfo.format);
+    assertEquals("image", fileInfo.format());
   }
 
   private Set<String> readLines(final File f) throws IOException {

--- a/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
+++ b/src/test/java/org/dita/dost/module/ImageMetadataModuleTest.java
@@ -72,11 +72,11 @@ public class ImageMetadataModuleTest {
       new InputSource(new File(expDir, "test.dita").toURI().toString()),
       new InputSource(f.toURI().toString())
     );
-    assertEquals("image", job.getFileInfo(create("img.png")).format);
-    assertEquals("image", job.getFileInfo(create("img.gif")).format);
-    assertEquals("image", job.getFileInfo(create("img.jpg")).format);
-    assertEquals("image", job.getFileInfo(create("img.svg")).format);
-    assertEquals("image", job.getFileInfo(create("img.xxx")).format);
+    assertEquals("image", job.getFileInfo(create("img.png")).format());
+    assertEquals("image", job.getFileInfo(create("img.gif")).format());
+    assertEquals("image", job.getFileInfo(create("img.jpg")).format());
+    assertEquals("image", job.getFileInfo(create("img.svg")).format());
+    assertEquals("image", job.getFileInfo(create("img.xxx")).format());
   }
 
   @AfterAll

--- a/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
+++ b/src/test/java/org/dita/dost/module/KeyrefModuleTest.java
@@ -191,15 +191,15 @@ public class KeyrefModuleTest {
         .build();
     job.add(inputMapFileInfo);
 
-    final XdmNode src = parse(inputMapFileInfo.src);
+    final XdmNode src = parse(inputMapFileInfo.src());
     final KeyScope childScope = new KeyScope(
       "A",
       "A",
       Map.of(
         "VAR",
-        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR",
-        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null, 1)
+        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src(), null, 1)
       ),
       emptyList()
     );
@@ -208,9 +208,9 @@ public class KeyrefModuleTest {
       null,
       Map.of(
         "VAR",
-        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR",
-        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src, null, 1)
+        new KeyDef("VAR", null, "local", "dita", inputMapFileInfo.src(), null, 1)
       ),
       singletonList(childScope)
     );
@@ -226,7 +226,7 @@ public class KeyrefModuleTest {
 
     final Document exp = b.parse(new File(baseDir, "exp" + File.separator + "test.ditamap"));
 
-    final ResolveTask subMapTask = res.stream().filter(r -> r.in().src.equals(subMap)).findFirst().get();
+    final ResolveTask subMapTask = res.stream().filter(r -> r.in().src().equals(subMap)).findFirst().get();
     assertEquals(subMapTask.scope(), childScope);
 
     final Document act = toDocument(destination.getXdmNode());
@@ -245,19 +245,19 @@ public class KeyrefModuleTest {
         .isInput(true)
         .build();
     job.add(inputMapFileInfo);
-    final XdmNode act = parse(inputMapFileInfo.src);
+    final XdmNode act = parse(inputMapFileInfo.src());
     final KeyScope childScope1 = new KeyScope(
       "A",
       "A",
       Map.of(
         "VAR",
-        new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR",
-        new KeyDef("A.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("A.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR2",
-        new KeyDef("A.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("A.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR3",
-        new KeyDef("A.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null, 1)
+        new KeyDef("A.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src(), null, 1)
       ),
       EMPTY_LIST
     );
@@ -266,13 +266,13 @@ public class KeyrefModuleTest {
       "B",
       Map.of(
         "VAR",
-        new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "B.VAR",
-        new KeyDef("B.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("B.VAR", new URI("topic.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "B.VAR2",
-        new KeyDef("B.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("B.VAR2", new URI("res.dita"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "B.VAR3",
-        new KeyDef("B.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src, null, 1)
+        new KeyDef("B.VAR3", new URI("res.png"), "local", "png", inputMapFileInfo.src(), null, 1)
       ),
       EMPTY_LIST
     );
@@ -288,11 +288,11 @@ public class KeyrefModuleTest {
     receiver.close();
 
     ResolveTask task = res.get(0);
-    assertEquals("topic.dita", task.in().file.toString());
+    assertEquals("topic.dita", task.in().file().toString());
     assertEquals(null, task.scope().name());
 
     task = res.get(1);
-    assertEquals("topic.dita", task.in().file.toString());
+    assertEquals("topic.dita", task.in().file().toString());
     assertEquals("A", task.scope().name());
     KeyDef keyDef = task.scope().keyDefinition().get("VAR");
     assertEquals(new URI("topic.dita"), keyDef.href);
@@ -300,13 +300,13 @@ public class KeyrefModuleTest {
     assertEquals(new URI("topic-1.dita"), keyDef.href);
 
     task = res.get(3);
-    assertEquals("res.png", task.in().file.toString());
+    assertEquals("res.png", task.in().file().toString());
     assertEquals("A", task.scope().name());
     keyDef = task.scope().keyDefinition().get("A.VAR3");
     assertEquals(new URI("res.png"), keyDef.href);
 
     task = res.get(4);
-    assertEquals("topic.dita", task.in().file.toString());
+    assertEquals("topic.dita", task.in().file().toString());
     assertEquals("B", task.scope().name());
     keyDef = task.scope().keyDefinition().get("VAR");
     assertEquals(new URI("topic.dita"), keyDef.href);
@@ -314,13 +314,13 @@ public class KeyrefModuleTest {
     assertEquals(new URI("topic-2.dita"), keyDef.href);
 
     task = res.get(5);
-    assertEquals("res.dita", task.in().file.toString());
+    assertEquals("res.dita", task.in().file().toString());
     assertEquals("B", task.scope().name());
     keyDef = task.scope().keyDefinition().get("B.VAR2");
     assertEquals(new URI("res-1.dita"), keyDef.href);
 
     task = res.get(6);
-    assertEquals("res.png", task.in().file.toString());
+    assertEquals("res.png", task.in().file().toString());
     assertEquals("B", task.scope().name());
     keyDef = task.scope().keyDefinition().get("B.VAR3");
     assertEquals(new URI("res.png"), keyDef.href);
@@ -366,15 +366,15 @@ public class KeyrefModuleTest {
         .isInput(true)
         .build();
     job.add(inputMapFileInfo);
-    final XdmNode act = parse(inputMapFileInfo.src);
+    final XdmNode act = parse(inputMapFileInfo.src());
     final KeyScope childScope1 = new KeyScope(
       "A",
       "A",
       Map.of(
         "VAR",
-        new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "A.VAR",
-        new KeyDef("A.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null, 1)
+        new KeyDef("A.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src(), null, 1)
       ),
       EMPTY_LIST
     );
@@ -383,9 +383,9 @@ public class KeyrefModuleTest {
       "B",
       Map.of(
         "VAR",
-        new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null, 1),
+        new KeyDef("VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src(), null, 1),
         "B.VAR",
-        new KeyDef("B.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src, null, 1)
+        new KeyDef("B.VAR", new URI("topic.dita#abc"), "local", "dita", inputMapFileInfo.src(), null, 1)
       ),
       EMPTY_LIST
     );
@@ -433,9 +433,9 @@ public class KeyrefModuleTest {
         .isInput(true)
         .build();
     job.add(inputMapFileInfo);
-    final XdmNode act = parse(inputMapFileInfo.src);
+    final XdmNode act = parse(inputMapFileInfo.src());
     Map<String, KeyDef> defsMap = new HashMap<>();
-    defsMap.put("Tool", new KeyDef("Tool", null, "local", "dita", inputMapFileInfo.src, null, 1));
+    defsMap.put("Tool", new KeyDef("Tool", null, "local", "dita", inputMapFileInfo.src(), null, 1));
 
     KeyScope submap1 = new KeyScope("submap", "mapref[6]map[6].submap", defsMap, List.of());
     KeyScope submap2 = new KeyScope("submap", "submap[8]map[6].submap", defsMap, List.of());

--- a/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/MapReaderModuleTest.java
@@ -94,24 +94,24 @@ public class MapReaderModuleTest {
     assertEquals(5, job.getFileInfo().size());
     for (Job.FileInfo fileInfo : job.getFileInfo()) {
       assertEquals(
-        Objects.equals(fileInfo.format, "ditamap"),
-        job.getStore().exists(tempDir.toURI().resolve(fileInfo.uri))
+        Objects.equals(fileInfo.format(), "ditamap"),
+        job.getStore().exists(tempDir.toURI().resolve(fileInfo.uri()))
       );
-      final URI src = srcDir.toURI().relativize(fileInfo.src);
+      final URI src = srcDir.toURI().relativize(fileInfo.src());
       switch (src.toString()) {
         case "root.ditamap":
         case "submap.ditamap":
-          assertEquals("ditamap", fileInfo.format);
+          assertEquals("ditamap", fileInfo.format());
           break;
         case "topic.dita":
         case "subtopic.dita":
-          assertEquals(null, fileInfo.format);
+          assertEquals(null, fileInfo.format());
           break;
         case "ext.pdf":
-          assertEquals("pdf", fileInfo.format);
+          assertEquals("pdf", fileInfo.format());
           break;
         default:
-          throw new RuntimeException("Unmapped " + fileInfo.uri);
+          throw new RuntimeException("Unmapped " + fileInfo.uri());
       }
     }
     assertFalse(logger.getMessages().stream().anyMatch(m -> m.level == Level.WARN));

--- a/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
+++ b/src/test/java/org/dita/dost/module/reader/TopicReaderModuleTest.java
@@ -70,10 +70,10 @@ public class TopicReaderModuleTest {
     job.add(new Job.FileInfo.Builder().src(root.resolve("mysite.dita")).uri(URI.create("mysite.dita")).build());
     job.add(new Job.FileInfo.Builder().src(root.resolve("myproduct.dita")).uri(URI.create("myproduct.dita")).build());
     job
-      .getFileInfo(fi -> fi.isInput)
+      .getFileInfo(fi -> fi.isInput())
       .forEach(fi -> {
         try {
-          Files.copy(Paths.get(fi.src), Paths.get(job.tempDirURI.resolve(fi.uri)));
+          Files.copy(Paths.get(fi.src()), Paths.get(job.tempDirURI.resolve(fi.uri())));
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/src/test/java/org/dita/dost/util/FileInfoTest.java
+++ b/src/test/java/org/dita/dost/util/FileInfoTest.java
@@ -21,7 +21,27 @@ public final class FileInfoTest {
 
   @Test
   public void testURIConstructor() throws URISyntaxException {
-    final FileInfo f = new FileInfo(new URI("foo" + URI_SEPARATOR + "bar"));
+    final FileInfo f = new FileInfo(
+      null,
+      new URI("foo" + URI_SEPARATOR + "bar"),
+      null,
+      null,
+      null,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    );
     assertEquals(new File("foo" + File.separator + "bar"), f.file());
     assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri());
   }

--- a/src/test/java/org/dita/dost/util/FileInfoTest.java
+++ b/src/test/java/org/dita/dost/util/FileInfoTest.java
@@ -22,21 +22,21 @@ public final class FileInfoTest {
   @Test
   public void testURIConstructor() throws URISyntaxException {
     final FileInfo f = new FileInfo(new URI("foo" + URI_SEPARATOR + "bar"));
-    assertEquals(new File("foo" + File.separator + "bar"), f.file);
-    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
+    assertEquals(new File("foo" + File.separator + "bar"), f.file());
+    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri());
   }
 
   @Test
   public void testFileBuilder() throws URISyntaxException {
     final FileInfo f = new Builder().file(new File("foo" + File.separator + "bar")).build();
-    assertEquals(new File("foo" + File.separator + "bar"), f.file);
-    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
+    assertEquals(new File("foo" + File.separator + "bar"), f.file());
+    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri());
   }
 
   @Test
   public void testURIBuilder() throws URISyntaxException {
     final FileInfo f = new Builder().uri(new URI("foo" + URI_SEPARATOR + "bar")).build();
-    assertEquals(new File("foo" + File.separator + "bar"), f.file);
-    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri);
+    assertEquals(new File("foo" + File.separator + "bar"), f.file());
+    assertEquals(new URI("foo" + URI_SEPARATOR + "bar"), f.uri());
   }
 }


### PR DESCRIPTION
## Description
Add record style getters for job item fields and instruct to use the getters instead of directly reading the fields.

## Motivation and Context
Cleaner code and better encapsulation.

## How Has This Been Tested?
Existing tests.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
No end-user visible changes.

